### PR TITLE
Add handling for empty resume interview results

### DIFF
--- a/app/routers/resume_interviews.py
+++ b/app/routers/resume_interviews.py
@@ -627,6 +627,12 @@ def list_resume_interviews_for_calendar(
         .all()
     )
 
+    if not rows:
+        return create_success_response(
+            [],
+            "No resume interviews found for the selected date range",
+        )
+
     payload = [
         _to_calendar_item(interview=interview, resume=resume, call_session=call_session, db=db)
         for interview, resume, call_session in rows


### PR DESCRIPTION
- Implemented a check to return a success response with a message when no resume interviews are found for the selected date range.
- This enhancement improves user experience by providing clear feedback when there are no results to display.