### PR TITLE
Implement caching for call analysis in VoiceAnalysisService

### DIFF
--- a/app/services/voice_analysis_service.py
+++ b/app/services/voice_analysis_service.py
@@ -43,6 +43,27 @@ class VoiceAnalysisService:
         # 🎯 FLEXIBLE MODEL SELECTION WITH FALLBACK
         # Priority: 1. Call's model, 2. Gemini 2.0 Flash, 3. Llama, 4. GPT-4o Mini
 
+        # 🚀 CACHING: Return existing analysis if already present
+        if call_session.call_metadata and "llm_call_analysis" in call_session.call_metadata:
+            cached_block = call_session.call_metadata["llm_call_analysis"]
+            
+            # Reconstruct transcript message count for the response
+            transcript_messages = transcript_service.get_messages_by_session(
+                db, call_session.id
+            )
+            
+            logger.info("📦 Transcript analysis fetched from DB for session %s", call_session.id)
+            return {
+                "call_session_id": str(call_session.id),
+                "transcript_message_count": len(transcript_messages),
+                "call_duration": call_session.duration,
+                "call_status": call_session.status,
+                "analysis": cached_block.get("analysis"),
+                "model_used": cached_block.get("model_used"),
+                "timestamp": cached_block.get("timestamp"),
+                "is_cached": True
+            }
+
         preferred_model: Optional[str] = None
         agent = None
         agent_prompt: Optional[str] = None


### PR DESCRIPTION
Previously, the /transcript/analyze endpoint would trigger a fresh LLM generation (summary, sentiment, recommendations) every time it was called, even if an analysis already existed for that specific call session. This resulted in Redundant Costs, High Latency, Inconsistent Data
I have implemented a "check-before-generate" logic in the VoiceAnalysisService.
The system now checks for existing analysis data before initiating a new LLM generation. By retrieving the llm_call_analysis object directly from the call_metadata JSON field in the database, that once a call is analyzed, subsequent requests are served instantly without incurring additional API costs or processing time.