### PR TITLE
fix: remove hardcoded secrets and bare except clause

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,54 @@
+# Copy this file to .env and fill in real values. Never commit .env.
+
+# Database
+DATABASE_URL=postgresql+psycopg2://postgres:password@localhost:5432/voiceagent
+
+# JWT
+SECRET_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=15
+REFRESH_TOKEN_EXPIRE_DAYS=7
+
+# Twilio
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
+
+# OpenAI
+OPENAI_API_KEY=
+
+# ElevenLabs
+ELEVENLABS_API_KEY=
+
+# Deepgram
+DEEPGRAM_API_KEY=
+
+# Stripe
+STRIPE_API_KEY=
+STRIPE_WEBHOOK_SECRET=
+
+# Google / OAuth
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Google Cloud TTS
+GOOGLE_APPLICATION_CREDENTIALS=
+
+# Pinecone
+PINECONE_API_KEY=
+PINECONE_INDEX_NAME=
+
+# SendGrid
+SENDGRID_API_KEY=
+
+# Redis
+REDIS_URL=redis://localhost:6379
+
+# Anthropic (for AI review agent)
+ANTHROPIC_API_KEY=
+
+# Server
+DEBUG=False
+HOST=0.0.0.0
+PORT=8000
+WEBHOOK_BASE_URL=https://your-domain.com

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -249,7 +249,7 @@ def get_optional_tenant_user(
         if user:
             user.current_tenant_id = tenant_uuid
         return user
-    except:
+    except Exception:
         return None
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -6,7 +6,7 @@ class Settings(BaseSettings):
     ADMIN_ROLE: str = "admin"
     
     DATABASE_URL: str = "postgresql+psycopg2://postgres:admin@localhost:5432/voiceagent"
-    SECRET_KEY: str = "supersecretkey"
+    SECRET_KEY: str = "change-me-in-production"
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7


### PR DESCRIPTION
## Summary

- **`app/core/config.py`**: Replace `SECRET_KEY = "supersecretkey"` with `"change-me-in-production"` so it's obvious the value must be overridden via environment variable before deployment
- **`app/api/deps.py`**: Change bare `except:` → `except Exception:` in `get_optional_tenant_user` to avoid silently swallowing unexpected errors (e.g., `KeyboardInterrupt`, `SystemExit`)
- **`.env.example`**: Add a template documenting every required environment variable so new developers know what to configure

## Test plan

- [ ] Verify app starts normally with `SECRET_KEY` set via `.env`
- [ ] Confirm JWT auth still works after the config change
- [ ] Check that `get_optional_tenant_user` still returns `None` on invalid tokens (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)