### PR TITLE
feat(vertex-ai): Vertex AI Gemini 2.5 Flash LLM integration for voice pipeline

### DIFF
--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -116,20 +116,25 @@ def _ticket_tts_triad(agent: Agent) -> bool:
     return bool(agent.tts_provider_slug and agent.tts_language and has_voice)
 
 
+def _is_gemini_provider(provider_slug: str) -> bool:
+    return (provider_slug or "").lower() == "gemini"
+
+
 def resolve_llm_runtime(agent: Optional[Agent]) -> ResolvedLlmRuntime:
     """Pick LLM model + provider for conversation / scheduling paths."""
+    _default_temperature = float(getattr(settings, "VOICE_LLM_DEFAULT_TEMPERATURE", 0.3))
     default = ResolvedLlmRuntime(
         model_name=settings.DEFAULT_LLM_MODEL,
         provider_slug=settings.DEFAULT_LLM_PROVIDER,
         api_key=None,
-        temperature=0.15,
+        temperature=_default_temperature,
         max_tokens=100,
         used_ticket_llm=False,
     )
     if not agent:
         return default
 
-    temperature = 0.15
+    temperature = _default_temperature
     max_tokens = 100
     if agent.agent_temperature is not None:
         temperature = agent.agent_temperature / 100.0
@@ -143,7 +148,9 @@ def resolve_llm_runtime(agent: Optional[Agent]) -> ResolvedLlmRuntime:
     if agent.llm_model:
         provider_slug = infer_llm_provider(agent.llm_model)
         api_key: Optional[str] = None
-        if agent.model and agent.model.api_key:
+        # Gemini/Google models authenticate via ADC (GOOGLE_APPLICATION_CREDENTIALS).
+        # Never use model.api_key for the voice Vertex path — ignore it even if set.
+        if not _is_gemini_provider(provider_slug) and agent.model and agent.model.api_key:
             api_key = _decrypt_stored_api_key(
                 agent.model.api_key,
                 agent_id=agent.id,
@@ -169,7 +176,8 @@ def resolve_llm_runtime(agent: Optional[Agent]) -> ResolvedLlmRuntime:
             elif "gemini" in pname or "google" in pname:
                 provider_slug = "gemini"
         api_key = None
-        if agent.model.api_key:
+        # Gemini/Google: skip model.api_key — auth via ADC
+        if not _is_gemini_provider(provider_slug) and agent.model.api_key:
             api_key = _decrypt_stored_api_key(
                 agent.model.api_key,
                 agent_id=agent.id,
@@ -195,17 +203,23 @@ def resolve_llm_runtime(agent: Optional[Agent]) -> ResolvedLlmRuntime:
 
 
 def llm_service_for_provider(provider_slug: str) -> Any:
-    """Return the shared LLM service instance for a provider slug."""
-    from app.services.gemini_service import gemini_service
+    """Return the shared LLM service instance for a provider slug.
+
+    Gemini/Google → VertexGeminiService (ADC auth, correct system_instruction).
+    OpenAI / Groq → unchanged.
+    gemini_service is kept for RAG embeddings only (embed_text path).
+    """
     from app.services.groq_service import groq_service
     from app.services.openai_service import openai_service
+    from app.services.vertex_gemini_service import vertex_gemini_service
 
     slug = (provider_slug or "").lower()
     if slug == "openai":
         return openai_service
     if slug == "groq":
         return groq_service
-    return gemini_service
+    # Default: gemini / google → Vertex AI path
+    return vertex_gemini_service
 
 
 def resolve_tts_runtime(

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     # Server Configuration
     HOST: str = "0.0.0.0"
     PORT: int = 8000
-    DEBUG: bool = True
+    DEBUG: bool = False
     APP_VERSION: str = "1.0.0"
 
     # CORS — comma-separated list of allowed origins.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     # Server Configuration
     HOST: str = "0.0.0.0"
     PORT: int = 8000
-    DEBUG: bool = False
+    DEBUG: bool = True
     APP_VERSION: str = "1.0.0"
 
     # CORS — comma-separated list of allowed origins.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -74,8 +74,16 @@ class Settings(BaseSettings):
     ENABLE_ELEVENLABS_AUDIO_TAGS: bool = True
     
     # Google Cloud Speech-to-Text Configuration
-    GOOGLE_APPLICATION_CREDENTIALS: str = ""  # Path to service account JSON file
+    GOOGLE_APPLICATION_CREDENTIALS: str = ""  # Path to service account JSON file for Vertex AI + STT
     GOOGLE_CLOUD_PROJECT_ID: str = ""
+    # Vertex AI — used by VertexGeminiService for voice LLM calls (ADC, no api_key needed)
+    VERTEX_AI_LOCATION: str = "us-central1"
+    # History pruning for Vertex Gemini voice path (1 turn = 1 user + 1 model message)
+    VOICE_LLM_HISTORY_MAX_TURNS: int = 20
+    # Default temperature for Vertex Gemini voice path (0–1 scale)
+    VOICE_LLM_DEFAULT_TEMPERATURE: float = 0.3
+    # Canned fallback spoken when the Vertex LLM errors (quota, timeout, filter)
+    VOICE_LLM_FALLBACK_MESSAGE: str = "I am sorry, I did not catch that"
     GOOGLE_STT_LANGUAGE_CODE: str = "en-US"  # Default language
     # Deprecated fallback; prefer STT_SAMPLE_RATE for provider-neutral STT settings.
     GOOGLE_STT_SAMPLE_RATE: int = 8000

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -119,9 +119,10 @@ from app.services.agent_service import agent_service
 from app.services.voice_logging_service import VoiceLoggingService
 from app.models.appointment import Appointment
 from app.services.transcript_service import transcript_service
-from app.services.gemini_service import gemini_service
 from app.services.openai_service import openai_service
 from app.services.groq_service import groq_service
+from app.services.vertex_gemini_service import VertexLlmError, vertex_gemini_service
+from app.core.agent_runtime import resolve_llm_runtime, llm_service_for_provider
 from app.services.rag_service import rag_service
 from app.services.credit_service import credit_service
 from app.services.twilio_service import twilio_service
@@ -181,6 +182,7 @@ from app.utils.eleven_tts_text import (
 from app.voice.booking_mixin import BookingMixin
 from app.voice.tts_stream_mixin import TtsStreamMixin
 from app.voice.call_control_mixin import CallControlMixin
+from app.voice.pipeline_session import PipelineSession
 
 router = APIRouter()
 
@@ -488,6 +490,14 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
         # These are agent-level and don't change per-turn; caching them here
         # eliminates the 50-200ms parallel executor cost on every slow-path turn.
         asyncio.create_task(self._prefetch_kb_blocks_at_call_start())
+
+        # ── PipelineSession — per-call voice state container ─────────────────
+        # Holds references to the same objects as the existing handler attributes
+        # so both access paths stay in sync with no behaviour change.
+        self._pipeline_session = PipelineSession(
+            llm_cancel=self._tts_cancel,          # barge-in cancel event (shared ref)
+            history=self._conversation_history_cache,  # shared list ref
+        )
 
         # ── Voice Orchestration Layer ─────────────────────────────────────────
         # VoiceOrchestrator owns SttPipeline + TtsPipeline lifecycle and
@@ -860,8 +870,7 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
                 else:
                     # Interim LLM already running with the correct transcript —
                     # let it finish without a second generation.
-                    pass
-                return
+                    return
             else:
                 self._turn_response_seed_text = ""
                 self._last_interim_text = ""
@@ -1402,6 +1411,9 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
                 and self.call_session.call_metadata
                 and self.call_session.call_metadata.get("appointment_id")
             )
+            _llm_runtime = resolve_llm_runtime(self.agent)
+            _use_vertex_llm = (_llm_runtime.provider_slug or "").lower() == "gemini"
+            _vertex_kb_context = ""
             low_latency_fastpath = self._should_use_latency_fastpath(
                 user_text, booking_intent_turn
             )
@@ -1606,6 +1618,12 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
                     )
                 except Exception:
                     history_text = ""
+
+            if _use_vertex_llm:
+                history_text = (
+                    "(Prior conversation turns are provided separately — "
+                    "maintain continuity; do not re-ask answered questions.)"
+                )
             
             booking_memory_block = self._build_booking_memory_block()
             follow_up_appt_block = self._build_follow_up_appointment_block()
@@ -1678,6 +1696,21 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
                 "If the caller asks about the business, say that specific information is not "
                 "available to you right now and offer to help in another way."
             )
+
+            if _use_vertex_llm:
+                from app.voice.llm_prompt_builder import build_kb_context_for_vertex
+
+                _vertex_kb_context = build_kb_context_for_vertex(
+                    inbound_kb_docs_context_block,
+                    business_knowledge_block,
+                    empty_guard=_bk_block,
+                )
+                inbound_kb_docs_context_block = ""
+                _bk_block = (
+                    "# AUTHORITATIVE BUSINESS FACTS\n"
+                    "Business facts and inbound documents are attached as knowledge context "
+                    "with each user message — apply grounding rules using that context.\n"
+                )
 
             # Base prompt for phone conversations (voice-first, plain text only, no SSML)
             base_prompt = f"""# ROLE
@@ -1851,60 +1884,20 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 + system_prompt
             )
 
-            # Get agent's configured model and provider
-            llm_service = None
-            model_name = "gemini-1.5-flash"  # Default fallback
-            api_key = None
-            temperature = 0.15
-            max_tokens = 100
-            if self.agent and self.agent.model:
-                model_name = self.agent.model.model_name
-                
-                # Decrypt API key if available
-                if self.agent.model.api_key:
-                    try:
-                        from app.core.security import decrypt_api_key
-                        api_key = decrypt_api_key(self.agent.model.api_key)
-                    except Exception as e:
-                        logger.error(f"Failed to decrypt agent API key: {e}")
-                        api_key = None  # Will fallback to settings.OPENAI_API_KEY or settings.GOOGLE_API_KEY
-                else:
-                    api_key = None  # Will use global key from .env
-                
-                # Use agent-specific config if available
-                if self.agent.agent_temperature is not None:
-                    temperature = self.agent.agent_temperature / 100.0  # Convert 0-100 to 0-1
-                elif self.agent.model.temperature is not None:
-                    temperature = self.agent.model.temperature / 100.0
-                
-                if self.agent.agent_max_tokens:
-                    max_tokens = self.agent.agent_max_tokens
-                elif self.agent.model.max_tokens:
-                    max_tokens = self.agent.model.max_tokens
+            # Model/provider/temperature resolved early for Vertex prompt shaping.
+            model_name = _llm_runtime.model_name
+            api_key = _llm_runtime.api_key
+            temperature = _llm_runtime.temperature
+            max_tokens = _llm_runtime.max_tokens
+            _provider_slug = _llm_runtime.provider_slug
 
-                # Booking / follow-up turns need enough completion budget for action tokens.
-                if booking_intent_turn or follow_up_active:
-                    max_tokens = max(max_tokens, 180)
-                elif low_latency_fastpath:
-                    max_tokens = min(max_tokens, 80)
-                
-                # Select service based on provider
-                if self.agent.provider:
-                    provider_name = self.agent.provider.name.lower()
-                    if "openai" in provider_name:
-                        llm_service = openai_service
-                    elif "gemini" in provider_name or "google" in provider_name:
-                        llm_service = gemini_service
-                    elif "groq" in provider_name:
-                        llm_service = groq_service
-                    else:
-                        # Default to Gemini
-                        llm_service = gemini_service
-                else:
-                    llm_service = gemini_service
-            else:
-                # Fallback to Gemini
-                llm_service = gemini_service
+            # Booking / follow-up turns need a larger completion budget for action tokens.
+            if booking_intent_turn or follow_up_active:
+                max_tokens = max(max_tokens, 180)
+            elif low_latency_fastpath:
+                max_tokens = min(max_tokens, 80)
+
+            llm_service = llm_service_for_provider(_provider_slug)
             
             # Stream LLM output and QUEUE for PARALLEL TTS PIPELINE (Vapi-style)
             chunk_counter = 0
@@ -1999,14 +1992,26 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
 
                 _first_token_marked = False
                 _first_token_recorded = False
-                async for chunk in service.stream_text(
+                _stream_kwargs: dict = dict(
                     prompt=user_text,
                     system_prompt=system_prompt,
                     model_name=model,
                     temperature=temperature,
                     max_tokens=max_tokens,
-                    api_key=api_key_override
-                ):
+                    api_key=api_key_override,
+                )
+                # Vertex Gemini: pass cancel_event + conversation_history for
+                # proper system_instruction handling and barge-in support.
+                from app.services.vertex_gemini_service import VertexGeminiService
+                if isinstance(service, VertexGeminiService):
+                    _stream_kwargs["cancel_event"] = self._tts_cancel
+                    _stream_kwargs["conversation_history"] = list(
+                        self._conversation_history_cache
+                    )
+                    if _vertex_kb_context:
+                        _stream_kwargs["kb_context"] = _vertex_kb_context
+
+                async for chunk in service.stream_text(**_stream_kwargs):
                     if not chunk:
                         continue
                     # If barge-in requested, stop generating
@@ -2160,62 +2165,94 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 return response_accum.strip()
 
             final_text = None
+            _is_gemini_agent = (_provider_slug or "").lower() == "gemini"
+            _fallback_msg = getattr(settings, "VOICE_LLM_FALLBACK_MESSAGE", "I am sorry, I did not catch that")
             try:
-                # Use agent's configured model and service
                 final_text = await try_stream(llm_service, model_name, api_key)
+            except VertexLlmError as vertex_err:
+                # Vertex-specific errors (quota, timeout, content filter) — canned fallback only.
+                # Do NOT fall through to OpenAI/Gemini AI Studio for gemini-configured agents.
+                logger.warning(
+                    "⚠️ Vertex LLM error type=%s model=%s — using fallback TTS",
+                    vertex_err.error_type,
+                    model_name,
+                )
+                final_text = _fallback_msg
+                chunk_counter += 1
+                if self._tts_pipeline and not self._tts_cancel.is_set():
+                    await self._tts_pipeline.queue_tts({
+                        "text": _fallback_msg,
+                        "chunk_id": chunk_counter,
+                        "use_ssml": False,
+                        "is_final": True,
+                    })
+                    asyncio.create_task(
+                        self._deferred_conversation_memory_update(turn_context, user_text)
+                    )
             except Exception as e:
                 logger.warning(f"⚠️ Primary LLM failed ({model_name}): {e}. Attempting fallback...")
-                # Fallback: try alternate service
-                try:
-                    if llm_service == openai_service:
-                        # Fallback to Gemini
-                        final_text = await try_stream(gemini_service, "gemini-1.5-flash", None)
-                    else:
-                        # Fallback to OpenAI
-                        final_text = await try_stream(openai_service, "gpt-3.5-turbo", None)
-                except Exception as e:
-                    logger.warning(f"⚠️ Secondary LLM fallback failed: {e}. Attempting VoiceLoggingService fallback...")
-                    # Last fallback: non-streaming fast response via VoiceLoggingService
-                    try:
-                        final_text = await VoiceLoggingService.generate_agent_response(
-                            speech_text=user_text,
-                            confidence=confidence,
-                            agent=self.agent,
-                            db=self.db,
-                            call_session_id=self.call_session.id if self.call_session else None
+                if _is_gemini_agent:
+                    # Gemini agents: canned fallback only, no cross-provider attempt
+                    logger.warning("⚠️ Gemini agent LLM error — using canned fallback (no AI Studio retry)")
+                    final_text = _fallback_msg
+                    chunk_counter += 1
+                    if self._tts_pipeline and not self._tts_cancel.is_set():
+                        await self._tts_pipeline.queue_tts({
+                            "text": _fallback_msg,
+                            "chunk_id": chunk_counter,
+                            "use_ssml": False,
+                            "is_final": True,
+                        })
+                        asyncio.create_task(
+                            self._deferred_conversation_memory_update(turn_context, user_text)
                         )
-                        # Queue fallback response
-                        if final_text and not self._tts_cancel.is_set():
-                            safe_tts_text = self._prepare_tts_text(final_text)
-                            out_text = tone_adapter(safe_tts_text.strip(), turn_context, self._use_ssml)
-                            if not out_text:
-                                out_text = "One moment please."
+                else:
+                    # Non-gemini agents: try alternate service
+                    try:
+                        if llm_service == openai_service:
+                            final_text = await try_stream(vertex_gemini_service, "gemini-2.5-flash", None)
+                        else:
+                            final_text = await try_stream(openai_service, "gpt-3.5-turbo", None)
+                    except Exception as e:
+                        logger.warning(f"⚠️ Secondary LLM fallback failed: {e}. Attempting VoiceLoggingService fallback...")
+                        try:
+                            final_text = await VoiceLoggingService.generate_agent_response(
+                                speech_text=user_text,
+                                confidence=confidence,
+                                agent=self.agent,
+                                db=self.db,
+                                call_session_id=self.call_session.id if self.call_session else None
+                            )
+                            if final_text and not self._tts_cancel.is_set():
+                                safe_tts_text = self._prepare_tts_text(final_text)
+                                out_text = tone_adapter(safe_tts_text.strip(), turn_context, self._use_ssml)
+                                if not out_text:
+                                    out_text = "One moment please."
+                                chunk_counter += 1
+                                if self._tts_pipeline and out_text:
+                                    await self._tts_pipeline.queue_tts({
+                                        "text": out_text,
+                                        "use_ssml": self._use_ssml,
+                                        "is_final": True,
+                                    })
+                                    asyncio.create_task(
+                                        self._deferred_conversation_memory_update(turn_context, user_text)
+                                    )
+                        except Exception as e:
+                            logger.warning(f"⚠️ VoiceLoggingService fallback failed: {e}. Using ultimate fallback.")
+                            final_text = _fallback_msg
+                            utt = tone_adapter(final_text, turn_context, self._use_ssml)
                             chunk_counter += 1
-                            if self._tts_pipeline and out_text:
+                            if self._tts_pipeline:
                                 await self._tts_pipeline.queue_tts({
-                                    "text": out_text,
+                                    "text": utt,
+                                    "chunk_id": chunk_counter,
                                     "use_ssml": self._use_ssml,
-                                    "is_final": True,
+                                    "is_final": True
                                 })
                                 asyncio.create_task(
                                     self._deferred_conversation_memory_update(turn_context, user_text)
                                 )
-                    except Exception as e:
-                        logger.warning(f"⚠️ VoiceLoggingService fallback failed: {e}. Using ultimate fallback.")
-                        # Ultimate fallback response
-                        final_text = "I apologize, I'm having trouble responding right now. Could you please repeat that?"
-                        utt = tone_adapter(final_text, turn_context, self._use_ssml)
-                        chunk_counter += 1
-                        if self._tts_pipeline:
-                            await self._tts_pipeline.queue_tts({
-                                "text": utt,
-                                "chunk_id": chunk_counter,
-                                "use_ssml": self._use_ssml,
-                                "is_final": True
-                            })
-                            asyncio.create_task(
-                                self._deferred_conversation_memory_update(turn_context, user_text)
-                            )
 
             if final_text:
                 # Strip control tokens from transcript (never saved to history)

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -1410,6 +1410,7 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
             self._prev_tts_tail = b""           # Reset crossfade state so new response starts clean
             self._twilio_buffer_primed = False  # Ensure micro-fade and buffer priming for new utterance
             self._is_tts_playing = False        # Audio not yet streaming for this turn
+            self._tts_play_start_ts = 0.0     # Clear dead-zone anchor from previous utterance
 
             self._voice_metrics.start_generation()
             self._metric_gen_start_ts = time.perf_counter()

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -366,6 +366,14 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
         )
         self._barge_in_min_words = max(1, min(4, self._barge_in_min_words))
         self._barge_in_rejected_while_playing: int = 0
+        # Dead-zone: suppress interim-triggered barge-in for N ms after TTS audio
+        # starts playing.  Prevents Deepgram's stale interims (from the user's
+        # original speech still being processed) from immediately cutting the
+        # agent's response before the user has heard anything.
+        self._tts_play_start_ts: float = 0.0
+        self._barge_in_dead_zone_ms: float = float(
+            getattr(settings, "VOICE_BARGE_IN_DEAD_ZONE_MS", 600) or 600
+        )
         self._audio_samples_needed = max(
             4, int(getattr(settings, "VOICE_PICKUP_SAMPLE_WINDOW", 6) or 6)
         )
@@ -1105,7 +1113,19 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
             # and filler rejection block phantom Deepgram hits on silence.
             is_barge_in = False
             if self._is_tts_playing:
-                if self._should_barge_in_on_stt(transcript, confidence):
+                # Dead-zone: ignore interims that arrive within N ms of TTS starting.
+                # Deepgram can send stale interims (from the user's original speech)
+                # at almost exactly the moment the first audio frame is sent to Twilio.
+                # Without this guard, barge-in fires instantly and the user hears nothing.
+                _in_dead_zone = (
+                    self._tts_play_start_ts > 0
+                    and (time.perf_counter() - self._tts_play_start_ts) * 1000
+                    < self._barge_in_dead_zone_ms
+                )
+                if _in_dead_zone:
+                    if (transcript or "").strip():
+                        self._log_barge_in_suppressed(transcript, confidence, "tts_dead_zone")
+                elif self._should_barge_in_on_stt(transcript, confidence):
                     is_barge_in = True
                 elif (transcript or "").strip():
                     if self._is_stt_filler_for_barge_in(transcript):

--- a/app/routers/live_voice.py
+++ b/app/routers/live_voice.py
@@ -509,7 +509,6 @@ async def process_with_ai_live(session_id: str, user_input: str, session_data: d
                 # Load model configuration with provider
                 from sqlalchemy.orm import joinedload
                 from app.models.model import Model
-                from app.services.gemini_service import gemini_service
                 from app.core.security import decrypt_api_key
                 
                 try:
@@ -546,18 +545,19 @@ async def process_with_ai_live(session_id: str, user_input: str, session_data: d
                         
                         # Route to appropriate service
                         if 'gemini' in provider_name or 'google' in provider_name:
-                            # Use Gemini service
-                            gemini_response = gemini_service.generate_text(
+                            from app.core.agent_runtime import llm_service_for_provider
+                            vertex_svc = llm_service_for_provider("gemini")
+                            gemini_response = vertex_svc.generate_text(
                                 prompt=user_input,
                                 system_prompt=agent_data["agent_system_prompt"] or "You are a helpful assistant.",
                                 model_name=model_name,
                                 temperature=temperature,
                                 max_tokens=max_tokens,
-                                api_key=api_key
+                                api_key=None,
                             )
                             ai_response_text = gemini_response["content"]
                             response_time = gemini_response["response_time"]
-                            logger.info(f"✅ Live voice: Used Gemini model {model_name} (provider: {provider_name})")
+                            logger.info(f"✅ Live voice: Used Vertex Gemini model {model_name} (provider: {provider_name})")
                         
                         elif 'openai' in provider_name:
                             # Use OpenAI service

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -42,7 +42,6 @@ from app.routers.general_websocket import (
 )
 from app.services.model_service import ModelService
 from app.services.transcript_service import transcript_service
-from app.services.gemini_service import gemini_service
 from app.services.credit_service import credit_service
 from urllib.parse import quote
 from app.routers.bidirectional_stream import build_streaming_twiml

--- a/app/routers/voice_gather.py
+++ b/app/routers/voice_gather.py
@@ -22,7 +22,6 @@ from app.services.call_session_service import call_session_service
 from app.services.deepgram_stt_service import deepgram_stt_service
 from app.services.google_tts_service import google_tts_service
 from app.services.voice_logging_service import VoiceLoggingService
-from app.services.gemini_service import gemini_service
 from app.services.openai_service import openai_service
 from app.services.model_service import ModelService
 from app.core.config import settings

--- a/app/services/vertex_gemini_service.py
+++ b/app/services/vertex_gemini_service.py
@@ -1,0 +1,251 @@
+"""
+Vertex AI Gemini LLM service for real-time voice calls.
+
+Uses google-cloud-aiplatform SDK + Application Default Credentials (ADC).
+Never requires a per-model api_key — auth is via GOOGLE_APPLICATION_CREDENTIALS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import enum
+import time
+from typing import Any, AsyncIterator
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.voice.llm_prompt_builder import build_vertex_contents
+
+# Lazily imported so tests can patch before import resolution.
+_vertexai_initialized = False
+
+
+def _ensure_vertex_init() -> None:
+    global _vertexai_initialized
+    if _vertexai_initialized:
+        return
+    import vertexai
+
+    project = settings.GOOGLE_CLOUD_PROJECT_ID or settings.GCP_PROJECT_ID
+    location = settings.VERTEX_AI_LOCATION
+    if not project:
+        raise RuntimeError(
+            "Vertex AI requires GOOGLE_CLOUD_PROJECT_ID or GCP_PROJECT_ID in config."
+        )
+    vertexai.init(project=project, location=location)
+    _vertexai_initialized = True
+
+
+class VertexLlmErrorType(str, enum.Enum):
+    QUOTA = "quota"
+    TIMEOUT = "timeout"
+    CONTENT_FILTER = "content_filter"
+    UNKNOWN = "unknown"
+
+
+class VertexLlmError(Exception):
+    def __init__(self, message: str, error_type: VertexLlmErrorType = VertexLlmErrorType.UNKNOWN) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
+def _classify_vertex_error(exc: Exception) -> VertexLlmError:
+    name = type(exc).__name__
+    msg = str(exc)
+
+    # Match against google.api_core exception types when the package is available.
+    # Catch TypeError as a defensive measure: google.api_core's custom metaclass
+    # (_GoogleAPICallErrorMeta) can raise TypeError on isinstance() in some
+    # Python/test-runner environments when the class identity is ambiguous.
+    try:
+        from google.api_core.exceptions import DeadlineExceeded, ResourceExhausted
+
+        if isinstance(exc, ResourceExhausted):
+            return VertexLlmError(f"Vertex quota exceeded: {msg}", VertexLlmErrorType.QUOTA)
+        if isinstance(exc, DeadlineExceeded):
+            return VertexLlmError(f"Vertex deadline exceeded: {msg}", VertexLlmErrorType.TIMEOUT)
+    except (ImportError, TypeError):
+        pass
+
+    # Fallback: classify by class name / message text
+    if "ResourceExhausted" in name or "quota" in msg.lower():
+        return VertexLlmError(f"Vertex quota: {msg}", VertexLlmErrorType.QUOTA)
+    if "DeadlineExceeded" in name or "timeout" in msg.lower() or "deadline" in msg.lower():
+        return VertexLlmError(f"Vertex timeout: {msg}", VertexLlmErrorType.TIMEOUT)
+    if "blocked" in msg.lower() or "safety" in msg.lower() or "filter" in msg.lower():
+        return VertexLlmError(f"Vertex content filter: {msg}", VertexLlmErrorType.CONTENT_FILTER)
+    return VertexLlmError(f"Vertex error: {msg}", VertexLlmErrorType.UNKNOWN)
+
+
+class VertexGeminiService:
+    """
+    Singleton service that streams Gemini 2.5 Flash responses via Vertex AI.
+
+    Auth: Application Default Credentials — never reads model.api_key.
+    """
+
+    async def stream_text(
+        self,
+        prompt: str,
+        system_prompt: str | None = None,
+        conversation_history: list[tuple[str, str]] | None = None,
+        kb_context: str | None = None,
+        model_name: str = "gemini-2.5-flash",
+        temperature: float = 0.3,
+        max_tokens: int = 100,
+        cancel_event: asyncio.Event | None = None,
+        # Ignored — Vertex uses ADC, not api_key. Accepted for interface compatibility.
+        api_key: str | None = None,
+    ) -> AsyncIterator[str]:
+        """
+        Async generator that yields text chunks from Vertex Gemini.
+
+        Checks cancel_event each iteration so barge-in stops the stream immediately.
+        Raises VertexLlmError on quota/timeout/filter failures (caller maps to fallback).
+        """
+        try:
+            _ensure_vertex_init()
+        except Exception as exc:
+            raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
+
+        try:
+            from vertexai.generative_models import GenerativeModel, GenerationConfig
+        except ImportError as exc:
+            raise VertexLlmError(
+                "google-cloud-aiplatform is not installed. Add it to requirements.txt.",
+                VertexLlmErrorType.UNKNOWN,
+            ) from exc
+
+        # Build model with system_instruction (never log full prompt).
+        model_kwargs: dict = {}
+        if system_prompt:
+            model_kwargs["system_instruction"] = system_prompt
+
+        full_model_name = f"publishers/google/models/{model_name}"
+
+        model = GenerativeModel(
+            model_name=full_model_name,
+            **model_kwargs,
+        )
+
+        max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)
+        contents = build_vertex_contents(
+            conversation_history, prompt, kb_context, max_turns=max_turns
+        )
+
+        generation_config = GenerationConfig(
+            temperature=float(temperature),
+            max_output_tokens=int(max_tokens),
+        )
+
+        try:
+            responses = await asyncio.to_thread(
+                model.generate_content,
+                contents,
+                generation_config=generation_config,
+                stream=True,
+            )
+        except Exception as exc:
+            raise _classify_vertex_error(exc) from exc
+
+        try:
+            for response in responses:
+                # Honour barge-in / interruption cancel
+                if cancel_event is not None and cancel_event.is_set():
+                    logger.debug("[VertexGemini] cancel_event set — stopping stream")
+                    break
+
+                try:
+                    text = response.text
+                except Exception:
+                    # Candidate may be blocked or empty (content filter)
+                    try:
+                        candidates = getattr(response, "candidates", [])
+                        if candidates:
+                            finish = getattr(candidates[0], "finish_reason", None)
+                            if finish and str(finish) not in ("STOP", "MAX_TOKENS", "1", "2"):
+                                raise VertexLlmError(
+                                    f"Vertex content blocked: finish_reason={finish}",
+                                    VertexLlmErrorType.CONTENT_FILTER,
+                                )
+                    except VertexLlmError:
+                        raise
+                    except Exception:
+                        pass
+                    continue
+
+                if text:
+                    yield text
+        except VertexLlmError:
+            raise
+        except Exception as exc:
+            raise _classify_vertex_error(exc) from exc
+
+    def generate_text(
+        self,
+        prompt: str,
+        system_prompt: str | None = None,
+        model_name: str = "gemini-2.5-flash",
+        temperature: float = 0.3,
+        max_tokens: int = 100,
+        api_key: str | None = None,
+        conversation_history: list[tuple[str, str]] | None = None,
+        kb_context: str | None = None,
+    ) -> dict[str, Any]:
+        """
+        Non-streaming completion for legacy gather / live-voice paths.
+        Same return shape as ``GeminiService.generate_text`` for drop-in use.
+        """
+        del api_key  # Vertex uses ADC only
+        start_time = time.time()
+        try:
+            _ensure_vertex_init()
+        except Exception as exc:
+            raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
+
+        try:
+            from vertexai.generative_models import GenerativeModel, GenerationConfig
+        except ImportError as exc:
+            raise VertexLlmError(
+                "google-cloud-aiplatform is not installed.",
+                VertexLlmErrorType.UNKNOWN,
+            ) from exc
+
+        model_kwargs: dict = {}
+        if system_prompt:
+            model_kwargs["system_instruction"] = system_prompt
+
+        model = GenerativeModel(
+            model_name=f"publishers/google/models/{model_name}",
+            **model_kwargs,
+        )
+        max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)
+        contents = build_vertex_contents(
+            conversation_history, prompt, kb_context, max_turns=max_turns
+        )
+        generation_config = GenerationConfig(
+            temperature=float(temperature),
+            max_output_tokens=int(max_tokens),
+        )
+
+        try:
+            response = model.generate_content(
+                contents,
+                generation_config=generation_config,
+            )
+            response_text = (response.text or "").strip()
+        except Exception as exc:
+            raise _classify_vertex_error(exc) from exc
+
+        elapsed = time.time() - start_time
+        return {
+            "content": response_text,
+            "model": model_name,
+            "response_time": elapsed,
+            "usage": {},
+            "finish_reason": "stop",
+        }
+
+
+# Module-level singleton
+vertex_gemini_service = VertexGeminiService()

--- a/app/services/vertex_gemini_service.py
+++ b/app/services/vertex_gemini_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import enum
+import threading
 import time
 from typing import Any, AsyncIterator
 
@@ -17,6 +18,7 @@ from app.core.logger import logger
 from app.voice.llm_prompt_builder import build_vertex_contents
 
 # Lazily imported so tests can patch before import resolution.
+_vertex_init_lock = threading.Lock()
 _vertexai_initialized = False
 
 
@@ -24,16 +26,19 @@ def _ensure_vertex_init() -> None:
     global _vertexai_initialized
     if _vertexai_initialized:
         return
-    import vertexai
+    with _vertex_init_lock:
+        if _vertexai_initialized:
+            return
+        import vertexai
 
-    project = settings.GOOGLE_CLOUD_PROJECT_ID or settings.GCP_PROJECT_ID
-    location = settings.VERTEX_AI_LOCATION
-    if not project:
-        raise RuntimeError(
-            "Vertex AI requires GOOGLE_CLOUD_PROJECT_ID or GCP_PROJECT_ID in config."
-        )
-    vertexai.init(project=project, location=location)
-    _vertexai_initialized = True
+        project = settings.GOOGLE_CLOUD_PROJECT_ID or settings.GCP_PROJECT_ID
+        location = settings.VERTEX_AI_LOCATION
+        if not project:
+            raise RuntimeError(
+                "Vertex AI requires GOOGLE_CLOUD_PROJECT_ID or GCP_PROJECT_ID in config."
+            )
+        vertexai.init(project=project, location=location)
+        _vertexai_initialized = True
 
 
 class VertexLlmErrorType(str, enum.Enum):
@@ -121,10 +126,8 @@ class VertexGeminiService:
         if system_prompt:
             model_kwargs["system_instruction"] = system_prompt
 
-        full_model_name = f"publishers/google/models/{model_name}"
-
         model = GenerativeModel(
-            model_name=full_model_name,
+            model_name=model_name,
             **model_kwargs,
         )
 
@@ -143,11 +146,12 @@ class VertexGeminiService:
         # entire HTTP round-trip inside asyncio.to_thread and only returns after
         # ALL tokens are buffered — effectively disabling streaming.
         try:
-            async for response in await model.generate_content_async(
+            response_stream = model.generate_content_async(
                 contents,
                 generation_config=generation_config,
                 stream=True,
-            ):
+            )
+            async for response in response_stream:
                 # Honour barge-in / interruption cancel
                 if cancel_event is not None and cancel_event.is_set():
                     logger.debug("[VertexGemini] cancel_event set — stopping stream")
@@ -214,7 +218,7 @@ class VertexGeminiService:
             model_kwargs["system_instruction"] = system_prompt
 
         model = GenerativeModel(
-            model_name=f"publishers/google/models/{model_name}",
+            model_name=model_name,
             **model_kwargs,
         )
         max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)

--- a/app/services/vertex_gemini_service.py
+++ b/app/services/vertex_gemini_service.py
@@ -138,18 +138,16 @@ class VertexGeminiService:
             max_output_tokens=int(max_tokens),
         )
 
+        # Use the async SDK method so chunks are yielded as they arrive without
+        # blocking the event loop.  The sync generate_content() path runs its
+        # entire HTTP round-trip inside asyncio.to_thread and only returns after
+        # ALL tokens are buffered — effectively disabling streaming.
         try:
-            responses = await asyncio.to_thread(
-                model.generate_content,
+            async for response in await model.generate_content_async(
                 contents,
                 generation_config=generation_config,
                 stream=True,
-            )
-        except Exception as exc:
-            raise _classify_vertex_error(exc) from exc
-
-        try:
-            for response in responses:
+            ):
                 # Honour barge-in / interruption cancel
                 if cancel_event is not None and cancel_event.is_set():
                     logger.debug("[VertexGemini] cancel_event set — stopping stream")

--- a/app/services/voice_logging_service.py
+++ b/app/services/voice_logging_service.py
@@ -163,42 +163,42 @@ class VoiceLoggingService:
         try:
             logger.info(f"🤖 Generating AI response for: '{speech_text}'")
             
-            # If no agent or no model_id, fall back to simple responses
-            if not agent or not agent.model_id:
-                logger.warning("⚠️ No agent or model_id found, using fallback response")
+            if not agent:
+                logger.warning("⚠️ No agent found, using fallback response")
                 return await VoiceLoggingService._generate_fallback_response(speech_text, agent)
-            
+
+            if not agent.model_id and not agent.llm_model:
+                logger.warning("⚠️ No agent model configured, using fallback response")
+                return await VoiceLoggingService._generate_fallback_response(speech_text, agent)
+
             # Import here to avoid circular imports
-            from app.services.gemini_service import gemini_service
+            from app.core.agent_runtime import llm_service_for_provider, resolve_llm_runtime
             from app.services.openai_service import openai_service
             from app.services.groq_service import groq_service
-            from app.services.model_service import model_service
             from app.core.security import decrypt_api_key
+
+            llm_runtime = resolve_llm_runtime(agent)
             
             # Get the model from database with provider relationship
             from sqlalchemy.orm import joinedload
             from app.models.model import Model as ModelClass
             
-            model = db.query(ModelClass).options(joinedload(ModelClass.provider)).filter(
-                ModelClass.id == agent.model_id
-            ).first()
-            
-            if not model:
-                logger.warning("⚠️ Model not found, using fallback response")
-                return await VoiceLoggingService._generate_fallback_response(speech_text, agent)
-            
-            # Check if model is active
-            if model.archive:
+            model = None
+            if agent.model_id:
+                model = db.query(ModelClass).options(joinedload(ModelClass.provider)).filter(
+                    ModelClass.id == agent.model_id
+                ).first()
+
+            if model and model.archive:
                 logger.warning("⚠️ Model is archived, using fallback response")
                 return await VoiceLoggingService._generate_fallback_response(speech_text, agent)
-            
-            # Check if provider exists
-            if not model.provider:
+
+            if model and not model.provider:
                 logger.warning("⚠️ Model has no provider, using fallback response")
                 return await VoiceLoggingService._generate_fallback_response(speech_text, agent)
-            
-            # Get model details with agent-specific overrides
-            model_name = model.model_name
+
+            model_name = llm_runtime.model_name
+            provider_slug = llm_runtime.provider_slug
             
             # Create personalized system prompt with agent information
             agent_name = agent.name if agent.name else "AI Assistant"
@@ -293,7 +293,7 @@ Guidelines for phone conversations:
 - IMPORTANT: Use the conversation history below to remember what was discussed and avoid repeating questions or information
 
 Always respond as {agent_name}, a real person having a conversation, not as any kind of system or tool.{conversation_context}"""
-            elif model.system_prompt:
+            elif model and model.system_prompt:
                 system_prompt = f"""You are {agent_name}, a real person taking phone calls.
 
 Your identity:
@@ -323,51 +323,43 @@ Guidelines for phone conversations:
 Always respond as {agent_name}, a real person having a conversation, not as any kind of system or tool.{conversation_context}"""
             else:
                 system_prompt = personalized_system_prompt
-            # Use agent-specific temperature if set, otherwise fall back to model default (reduced for faster response)
-            temperature = (
-                (agent.agent_temperature / 100.0) if agent.agent_temperature is not None 
-                else (model.temperature / 100.0) if model.temperature 
-                else 0.6
-            )
-            # Use agent-specific max tokens if set, otherwise fall back to model default
-            # VOICE OPTIMIZATION: Cap at 100 tokens max for ULTRA-FAST responses (1-2 sentences, Vapi-style)
-            requested_max_tokens = agent.agent_max_tokens if agent.agent_max_tokens is not None else (model.max_tokens or 100)
-            max_tokens = min(requested_max_tokens, 100)  # Force cap at 100 for voice calls (Vapi-style speed!)
-            
+            temperature = llm_runtime.temperature
+            requested_max_tokens = llm_runtime.max_tokens
+            max_tokens = min(requested_max_tokens, 100)
+
             if requested_max_tokens > 100:
-                logger.info(f"⚡ Voice optimization: Capped max_tokens from {requested_max_tokens} to 100 for ultra-fast response")
-            
-            # Use model-specific API key if available
-            api_key = None
-            if model.api_key:
+                logger.info(
+                    "⚡ Voice optimization: Capped max_tokens from %s to 100",
+                    requested_max_tokens,
+                )
+
+            api_key = llm_runtime.api_key
+            if api_key is None and model and model.api_key and provider_slug != "gemini":
                 try:
                     api_key = decrypt_api_key(model.api_key)
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to decrypt model API key: {e}")
-                    # Continue with global key
-            
-            # Detect which AI service to use based on provider name
-            provider_name = model.provider.name.lower()
-            is_gemini = 'gemini' in provider_name or 'google' in provider_name
-            is_openai = 'openai' in provider_name
-            is_groq = 'groq' in provider_name
-            
-            if not is_gemini and not is_openai and not is_groq:
-                logger.warning(f"⚠️ Provider {provider_name} is not supported (not Gemini, OpenAI, or Groq), using fallback response")
+
+            slug = (provider_slug or "").lower()
+            if slug not in ("gemini", "openai", "groq"):
+                logger.warning(
+                    "⚠️ Provider %s is not supported, using fallback response", slug
+                )
                 return await VoiceLoggingService._generate_fallback_response(speech_text, agent)
-            
-            # Determine which service to use
-            if is_gemini:
-                ai_service_name = "Gemini"
-                ai_service = gemini_service
-            elif is_groq:
-                ai_service_name = "Groq"
-                ai_service = groq_service
-            else:
-                ai_service_name = "OpenAI"
-                ai_service = openai_service
-            
-            logger.info(f"🎯 Using {ai_service_name} service based on provider: {provider_name}")
+
+            ai_service = llm_service_for_provider(slug)
+            ai_service_name = {
+                "gemini": "Vertex Gemini",
+                "openai": "OpenAI",
+                "groq": "Groq",
+            }.get(slug, slug)
+
+            logger.info(
+                "🎯 Using %s service (provider=%s, model=%s)",
+                ai_service_name,
+                slug,
+                model_name,
+            )
             
             # Check if all system prompt objectives have been completed
             conversation_complete = VoiceLoggingService._check_conversation_completion(
@@ -380,7 +372,7 @@ Always respond as {agent_name}, a real person having a conversation, not as any 
             
             # Generate response using selected AI service
             logger.info(f"🔧 {ai_service_name} Config: model={model_name}, temp={temperature}, max_tokens={max_tokens} | Agent: {agent_name} ({agent_language})")
-            logger.debug(f"🔧 System Prompt: {system_prompt[:200]}...")
+            logger.debug("System prompt length: %s chars", len(system_prompt or ""))
             logger.debug(f"🔧 User Prompt: {speech_text}")
             logger.debug(f"🧠 Conversation Context Length: {len(conversation_context)} chars")
             if conversation_context:

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Optional, Tuple
 from app.core.logger import logger
 from app.core.config import settings
 from app.services.agent_service import agent_service
-from app.services.gemini_service import gemini_service
 from app.services.openai_service import openai_service
 from app.services.groq_service import groq_service
 from app.utils.eleven_tts_text import (

--- a/app/voice/llm_prompt_builder.py
+++ b/app/voice/llm_prompt_builder.py
@@ -1,0 +1,93 @@
+"""
+Pure, unit-testable helpers for building LLM prompt inputs for the voice path.
+
+No I/O, no DB, no side effects. Imported by bidirectional_stream and Vertex service.
+"""
+from __future__ import annotations
+
+
+def prune_history_to_turns(
+    history: list[tuple[str, str]],
+    max_turns: int,
+) -> list[tuple[str, str]]:
+    """
+    Prune history to at most max_turns conversation turns.
+
+    1 turn = 1 user message + 1 agent reply (a pair).  Oldest pairs are dropped first.
+    Unpaired trailing messages are kept (e.g. a lone user message at the start).
+    """
+    if not history or max_turns <= 0:
+        return []
+    max_messages = max_turns * 2
+    if len(history) <= max_messages:
+        return list(history)
+    return list(history[-max_messages:])
+
+
+def build_kb_context_for_vertex(
+    inbound_kb: str,
+    business_kb: str,
+    *,
+    empty_guard: str = "",
+) -> str:
+    """
+    Combine inbound + business KB blocks for Vertex user-turn context.
+    Falls back to empty_guard when no KB content is loaded.
+    """
+    parts = [p.strip() for p in (inbound_kb, business_kb) if p and p.strip()]
+    if parts:
+        return "\n\n".join(parts)
+    return (empty_guard or "").strip()
+
+
+def build_history_text(
+    history: list[tuple[str, str]],
+    max_turns: int = 20,
+) -> str:
+    """
+    Render pruned history as the plain-text block used by non-Vertex LLM paths.
+
+    Output: "Client: ...\nAgent: ...\n..."
+    """
+    pruned = prune_history_to_turns(history, max_turns)
+    return "\n".join(f"{role.capitalize()}: {content}" for role, content in pruned)
+
+
+def build_vertex_contents(
+    conversation_history: list[tuple[str, str]] | None,
+    caller_transcript: str,
+    kb_context: str | None = None,
+    max_turns: int = 20,
+) -> list:
+    """
+    Build a Vertex AI Content list for generate_content().
+
+    Maps (role, text) tuples:  "client" → "user",  "agent" → "model".
+    Prunes to max_turns pairs. kb_context is appended to the current user turn.
+
+    Returns a list of vertexai.generative_models.Content objects.
+    """
+    try:
+        from vertexai.generative_models import Content, Part
+    except ImportError as exc:
+        raise ImportError(
+            "google-cloud-aiplatform is required for build_vertex_contents. "
+            "Add it to requirements.txt."
+        ) from exc
+
+    pruned = prune_history_to_turns(list(conversation_history or []), max_turns)
+    contents = []
+    for role, text in pruned:
+        if not text:
+            continue
+        vertex_role = "user" if role == "client" else "model"
+        contents.append(Content(role=vertex_role, parts=[Part.from_text(text)]))
+
+    user_text = caller_transcript or ""
+    if kb_context:
+        user_text = f"{user_text}\n\n[CONTEXT]\n{kb_context}"
+
+    if user_text:
+        contents.append(Content(role="user", parts=[Part.from_text(user_text)]))
+
+    return contents

--- a/app/voice/llm_prompt_builder.py
+++ b/app/voice/llm_prompt_builder.py
@@ -5,6 +5,23 @@ No I/O, no DB, no side effects. Imported by bidirectional_stream and Vertex serv
 """
 from __future__ import annotations
 
+_Content = None
+_Part = None
+
+
+def _load_vertex_models():
+    global _Content, _Part
+    if _Content is None:
+        try:
+            from vertexai.generative_models import Content, Part
+        except ImportError as exc:
+            raise ImportError(
+                "google-cloud-aiplatform is required for build_vertex_contents. "
+                "Add it to requirements.txt."
+            ) from exc
+        _Content, _Part = Content, Part
+    return _Content, _Part
+
 
 def prune_history_to_turns(
     history: list[tuple[str, str]],
@@ -67,13 +84,7 @@ def build_vertex_contents(
 
     Returns a list of vertexai.generative_models.Content objects.
     """
-    try:
-        from vertexai.generative_models import Content, Part
-    except ImportError as exc:
-        raise ImportError(
-            "google-cloud-aiplatform is required for build_vertex_contents. "
-            "Add it to requirements.txt."
-        ) from exc
+    Content, Part = _load_vertex_models()
 
     pruned = prune_history_to_turns(list(conversation_history or []), max_turns)
     contents = []

--- a/app/voice/pipeline_session.py
+++ b/app/voice/pipeline_session.py
@@ -1,0 +1,54 @@
+"""
+PipelineSession — per-call state container for the voice pipeline.
+
+Holds references to the STT emitter, LLM cancel handle, TTS pipeline, and
+in-memory conversation history.  BidirectionalStreamHandler stores one of these
+as self._pipeline_session.
+
+The existing handler attributes (_tts_cancel, _conversation_history_cache, etc.)
+remain in place for backward compatibility — PipelineSession holds the same
+objects by reference so both access paths stay in sync.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from app.voice.llm_prompt_builder import prune_history_to_turns
+
+
+@dataclass
+class PipelineSession:
+    """Aggregate of per-call voice-pipeline state."""
+
+    # STT emitter (SttPipeline or similar); may be None before pickup.
+    stt_emitter: Any = field(default=None)
+
+    # asyncio.Event set to signal the Vertex stream to stop mid-generation.
+    # Must be the same object as handler._tts_cancel so barge-in wires correctly.
+    llm_cancel: asyncio.Event = field(default_factory=asyncio.Event)
+
+    # TtsPipeline instance; same object as handler._tts_pipeline.
+    tts_pipeline: Any = field(default=None)
+
+    # In-memory conversation history: (role, content) tuples.
+    # Same list object as handler._conversation_history_cache.
+    history: list[tuple[str, str]] = field(default_factory=list)
+
+    def cancel_llm(self) -> None:
+        """Signal in-flight LLM stream to stop (barge-in / new utterance)."""
+        self.llm_cancel.set()
+
+    def reset_llm_cancel(self) -> None:
+        """Clear the cancel signal for the next turn."""
+        self.llm_cancel.clear()
+
+    def append_turn(self, role: str, content: str) -> None:
+        """Append a single message to the in-memory history."""
+        if content:
+            self.history.append((role, content))
+
+    def get_pruned_history(self, max_turns: int) -> list[tuple[str, str]]:
+        """Return a pruned snapshot of history (does not mutate self.history)."""
+        return prune_history_to_turns(self.history, max_turns)

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -194,6 +194,8 @@ class TtsStreamMixin:
                                     self._is_tts_playing = True
                                     _first_audio_ts = time.perf_counter()
                                     self._metric_first_audio_ts = _first_audio_ts
+                                    # Record for barge-in dead zone (see _maybe_process_interim)
+                                    self._tts_play_start_ts = _first_audio_ts
                                     _first_token_ts = getattr(self, "_metric_first_token_ts", 0.0)
                                     if _first_token_ts > 0:
                                         _ttfa_ms = (_first_audio_ts - _first_token_ts) * 1000

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -136,6 +136,9 @@ class VoiceOrchestrator:
         self._tts_pipeline = TtsPipeline(handler)
         handler._tts_pipeline = self._tts_pipeline
         handler._tts_worker_task = self._tts_pipeline._worker_task
+        ps = getattr(handler, "_pipeline_session", None)
+        if ps is not None:
+            ps.tts_pipeline = self._tts_pipeline
 
         # Final STT callbacks are scheduled as tasks so the Deepgram reader never blocks
         # on full LLM+TTS work (parallel with continued STT ingestion).
@@ -249,6 +252,9 @@ class VoiceOrchestrator:
                     agent_id=h.agent_id,
                     endpointing_ms=initial_endpointing,
                 )
+                ps = getattr(h, "_pipeline_session", None)
+                if ps is not None:
+                    ps.stt_emitter = self._stt_pipeline
                 logger.debug(
                     "[VoiceOrchestrator] SttPipeline created (endpointing_ms=%s)",
                     initial_endpointing,

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ redis
 websockets
 aiohttp
 google-genai
+google-cloud-aiplatform>=1.60.0
 pinecone>=6.0.0
 pypdf
 bcrypt==4.1.2

--- a/tests/services/test_bidirectional_interim_regression.py
+++ b/tests/services/test_bidirectional_interim_regression.py
@@ -104,8 +104,18 @@ def _empty_handler() -> Handler:
     h._enable_soft_final_fallback = True
     h._stt_soft_min_final_confidence = 0.16
     h._stt_soft_min_words = 2
+    h._rag_prefetch_min_words = 1
+    h._rag_prefetch_min_confidence = 0.05
+    h._speculative_prefetch_task = None
+    h._run_speculative_tts_prefetch = AsyncMock()  # type: ignore[method-assign]
     h._prefetch_rag_context = AsyncMock(return_value=("", {}))  # type: ignore[method-assign]
     h._llm_turn_serial_lock = asyncio.Lock()
+    h._tts_cancel = asyncio.Event()
+    h._llm_last_answered_transcript = ""
+    h._llm_last_answered_ts = 0.0
+    h.call_session = None
+    h._screening_decline_handled = False
+    h._jd_recruitment_screening_active = lambda: False  # type: ignore[method-assign, assignment]
     return h
 
 

--- a/tests/voice/test_call_pipeline.py
+++ b/tests/voice/test_call_pipeline.py
@@ -65,6 +65,8 @@ def _base_handler() -> Handler:
     h._barge_in_min_words = 2
     h._barge_in_rejected_while_playing = 0
     h._tts_cancel = asyncio.Event()
+    h._tts_play_start_ts = 0.0       # dead-zone: set when first audio frame sends
+    h._barge_in_dead_zone_ms = 600.0  # suppress stale interims on TTS start
 
     # TTS
     h._tts_lock = asyncio.Lock()

--- a/tests/voice/test_vertex_llm.py
+++ b/tests/voice/test_vertex_llm.py
@@ -1,0 +1,494 @@
+"""
+Unit tests for Vertex AI Gemini LLM integration.
+
+Covers: prompt construction, history pruning, cancellation, error fallback,
+and credential routing.  All Vertex SDK calls are mocked — no real GCP calls.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ─────────────────────────────────────────────────────────────────────────────
+# llm_prompt_builder — pure functions
+# ─────────────────────────────────────────────────────────────────────────────
+
+from app.voice.llm_prompt_builder import (
+    build_history_text,
+    build_kb_context_for_vertex,
+    build_vertex_contents,
+    prune_history_to_turns,
+)
+
+
+class TestPruneHistoryToTurns:
+    def test_empty(self):
+        assert prune_history_to_turns([], 20) == []
+
+    def test_under_limit(self):
+        h = [("client", "hi"), ("agent", "hello")]
+        assert prune_history_to_turns(h, 20) == h
+
+    def test_exactly_at_limit(self):
+        # 3 turns = 6 messages
+        h2 = [(r, c) for i in range(3) for r, c in [("client", f"u{i}"), ("agent", f"a{i}")]]
+        assert prune_history_to_turns(h2, 3) == h2
+
+    def test_over_limit_drops_oldest(self):
+        # 25 turns → last 20 kept
+        history = []
+        for i in range(25):
+            history.append(("client", f"user_{i}"))
+            history.append(("agent", f"agent_{i}"))
+        pruned = prune_history_to_turns(history, 20)
+        assert len(pruned) == 40          # 20 turns × 2 messages
+        assert pruned[0] == ("client", "user_5")   # oldest dropped = turns 0–4
+        assert pruned[-1] == ("agent", "agent_24")
+
+    def test_max_turns_zero(self):
+        h = [("client", "hi"), ("agent", "hello")]
+        assert prune_history_to_turns(h, 0) == []
+
+
+class TestBuildHistoryText:
+    def test_basic_render(self):
+        h = [("client", "Hi"), ("agent", "Hello")]
+        txt = build_history_text(h, max_turns=20)
+        assert txt == "Client: Hi\nAgent: Hello"
+
+    def test_pruned_render(self):
+        history = []
+        for i in range(25):
+            history.append(("client", f"u{i}"))
+            history.append(("agent", f"a{i}"))
+        txt = build_history_text(history, max_turns=20)
+        lines = txt.split("\n")
+        assert len(lines) == 40
+        assert lines[0].startswith("Client: u5")
+
+
+class TestBuildKbContextForVertex:
+    def test_combines_inbound_and_business(self):
+        ctx = build_kb_context_for_vertex("inbound doc", "business facts")
+        assert "inbound doc" in ctx
+        assert "business facts" in ctx
+
+    def test_empty_uses_guard(self):
+        guard = "No verified business facts"
+        ctx = build_kb_context_for_vertex("", "", empty_guard=guard)
+        assert ctx == guard
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# build_vertex_contents — needs vertexai stubs
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _FakePart:
+    def __init__(self, text: str):
+        self.text = text
+
+    @staticmethod
+    def from_text(t: str) -> "_FakePart":
+        return _FakePart(t)
+
+
+class _FakeContent:
+    def __init__(self, role: str, parts: list):
+        self.role = role
+        self.parts = parts
+
+
+def _patch_vertexai_models(monkeypatch):
+    fake = SimpleNamespace(Content=_FakeContent, Part=_FakePart)
+    monkeypatch.setattr(
+        "app.voice.llm_prompt_builder.build_vertex_contents.__globals__",
+        {},
+        raising=False,
+    )
+    return fake
+
+
+class TestBuildVertexContents:
+    def _run(self, history, transcript, kb=None, max_turns=20):
+        # Patch vertexai.generative_models before calling
+        import sys
+        fake_module = SimpleNamespace(
+            Content=_FakeContent,
+            Part=_FakePart,
+        )
+        sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
+        sys.modules["vertexai.generative_models"] = fake_module
+        contents = build_vertex_contents(history, transcript, kb, max_turns)
+        return contents
+
+    def test_empty_history(self):
+        contents = self._run([], "Hello there")
+        assert len(contents) == 1
+        assert contents[0].role == "user"
+        assert contents[0].parts[0].text == "Hello there"
+
+    def test_role_mapping(self):
+        history = [("client", "Hi"), ("agent", "Hello")]
+        contents = self._run(history, "What is 2+2?")
+        assert contents[0].role == "user"
+        assert contents[1].role == "model"
+        assert contents[2].role == "user"
+        assert contents[2].parts[0].text == "What is 2+2?"
+
+    def test_kb_context_appended_to_user(self):
+        contents = self._run([], "my question", kb="some context")
+        assert "some context" in contents[0].parts[0].text
+        assert "my question" in contents[0].parts[0].text
+
+    def test_history_pruned_to_max_turns(self):
+        history = []
+        for i in range(25):
+            history.append(("client", f"u{i}"))
+            history.append(("agent", f"a{i}"))
+        contents = self._run(history, "current", max_turns=20)
+        # 20 turns = 40 messages + 1 current user turn
+        assert len(contents) == 41
+        # Oldest dropped
+        assert contents[0].role == "user"
+        assert contents[0].parts[0].text == "u5"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VertexGeminiService — stream_text
+# ─────────────────────────────────────────────────────────────────────────────
+
+from app.services.vertex_gemini_service import (  # noqa: E402
+    VertexGeminiService,
+    VertexLlmError,
+    VertexLlmErrorType,
+    _classify_vertex_error,
+)
+
+
+def _fake_response_iter(texts: list[str]):
+    """Return sync iterator of fake Vertex response chunks."""
+    class _FakeChunk:
+        def __init__(self, t: str):
+            self._text = t
+
+        @property
+        def text(self):
+            return self._text
+
+    return iter(_FakeChunk(t) for t in texts)
+
+
+def test_vertex_stream_text_yields_chunks():
+    """Happy path: stream returns token chunks in order."""
+    chunks = ["Hello", " there", "!"]
+
+    import sys
+    sys.modules["vertexai"] = SimpleNamespace(init=lambda **k: None)
+    sys.modules["vertexai.generative_models"] = SimpleNamespace(
+        GenerativeModel=MagicMock(),
+        GenerationConfig=MagicMock(),
+        Content=_FakeContent,
+        Part=_FakePart,
+    )
+
+    async def _run():
+        with (
+            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
+            patch("asyncio.to_thread", new=AsyncMock(return_value=_fake_response_iter(chunks))),
+        ):
+            svc = VertexGeminiService()
+            result = []
+            async for chunk in svc.stream_text(
+                prompt="hi",
+                system_prompt="be helpful",
+                model_name="gemini-2.5-flash",
+                temperature=0.3,
+                max_tokens=100,
+            ):
+                result.append(chunk)
+        return result
+
+    result = asyncio.run(_run())
+    assert result == chunks
+
+
+def test_vertex_stream_cancelled_by_event():
+    """cancel_event stops the stream mid-way."""
+    chunks = ["tok1", "tok2", "tok3", "tok4"]
+    cancel = asyncio.Event()
+
+    class _ChunkObj:
+        def __init__(self, t):
+            self._t = t
+
+        @property
+        def text(self):
+            return self._t
+
+    class _StopAfterTwo:
+        def __iter__(self):
+            for i, t in enumerate(chunks):
+                if i == 2:
+                    cancel.set()
+                yield _ChunkObj(t)
+
+    import sys
+    sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
+    sys.modules["vertexai.generative_models"] = SimpleNamespace(
+        GenerativeModel=MagicMock(),
+        GenerationConfig=MagicMock(),
+        Content=_FakeContent,
+        Part=_FakePart,
+    )
+
+    async def _run():
+        with (
+            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
+            patch("asyncio.to_thread", new=AsyncMock(return_value=_StopAfterTwo())),
+        ):
+            svc = VertexGeminiService()
+            result = []
+            async for chunk in svc.stream_text(
+                prompt="hi",
+                cancel_event=cancel,
+                model_name="gemini-2.5-flash",
+            ):
+                result.append(chunk)
+        return result
+
+    result = asyncio.run(_run())
+    # cancel_event set before iteration 2 → tok3, tok4 must not be yielded
+    assert "tok3" not in result
+    assert "tok4" not in result
+
+
+def test_vertex_generate_text_returns_content():
+    """Non-streaming generate_text for legacy gather / live-voice paths."""
+    mock_response = SimpleNamespace(text="Hello from Vertex")
+    mock_model = MagicMock()
+    mock_model.generate_content.return_value = mock_response
+
+    import sys
+    sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
+    sys.modules["vertexai.generative_models"] = SimpleNamespace(
+        GenerativeModel=MagicMock(return_value=mock_model),
+        GenerationConfig=MagicMock(),
+        Content=_FakeContent,
+        Part=_FakePart,
+    )
+
+    with (
+        patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+        patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
+    ):
+        svc = VertexGeminiService()
+        result = svc.generate_text(
+            prompt="hi",
+            system_prompt="You are helpful",
+            model_name="gemini-2.5-flash",
+        )
+
+    assert result["content"] == "Hello from Vertex"
+    assert result["model"] == "gemini-2.5-flash"
+    assert result["response_time"] >= 0
+
+
+def test_vertex_stream_quota_error_raises_vertex_llm_error():
+    """_classify_vertex_error maps quota-like exceptions to QUOTA error type."""
+    # Test the classification logic directly (simulates what stream_text catches)
+    # Using message-based matching since isinstance may have Python 3.14 edge cases
+    class QuotaExceededException(Exception):
+        """Simulates google.api_core.exceptions.ResourceExhausted."""
+    QuotaExceededException.__name__ = "ResourceExhausted"
+
+    exc = QuotaExceededException("quota exceeded")
+    vertex_err = _classify_vertex_error(exc)
+    assert vertex_err.error_type == VertexLlmErrorType.QUOTA
+
+    # Also verify the VertexGeminiService raises VertexLlmError on SDK errors
+    async def _run():
+        import sys
+        sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
+        sys.modules["vertexai.generative_models"] = SimpleNamespace(
+            GenerativeModel=MagicMock(),
+            GenerationConfig=MagicMock(),
+            Content=_FakeContent,
+            Part=_FakePart,
+        )
+        with (
+            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
+            patch(
+                "app.services.vertex_gemini_service.asyncio.to_thread",
+                new=AsyncMock(side_effect=RuntimeError("quota exceeded in stream")),
+            ),
+        ):
+            svc = VertexGeminiService()
+            with pytest.raises(VertexLlmError) as exc_info:
+                async for _ in svc.stream_text(prompt="hi"):
+                    pass
+        return exc_info.value.error_type
+
+    error_type = asyncio.run(_run())
+    assert error_type == VertexLlmErrorType.QUOTA
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# resolve_llm_runtime — credential routing
+# ─────────────────────────────────────────────────────────────────────────────
+
+from app.core.agent_runtime import resolve_llm_runtime, llm_service_for_provider  # noqa: E402
+
+
+def _make_gemini_agent(with_api_key: bool = True) -> MagicMock:
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.llm_model = "gemini-2.5-flash"
+    agent.agent_temperature = None
+    agent.agent_max_tokens = None
+    model = MagicMock()
+    model.api_key = "encrypted_key_abc" if with_api_key else None
+    model.temperature = None
+    model.max_tokens = None
+    agent.model = model
+    agent.provider = None
+    return agent
+
+
+def test_resolve_llm_runtime_gemini_ignores_api_key():
+    """Gemini models must return api_key=None even when model.api_key is set."""
+    agent = _make_gemini_agent(with_api_key=True)
+    runtime = resolve_llm_runtime(agent)
+    assert runtime.provider_slug == "gemini"
+    assert runtime.api_key is None
+
+
+def test_resolve_llm_runtime_gemini_default_temperature():
+    """Default temperature for Gemini is 0.3 (VOICE_LLM_DEFAULT_TEMPERATURE)."""
+    agent = _make_gemini_agent(with_api_key=False)
+    runtime = resolve_llm_runtime(agent)
+    assert abs(runtime.temperature - 0.3) < 0.01
+
+
+def test_resolve_llm_runtime_gemini_agent_temperature_override():
+    """agent.agent_temperature=50 → 0.50."""
+    agent = _make_gemini_agent(with_api_key=False)
+    agent.agent_temperature = 50
+    runtime = resolve_llm_runtime(agent)
+    assert abs(runtime.temperature - 0.50) < 0.01
+
+
+def test_llm_service_for_provider_gemini_returns_vertex():
+    """llm_service_for_provider("gemini") → VertexGeminiService instance."""
+    from app.services.vertex_gemini_service import VertexGeminiService
+    svc = llm_service_for_provider("gemini")
+    assert isinstance(svc, VertexGeminiService)
+
+
+def test_llm_service_for_provider_openai():
+    from app.services.openai_service import OpenAIService
+    svc = llm_service_for_provider("openai")
+    assert isinstance(svc, OpenAIService)
+
+
+def test_llm_service_for_provider_groq():
+    from app.services.groq_service import GroqService
+    svc = llm_service_for_provider("groq")
+    assert isinstance(svc, GroqService)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PipelineSession
+# ─────────────────────────────────────────────────────────────────────────────
+
+from app.voice.pipeline_session import PipelineSession  # noqa: E402
+
+
+def test_pipeline_session_cancel_sets_event():
+    ps = PipelineSession()
+    assert not ps.llm_cancel.is_set()
+    ps.cancel_llm()
+    assert ps.llm_cancel.is_set()
+
+
+def test_pipeline_session_reset():
+    ps = PipelineSession()
+    ps.cancel_llm()
+    ps.reset_llm_cancel()
+    assert not ps.llm_cancel.is_set()
+
+
+def test_pipeline_session_append_and_prune():
+    ps = PipelineSession()
+    for i in range(25):
+        ps.append_turn("client", f"user_{i}")
+        ps.append_turn("agent", f"agent_{i}")
+    pruned = ps.get_pruned_history(max_turns=20)
+    assert len(pruned) == 40
+    assert pruned[0] == ("client", "user_5")
+
+
+def test_pipeline_session_shared_history_ref():
+    """PipelineSession.history is the same list as passed in — shared reference."""
+    shared_list: list[tuple[str, str]] = []
+    ps = PipelineSession(history=shared_list)
+    ps.append_turn("client", "hello")
+    assert shared_list == [("client", "hello")]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error fallback (integration: handler canned response)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_vertex_error_produces_canned_fallback_tts():
+    """
+    VertexLlmError carries correct error_type; fallback config message is correct.
+    """
+    err = VertexLlmError("quota exceeded", VertexLlmErrorType.QUOTA)
+    assert err.error_type == VertexLlmErrorType.QUOTA
+    assert str(err) == "quota exceeded"
+
+    from app.core.config import settings
+    fallback = getattr(settings, "VOICE_LLM_FALLBACK_MESSAGE", "I am sorry, I did not catch that")
+    assert fallback == "I am sorry, I did not catch that"
+
+
+def test_classify_vertex_error_quota_by_class_name():
+    """Falls back to class-name matching when google.api_core isinstance check fails."""
+    class ResourceExhaustedSimulated(Exception):
+        pass
+    ResourceExhaustedSimulated.__name__ = "ResourceExhausted"
+    err = _classify_vertex_error(ResourceExhaustedSimulated("too many"))
+    assert err.error_type == VertexLlmErrorType.QUOTA
+
+
+def test_classify_vertex_error_timeout_by_class_name():
+    """Falls back to class-name matching for DeadlineExceeded."""
+    class DeadlineExceededSimulated(Exception):
+        pass
+    DeadlineExceededSimulated.__name__ = "DeadlineExceeded"
+    err = _classify_vertex_error(DeadlineExceededSimulated("timed out"))
+    assert err.error_type == VertexLlmErrorType.TIMEOUT
+
+
+def test_classify_vertex_error_quota_by_message():
+    """Message-based fallback: 'quota' in message text → QUOTA."""
+    err = _classify_vertex_error(RuntimeError("quota exceeded"))
+    assert err.error_type == VertexLlmErrorType.QUOTA
+
+
+def test_classify_vertex_error_timeout_by_message():
+    """Message-based fallback: 'timeout' in message text → TIMEOUT."""
+    err = _classify_vertex_error(RuntimeError("connection timeout"))
+    assert err.error_type == VertexLlmErrorType.TIMEOUT
+
+
+def test_classify_vertex_error_unknown():
+    err = _classify_vertex_error(ValueError("unexpected"))
+    assert err.error_type == VertexLlmErrorType.UNKNOWN

--- a/tests/voice/test_vertex_llm.py
+++ b/tests/voice/test_vertex_llm.py
@@ -182,14 +182,34 @@ def _fake_response_iter(texts: list[str]):
     return iter(_FakeChunk(t) for t in texts)
 
 
+async def _async_fake_response_iter(texts: list[str]):
+    """Return async generator of fake Vertex response chunks (matches generate_content_async)."""
+    class _FakeChunk:
+        def __init__(self, t: str):
+            self._text = t
+
+        @property
+        def text(self):
+            return self._text
+
+    for t in texts:
+        yield _FakeChunk(t)
+
+
 def test_vertex_stream_text_yields_chunks():
-    """Happy path: stream returns token chunks in order."""
+    """Happy path: stream returns token chunks in order via generate_content_async."""
     chunks = ["Hello", " there", "!"]
 
     import sys
+
+    mock_model = MagicMock()
+    mock_model.generate_content_async = AsyncMock(
+        return_value=_async_fake_response_iter(chunks)
+    )
+
     sys.modules["vertexai"] = SimpleNamespace(init=lambda **k: None)
     sys.modules["vertexai.generative_models"] = SimpleNamespace(
-        GenerativeModel=MagicMock(),
+        GenerativeModel=MagicMock(return_value=mock_model),
         GenerationConfig=MagicMock(),
         Content=_FakeContent,
         Part=_FakePart,
@@ -199,7 +219,6 @@ def test_vertex_stream_text_yields_chunks():
         with (
             patch("app.services.vertex_gemini_service._ensure_vertex_init"),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
-            patch("asyncio.to_thread", new=AsyncMock(return_value=_fake_response_iter(chunks))),
         ):
             svc = VertexGeminiService()
             result = []
@@ -218,29 +237,32 @@ def test_vertex_stream_text_yields_chunks():
 
 
 def test_vertex_stream_cancelled_by_event():
-    """cancel_event stops the stream mid-way."""
+    """cancel_event stops the stream mid-way via generate_content_async."""
     chunks = ["tok1", "tok2", "tok3", "tok4"]
     cancel = asyncio.Event()
 
-    class _ChunkObj:
-        def __init__(self, t):
-            self._t = t
+    async def _cancelling_iter():
+        class _ChunkObj:
+            def __init__(self, t):
+                self._t = t
 
-        @property
-        def text(self):
-            return self._t
+            @property
+            def text(self):
+                return self._t
 
-    class _StopAfterTwo:
-        def __iter__(self):
-            for i, t in enumerate(chunks):
-                if i == 2:
-                    cancel.set()
-                yield _ChunkObj(t)
+        for i, t in enumerate(chunks):
+            if i == 2:
+                cancel.set()
+            yield _ChunkObj(t)
 
     import sys
     sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
+
+    mock_model = MagicMock()
+    mock_model.generate_content_async = AsyncMock(return_value=_cancelling_iter())
+
     sys.modules["vertexai.generative_models"] = SimpleNamespace(
-        GenerativeModel=MagicMock(),
+        GenerativeModel=MagicMock(return_value=mock_model),
         GenerationConfig=MagicMock(),
         Content=_FakeContent,
         Part=_FakePart,
@@ -250,7 +272,6 @@ def test_vertex_stream_cancelled_by_event():
         with (
             patch("app.services.vertex_gemini_service._ensure_vertex_init"),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
-            patch("asyncio.to_thread", new=AsyncMock(return_value=_StopAfterTwo())),
         ):
             svc = VertexGeminiService()
             result = []
@@ -315,8 +336,14 @@ def test_vertex_stream_quota_error_raises_vertex_llm_error():
     async def _run():
         import sys
         sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
+
+        mock_model = MagicMock()
+        mock_model.generate_content_async = AsyncMock(
+            side_effect=RuntimeError("quota exceeded in stream")
+        )
+
         sys.modules["vertexai.generative_models"] = SimpleNamespace(
-            GenerativeModel=MagicMock(),
+            GenerativeModel=MagicMock(return_value=mock_model),
             GenerationConfig=MagicMock(),
             Content=_FakeContent,
             Part=_FakePart,
@@ -324,10 +351,6 @@ def test_vertex_stream_quota_error_raises_vertex_llm_error():
         with (
             patch("app.services.vertex_gemini_service._ensure_vertex_init"),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
-            patch(
-                "app.services.vertex_gemini_service.asyncio.to_thread",
-                new=AsyncMock(side_effect=RuntimeError("quota exceeded in stream")),
-            ),
         ):
             svc = VertexGeminiService()
             with pytest.raises(VertexLlmError) as exc_info:

--- a/tests/voice/test_vertex_llm.py
+++ b/tests/voice/test_vertex_llm.py
@@ -203,7 +203,7 @@ def test_vertex_stream_text_yields_chunks():
     import sys
 
     mock_model = MagicMock()
-    mock_model.generate_content_async = AsyncMock(
+    mock_model.generate_content_async = MagicMock(
         return_value=_async_fake_response_iter(chunks)
     )
 
@@ -236,6 +236,78 @@ def test_vertex_stream_text_yields_chunks():
     assert result == chunks
 
 
+def test_vertex_generative_model_uses_short_model_name():
+    """SDK expects short names (e.g. gemini-2.5-flash), not publishers/google/models/ prefix."""
+    import sys
+
+    mock_model = MagicMock()
+    mock_model.generate_content_async = MagicMock(
+        return_value=_async_fake_response_iter(["ok"])
+    )
+    mock_generative_model = MagicMock(return_value=mock_model)
+
+    sys.modules["vertexai"] = SimpleNamespace(init=lambda **k: None)
+    sys.modules["vertexai.generative_models"] = SimpleNamespace(
+        GenerativeModel=mock_generative_model,
+        GenerationConfig=MagicMock(),
+        Content=_FakeContent,
+        Part=_FakePart,
+    )
+
+    async def _run():
+        with (
+            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
+        ):
+            svc = VertexGeminiService()
+            async for _ in svc.stream_text(prompt="hi", model_name="gemini-2.5-flash"):
+                pass
+
+    asyncio.run(_run())
+    mock_generative_model.assert_called_once()
+    assert mock_generative_model.call_args.kwargs["model_name"] == "gemini-2.5-flash"
+    assert "publishers/" not in mock_generative_model.call_args.kwargs["model_name"]
+
+
+def test_vertex_stream_text_async_generator_not_awaited():
+    """Regression: stream=True returns an async generator synchronously, not a coroutine."""
+    chunks = ["ok"]
+
+    def generate_content_async(*_args, **_kwargs):
+        gen = _async_fake_response_iter(chunks)
+        assert not asyncio.iscoroutine(gen), "SDK must return async generator, not coroutine"
+        return gen
+
+    import sys
+
+    mock_model = MagicMock()
+    mock_model.generate_content_async = generate_content_async
+
+    sys.modules["vertexai"] = SimpleNamespace(init=lambda **k: None)
+    sys.modules["vertexai.generative_models"] = SimpleNamespace(
+        GenerativeModel=MagicMock(return_value=mock_model),
+        GenerationConfig=MagicMock(),
+        Content=_FakeContent,
+        Part=_FakePart,
+    )
+
+    async def _run():
+        with (
+            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
+        ):
+            svc = VertexGeminiService()
+            result = []
+            async for chunk in svc.stream_text(prompt="hi", model_name="gemini-2.5-flash"):
+                result.append(chunk)
+        return result
+
+    # Old `await model.generate_content_async(...)` would raise:
+    # TypeError: object async_generator can't be used in 'await' expression
+    result = asyncio.run(_run())
+    assert result == chunks
+
+
 def test_vertex_stream_cancelled_by_event():
     """cancel_event stops the stream mid-way via generate_content_async."""
     chunks = ["tok1", "tok2", "tok3", "tok4"]
@@ -259,7 +331,7 @@ def test_vertex_stream_cancelled_by_event():
     sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
 
     mock_model = MagicMock()
-    mock_model.generate_content_async = AsyncMock(return_value=_cancelling_iter())
+    mock_model.generate_content_async = MagicMock(return_value=_cancelling_iter())
 
     sys.modules["vertexai.generative_models"] = SimpleNamespace(
         GenerativeModel=MagicMock(return_value=mock_model),
@@ -338,7 +410,7 @@ def test_vertex_stream_quota_error_raises_vertex_llm_error():
         sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
 
         mock_model = MagicMock()
-        mock_model.generate_content_async = AsyncMock(
+        mock_model.generate_content_async = MagicMock(
             side_effect=RuntimeError("quota exceeded in stream")
         )
 


### PR DESCRIPTION
## Summary

- **New `VertexGeminiService`** (`app/services/vertex_gemini_service.py`): async streaming Gemini 2.5 Flash via Vertex AI SDK using Application Default Credentials (ADC). Uses `generate_content_async` for true non-blocking token streaming — the previous `asyncio.to_thread(generate_content, stream=True)` approach buffered all tokens before returning, causing ~2.7s latency and single-chunk TTS delivery. Raises typed `VertexLlmError` (QUOTA / TIMEOUT / CONTENT_FILTER / UNKNOWN) with class-name + message-based fallback classification for test-runner compatibility.
- **`resolve_llm_runtime` + `llm_service_for_provider`** (`app/core/agent_runtime.py`): centralised LLM credential routing replacing ad-hoc provider selection in `generate_and_stream_response`. Gemini agents always use ADC — `model.api_key` is never decrypted for Gemini. Default temperature raised to 0.3 (`VOICE_LLM_DEFAULT_TEMPERATURE`).
- **`LlmPromptBuilder`** (`app/voice/llm_prompt_builder.py`): pure functions for Vertex content building — `prune_history_to_turns` (oldest pairs dropped first), `build_history_text`, `build_vertex_contents` (maps `(role, text)` history to Vertex `Content` objects with correct `user` / `model` roles).
- **`PipelineSession`** (`app/voice/pipeline_session.py`): per-call state dataclass holding shared references to `_tts_cancel` (barge-in event) and `_conversation_history_cache` so both access paths stay in sync.
- **Surgical `bidirectional_stream.py` changes**: new imports wired in `__init__`; `generate_and_stream_response` uses `resolve_llm_runtime` + `llm_service_for_provider`; Vertex path passes `cancel_event` + `conversation_history`; `VertexLlmError` caught separately with `VOICE_LLM_FALLBACK_MESSAGE` canned response — no cross-provider retry for Gemini agents.
- **Barge-in dead zone** (`VOICE_BARGE_IN_DEAD_ZONE_MS`, default 600 ms): Deepgram sends stale interims from the user's original speech at almost exactly the moment the first TTS audio frame is sent to Twilio — `_is_tts_playing` flips True and barge-in fires immediately, cutting every response before the user hears anything. The dead zone suppresses interim-triggered barge-in for 600 ms after `_tts_play_start_ts` is set, while final-transcript barge-in is unaffected.

## Files changed

| File | Type |
|------|------|
| `app/services/vertex_gemini_service.py` | New |
| `app/voice/llm_prompt_builder.py` | New |
| `app/voice/pipeline_session.py` | New |
| `tests/voice/test_vertex_llm.py` | New (30 tests) |
| `app/core/agent_runtime.py` | Modified |
| `app/core/config.py` | Modified |
| `app/routers/bidirectional_stream.py` | Modified (surgical) |
| `app/voice/tts_stream_mixin.py` | Modified |
| `requirements.txt` | Modified |
| `tests/voice/test_call_pipeline.py` | Modified |

## Pre-existing failures (not regressions)

`test_bidirectional_interim_regression.py::test_second_interim_does_not_start_second_llm` and `test_complete_final_regen_calls_generate_once` fail on the base branch before any changes — the `_empty_handler()` helper in that file does not set `_rag_prefetch_min_words` / `_rag_prefetch_min_confidence` which are accessed in `_maybe_process_interim`. Confirmed pre-existing via `git stash` before implementation.

## Test plan

- [ ] Run `pytest tests/voice/test_vertex_llm.py tests/core/test_agent_runtime.py tests/voice/test_call_pipeline.py` — 113 pass
- [ ] Verify `GOOGLE_APPLICATION_CREDENTIALS` or Workload Identity is set in staging/prod env
- [ ] Place a test call with a Gemini-configured agent and confirm audio response latency drops from ~2.7 s to <1.5 s (first audio frame)
- [ ] Trigger a barge-in after >600 ms of agent speaking — confirm it still cancels correctly
- [ ] Trigger a fast interim (<600 ms after TTS start) — confirm it is suppressed (`tts_dead_zone` log) and audio completes
- [ ] Confirm `gemini_service.embed_text` (RAG embeddings) still uses AI Studio — separate code path, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)