### PR TITLE
feat(livekit): BE1-S2-01 — LiveKit room management foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,18 @@ REDIS_URL=redis://localhost:6379
 # Anthropic (for AI review agent)
 ANTHROPIC_API_KEY=
 
+# LiveKit (self-hosted real-time audio transport — GKE internal, port 7880)
+# In GKE: http://livekit:7880  (ClusterIP service, NOT public)
+# API key + secret are injected from GCP Secret Manager at runtime in both
+# the LiveKit Deployment and the API server Deployment.
+LIVEKIT_URL=http://localhost:7880
+LIVEKIT_API_KEY=
+LIVEKIT_API_SECRET=
+LIVEKIT_TOKEN_TTL=3600
+LIVEKIT_ROOM_EMPTY_TIMEOUT=30
+LIVEKIT_MAX_PARTICIPANTS=2
+LIVEKIT_ENABLED=false
+
 # Server
 DEBUG=False
 HOST=0.0.0.0

--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,10 @@ STRIPE_WEBHOOK_SECRET=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
-# Google Cloud TTS
+# Google Cloud TTS + STT (Application Default Credentials)
+# Set to the path of a service-account JSON key file, OR export the JSON content
+# directly as the env var value.  Used for both google-cloud-texttospeech and
+# google-cloud-speech (ADC — no per-call key file required).
 GOOGLE_APPLICATION_CREDENTIALS=
 
 # Pinecone
@@ -58,6 +61,26 @@ LIVEKIT_TOKEN_TTL=3600
 LIVEKIT_ROOM_EMPTY_TIMEOUT=30
 LIVEKIT_MAX_PARTICIPANTS=2
 LIVEKIT_ENABLED=false
+
+# STT (Speech-to-Text)
+# Silence threshold: how long (ms) without audio before treating utterance as complete.
+# Used by GoogleSttService and Deepgram path alike.
+SILENCE_THRESHOLD_MS=1500
+# STT latency SLO (ticket: speech end → final transcript p95 < 400ms in staging)
+STT_P95_THRESHOLD_MS: int = 400
+
+# NOTE: Google STT requires ffmpeg to be installed on the host:
+#   Linux:  apt-get install -y ffmpeg
+#   macOS:  brew install ffmpeg
+# ffmpeg is used by LiveKitAudioProcessor to resample non-16kHz PCM → LINEAR16.
+
+# Live Google STT integration tests (optional local/staging):
+#   RUN_GOOGLE_STT_INTEGRATION=1 pytest tests/integration/test_google_stt_live.py -v
+# Staging p95 enforcement (p95 < 400ms):
+#   STT_STRICT_LATENCY=1 RUN_GOOGLE_STT_INTEGRATION=1 pytest tests/integration/test_google_stt_live.py -v
+# Staging log analysis after test calls:
+#   python scripts/stt_latency_p95.py --log app.log --threshold 400
+# GOOGLE_APPLICATION_CREDENTIALS supports inline JSON or a file path (local dev).
 
 # Server
 DEBUG=False

--- a/.env.example
+++ b/.env.example
@@ -90,3 +90,12 @@ WEBHOOK_BASE_URL=https://your-domain.com
 
 # Outbound call concurrency limit per workspace (default: 10)
 OUTBOUND_MAX_CONCURRENT_PER_WORKSPACE=10
+
+# GCS Call Recordings (Sprint 4)
+# Service account credentials are loaded from GOOGLE_APPLICATION_CREDENTIALS (ADC).
+# The service account must have roles/storage.objectCreator + roles/storage.objectViewer on the bucket.
+GCS_RECORDINGS_BUCKET=your-recordings-bucket-name
+GCS_RECORDINGS_SIGNED_URL_EXPIRY_SECONDS=3600
+GCS_RECORDINGS_PREFIX=recordings
+# Infra: apply a GCS lifecycle rule to delete objects older than 90 days under the recordings/ prefix.
+# Sprint 5 (HIPAA): set CMEK encryption key for the bucket (customer-managed encryption).

--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,6 @@ DEBUG=False
 HOST=0.0.0.0
 PORT=8000
 WEBHOOK_BASE_URL=https://your-domain.com
+
+# Outbound call concurrency limit per workspace (default: 10)
+OUTBOUND_MAX_CONCURRENT_PER_WORKSPACE=10

--- a/alembic/versions/20260608_add_stt_catalog_and_agent_stt_columns.py
+++ b/alembic/versions/20260608_add_stt_catalog_and_agent_stt_columns.py
@@ -1,0 +1,285 @@
+"""add STT catalog tables and agent STT columns
+
+Revision ID: 20260608_stt_catalog
+Revises: 20260602_schema_v2
+Create Date: 2026-06-08
+
+Creates sttprovider + sttmodel catalog tables, agent STT FK columns,
+and seeds deepgram (nova-3, nova-2), google (chirp-3), elevenlabs (scrib-v1).
+"""
+from typing import Sequence, Union
+
+import json
+import uuid as _uuid
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260608_stt_catalog"
+down_revision: Union[str, Sequence[str], None] = "20260602_schema_v2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(conn, name: str) -> bool:
+    return (
+        conn.execute(
+            sa.text("SELECT to_regclass(:name)"),
+            {"name": name},
+        ).scalar()
+        is not None
+    )
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    return (
+        conn.execute(
+            sa.text(
+                """
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = :table AND column_name = :column
+                LIMIT 1
+                """
+            ),
+            {"table": table, "column": column},
+        ).scalar()
+        is not None
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not _table_exists(conn, "sttprovider"):
+        op.create_table(
+            "sttprovider",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column("slug", sa.String(50), nullable=False, unique=True),
+            sa.Column("display_name", sa.String(100), nullable=False),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("supports_streaming", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_sttprovider_slug", "sttprovider", ["slug"], unique=True)
+
+    if not _table_exists(conn, "sttmodel"):
+        op.create_table(
+            "sttmodel",
+            sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+            sa.Column(
+                "provider_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("sttprovider.id"),
+                nullable=False,
+            ),
+            sa.Column("external_model_id", sa.String(255), nullable=False),
+            sa.Column("display_name", sa.String(255), nullable=False),
+            sa.Column("language_code", sa.String(20), nullable=False, server_default="en-US"),
+            sa.Column("sample_rate_hz", sa.Integer(), nullable=False, server_default="16000"),
+            sa.Column("encoding", sa.String(20), nullable=False, server_default="LINEAR16"),
+            sa.Column("metadata_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+            sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("provider_id", "external_model_id", name="uq_sttmodel_provider_external"),
+        )
+        op.create_index("ix_sttmodel_provider_id", "sttmodel", ["provider_id"])
+        op.create_index("ix_sttmodel_is_active", "sttmodel", ["is_active"])
+
+    if not _column_exists(conn, "agent", "stt_provider_slug"):
+        op.add_column("agent", sa.Column("stt_provider_slug", sa.String(40), nullable=True))
+    if not _column_exists(conn, "agent", "stt_model_external_id"):
+        op.add_column("agent", sa.Column("stt_model_external_id", sa.String(255), nullable=True))
+    if not _column_exists(conn, "agent", "stt_language_code"):
+        op.add_column("agent", sa.Column("stt_language_code", sa.String(20), nullable=True))
+    if not _column_exists(conn, "agent", "stt_provider_id"):
+        op.add_column(
+            "agent",
+            sa.Column(
+                "stt_provider_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("sttprovider.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+    if not _column_exists(conn, "agent", "stt_model_id"):
+        op.add_column(
+            "agent",
+            sa.Column(
+                "stt_model_id",
+                postgresql.UUID(as_uuid=True),
+                sa.ForeignKey("sttmodel.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+    if not _column_exists(conn, "agent", "stt_settings_json"):
+        op.add_column(
+            "agent",
+            sa.Column("stt_settings_json", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        )
+
+    # Agent indexes (idempotent)
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_agent_stt_provider_id ON agent (stt_provider_id)"
+        )
+    )
+    op.execute(
+        sa.text("CREATE INDEX IF NOT EXISTS ix_agent_stt_model_id ON agent (stt_model_id)")
+    )
+
+    deepgram_id = str(_uuid.UUID("00000000-0000-0000-0000-000000000101"))
+    google_id = str(_uuid.UUID("00000000-0000-0000-0000-000000000102"))
+    elevenlabs_id = str(_uuid.UUID("00000000-0000-0000-0000-000000000103"))
+
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO sttprovider (id, slug, display_name, is_active, supports_streaming)
+            VALUES
+              (:did, 'deepgram', 'Deepgram', true, true),
+              (:gid, 'google', 'Google Cloud STT', true, true),
+              (:eid, 'elevenlabs', 'ElevenLabs Scribe', true, false)
+            ON CONFLICT (slug) DO NOTHING
+            """
+        ).bindparams(did=deepgram_id, gid=google_id, eid=elevenlabs_id)
+    )
+
+    nova3_id = str(_uuid.UUID("00000000-0000-0000-0001-000000000001"))
+    nova2_id = str(_uuid.UUID("00000000-0000-0000-0001-000000000002"))
+    chirp3_id = str(_uuid.UUID("00000000-0000-0000-0001-000000000003"))
+    scribe_id = str(_uuid.UUID("00000000-0000-0000-0001-000000000004"))
+
+    model_rows = [
+        (
+            nova3_id,
+            deepgram_id,
+            "nova-3",
+            "Deepgram Nova 3",
+            "en",
+            8000,
+            "MULAW",
+            json.dumps(
+                {"api_model": "nova-3", "encoding": "mulaw", "sample_rate_hz": 8000}
+            ),
+        ),
+        (
+            nova2_id,
+            deepgram_id,
+            "nova-2",
+            "Deepgram Nova 2",
+            "en",
+            8000,
+            "MULAW",
+            json.dumps(
+                {"api_model": "nova-2", "encoding": "mulaw", "sample_rate_hz": 8000}
+            ),
+        ),
+        (
+            chirp3_id,
+            google_id,
+            "chirp-3",
+            "Google Chirp 3",
+            "en-AU",
+            16000,
+            "LINEAR16",
+            json.dumps(
+                {
+                    "api_model": "chirp_3",
+                    "google_model": "phone_call",
+                    "use_enhanced": True,
+                    "encoding": "LINEAR16",
+                    "sample_rate_hz": 16000,
+                }
+            ),
+        ),
+        (
+            scribe_id,
+            elevenlabs_id,
+            "scrib-v1",
+            "ElevenLabs Scribe",
+            "en",
+            16000,
+            "LINEAR16",
+            json.dumps({"api_model": "scribe_v1"}),
+        ),
+    ]
+    for row in model_rows:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO sttmodel (
+                  id, provider_id, external_model_id, display_name,
+                  language_code, sample_rate_hz, encoding, metadata_json, is_active
+                )
+                VALUES (
+                  CAST(:id AS uuid), CAST(:provider_id AS uuid), :external_model_id,
+                  :display_name, :language_code, :sample_rate_hz, :encoding,
+                  CAST(:metadata_json AS jsonb), true
+                )
+                ON CONFLICT (provider_id, external_model_id) DO NOTHING
+                """
+            ),
+            {
+                "id": row[0],
+                "provider_id": row[1],
+                "external_model_id": row[2],
+                "display_name": row[3],
+                "language_code": row[4],
+                "sample_rate_hz": row[5],
+                "encoding": row[6],
+                "metadata_json": row[7],
+            },
+        )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE agent
+            SET
+              stt_provider_slug      = 'deepgram',
+              stt_model_external_id = 'nova-3',
+              stt_language_code    = 'en',
+              stt_provider_id      = :pid,
+              stt_model_id         = :mid
+            WHERE stt_provider_slug IS NULL
+            """
+        ).bindparams(pid=deepgram_id, mid=nova3_id)
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE sttmodel
+            SET metadata_json = (
+                COALESCE(metadata_json::jsonb, '{}'::jsonb)
+                || CAST(:patch AS jsonb)
+            )::json
+            WHERE external_model_id = 'chirp-3'
+              AND provider_id IN (SELECT id FROM sttprovider WHERE slug = 'google')
+            """
+        ),
+        {
+            "patch": json.dumps({"use_enhanced": True, "google_model": "phone_call"}),
+        },
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_stt_model_id", table_name="agent")
+    op.drop_index("ix_agent_stt_provider_id", table_name="agent")
+    op.drop_column("agent", "stt_settings_json")
+    op.drop_column("agent", "stt_model_id")
+    op.drop_column("agent", "stt_provider_id")
+    op.drop_column("agent", "stt_language_code")
+    op.drop_column("agent", "stt_model_external_id")
+    op.drop_column("agent", "stt_provider_slug")
+
+    op.drop_index("ix_sttmodel_is_active", table_name="sttmodel")
+    op.drop_index("ix_sttmodel_provider_id", table_name="sttmodel")
+    op.drop_table("sttmodel")
+
+    op.drop_index("ix_sttprovider_slug", table_name="sttprovider")
+    op.drop_table("sttprovider")

--- a/alembic/versions/20260609_add_call_recording_gcs_fields.py
+++ b/alembic/versions/20260609_add_call_recording_gcs_fields.py
@@ -1,0 +1,67 @@
+"""add_call_recording_gcs_fields
+
+Merges outbound-dispatch and stt-catalog heads, then adds GCS recording
+columns to callsession.
+
+Revision ID: 20260609_call_recording
+Revises: 20260608_outbound_status_idx, 20260608_stt_catalog
+Create Date: 2026-06-09
+
+Changes:
+- callsession: recording_gcs_path VARCHAR(500) nullable
+- callsession: recording_error BOOLEAN NOT NULL default false
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260609_call_recording"
+down_revision: Union[str, Sequence[str], None] = (
+    "20260608_outbound_status_idx",
+    "20260608_stt_catalog",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_column(conn, table: str, column: str) -> bool:
+    return conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = :tbl AND column_name = :col)"
+        ),
+        {"tbl": table, "col": column},
+    ).scalar()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if not _has_column(conn, "callsession", "recording_gcs_path"):
+        op.add_column(
+            "callsession",
+            sa.Column("recording_gcs_path", sa.String(500), nullable=True),
+        )
+
+    if not _has_column(conn, "callsession", "recording_error"):
+        op.add_column(
+            "callsession",
+            sa.Column(
+                "recording_error",
+                sa.Boolean(),
+                nullable=False,
+                server_default="false",
+            ),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_column(conn, "callsession", "recording_error"):
+        op.drop_column("callsession", "recording_error")
+
+    if _has_column(conn, "callsession", "recording_gcs_path"):
+        op.drop_column("callsession", "recording_gcs_path")

--- a/alembic/versions/20260610_apply_callsession_outbound_status_index.py
+++ b/alembic/versions/20260610_apply_callsession_outbound_status_index.py
@@ -1,11 +1,11 @@
-"""add_callsession_outbound_status_index
+"""apply_callsession_outbound_status_index
 
-Adds a composite index on callsession(tenant_id, call_type, status) to support
-efficient per-workspace concurrent outbound call count queries.
+Linear follow-up: the outbound status index branch was skipped when the
+recording merge ran against the duplicate a1b2c3d4e5f6 revision id.
 
-Revision ID: 20260608_outbound_status_idx
-Revises: f6b7c8d9e0f1
-Create Date: 2026-06-08
+Revision ID: 20260610_outbound_idx
+Revises: 20260609_call_recording
+Create Date: 2026-06-10
 """
 
 from typing import Sequence, Union
@@ -13,8 +13,8 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "20260608_outbound_status_idx"
-down_revision: Union[str, Sequence[str], None] = "f6b7c8d9e0f1"
+revision: str = "20260610_outbound_idx"
+down_revision: Union[str, Sequence[str], None] = "20260609_call_recording"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
@@ -41,4 +41,6 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_index("ix_callsession_tenant_calltype_status", table_name="callsession")
+    conn = op.get_bind()
+    if _has_index(conn, "ix_callsession_tenant_calltype_status"):
+        op.drop_index("ix_callsession_tenant_calltype_status", table_name="callsession")

--- a/alembic/versions/a1b2c3d4e5f6_add_callsession_outbound_status_index.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_callsession_outbound_status_index.py
@@ -1,0 +1,31 @@
+"""add_callsession_outbound_status_index
+
+Adds a composite index on callsession(tenant_id, call_type, status) to support
+efficient per-workspace concurrent outbound call count queries.
+
+Revision ID: a1b2c3d4e5f6
+Revises: f6b7c8d9e0f1
+Create Date: 2026-06-08
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "f6b7c8d9e0f1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_callsession_tenant_calltype_status",
+        "callsession",
+        ["tenant_id", "call_type", "status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_callsession_tenant_calltype_status", table_name="callsession")

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -41,6 +41,7 @@ from app.routers.general_websocket import router as general_websocket_router
 from app.routers.calendar import router as calendar_router
 from app.routers.inbound_crm import router as inbound_crm_router
 from app.routers.internal_tts import router as internal_tts_router
+from app.routers.internal_stt import router as internal_stt_router
 from app.routers.business_knowledge import router as business_knowledge_router
 
 api_router = APIRouter()
@@ -88,6 +89,7 @@ api_router.include_router(openai.router, prefix="/openai", tags=["openai"], incl
 api_router.include_router(tts_audio_router, prefix="/tts", tags=["Google TTS"], include_in_schema=False)
 api_router.include_router(tts_router, prefix="/tts", tags=["TTS"])
 api_router.include_router(internal_tts_router, prefix="/internal/tts", tags=["Internal TTS"])
+api_router.include_router(internal_stt_router, prefix="/internal/stt", tags=["Internal STT"])
 api_router.include_router(
     bidirectional_stream_router,
     prefix="/stream",

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -19,6 +19,7 @@ from app.routers.agents import router as agent_router
 from app.routers.call_flows import router as call_flows_router
 from app.routers.folders import router as folders_router
 from app.routers.bidirectional_stream import router as bidirectional_stream_router
+from app.routers.livekit_bridge import router as livekit_bridge_router
 from app.routers.call_logs import router as call_logs_router
 from app.routers.call_sessions import router as call_sessions_router
 from app.routers.clickup_oauth import router as clickup_oauth_router
@@ -94,6 +95,12 @@ api_router.include_router(
     bidirectional_stream_router,
     prefix="/stream",
     tags=["Bidirectional Streaming"],
+    include_in_schema=False,
+)
+api_router.include_router(
+    livekit_bridge_router,
+    prefix="/livekit",
+    tags=["LiveKit Bridge"],
     include_in_schema=False,
 )
 api_router.include_router(scheduled_calls_router, prefix="/schedule", tags=["Scheduled Calls"])

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -44,6 +44,7 @@ from app.routers.inbound_crm import router as inbound_crm_router
 from app.routers.internal_tts import router as internal_tts_router
 from app.routers.internal_stt import router as internal_stt_router
 from app.routers.business_knowledge import router as business_knowledge_router
+from app.routers.recordings import router as recordings_router
 
 api_router = APIRouter()
 api_router.include_router(user.router, prefix="/users", tags=["users"])
@@ -146,3 +147,4 @@ api_router.include_router(
     prefix="/recruiting/dashboard",
     tags=["Recruiting Dashboard"],
 )
+api_router.include_router(recordings_router, prefix="/recordings", tags=["Call Recordings"])

--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -70,6 +70,19 @@ class ResolvedLlmRuntime:
 
 
 @dataclass(frozen=True)
+class ResolvedSttRuntime:
+    """Runtime STT config resolved from agent + optional flow settings override."""
+
+    provider_slug: str          # "deepgram" | "google" | "elevenlabs"
+    model_id: str               # user-facing modelId e.g. "nova-3", "chirp-3"
+    language_code: str          # BCP-47 e.g. "en-AU", "en"
+    sample_rate_hz: int         # from sttmodel catalog (e.g. 8000 or 16000)
+    encoding: str               # "MULAW" | "LINEAR16"
+    silence_threshold_ms: int   # from stt_settings_json or default 1500
+    api_config: dict[str, Any]  # provider-specific params from metadata_json
+
+
+@dataclass(frozen=True)
 class ResolvedTtsRuntime:
     adapter_slug: str
     voice_external_id: Optional[str]
@@ -331,3 +344,92 @@ def resolve_tts_adapter_slug(
 ) -> Optional[str]:
     """Convenience for call sites that only need the adapter slug string."""
     return resolve_tts_runtime(agent, db=db).adapter_slug
+
+
+_DEFAULT_STT_PROVIDER_SLUG = "deepgram"
+_DEFAULT_STT_MODEL_ID = "nova-3"
+_DEFAULT_STT_LANGUAGE_CODE = "en"
+_DEFAULT_STT_SAMPLE_RATE = 8000
+_DEFAULT_STT_ENCODING = "MULAW"
+_DEFAULT_SILENCE_THRESHOLD_MS = 1500
+
+
+def resolve_stt_runtime(
+    agent: Optional[Agent],
+    *,
+    flow_language_code: Optional[str] = None,
+    db: "Session | None" = None,
+) -> ResolvedSttRuntime:
+    """Resolve STT runtime config from agent + optional callflow language override.
+
+    Priority (high → low):
+      1. flow_language_code  (callflow.settings.sttLanguageCode)
+      2. agent.stt_language_code
+      3. sttmodel.language_code (catalog default)
+
+    metadata_json carries internal API params (e.g. google_model: "phone_call")
+    — never surfaced in API responses.
+    """
+    # Defaults when no agent or STT fields missing
+    provider_slug = _DEFAULT_STT_PROVIDER_SLUG
+    model_id = _DEFAULT_STT_MODEL_ID
+    language_code = _DEFAULT_STT_LANGUAGE_CODE
+    sample_rate_hz = _DEFAULT_STT_SAMPLE_RATE
+    encoding = _DEFAULT_STT_ENCODING
+    silence_threshold_ms = _DEFAULT_SILENCE_THRESHOLD_MS
+    api_config: dict[str, Any] = {}
+
+    if agent and agent.stt_provider_slug:
+        provider_slug = agent.stt_provider_slug
+    if agent and agent.stt_model_external_id:
+        model_id = agent.stt_model_external_id
+
+    # Language priority: flow override > agent column > catalog default
+    if flow_language_code and flow_language_code.strip():
+        language_code = flow_language_code.strip()
+    elif agent and agent.stt_language_code and agent.stt_language_code.strip():
+        language_code = agent.stt_language_code.strip()
+
+    # Load metadata from catalog model when DB session available
+    if db is not None and agent and agent.stt_model_id:
+        try:
+            from app.models.stt_model import STTModel
+            stt_model_row = db.query(STTModel).filter(STTModel.id == agent.stt_model_id).first()
+            if stt_model_row:
+                sample_rate_hz = stt_model_row.sample_rate_hz or sample_rate_hz
+                encoding = stt_model_row.encoding or encoding
+                # catalog default language (lowest priority)
+                if not flow_language_code and not (agent and agent.stt_language_code):
+                    language_code = stt_model_row.language_code or language_code
+                api_config = dict(stt_model_row.metadata_json or {})
+        except Exception as exc:
+            logger.warning("resolve_stt_runtime: failed to load catalog model: %s", exc)
+    elif provider_slug == "google":
+        # Google needs LINEAR16 @ 16kHz — set safe defaults even without DB
+        sample_rate_hz = 16000
+        encoding = "LINEAR16"
+
+    # Google chirp-3 → phone_call + enhanced (Google telephony best practice).
+    if provider_slug == "google" and model_id == "chirp-3":
+        api_config = dict(api_config or {})
+        api_config.setdefault("google_model", "phone_call")
+        api_config["use_enhanced"] = True
+
+    # Silence threshold from agent.stt_settings_json
+    if agent and agent.stt_settings_json:
+        raw = agent.stt_settings_json
+        if isinstance(raw, dict):
+            try:
+                silence_threshold_ms = int(raw.get("silence_threshold_ms", silence_threshold_ms))
+            except (TypeError, ValueError):
+                pass
+
+    return ResolvedSttRuntime(
+        provider_slug=provider_slug,
+        model_id=model_id,
+        language_code=language_code,
+        sample_rate_hz=sample_rate_hz,
+        encoding=encoding,
+        silence_threshold_ms=silence_threshold_ms,
+        api_config=api_config,
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -332,6 +332,11 @@ class Settings(BaseSettings):
     LIVEKIT_MAX_PARTICIPANTS: int = 2       # enforced at SDK CreateRoomRequest level
     LIVEKIT_ENABLED: bool = True
 
+    # Outbound call concurrency — max simultaneous outbound calls per workspace.
+    # Counts outbound sessions with status IN (initiated, ringing, connected, in-progress).
+    # Increase at the tenant level by changing this value (no per-tenant override yet).
+    OUTBOUND_MAX_CONCURRENT_PER_WORKSPACE: int = 10
+
     # Resume ↔ job matching (recruiting): LLM + rules
     # hybrid = blend (recommended); rules = heuristics only; ai = LLM scores (rules if LLM fails)
     RECRUIT_MATCH_MODE: str = "hybrid"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -320,6 +320,15 @@ class Settings(BaseSettings):
     MONDAY_BOARD_ID: str = ""  # Monday.com Board ID for scheduled calls
     MONDAY_WORKSPACE_ID: Optional[str] = None  # Optional workspace to create tenant boards in
 
+    # LiveKit — self-hosted real-time audio transport (GKE internal, port 7880)
+    LIVEKIT_URL: str = ""
+    LIVEKIT_API_KEY: str = ""
+    LIVEKIT_API_SECRET: str = ""
+    LIVEKIT_TOKEN_TTL: int = 3600           # seconds; 1 hour
+    LIVEKIT_ROOM_EMPTY_TIMEOUT: int = 30    # seconds before auto-close when empty
+    LIVEKIT_MAX_PARTICIPANTS: int = 2       # enforced at SDK CreateRoomRequest level
+    LIVEKIT_ENABLED: bool = True
+
     # Resume ↔ job matching (recruiting): LLM + rules
     # hybrid = blend (recommended); rules = heuristics only; ai = LLM scores (rules if LLM fails)
     RECRUIT_MATCH_MODE: str = "hybrid"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -332,6 +332,13 @@ class Settings(BaseSettings):
     LIVEKIT_MAX_PARTICIPANTS: int = 2       # enforced at SDK CreateRoomRequest level
     LIVEKIT_ENABLED: bool = True
 
+    # GCS call recordings — Sprint 4
+    # Bucket must have a lifecycle rule: delete recordings/ prefix objects after 90 days.
+    # Infra: GCS lifecycle rule deletes recordings/ prefix objects after 90 days (set in bucket policy, not here).
+    GCS_RECORDINGS_BUCKET: str = ""
+    GCS_RECORDINGS_SIGNED_URL_EXPIRY_SECONDS: int = 3600
+    GCS_RECORDINGS_PREFIX: str = "recordings"
+
     # Outbound call concurrency — max simultaneous outbound calls per workspace.
     # Counts outbound sessions with status IN (initiated, ringing, connected, in-progress).
     # Increase at the tenant level by changing this value (no per-tenant override yet).

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -115,6 +115,9 @@ class Settings(BaseSettings):
     # Secondary dedup in STT pipeline: normalized text, same window idea as handler (seconds).
     VOICE_STT_FINAL_NORMALIZED_DEDUP_SEC: float = 6.0
     STT_SAMPLE_RATE: int = 8000  # provider-neutral STT sample rate (Twilio MULAW default)
+    # Multi-provider STT silence threshold: ms of no audio before treating utterance as done.
+    # Applies to Google STT path; Deepgram uses its own endpointing above.
+    SILENCE_THRESHOLD_MS: int = 1500
 
     # Google Cloud Text-to-Speech (TTS) endpoint/voice overrides
     # Docs: https://cloud.google.com/text-to-speech/docs/endpoints

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -97,6 +97,54 @@ def is_staging() -> bool:
 
 
 @lru_cache(maxsize=1)
+def _load_livekit_production_credentials() -> tuple[str, str, str]:
+    """Fetch LiveKit credentials from Secret Manager (cached after first call)."""
+    url = _fetch_from_secret_manager("LIVEKIT_URL") or settings.LIVEKIT_URL
+    api_key = _fetch_from_secret_manager("LIVEKIT_API_KEY") or settings.LIVEKIT_API_KEY
+    api_secret = _fetch_from_secret_manager("LIVEKIT_API_SECRET") or settings.LIVEKIT_API_SECRET
+    if not url or not api_key or not api_secret:
+        raise RuntimeError(
+            "LiveKit credentials unavailable. Set GCP_PROJECT_ID and Secret Manager secrets "
+            "(LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET) or the equivalent env vars."
+        )
+    return url, api_key, api_secret
+
+
+def get_livekit_credentials() -> tuple[str, str, str]:
+    """
+    Return (url, api_key, api_secret) appropriate for the current environment.
+
+    - production/staging → GCP Secret Manager with env-var fallback
+      (secrets injected as env vars in both LiveKit GKE Deployment and API server Deployment)
+    - development        → env-var / .env values
+
+    Raises RuntimeError in staging/production when credentials are absent.
+    Raises ValueError in development when credentials are absent.
+    """
+    env = settings.ENVIRONMENT.lower()
+
+    if env in ("production", "staging"):
+        url, api_key, api_secret = _load_livekit_production_credentials()
+        if not url or not api_key or not api_secret:
+            raise RuntimeError(
+                f"LiveKit credentials unavailable in {env}. "
+                "Set LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET via Secret Manager or env vars."
+            )
+        return url, api_key, api_secret
+
+    # development — plain env vars / .env
+    url = settings.LIVEKIT_URL
+    api_key = settings.LIVEKIT_API_KEY
+    api_secret = settings.LIVEKIT_API_SECRET
+    if not url or not api_key or not api_secret:
+        raise ValueError(
+            "LiveKit credentials not configured. Add LIVEKIT_URL, LIVEKIT_API_KEY, "
+            "and LIVEKIT_API_SECRET to your .env file for local development."
+        )
+    return url, api_key, api_secret
+
+
+@lru_cache(maxsize=1)
 def get_rime_api_key() -> str:
     """
     Return the Rime TTS API key appropriate for the current environment.

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -49,3 +49,7 @@ from app.models.resume import Resume
 from app.models.resume_interview import ResumeInterview
 from app.models.api_key import Apikey
 from app.models.stripe_checkout_fulfillment import StripeCheckoutFulfillment
+
+# STT catalog
+from app.models.stt_provider import STTProvider
+from app.models.stt_model import STTModel

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,24 @@ async def lifespan(app: FastAPI):
         logger.error("Rime TTS misconfigured: %s", exc)
         raise
 
+    if settings.LIVEKIT_ENABLED:
+        from app.core.secret_manager import get_livekit_credentials
+
+        try:
+            get_livekit_credentials()
+            logger.info("LiveKit credentials configured")
+        except (ValueError, RuntimeError) as exc:
+            env = settings.ENVIRONMENT.lower()
+            if env in ("staging", "production"):
+                logger.error("LiveKit credentials missing in %s: %s", env, exc)
+                raise
+            else:
+                logger.warning(
+                    "LiveKit credentials not configured: %s — set LIVEKIT_ENABLED=false "
+                    "or add LIVEKIT_URL/LIVEKIT_API_KEY/LIVEKIT_API_SECRET to .env",
+                    exc,
+                )
+
     if settings.API_DOCS_ENABLED:
         if settings.API_DOCS_USERNAME and settings.API_DOCS_PASSWORD:
             logger.info(

--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -41,6 +41,24 @@ class Agent(Base):
     # Smart callback flag — agent proactively calls back when a slot opens.
     smart_callback = Column(Boolean, default=False, nullable=False, server_default="false")
 
+    # ── STT model triad (mirrors TTS triad: provider_slug / external_id / language) ──
+    stt_provider_slug = Column(String(40), nullable=True)
+    stt_model_external_id = Column(String(255), nullable=True)
+    stt_language_code = Column(String(20), nullable=True)
+    stt_provider_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("sttprovider.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    stt_model_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("sttmodel.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    stt_settings_json = Column(JSON, nullable=True)
+
     # Agent-specific model configuration (overrides model defaults)
     agent_temperature = Column(Integer, nullable=True)  # Agent-specific temperature (0-100)
     agent_max_tokens = Column(Integer, nullable=True)   # Agent-specific max tokens
@@ -74,6 +92,8 @@ class Agent(Base):
     provider = relationship("Provider")  # Provider relationship for filtering models
     tts_provider = relationship("TTSProvider", back_populates="agents")
     tts_voice = relationship("TTSVoice", back_populates="agents")
+    stt_provider = relationship("STTProvider", back_populates="agents", foreign_keys=[stt_provider_id])
+    stt_model = relationship("STTModel", back_populates="agents", foreign_keys=[stt_model_id])
     transfer_route = relationship("TransferRoute", back_populates="agents")
 
     __table_args__ = (

--- a/app/models/call_session.py
+++ b/app/models/call_session.py
@@ -31,7 +31,11 @@ class CallSession(Base):
     # Call content
     call_transcript = Column(JSONB, nullable=True)  # Store as JSON array of messages
     response_times = Column(JSONB, nullable=True)  # Store response times for each interaction
-    recording_url = Column(String(500), nullable=True)  # URL to the call recording
+    recording_url = Column(String(500), nullable=True)  # Legacy Twilio recording URL (kept for compat)
+
+    # GCS recording (Sprint 4 — replaces Twilio recording for LiveKit calls)
+    recording_gcs_path = Column(String(500), nullable=True)  # e.g. recordings/{workspaceId}/{callId}/{date}.opus
+    recording_error = Column(Boolean, nullable=False, server_default="false")
     
     # Phone numbers and external IDs
     twilio_call_sid = Column(String(255), nullable=True, index=True)

--- a/app/models/stt_model.py
+++ b/app/models/stt_model.py
@@ -1,0 +1,29 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, JSON, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import uuid
+
+from app.db.base_class import Base
+
+
+class STTModel(Base):
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    provider_id = Column(UUID(as_uuid=True), ForeignKey("sttprovider.id"), nullable=False, index=True)
+    external_model_id = Column(String(255), nullable=False)
+    display_name = Column(String(255), nullable=False)
+    language_code = Column(String(20), nullable=False, default="en-US")
+    sample_rate_hz = Column(Integer, nullable=False, default=16000)
+    encoding = Column(String(20), nullable=False, default="LINEAR16")
+    # Provider API mapping — NOT exposed in API responses
+    metadata_json = Column(JSON, nullable=True)
+    is_active = Column(Boolean, default=True, nullable=False, server_default="true", index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    provider = relationship("STTProvider", back_populates="models")
+    agents = relationship("Agent", back_populates="stt_model", foreign_keys="Agent.stt_model_id")
+
+    __table_args__ = (
+        UniqueConstraint("provider_id", "external_model_id", name="uq_sttmodel_provider_external"),
+    )

--- a/app/models/stt_provider.py
+++ b/app/models/stt_provider.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Boolean, Column, DateTime, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import uuid
+
+from app.db.base_class import Base
+
+
+class STTProvider(Base):
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    slug = Column(String(50), nullable=False, unique=True, index=True)
+    display_name = Column(String(100), nullable=False)
+    is_active = Column(Boolean, default=True, nullable=False, server_default="true")
+    supports_streaming = Column(Boolean, default=True, nullable=False, server_default="true")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    models = relationship("STTModel", back_populates="provider", cascade="all, delete-orphan")
+    agents = relationship("Agent", back_populates="stt_provider", foreign_keys="Agent.stt_provider_id")

--- a/app/routers/agents.py
+++ b/app/routers/agents.py
@@ -22,6 +22,7 @@ from app.models.user import User
 from app.schemas.agent import (
     AgentCreate,
     AgentListResponse,
+    AgentOut,
     AgentUpdate,
     LanguageEnum,
     VoiceTypeEnum,
@@ -83,7 +84,12 @@ def _serialize_out(agent) -> dict[str, Any]:
     return agent_to_out(agent).model_dump(by_alias=True, mode="json")
 
 
-@router.post("/", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    status_code=status.HTTP_201_CREATED,
+    response_model=AgentOut,
+    response_model_by_alias=True,
+)
 def create_agent(
     agent_in: AgentCreate,
     request: Request,
@@ -108,10 +114,14 @@ def create_agent(
                 extras={"allowedValues": agent_service.list_active_llm_model_names(db)},
             )
         raise
-    return JSONResponse(status_code=status.HTTP_201_CREATED, content=_serialize_out(agent))
+    return agent_to_out(agent)
 
 
-@router.get("/{agent_id}")
+@router.get(
+    "/{agent_id}",
+    response_model=AgentOut,
+    response_model_by_alias=True,
+)
 def get_agent(
     agent_id: uuid.UUID,
     principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
@@ -119,7 +129,7 @@ def get_agent(
 ):
     """Get agent by id (404 if missing or other workspace)."""
     agent = agent_service.get_agent_by_id(db, agent_id, _workspace_id(principal))
-    return _serialize_out(agent)
+    return agent_to_out(agent)
 
 
 @router.get("/", response_model=AgentListResponse, response_model_by_alias=True)
@@ -140,7 +150,11 @@ def list_agents(
     )
 
 
-@router.put("/{agent_id}")
+@router.put(
+    "/{agent_id}",
+    response_model=AgentOut,
+    response_model_by_alias=True,
+)
 def update_agent(
     agent_id: uuid.UUID,
     agent_update: AgentUpdate,
@@ -174,7 +188,7 @@ def update_agent(
                 extras={"fields": [{"path": "elevenLabsApiKey", "message": str(exc.detail)}]},
             )
         raise
-    return _serialize_out(agent)
+    return agent_to_out(agent)
 
 
 @router.delete("/{agent_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -122,7 +122,7 @@ from app.services.transcript_service import transcript_service
 from app.services.openai_service import openai_service
 from app.services.groq_service import groq_service
 from app.services.vertex_gemini_service import VertexLlmError, vertex_gemini_service
-from app.core.agent_runtime import resolve_llm_runtime, llm_service_for_provider
+from app.core.agent_runtime import resolve_llm_runtime, resolve_stt_runtime, llm_service_for_provider
 from app.services.rag_service import rag_service
 from app.services.credit_service import credit_service
 from app.services.twilio_service import twilio_service
@@ -513,7 +513,57 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
         # It writes _tts_pipeline and _tts_worker_task back onto this handler
         # so all existing methods that reference self._tts_pipeline keep working.
         self._voice_orchestrator = VoiceOrchestrator(self)
-    
+        self._wire_stt_runtime()
+
+    def _flow_stt_language_code(self) -> Optional[str]:
+        """Read optional STT language override from call flow settings JSON."""
+        if not self.call_session or not self.call_session.call_flow_id:
+            return None
+        try:
+            from app.models.call_flow import CallFlow
+
+            flow = (
+                self.db.query(CallFlow)
+                .filter(
+                    CallFlow.id == self.call_session.call_flow_id,
+                    CallFlow.is_deleted == False,  # noqa: E712
+                )
+                .first()
+            )
+            if not flow or not isinstance(flow.settings, dict):
+                return None
+            raw = flow.settings.get("sttLanguageCode") or flow.settings.get(
+                "stt_language_code"
+            )
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+        except Exception as exc:
+            logger.debug("Could not load call flow STT language override: %s", exc)
+        return None
+
+    def _wire_stt_runtime(self) -> None:
+        """Resolve agent STT config and attach to VoiceOrchestrator."""
+        try:
+            flow_lang = self._flow_stt_language_code()
+            resolved = resolve_stt_runtime(
+                self.agent,
+                flow_language_code=flow_lang,
+                db=self.db,
+            )
+            self._voice_orchestrator.set_resolved_stt(resolved)
+            logger.info(
+                "[STT runtime] provider=%s model_id=%s language=%s sample_rate=%s encoding=%s",
+                resolved.provider_slug,
+                resolved.model_id,
+                resolved.language_code,
+                resolved.sample_rate_hz,
+                resolved.encoding,
+            )
+        except Exception as exc:
+            logger.warning(
+                "[STT runtime] resolve failed — Deepgram fallback: %s", exc, exc_info=True
+            )
+
     def _load_session_data(self):
         """Load call session and agent data"""
         try:
@@ -1056,10 +1106,13 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
                     await self._send_in_progress_status(transcript, confidence)
                     self._in_progress_sent = True
 
-                # Add to transcript (always)
+                # Persist redacted client speech for post-call analysis; LLM uses original below.
+                from app.core.pii_redactor import redact_pii
+
+                transcript_for_db = redact_pii(transcript)
                 await self._add_to_transcript(
                     "client",
-                    transcript,
+                    transcript_for_db if isinstance(transcript_for_db, str) else str(transcript_for_db),
                     "speech",
                     confidence,
                     defer_post_write=True,
@@ -2669,6 +2722,8 @@ async def _receive_or_stop(
             recv_task.cancel()
             return None
         return recv_task.result()
+    except WebSocketDisconnect:
+        raise
     except Exception:
         return None
 

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -419,6 +419,8 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
         self._llm_response_task: Optional[asyncio.Task] = None
         self._auto_greeting_sent = False
         self._recording_started = False
+        self._lk_caller_publisher = None
+        self._lk_agent_publisher = None
         self._screening_decline_handled = False
 
         # Deepgram can emit the same is_final twice within a short window — avoid triple LLM/transcript
@@ -801,6 +803,9 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
                 return
 
             audio_data = base64.b64decode(payload)
+            pub = self._lk_caller_publisher
+            if pub and pub.connected:
+                await pub.publish_mulaw(audio_data)
             await self._voice_orchestrator.on_audio_chunk(audio_data)
 
         except Exception as e:
@@ -2489,30 +2494,35 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
             except Exception:
                 pass
 
-            # Inbound calls use Connect/Stream, so start recording explicitly here.
-            # This enables recording-status webhook -> call_session.recording_url persistence.
-            if (
-                self.call_sid
-                and self.call_session
-                and self.call_session.call_type == "inbound"
-                and not self._recording_started
-            ):
-                try:
-                    account_sid, auth_token = get_twilio_credentials_for_call(
-                        self.db, self.call_session
-                    )
-                    started = twilio_service.start_recording_with_credentials(
-                        self.call_sid, account_sid, auth_token
-                    )
-                    if started:
-                        self._recording_started = True
-                except Exception as rec_err:
-                    logger.warning(
-                        "Could not start inbound recording (call_sid=%s, session=%s): %s",
-                        self.call_sid,
-                        self.call_session.id if self.call_session else None,
-                        rec_err,
-                    )
+            # Recording: gate on recording_enabled for this call's number.
+            if self.call_sid and self.call_session and not self._recording_started:
+                from app.services.recording_config_service import get_recording_enabled_for_call
+
+                _rec_enabled = get_recording_enabled_for_call(self.db, self.call_session)
+                if _rec_enabled:
+                    if settings.LIVEKIT_ENABLED:
+                        if self.call_session.call_type == "inbound":
+                            asyncio.create_task(self._start_livekit_recording())
+                        elif (self.call_session.call_type or "").lower() == "outbound":
+                            asyncio.create_task(self._setup_livekit_agent_publisher())
+                    elif self.call_session.call_type == "inbound":
+                        # Fallback: legacy Twilio recording when LiveKit is disabled
+                        try:
+                            account_sid, auth_token = get_twilio_credentials_for_call(
+                                self.db, self.call_session
+                            )
+                            started = twilio_service.start_recording_with_credentials(
+                                self.call_sid, account_sid, auth_token
+                            )
+                            if started:
+                                self._recording_started = True
+                        except Exception as rec_err:
+                            logger.warning(
+                                "Could not start inbound Twilio recording (call_sid=%s, session=%s): %s",
+                                self.call_sid,
+                                self.call_session.id if self.call_session else None,
+                                rec_err,
+                            )
 
             # DO NOT start credit monitoring or greeting here!
             # Wait for first media packet (user actually picks up - VAPI-style)
@@ -2660,6 +2670,108 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
         if not self._post_call_orchestration_scheduled:
             self._post_call_orchestration_scheduled = True
             asyncio.create_task(self._post_call_appointment_workflow())
+
+        try:
+            await self._teardown_livekit_recording()
+        except Exception as rec_stop_err:
+            logger.debug("LiveKit recording teardown: %s", rec_stop_err)
+
+        # Schedule GCS recording upload (non-blocking; upload service checks recording_enabled)
+        if self.call_session:
+            from app.services.call_recording_upload_service import schedule_recording_upload
+            schedule_recording_upload(self.call_session.id)
+
+    async def _setup_livekit_agent_publisher(self) -> None:
+        """Outbound LiveKit bridge: mirror agent TTS into the existing room."""
+        if not self.call_session or self._lk_agent_publisher:
+            return
+        from app.services.recording_config_service import get_recording_enabled_for_call
+        from app.voice.livekit_twilio_bridge import LiveKitTwilioPublisher
+
+        if not get_recording_enabled_for_call(self.db, self.call_session):
+            return
+
+        room_name = f"room_{self.call_session.id}"
+        self._lk_agent_publisher = LiveKitTwilioPublisher(room_name, role="agent")
+        if await self._lk_agent_publisher.connect():
+            logger.info(
+                "LiveKit agent recording publisher ready: session=%s",
+                self.call_session.id,
+            )
+
+    async def _disconnect_livekit_recording_publishers(self) -> None:
+        for attr in ("_lk_caller_publisher", "_lk_agent_publisher"):
+            pub = getattr(self, attr, None)
+            if pub:
+                try:
+                    await pub.disconnect()
+                except Exception:
+                    pass
+            setattr(self, attr, None)
+
+    async def _teardown_livekit_recording(self) -> None:
+        if not self.call_session:
+            return
+        recording_meta = (self.call_session.call_metadata or {}).get("recording")
+        if isinstance(recording_meta, dict) and recording_meta.get("egress_id"):
+            from app.services.livekit_recording_service import livekit_recording_service
+
+            await livekit_recording_service.stop_room_recording(recording_meta["egress_id"])
+        await self._disconnect_livekit_recording_publishers()
+
+    async def _start_livekit_recording(self) -> None:
+        """Inbound: create room, publish caller+agent audio, start egress."""
+        if not self.call_session or not self.agent:
+            return
+        try:
+            from app.services.gcs_recording_service import build_gcs_key
+            from app.services.livekit_recording_service import livekit_recording_service
+            from app.services.livekit_service import livekit_service
+            from app.voice.livekit_twilio_bridge import LiveKitTwilioPublisher
+
+            room_name = f"room_{self.call_session.id}"
+            await livekit_service.create_room(self.call_session.id, self.agent.id)
+
+            self._lk_caller_publisher = LiveKitTwilioPublisher(room_name, role="caller")
+            self._lk_agent_publisher = LiveKitTwilioPublisher(room_name, role="agent")
+            caller_ok = await self._lk_caller_publisher.connect()
+            agent_ok = await self._lk_agent_publisher.connect()
+            if not caller_ok or not agent_ok:
+                logger.warning(
+                    "LiveKit recording publishers failed for session %s",
+                    self.call_session.id,
+                )
+                await self._disconnect_livekit_recording_publishers()
+                return
+
+            gcs_path = build_gcs_key(
+                workspace_id=self.call_session.tenant_id,
+                call_id=self.call_session.id,
+                end_time=self.call_session.end_time,
+            )
+            egress_id = await livekit_recording_service.start_room_recording(
+                call_id=self.call_session.id,
+                workspace_id=self.call_session.tenant_id,
+                gcs_path=gcs_path,
+            )
+            if egress_id:
+                meta = dict(self.call_session.call_metadata or {})
+                meta["recording"] = {"egress_id": egress_id, "gcs_path": gcs_path}
+                self.call_session.call_metadata = meta
+                self.db.commit()
+                self._recording_started = True
+                logger.info(
+                    "LiveKit recording started: session=%s egress_id=%s",
+                    self.call_session.id,
+                    egress_id,
+                )
+        except Exception as exc:
+            logger.warning(
+                "Could not start LiveKit recording for session %s: %s",
+                self.call_session.id if self.call_session else None,
+                exc,
+            )
+            await self._disconnect_livekit_recording_publishers()
 
     def _post_call_appointment_sync(self) -> None:
         from app.db.session import SessionLocal

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -3,14 +3,21 @@ from datetime import datetime, timezone
 from fastapi import APIRouter
 
 from app.core.config import settings
+from app.services.livekit_service import livekit_service
 
 router = APIRouter()
 
 
 @router.get("/health")
-def health_check() -> dict:
+async def health_check() -> dict:
+    try:
+        livekit_status = await livekit_service.health_check()
+    except Exception:
+        livekit_status = "degraded"
+
     return {
         "status": "ok",
         "version": settings.APP_VERSION,
         "timestamp": datetime.now(timezone.utc).isoformat(),
+        "livekit": livekit_status,
     }

--- a/app/routers/internal_stt.py
+++ b/app/routers/internal_stt.py
@@ -1,0 +1,78 @@
+"""
+STT catalog API — read-only endpoints for frontend provider/model dropdowns.
+Mirrors internal_tts.py pattern.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant
+from app.models.user import User
+from app.models.stt_provider import STTProvider
+from app.models.stt_model import STTModel
+from app.services.stt_catalog_service import stt_catalog_service
+
+
+router = APIRouter()
+
+
+# ── Response schemas ──────────────────────────────────────────────────────────
+
+class STTProviderOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    slug: str
+    display_name: str
+    is_active: bool
+    supports_streaming: bool
+
+
+class STTModelOut(BaseModel):
+    """Public STT model projection — never exposes metadata_json (internal API params)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    provider_id: uuid.UUID = Field(..., serialization_alias="providerId")
+    external_model_id: str = Field(..., serialization_alias="modelId")
+    display_name: str = Field(..., serialization_alias="displayName")
+    language_code: str = Field(..., serialization_alias="languageCode")
+    sample_rate_hz: int = Field(..., serialization_alias="sampleRateHz")
+    encoding: str
+    is_active: bool = Field(..., serialization_alias="isActive")
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.get("/providers", response_model=List[STTProviderOut])
+def list_stt_providers(
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> List[STTProvider]:
+    """List active STT providers for agent configuration dropdowns."""
+    return stt_catalog_service.list_providers(db, active_only=True)
+
+
+@router.get("/providers/{provider_id}/models", response_model=List[STTModelOut])
+def list_stt_models(
+    provider_id: uuid.UUID,
+    language_code: Optional[str] = None,
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> List[STTModel]:
+    """List active STT models for a provider, optionally filtered by language_code."""
+    provider = db.query(STTProvider).filter(STTProvider.id == provider_id).first()
+    if not provider:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="STT provider not found.",
+        )
+    return stt_catalog_service.list_models(
+        db, provider_id=provider_id, language_code=language_code, active_only=True
+    )

--- a/app/routers/livekit_bridge.py
+++ b/app/routers/livekit_bridge.py
@@ -1,0 +1,140 @@
+"""
+LiveKit ↔ Twilio Media Stream bridge WebSocket.
+
+Ticket TwiML::
+    <Connect><Stream url="wss://{host}/api/v1/livekit/{roomName}"/></Connect>
+
+Twilio audio is published into the pre-provisioned LiveKit room; the same
+WebSocket also drives BidirectionalStreamHandler (STT/TTS/LLM).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import uuid
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+from app.core.logger import logger
+from app.db.session import SessionLocal
+from app.routers.bidirectional_stream import (
+    BidirectionalStreamHandler,
+    _receive_or_stop,
+)
+from app.services.call_session_service import call_session_service
+from app.services.livekit_service import livekit_service
+from app.voice.livekit_twilio_bridge import LiveKitTwilioPublisher
+
+router = APIRouter()
+
+
+def _call_session_id_from_room(room_name: str) -> uuid.UUID | None:
+    try:
+        livekit_service._validate_room_name(room_name)
+        return uuid.UUID(room_name.removeprefix("room_"))
+    except (ValueError, AttributeError):
+        return None
+
+
+@router.websocket("/{room_name}")
+async def livekit_twilio_bridge_websocket(
+    websocket: WebSocket,
+    room_name: str,
+) -> None:
+    """
+    Twilio Media Stream endpoint — bridges caller audio into LiveKit and runs
+    the voice agent on the same socket.
+    """
+    session_id = _call_session_id_from_room(room_name)
+    if session_id is None:
+        logger.warning("[LiveKitBridge] invalid room name: %s", room_name)
+        await websocket.close(code=1008, reason="Invalid room name")
+        return
+
+    try:
+        await websocket.accept()
+    except Exception as exc:
+        logger.error("[LiveKitBridge] accept failed: %s", exc)
+        return
+
+    db = SessionLocal()
+    call_session = call_session_service.get_call_session_by_id(db, session_id)
+    if not call_session:
+        logger.warning("[LiveKitBridge] no call session for room=%s", room_name)
+        await websocket.close(code=1008, reason="Call session not found")
+        db.close()
+        return
+
+    agent_id = str(call_session.agent_id)
+    call_session_id = str(call_session.id)
+
+    lk_publisher = LiveKitTwilioPublisher(room_name)
+    lk_ok = await lk_publisher.connect()
+
+    handler = BidirectionalStreamHandler(
+        websocket=websocket,
+        call_session_id=call_session_id,
+        agent_id=agent_id,
+        db=db,
+    )
+
+    logger.info(
+        "[LiveKitBridge] session=%s room=%s livekit_publish=%s",
+        call_session_id,
+        room_name,
+        lk_ok,
+    )
+
+    try:
+        while True:
+            raw = await _receive_or_stop(websocket, handler._stop_event)
+            if raw is None:
+                logger.info(
+                    "[LiveKitBridge] internal stop session=%s", call_session_id
+                )
+                break
+
+            message = json.loads(raw)
+            event = message.get("event")
+
+            if event == "start":
+                await handler.handle_start_message(message)
+            elif event == "media":
+                if lk_ok:
+                    payload = message.get("media", {}).get("payload")
+                    if payload:
+                        try:
+                            mulaw = base64.b64decode(payload)
+                            await lk_publisher.publish_mulaw(mulaw)
+                        except Exception as exc:
+                            logger.debug(
+                                "[LiveKitBridge] media decode/publish: %s", exc
+                            )
+                await handler.handle_media_message(message)
+            elif event == "stop":
+                await handler.handle_stop_message(message)
+                break
+            elif event in ("connected", "mark"):
+                pass
+
+    except WebSocketDisconnect:
+        logger.info("[LiveKitBridge] disconnected session=%s", call_session_id)
+    except Exception as exc:
+        logger.error(
+            "[LiveKitBridge] error session=%s: %s",
+            call_session_id,
+            exc,
+            exc_info=True,
+        )
+    finally:
+        try:
+            await handler._full_shutdown()
+        except Exception as exc:
+            logger.debug("[LiveKitBridge] shutdown: %s", exc)
+        await lk_publisher.disconnect()
+        try:
+            await websocket.close()
+        except Exception:
+            pass
+        db.close()

--- a/app/routers/phone_numbers.py
+++ b/app/routers/phone_numbers.py
@@ -35,6 +35,8 @@ from app.schemas.phone_number import (
     PurchasePhoneNumberRequest,
     PurchasePhoneNumberResponse,
     PhoneNumberSearchResponse,
+    NumberConfigurationRequest,
+    NumberConfigurationResponse,
 )
 from app.services.phone_number_service import phone_number_service
 from app.services.twilio_service import twilio_service
@@ -359,3 +361,55 @@ async def delete_phone_number(
     if not ok:
         raise HTTPException(status_code=404, detail="Phone number not found")
     return create_success_response({"deleted": True}, "Phone number deleted")
+
+
+# ---------------------------------------------------------------------------
+# Number Configuration — /{phone_number_id}/configuration
+# PUT  upsert recording_enabled, max_duration_seconds, business_hours
+# GET  read current configuration
+# ---------------------------------------------------------------------------
+
+
+@router.put(
+    "/{phone_number_id}/configuration",
+    response_model=SuccessResponse[NumberConfigurationResponse],
+)
+async def upsert_number_configuration(
+    phone_number_id: uuid.UUID,
+    request: NumberConfigurationRequest,
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> SuccessResponse[NumberConfigurationResponse]:
+    """Update or create the per-number configuration (recording, duration, hours)."""
+    config = phone_number_service.upsert_number_configuration(
+        db=db,
+        phone_number_id=phone_number_id,
+        tenant_id=user.current_tenant_id,
+        recording_enabled=request.recording_enabled,
+        max_duration_seconds=request.max_duration_seconds,
+        business_hours=request.business_hours.model_dump() if request.business_hours else None,
+    )
+    return create_success_response(
+        NumberConfigurationResponse.model_validate(config),
+        "Number configuration updated",
+    )
+
+
+@router.get(
+    "/{phone_number_id}/configuration",
+    response_model=SuccessResponse[NumberConfigurationResponse],
+)
+async def get_number_configuration(
+    phone_number_id: uuid.UUID,
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> SuccessResponse[NumberConfigurationResponse]:
+    """Retrieve the per-number configuration."""
+    pn = phone_number_service._require_number(db, phone_number_id, user.current_tenant_id)
+    config = pn.configuration
+    if config is None:
+        raise HTTPException(status_code=404, detail="No configuration found for this number")
+    return create_success_response(
+        NumberConfigurationResponse.model_validate(config),
+        "Number configuration retrieved",
+    )

--- a/app/routers/recordings.py
+++ b/app/routers/recordings.py
@@ -1,0 +1,99 @@
+"""
+GET /api/v1/recordings/{call_id}
+
+Returns a short-lived GCS signed URL for the call recording.
+
+404 cases:
+  - call_session not found or wrong tenant
+  - recording_enabled was false for that call's number
+  - no recording_gcs_path and recording_error=true (upload failed)
+  - no recording_gcs_path yet (not yet uploaded)
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Union
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant
+from app.core.config import settings
+from app.core.logger import logger
+from app.models.call_session import CallSession
+from app.schemas.base import SuccessResponse
+from app.schemas.recording import RecordingResponse
+from app.services.recording_config_service import get_recording_enabled_for_call
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+
+@router.get("/{call_id}", response_model=SuccessResponse[RecordingResponse])
+async def get_recording(
+    call_id: uuid.UUID,
+    principal: Union[object] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> SuccessResponse[RecordingResponse]:
+    """
+    Return a signed GCS URL for the call recording.
+
+    URL expires in {GCS_RECORDINGS_SIGNED_URL_EXPIRY_SECONDS} seconds (default 3600).
+    """
+    tenant_id = principal.current_tenant_id
+
+    # Tenant-scoped lookup
+    session = (
+        db.query(CallSession)
+        .filter(CallSession.id == call_id, CallSession.tenant_id == tenant_id)
+        .first()
+    )
+    if session is None:
+        raise HTTPException(status_code=404, detail="Recording not found")
+
+    # Check recording was enabled for this call's number
+    if not get_recording_enabled_for_call(db, session):
+        raise HTTPException(status_code=404, detail="Recording not enabled for this call")
+
+    # No path + error = upload failed
+    if not session.recording_gcs_path and session.recording_error:
+        raise HTTPException(status_code=404, detail="Recording upload failed for this call")
+
+    # No path yet = not uploaded (may still be processing)
+    if not session.recording_gcs_path:
+        raise HTTPException(status_code=404, detail="Recording not available yet")
+
+    # Generate signed URL
+    try:
+        from app.services import gcs_recording_service
+
+        signed_url = gcs_recording_service.generate_signed_url(
+            gcs_path=session.recording_gcs_path,
+            expiry_seconds=settings.GCS_RECORDINGS_SIGNED_URL_EXPIRY_SECONDS,
+        )
+    except Exception as exc:
+        logger.error(
+            "Failed to generate signed URL for session %s path %s: %s",
+            call_id,
+            session.recording_gcs_path,
+            exc,
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail="Could not generate recording URL")
+
+    # Optionally fetch file size from GCS (best-effort)
+    size: int | None = None
+    try:
+        size = gcs_recording_service.get_object_size(session.recording_gcs_path)
+    except Exception:
+        pass
+
+    return create_success_response(
+        RecordingResponse(
+            url=signed_url,
+            duration=session.duration,
+            size=size,
+        ),
+        "Recording URL generated",
+    )

--- a/app/routers/scheduled_calls.py
+++ b/app/routers/scheduled_calls.py
@@ -449,7 +449,7 @@ async def create_single_scheduled_call(
 
     **n8n → `/voice/call/initiate`:** Trello cards created for **appointment follow-up** reminders include
     `Appointment ID: <uuid>` in the card description. Pass that value as `appointment_id` in the initiate
-    JSON body (with `agentId`, `userPhoneNumber`, `tenant_id`, `user_id`, and CRM fields) so the outbound
+    JSON body (with `agentId`, `toNumber`, `tenant_id`, `user_id`, and CRM fields) so the outbound
     call runs the follow-up confirmation flow.
     """
     try:

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -465,7 +465,14 @@ async def handle_call_events_webhook(
                 maybe_update_resume_status_on_call_completed(db, call_session.id)
             except Exception as mq_exc:
                 logger.warning("Resume screening qualify on completed webhook: %s", mq_exc, exc_info=True)
-            
+
+            # Schedule GCS recording upload (non-blocking; skipped if recording_enabled=false)
+            try:
+                from app.services.call_recording_upload_service import schedule_recording_upload
+                schedule_recording_upload(call_session.id)
+            except Exception as _ru_exc:
+                logger.warning("Recording upload schedule failed: %s", _ru_exc)
+
             logger.info(f"✅ Updated call session {call_session.id} status to: {call_status} with ended_reason: hung up")
             
             # Broadcast status update to WebSocket (SINGLE COMPREHENSIVE BROADCAST)

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -70,6 +70,7 @@ router = APIRouter()
 model_service = ModelService()
 
 @router.post("/call/initiate", response_model=SuccessResponse[CallInitiateResponse])
+@router.post("/call/initiate/send", response_model=SuccessResponse[CallInitiateResponse])
 async def initiate_call(
     call_request: CallInitiateRequest,
     http_request: Request,
@@ -77,8 +78,8 @@ async def initiate_call(
     db: Session = Depends(get_db)
 ):
     """
-    Endpoint to initiate a voice call using Twilio.
-    Thin wrapper around `voice_call_service.initiate_call`.
+    Initiate an outbound voice call.
+    /call/initiate/send is an alias for backward compatibility and direct dispatch.
     """
     return await initiate_call_service(call_request, http_request, user, db)
 
@@ -225,8 +226,24 @@ async def handle_incoming_call(
         return _fallback_twiml("Sorry, we are unable to connect your call right now.")
 
 
+# Twilio CallStatus → internal lifecycle status (GAP 4).
+# "busy" maps to "no_answer" per ticket spec (both mean the callee was unreachable).
+# "in-progress" and "answered" are skipped for outbound (handled by first media packet
+# in bidirectional_stream.py); they map to "connected" for inbound/other flows.
+_TWILIO_TO_INTERNAL_STATUS: dict[str, str] = {
+    "initiated": "initiated",
+    "ringing": "ringing",
+    "in-progress": "connected",
+    "answered": "connected",
+    "completed": "completed",
+    "failed": "failed",
+    "no-answer": "no_answer",
+    "busy": "no_answer",
+}
+
+
 @router.post("/call-events", response_class=HTMLResponse, include_in_schema=False)
-@router.post("/webhook/call-events", response_class=HTMLResponse,include_in_schema=False)
+@router.post("/webhook/call-events", response_class=HTMLResponse, include_in_schema=False)
 async def handle_call_events_webhook(
     request: Request,
     agentId: Optional[str] = Query(None),
@@ -387,6 +404,7 @@ async def handle_call_events_webhook(
         # Update call session status if we have a call session and status
         # ⚠️ SKIP automatic update for "answered" and "in-progress" - handled in specific handlers below
         # "in-progress" will ONLY be set when media streaming actually starts (first media packet in bidirectional_stream.py)
+        internal_status = _TWILIO_TO_INTERNAL_STATUS.get(call_status, call_status)
         if (
             call_session
             and call_status
@@ -395,8 +413,11 @@ async def handle_call_events_webhook(
                 or direction == "inbound"
             )
         ):
-            logger.info(f"🔄 Updating call session {call_session.id} status to: {call_status}")
-            call_session.status = call_status
+            logger.info(
+                "🔄 Updating call session %s status: %s → %s",
+                call_session.id, call_status, internal_status,
+            )
+            call_session.status = internal_status
         elif call_session and call_status in ["answered", "in-progress"]:
             logger.debug(f"🔍 DEBUG: Skipping automatic status update for '{call_status}' - will be set when media streaming starts")
         
@@ -631,88 +652,38 @@ async def handle_call_events_webhook(
             
             return HTMLResponse("", media_type="application/xml")
         
-        elif call_status == "busy":
-            # Call busy - handle busy signal
-            logger.info(f"Call busy - SID: {call_sid}")
-            
-            # Broadcast call busy event (non-blocking - fire and forget)
+        elif call_status in ("busy", "no-answer"):
+            # Both busy and no-answer → internal "no_answer" (per ticket spec)
+            logger.info(f"Call {call_status} (internal: no_answer) - SID: {call_sid}")
             if call_session:
                 try:
                     asyncio.create_task(broadcast_call_status_update(
                         call_session_id=str(call_session.id),
-                        status="busy",
+                        status="no_answer",
                         metadata={
                             "call_sid": call_sid,
+                            "twilio_status": call_status,
                             "direction": direction,
                             "timestamp": datetime.now(timezone.utc).isoformat()
                         }
                     ))
-                    logger.debug(f"✅ Queued call busy event for session {call_session.id}")
-                    
-                    # Also broadcast call ended event for busy calls (non-blocking - fire and forget)
                     asyncio.create_task(broadcast_call_ended(
                         call_session_id=str(call_session.id),
-                        reason="busy",
+                        reason="no_answer",
                         duration=0,
                         metadata={
                             "call_sid": call_sid,
+                            "twilio_status": call_status,
                             "direction": direction,
                             "timestamp": datetime.now(timezone.utc).isoformat()
                         }
                     ))
-                    logger.debug(f"✅ Queued call ended (busy) event for session {call_session.id}")
                 except Exception as e:
-                    logger.error(f"❌ Failed to broadcast call busy event: {e}")
-                
-                # Stop credit monitoring when call is busy
+                    logger.error(f"❌ Failed to broadcast no_answer event: {e}")
                 try:
                     credit_service.stop_credit_monitoring(call_session.id)
-                    logger.debug(f"✅ Stopped credit monitoring for busy call session {call_session.id}")
                 except Exception as e:
                     logger.warning(f"⚠️ Failed to stop credit monitoring (non-critical): {e}")
-            
-            return HTMLResponse("", media_type="application/xml")
-        
-        elif call_status == "no-answer":
-            # Call no-answer - handle no answer
-            logger.info(f"Call no-answer - SID: {call_sid}")
-            
-            # Broadcast call no-answer event (non-blocking - fire and forget)
-            if call_session:
-                try:
-                    asyncio.create_task(broadcast_call_status_update(
-                        call_session_id=str(call_session.id),
-                        status="no-answer",
-                        metadata={
-                            "call_sid": call_sid,
-                            "direction": direction,
-                            "timestamp": datetime.now(timezone.utc).isoformat()
-                        }
-                    ))
-                    logger.debug(f"✅ Queued call no-answer event for session {call_session.id}")
-                    
-                    # Also broadcast call ended event for no-answer calls (non-blocking - fire and forget)
-                    asyncio.create_task(broadcast_call_ended(
-                        call_session_id=str(call_session.id),
-                        reason="no-answer",
-                        duration=0,
-                        metadata={
-                            "call_sid": call_sid,
-                            "direction": direction,
-                            "timestamp": datetime.now(timezone.utc).isoformat()
-                        }
-                    ))
-                    logger.debug(f"✅ Queued call ended (no-answer) event for session {call_session.id}")
-                except Exception as e:
-                    logger.error(f"❌ Failed to broadcast call no-answer event: {e}")
-                
-                # Stop credit monitoring when call has no-answer
-                try:
-                    credit_service.stop_credit_monitoring(call_session.id)
-                    logger.debug(f"✅ Stopped credit monitoring for no-answer call session {call_session.id}")
-                except Exception as e:
-                    logger.warning(f"⚠️ Failed to stop credit monitoring (non-critical): {e}")
-            
             return HTMLResponse("", media_type="application/xml")
         
         else:

--- a/app/routers/voice_gather.py
+++ b/app/routers/voice_gather.py
@@ -682,34 +682,55 @@ async def streaming_greeting_webhook(
         
         # ✅ User answered! Return streaming TwiML
         logger.info(f"✅ Call answered (status: '{call_status}') - Starting streaming!")
-        
-        # Build WebSocket URL for bidirectional streaming
-        ws_protocol = "wss" if "https" in settings.WEBHOOK_BASE_URL else "ws"
-        ws_base = settings.WEBHOOK_BASE_URL.replace("https://", "").replace("http://", "")
-        ws_url = f"{ws_protocol}://{ws_base}/api/v1/stream/ws/bidirectional/{callSessionId}/{agentId}"
-        
-        # Create TwiML response with bidirectional streaming
-        response = VoiceResponse()
-        
-        # Start bidirectional media stream
+
         from twilio.twiml.voice_response import Connect, Stream
-        
-        # DIRECT STREAM - User answered, connect now!
+
+        ws_url: str | None = None
+        if settings.LIVEKIT_ENABLED and callSessionId:
+            try:
+                session_uuid = uuid.UUID(callSessionId)
+                cs = call_session_service.get_call_session_by_id(db, session_uuid)
+                if cs and cs.call_metadata and "livekit" in cs.call_metadata:
+                    room_name = (cs.call_metadata["livekit"] or {}).get("room_name")
+                    if room_name:
+                        from app.voice.livekit_twilio_bridge import (
+                            build_livekit_stream_ws_url,
+                        )
+
+                        ws_url = build_livekit_stream_ws_url(room_name)
+                        logger.info(
+                            "LiveKit bridge TwiML for session %s → %s",
+                            callSessionId,
+                            ws_url,
+                        )
+            except Exception as lk_exc:
+                logger.warning(
+                    "LiveKit stream URL resolution failed (fallback to bidirectional): %s",
+                    lk_exc,
+                )
+
+        if not ws_url:
+            ws_protocol = "wss" if "https" in settings.WEBHOOK_BASE_URL else "ws"
+            ws_base = settings.WEBHOOK_BASE_URL.replace("https://", "").replace(
+                "http://", ""
+            )
+            ws_url = (
+                f"{ws_protocol}://{ws_base}/api/v1/stream/ws/bidirectional/"
+                f"{callSessionId}/{agentId}"
+            )
+
+        response = VoiceResponse()
         connect = Connect()
         stream = Stream(url=ws_url)
-        
-        # Add essential parameters only
         stream.parameter(name="callSid", value=call_sid)
         stream.parameter(name="agentId", value=agentId)
         stream.parameter(name="callSessionId", value=callSessionId)
-        
         connect.append(stream)
         response.append(connect)
-        
-        logger.info(f"⚡ Streaming TwiML returned - User answered, connecting WebSocket!")
-        logger.debug(f"🔗 WebSocket: {ws_url}")
-        
-        # RETURN STREAMING TWIML - User has answered!
+
+        logger.info("⚡ Streaming TwiML returned - User answered, connecting WebSocket!")
+        logger.debug("🔗 WebSocket: %s", ws_url)
+
         return HTMLResponse(str(response), media_type="application/xml")
     
     except Exception as e:

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -16,6 +16,10 @@ _TTS_SLUG_ALIASES: dict[str, str] = {
     "11labs_byo": "elevenlabs_byo",
 }
 
+_DEFAULT_STT_PROVIDER = "deepgram"
+_DEFAULT_STT_MODEL_ID = "nova-3"
+_DEFAULT_STT_LANGUAGE_CODE = "en"
+
 
 class LanguageEnum(str, Enum):
     en = "en"
@@ -56,6 +60,52 @@ def tts_slug_to_api_provider(slug: str) -> TtsProviderEnum:
     """Map stored slug to API enum (supports legacy rows)."""
     canonical = normalize_tts_provider_slug(slug)
     return TtsProviderEnum(canonical)
+
+
+class SttProviderEnum(str, Enum):
+    deepgram = "deepgram"
+    google = "google"
+    elevenlabs = "elevenlabs"
+
+
+class SttModelSchema(BaseModel):
+    """Ticket ``sttModel`` fragment — validated against STT catalog in service layer."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    provider: SttProviderEnum
+    model_id: str = Field(..., min_length=1, max_length=255, alias="modelId")
+    language_code: str = Field(..., min_length=2, max_length=20, alias="languageCode")
+
+    @field_validator("model_id")
+    @classmethod
+    def _strip_model_id(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("must not be blank")
+        return cleaned
+
+    @field_validator("language_code")
+    @classmethod
+    def _strip_language_code(cls, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            raise ValueError("must not be blank")
+        return cleaned
+
+
+class SttSettingsJsonSchema(BaseModel):
+    """Optional STT tuning stored on ``agent.stt_settings_json``."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    silence_threshold_ms: Optional[int] = Field(
+        default=1500,
+        ge=300,
+        le=5000,
+        alias="silenceThresholdMs",
+        description="Silence duration (ms) before isSilence=true is emitted.",
+    )
 
 
 class TtsSettingsJsonSchema(BaseModel):
@@ -116,6 +166,19 @@ class AgentCreate(BaseModel):
     name: str = Field(..., min_length=3, max_length=80)
     llm_model: str = Field(..., min_length=1, max_length=100, alias="llmModel")
     tts_model: TtsModelSchema = Field(..., alias="ttsModel")
+    stt_model: Optional[SttModelSchema] = Field(
+        default=None,
+        alias="sttModel",
+        description=(
+            "STT provider + model. Defaults to deepgram/nova-3/en when omitted. "
+            "Use provider='google', modelId='chirp-3', languageCode='en-AU' for Google STT."
+        ),
+    )
+    stt_settings: Optional[SttSettingsJsonSchema] = Field(
+        default=None,
+        alias="sttSettings",
+        description="Optional STT tuning (e.g. silenceThresholdMs).",
+    )
     status: AgentStatusEnum = AgentStatusEnum.pending
     eleven_labs_api_key: Optional[str] = Field(
         default=None,
@@ -179,6 +242,8 @@ class AgentUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=3, max_length=80)
     llm_model: Optional[str] = Field(None, min_length=1, max_length=100, alias="llmModel")
     tts_model: Optional[TtsModelSchema] = Field(None, alias="ttsModel")
+    stt_model: Optional[SttModelSchema] = Field(None, alias="sttModel")
+    stt_settings: Optional[SttSettingsJsonSchema] = Field(None, alias="sttSettings")
     status: Optional[AgentStatusEnum] = None
     eleven_labs_api_key: Optional[str] = Field(
         default=None,
@@ -247,6 +312,7 @@ class AgentOut(BaseModel):
     name: str
     llm_model: Optional[str] = Field(default=None, serialization_alias="llmModel")
     tts_model: Optional[TtsModelSchema] = Field(default=None, serialization_alias="ttsModel")
+    stt_model: Optional[SttModelSchema] = Field(default=None, serialization_alias="sttModel")
     status: AgentStatusEnum
     created_at: datetime = Field(..., serialization_alias="createdAt")
     updated_at: Optional[datetime] = Field(default=None, serialization_alias="updatedAt")
@@ -260,7 +326,7 @@ class AgentOut(BaseModel):
 
 
 def agent_to_out(agent: Agent) -> AgentOut:
-    """Map ORM row to response; omit ``encrypted_elevenlabs_api_key``."""
+    """Map ORM row to response; omit ``encrypted_elevenlabs_api_key`` and catalog UUIDs."""
     tts_model: Optional[TtsModelSchema] = None
     if agent.tts_provider_slug and agent.tts_voice_external_id and agent.tts_language:
         try:
@@ -272,6 +338,17 @@ def agent_to_out(agent: Agent) -> AgentOut:
         except ValueError:
             tts_model = None
 
+    stt_model: Optional[SttModelSchema] = None
+    if agent.stt_provider_slug and agent.stt_model_external_id and agent.stt_language_code:
+        try:
+            stt_model = SttModelSchema(
+                provider=SttProviderEnum(agent.stt_provider_slug),
+                model_id=agent.stt_model_external_id,
+                language_code=agent.stt_language_code,
+            )
+        except ValueError:
+            stt_model = None
+
     try:
         status = AgentStatusEnum(agent.status or "pending")
     except ValueError:
@@ -282,6 +359,7 @@ def agent_to_out(agent: Agent) -> AgentOut:
         name=agent.name,
         llm_model=agent.llm_model,
         tts_model=tts_model,
+        stt_model=stt_model,
         status=status,
         created_at=agent.created_at,
         updated_at=agent.updated_at,

--- a/app/schemas/recording.py
+++ b/app/schemas/recording.py
@@ -1,0 +1,15 @@
+"""Recording API schemas — Pydantic v2."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class RecordingResponse(BaseModel):
+    """Response for GET /api/v1/recordings/{call_id}."""
+
+    url: str = Field(..., description="GCS signed URL (expires in 1 hour)")
+    duration: Optional[int] = Field(None, description="Call duration in seconds")
+    size: Optional[int] = Field(None, description="Recording file size in bytes")

--- a/app/schemas/twilio.py
+++ b/app/schemas/twilio.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from typing import List, Optional, Dict, Any
 
 
@@ -61,7 +61,9 @@ class AccountInfo(BaseModel):
 # Voice call initiation schemas
 class CallInitiateRequest(BaseModel):
     agentId: str
-    userPhoneNumber: str
+    toNumber: str
+    # Explicit caller ID — if provided, must match the agent's bound active phone number.
+    fromNumber: Optional[str] = None
     phone_number_id: Optional[str] = None  # Optional, user ka selected phone number ID (VAPI style)
     jd_context: Optional[Dict[str, Any]] = None  # Optional JD payload from scheduler/n8n
     # Optional: resolve resume + job from DB and enrich the agent prompt (same as jd_context.jd_id / resume_id)
@@ -70,13 +72,13 @@ class CallInitiateRequest(BaseModel):
     appointment_id: Optional[str] = None  # Follow-up reminder: n8n / Trello → initiate
     tenant_id: Optional[str] = None  # Required when using webhook secret (n8n)
     user_id: Optional[str] = None  # Optional, for n8n webhook calls
-    
+
     # Legacy Monday.com fields (for backward compatibility)
     board_id: Optional[str] = None  # Optional, Monday.com board ID from n8n workflow (legacy)
     monday_item_id: Optional[str] = None  # Optional, Monday.com item ID from n8n workflow (legacy)
     status_column_id: Optional[str] = None  # Optional, Monday.com status column ID from n8n workflow (legacy)
     call_session_id_column_id: Optional[str] = None  # Optional, Monday.com call_session_id column ID from n8n workflow (legacy)
-    
+
     # Generic CRM fields (for multi-CRM support)
     crm_container_id: Optional[str] = None  # Generic: board_id/list_id/project_id from n8n workflow
     crm_item_id: Optional[str] = None  # Generic: item_id/task_id/issue_id/card_id from n8n workflow
@@ -84,6 +86,32 @@ class CallInitiateRequest(BaseModel):
     call_session_id_field_id: Optional[str] = None  # Generic: call_session_id field ID from n8n workflow
     crm_type: Optional[str] = None  # "monday" | "clickup" | "jira" | "trello" from n8n workflow
     callFlowId: Optional[str] = None  # Optional UUID — binds this call session to a CallFlow
+
+    @field_validator("toNumber")
+    @classmethod
+    def validate_to_number(cls, v: str) -> str:
+        from app.schemas.phone_number import _validate_e164
+
+        try:
+            return _validate_e164(v.strip())
+        except ValueError:
+            raise ValueError(
+                f"Invalid destination phone number '{v}'. Must be E.164 format (e.g. +15551234567)"
+            )
+
+    @field_validator("fromNumber")
+    @classmethod
+    def validate_from_number(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        from app.schemas.phone_number import _validate_e164
+
+        try:
+            return _validate_e164(v.strip())
+        except ValueError:
+            raise ValueError(
+                f"Invalid fromNumber '{v}'. Must be E.164 format (e.g. +15550000000)"
+            )
 
 
 class CallInitiateResponse(BaseModel):

--- a/app/schemas/twilio.py
+++ b/app/schemas/twilio.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
-import uuid
 
 
 # Phone number management schemas
@@ -84,6 +83,7 @@ class CallInitiateRequest(BaseModel):
     status_field_id: Optional[str] = None  # Generic: status column/field ID from n8n workflow
     call_session_id_field_id: Optional[str] = None  # Generic: call_session_id field ID from n8n workflow
     crm_type: Optional[str] = None  # "monday" | "clickup" | "jira" | "trello" from n8n workflow
+    callFlowId: Optional[str] = None  # Optional UUID — binds this call session to a CallFlow
 
 
 class CallInitiateResponse(BaseModel):

--- a/app/services/agent_service.py
+++ b/app/services/agent_service.py
@@ -10,6 +10,8 @@ from app.models.knowledge_base_document import KnowledgeBaseDocument
 from app.models.business_knowledge import BusinessKnowledge
 from app.models.tts_provider import TTSProvider
 from app.models.tts_voice import TTSVoice
+from app.models.stt_provider import STTProvider
+from app.models.stt_model import STTModel
 from app.schemas.agent import (
     AgentCreate,
     AgentUpdate,
@@ -17,6 +19,11 @@ from app.schemas.agent import (
     AgentStatusEnum,
     TtsModelSchema,
     TtsProviderEnum,
+    SttModelSchema,
+    SttProviderEnum,
+    _DEFAULT_STT_PROVIDER,
+    _DEFAULT_STT_MODEL_ID,
+    _DEFAULT_STT_LANGUAGE_CODE,
     agent_to_out,
     normalize_tts_provider_slug,
 )
@@ -118,6 +125,65 @@ class AgentService:
             "tts_voice_id": voice.id,
         }
 
+    def _resolve_stt_model(
+        self,
+        db: Session,
+        stt: Optional[SttModelSchema],
+    ) -> Dict[str, Any]:
+        """Validate and resolve STT provider + model to DB FK ids + slug triad.
+
+        Falls back to deepgram/nova-3/en when stt is None (backward compat).
+        modelId is the user-facing ID (e.g. 'nova-3', 'chirp-3'), never 'phone_call'.
+        """
+        if stt is None:
+            slug = _DEFAULT_STT_PROVIDER
+            model_id_str = _DEFAULT_STT_MODEL_ID
+            lang = _DEFAULT_STT_LANGUAGE_CODE
+        else:
+            slug = stt.provider.value
+            model_id_str = stt.model_id
+            lang = stt.language_code
+
+        provider = (
+            db.query(STTProvider)
+            .filter(
+                STTProvider.slug == slug,
+                STTProvider.is_active == True,  # noqa: E712
+            )
+            .first()
+        )
+        if not provider:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid sttModel.provider '{slug}'. Provider not found or inactive.",
+            )
+
+        model = (
+            db.query(STTModel)
+            .filter(
+                STTModel.provider_id == provider.id,
+                STTModel.external_model_id == model_id_str,
+                STTModel.is_active == True,  # noqa: E712
+            )
+            .first()
+        )
+        if not model:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Invalid sttModel.modelId '{model_id_str}' "
+                    f"for provider '{slug}'. Not found or inactive."
+                ),
+            )
+
+        return {
+            "stt_provider_slug": slug,
+            "stt_model_external_id": model_id_str,
+            "stt_language_code": lang,
+            "stt_provider_id": provider.id,
+            "stt_model_id": model.id,
+        }
+
     def _encrypt_byo_key(self, raw_key: str, db: Session) -> str:
         try:
             return encrypt_elevenlabs_key(raw_key, db)
@@ -131,16 +197,22 @@ class AgentService:
     def _ticket_payload_from_create(self, db: Session, agent_in: AgentCreate) -> Dict[str, Any]:
         model = self._resolve_llm_model(db, agent_in.llm_model)
         tts_fields = self._resolve_tts_model(db, agent_in.tts_model)
+        stt_fields = self._resolve_stt_model(db, agent_in.stt_model)
         encrypted_key: Optional[str] = None
         if agent_in.tts_model.provider == TtsProviderEnum.elevenlabs_byo:
             encrypted_key = self._encrypt_byo_key(agent_in.eleven_labs_api_key or "", db)
+        stt_settings: Optional[Dict[str, Any]] = None
+        if agent_in.stt_settings is not None:
+            stt_settings = agent_in.stt_settings.model_dump(by_alias=False, exclude_none=True)
         return {
             "llm_model": model.model_name,
             "model_id": model.id,
             "provider_id": model.provider_id,
             "status": agent_in.status.value,
             "encrypted_elevenlabs_api_key": encrypted_key,
+            "stt_settings_json": stt_settings,
             **tts_fields,
+            **stt_fields,
         }
 
     def _apply_ticket_update(
@@ -161,6 +233,12 @@ class AgentService:
             update_dict.update(self._resolve_tts_model(db, agent_in.tts_model))
             if agent_in.tts_model.provider != TtsProviderEnum.elevenlabs_byo:
                 update_dict["encrypted_elevenlabs_api_key"] = None
+        if agent_in.stt_model is not None:
+            update_dict.update(self._resolve_stt_model(db, agent_in.stt_model))
+        if agent_in.stt_settings is not None:
+            update_dict["stt_settings_json"] = agent_in.stt_settings.model_dump(
+                by_alias=False, exclude_none=True
+            )
         if agent_in.eleven_labs_api_key is not None:
             update_dict["encrypted_elevenlabs_api_key"] = self._encrypt_byo_key(
                 agent_in.eleven_labs_api_key, db
@@ -439,7 +517,7 @@ class AgentService:
 
         # Sanitize string fields (exclude ticket-only nested objects)
         agent_data = agent_in.model_dump(
-            exclude={"tts_model", "eleven_labs_api_key", "llm_model", "status"}
+            exclude={"tts_model", "stt_model", "stt_settings", "eleven_labs_api_key", "llm_model", "status"}
         )
         agent_data.update(ticket_data)
         for field in ['name', 'system_prompt', 'fallback_response', 'greeting_message']:
@@ -568,7 +646,7 @@ class AgentService:
 
         update_dict = agent_update.model_dump(
             exclude_unset=True,
-            exclude={"tts_model", "eleven_labs_api_key", "llm_model", "status"},
+            exclude={"tts_model", "stt_model", "stt_settings", "eleven_labs_api_key", "llm_model", "status"},
         )
         self._apply_ticket_update(db, agent_update, agent, update_dict)
 

--- a/app/services/call_recording_upload_service.py
+++ b/app/services/call_recording_upload_service.py
@@ -1,0 +1,233 @@
+"""
+Call Recording Upload Service — post-call async GCS upload job.
+
+Follows the same pattern as inbound_call_crm_sync_service:
+  schedule_recording_upload() → asyncio.create_task() → run_in_executor()
+
+Flow:
+  1. Load call_session
+  2. Skip if recording not enabled / already has a path / egress_id missing
+  3. Check LiveKit egress status (COMPLETE)
+  4. Update GCS object metadata (callId, workspaceId, agentId, duration)
+  5. On success: set recording_gcs_path, clear recording_error
+  6. On failure: log error, set recording_error=True — no auto-retry in Sprint 2
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Optional
+
+from app.core.logger import logger
+
+
+def schedule_recording_upload(call_session_id: uuid.UUID) -> None:
+    """
+    Fire-and-forget: schedule GCS upload after call ends.
+
+    Mirrors schedule_inbound_crm_sync() in inbound_call_crm_sync_service.
+    Called from bidirectional_stream._full_shutdown() and
+    voice.handle_call_events_webhook (status=completed).
+    """
+    asyncio.create_task(_upload_recording_task(call_session_id))
+
+
+async def _upload_recording_task(call_session_id: uuid.UUID) -> None:
+    try:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _upload_recording_sync, call_session_id)
+    except Exception as exc:
+        logger.error(
+            "Recording upload task failed for session %s: %s",
+            call_session_id,
+            exc,
+            exc_info=True,
+        )
+
+
+def _upload_recording_sync(call_session_id: uuid.UUID) -> None:
+    """
+    Synchronous upload worker — runs in executor so it doesn't block the event loop.
+
+    Uses its own DB session (same pattern as _post_call_appointment_sync).
+    """
+    from app.db.session import SessionLocal
+    from app.models.call_session import CallSession
+    from app.services.recording_config_service import get_recording_enabled_for_call
+
+    db = SessionLocal()
+    try:
+        session: Optional[CallSession] = db.get(CallSession, call_session_id)
+        if session is None:
+            logger.warning("Recording upload: call_session %s not found", call_session_id)
+            return
+
+        # Skip if recording was not enabled for this call's number
+        if not get_recording_enabled_for_call(db, session):
+            logger.debug(
+                "Recording upload: recording_enabled=false for session %s — skipping",
+                call_session_id,
+            )
+            return
+
+        # Skip if already uploaded
+        if session.recording_gcs_path:
+            logger.debug(
+                "Recording upload: session %s already has recording_gcs_path — skipping",
+                call_session_id,
+            )
+            return
+
+        # Retrieve egress_id stored during recording start
+        recording_meta = _get_recording_meta(session)
+        egress_id = recording_meta.get("egress_id") if recording_meta else None
+        gcs_path = recording_meta.get("gcs_path") if recording_meta else None
+
+        if not egress_id or not gcs_path:
+            logger.info(
+                "Recording upload: no egress_id/gcs_path for session %s — skipping",
+                call_session_id,
+            )
+            return
+
+        # Check LiveKit egress completed
+        _check_and_finalize(db, session, egress_id, gcs_path)
+
+    except Exception as exc:
+        logger.error(
+            "Recording upload sync error for session %s: %s",
+            call_session_id,
+            exc,
+            exc_info=True,
+        )
+    finally:
+        db.close()
+
+
+def _get_recording_meta(session) -> Optional[dict]:
+    """Extract the recording sub-dict from call_session.call_metadata."""
+    meta = session.call_metadata
+    if not isinstance(meta, dict):
+        return None
+    return meta.get("recording")
+
+
+def _check_and_finalize(db, session, egress_id: str, gcs_path: str) -> None:
+    """
+    Poll LiveKit egress status synchronously (blocking) and finalize the recording.
+
+    LiveKit egress should be COMPLETE shortly after call end.  We do a single
+    status check; if FAILED/ABORTED, record the error.  If still in progress,
+    we log a warning — no retry in Sprint 2.
+    """
+    from app.services import gcs_recording_service
+
+    # We need an async loop to call LiveKit's async API from sync context.
+    try:
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(_stop_egress_async(egress_id))
+        loop.run_until_complete(asyncio.sleep(1.5))
+        egress_info = loop.run_until_complete(_fetch_egress_info_async(egress_id))
+    except Exception as exc:
+        logger.error("Failed to fetch LiveKit egress info for %s: %s", egress_id, exc)
+        _mark_recording_error(db, session)
+        return
+    finally:
+        try:
+            loop.close()
+        except Exception:
+            pass
+
+    if egress_info is None:
+        logger.warning("LiveKit egress %s not found — marking recording_error", egress_id)
+        _mark_recording_error(db, session)
+        return
+
+    # Use integer constants to avoid importing livekit.api at the top of this file.
+    # EGRESS_COMPLETE=3, EGRESS_FAILED=4, EGRESS_ABORTED=5
+    # These are stable protobuf enum values from livekit-protocol.
+    _EGRESS_COMPLETE = 3
+    _EGRESS_FAILED = 4
+    _EGRESS_ABORTED = 5
+
+    status = egress_info.status
+
+    if status in (_EGRESS_FAILED, _EGRESS_ABORTED):
+        logger.error(
+            "LiveKit egress %s failed/aborted (status=%s) for session %s",
+            egress_id,
+            status,
+            session.id,
+        )
+        _mark_recording_error(db, session)
+        return
+
+    if status != _EGRESS_COMPLETE:
+        logger.warning(
+            "LiveKit egress %s status=%s for session %s — not yet complete, no retry in Sprint 2",
+            egress_id,
+            status,
+            session.id,
+        )
+        _mark_recording_error(db, session)
+        return
+
+    # Egress COMPLETE — update GCS metadata then mark DB
+    try:
+        metadata = {
+            "callId": str(session.id),
+            "workspaceId": str(session.tenant_id),
+            "agentId": str(session.agent_id),
+            "duration": str(session.duration or ""),
+        }
+        gcs_recording_service.update_object_metadata(gcs_path, metadata)
+    except Exception as exc:
+        logger.warning(
+            "GCS metadata update failed for %s: %s (continuing — path will still be set)",
+            gcs_path,
+            exc,
+        )
+
+    # Update DB record
+    try:
+        session.recording_gcs_path = gcs_path
+        session.recording_error = False
+        db.commit()
+        logger.info(
+            "Recording finalized: session=%s gcs_path=%s",
+            session.id,
+            gcs_path,
+        )
+    except Exception as exc:
+        logger.error(
+            "DB update failed for recording session %s: %s",
+            session.id,
+            exc,
+            exc_info=True,
+        )
+        db.rollback()
+
+
+async def _fetch_egress_info_async(egress_id: str):
+    """Async helper to fetch LiveKit egress info."""
+    from app.services.livekit_recording_service import livekit_recording_service
+
+    return await livekit_recording_service.get_egress_info(egress_id)
+
+
+async def _stop_egress_async(egress_id: str) -> None:
+    """Ensure egress is stopped before polling completion status."""
+    from app.services.livekit_recording_service import livekit_recording_service
+
+    await livekit_recording_service.stop_room_recording(egress_id)
+
+
+def _mark_recording_error(db, session) -> None:
+    """Set recording_error=True on the call_session.  No retry in Sprint 2."""
+    try:
+        session.recording_error = True
+        db.commit()
+    except Exception as exc:
+        logger.error("Failed to set recording_error for session %s: %s", session.id, exc)
+        db.rollback()

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -22,11 +22,13 @@ from app.services.inbound_call_crm_sync_service import (
 class CallSessionService:
     """Service class for handling call session operations"""
     
-    def create_call_session(self, db: Session, user_id: uuid.UUID, agent_id: uuid.UUID, 
+    def create_call_session(self, db: Session, user_id: uuid.UUID, agent_id: uuid.UUID,
                            tenant_id: uuid.UUID, twilio_call_sid: str = None,
                            from_number: str = None, to_number: str = None,
                            call_type: str = "inbound", assistant_phone_number: str = None,
-                           customer_phone_number: str = None) -> CallSession:
+                           customer_phone_number: str = None,
+                           session_id: Optional[uuid.UUID] = None,
+                           status: str = "active") -> CallSession:
         """
         Create a new call session and associated call log
         
@@ -47,11 +49,12 @@ class CallSessionService:
         """
         
         call_session = CallSession(
+            id=session_id if session_id is not None else uuid.uuid4(),
             user_id=user_id,
             agent_id=agent_id,
             tenant_id=tenant_id,
             start_time=datetime.utcnow(),
-            status="active",
+            status=status,
             call_type=call_type,
             twilio_call_sid=twilio_call_sid,
             from_number=from_number,
@@ -195,7 +198,7 @@ class CallSessionService:
                 if transferred is not None:
                     call_session.transferred = transferred
                 
-                if status in ["completed", "failed", "busy"]:
+                if status in ["completed", "failed", "busy", "no_answer"]:
                     call_session.end_time = datetime.now(timezone.utc)
                     if call_session.start_time:
                         duration = (call_session.end_time - call_session.start_time).total_seconds()

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -311,7 +311,7 @@ class CreditService:
                     break
                 
                 # Only deduct for active call statuses
-                if call_session.status not in ["active", "in-progress", "answered"]:
+                if call_session.status not in ["active", "in-progress", "connected", "answered"]:
                     # Call ended - do final deduction for remaining time
                     await self._finalize_call_credits(
                         db, call_session_id, tenant_id, model_name, credits_per_minute, call_session

--- a/app/services/gcs_recording_service.py
+++ b/app/services/gcs_recording_service.py
@@ -1,0 +1,120 @@
+"""
+GCS Recording Service — upload call recordings and generate signed URLs.
+
+Credentials are loaded via ADC (GOOGLE_APPLICATION_CREDENTIALS) using the
+same pattern as GoogleSttService and VertexGeminiService.
+
+# Infra: GCS lifecycle rule deletes recordings/ prefix objects after 90 days.
+# Apply the following lifecycle condition to the bucket via Terraform or gcloud:
+#   condition: { age: 90, matchesPrefix: ["recordings/"] }
+#   action: { type: "Delete" }
+
+# Sprint 5: use CMEK encryption key for HIPAA tenants (customer-managed encryption).
+# Wire the key ARN via GCS_CMEK_KEY_NAME env var and pass kms_key_name to blob.rewrite().
+"""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+from typing import Optional
+
+from app.core.config import settings
+from app.core.logger import logger
+
+
+def _get_gcs_client():
+    """Return an authenticated GCS client using ADC."""
+    from google.cloud import storage  # type: ignore
+
+    return storage.Client()
+
+
+def build_gcs_key(workspace_id: uuid.UUID, call_id: uuid.UUID, end_time: Optional[datetime.datetime] = None) -> str:
+    """Return the canonical GCS object key for a call recording."""
+    date_str = (end_time or datetime.datetime.now(datetime.timezone.utc)).strftime("%Y%m%d")
+    return f"{settings.GCS_RECORDINGS_PREFIX}/{workspace_id}/{call_id}/{date_str}.opus"
+
+
+def upload_recording(
+    key: str,
+    file_bytes: bytes,
+    metadata: dict,
+    content_type: str = "audio/ogg; codecs=opus",
+) -> str:
+    """
+    Upload an Opus recording to GCS and set custom metadata.
+
+    Returns the full GCS path (key) after a successful upload.
+    Raises on any GCS error — caller is responsible for error handling.
+    """
+    from google.cloud import storage  # type: ignore
+
+    client = _get_gcs_client()
+    bucket = client.bucket(settings.GCS_RECORDINGS_BUCKET)
+    blob = bucket.blob(key)
+
+    # Custom metadata: callId, workspaceId, agentId, duration
+    blob.metadata = {str(k): str(v) for k, v in metadata.items() if v is not None}
+    blob.upload_from_string(file_bytes, content_type=content_type)
+
+    logger.info("GCS upload complete: gs://%s/%s (%d bytes)", settings.GCS_RECORDINGS_BUCKET, key, len(file_bytes))
+    return key
+
+
+def update_object_metadata(key: str, metadata: dict) -> None:
+    """Patch custom metadata on an already-uploaded GCS object."""
+    from google.cloud import storage  # type: ignore
+
+    client = _get_gcs_client()
+    bucket = client.bucket(settings.GCS_RECORDINGS_BUCKET)
+    blob = bucket.get_blob(key)
+    if blob is None:
+        logger.warning("GCS patch_metadata: object not found: %s", key)
+        return
+    blob.metadata = {str(k): str(v) for k, v in metadata.items() if v is not None}
+    blob.patch()
+    logger.debug("GCS metadata updated: %s", key)
+
+
+def get_object_size(key: str) -> Optional[int]:
+    """Return the size in bytes of a GCS object, or None if not found."""
+    from google.cloud import storage  # type: ignore
+
+    client = _get_gcs_client()
+    bucket = client.bucket(settings.GCS_RECORDINGS_BUCKET)
+    blob = bucket.get_blob(key)
+    return blob.size if blob else None
+
+
+def generate_signed_url(
+    gcs_path: str,
+    expiry_seconds: int = settings.GCS_RECORDINGS_SIGNED_URL_EXPIRY_SECONDS,
+) -> str:
+    """
+    Generate a short-lived V4 signed URL for direct client download.
+
+    Requires a service account with roles/storage.objectViewer.
+    Uses service account credentials from GOOGLE_APPLICATION_CREDENTIALS (ADC).
+
+    # Sprint 5: for HIPAA tenants, ensure the bucket uses CMEK encryption.
+    """
+    import google.auth  # type: ignore
+    from google.auth.transport import requests as google_requests  # type: ignore
+    from google.cloud import storage  # type: ignore
+
+    credentials, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+    # Refresh credentials so we have a valid access token for signing.
+    credentials.refresh(google_requests.Request())
+
+    client = storage.Client(credentials=credentials)
+    bucket = client.bucket(settings.GCS_RECORDINGS_BUCKET)
+    blob = bucket.blob(gcs_path)
+
+    url = blob.generate_signed_url(
+        version="v4",
+        expiration=datetime.timedelta(seconds=expiry_seconds),
+        method="GET",
+        credentials=credentials,
+    )
+    return url

--- a/app/services/google_stt_service.py
+++ b/app/services/google_stt_service.py
@@ -1,0 +1,387 @@
+"""
+Google Cloud Speech-to-Text v1p1beta1 streaming service.
+
+Authentication: Application Default Credentials (ADC) or GOOGLE_APPLICATION_CREDENTIALS
+(JSON content / file path). Workload Identity in GKE uses ADC with no env set.
+
+Catalog display model "chirp-3" maps to API model "phone_call" via metadata_json.google_model.
+
+Stream auto-restarts at the Google-imposed 5-minute limit with buffered audio replay.
+Recoverable errors (quota, transient network) trigger bounded automatic restarts.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import queue
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from app.core.config import settings
+from app.core.logger import logger
+
+_STREAM_RESTART_SECONDS = 290  # restart before Google's ~305s hard limit
+_AUDIO_BUFFER_MAX_BYTES = 1_024 * 1_024
+_MAX_ERROR_RESTARTS = 3
+_ERROR_RESTART_WINDOW_SEC = 60.0
+_ERROR_BACKOFF_SEC = 0.75
+
+
+class GoogleSttService:
+    """Service for Google Cloud STT v1p1beta1 bidirectional streaming."""
+
+    def __init__(self) -> None:
+        self._credentials_initialized = False
+        self._auth_mode_logged = False
+
+    def _initialize_credentials(self) -> None:
+        """Resolve credentials for SpeechClient (ADC or service account file)."""
+        if self._credentials_initialized:
+            return
+        import json
+        import tempfile
+
+        creds_env = (settings.GOOGLE_APPLICATION_CREDENTIALS or "").strip()
+        auth_mode = "ADC"
+        if creds_env:
+            try:
+                json.loads(creds_env)
+                with tempfile.NamedTemporaryFile(
+                    mode="w", delete=False, suffix=".json"
+                ) as f:
+                    f.write(creds_env)
+                    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = f.name
+                auth_mode = "service_account_json_env"
+            except (json.JSONDecodeError, ValueError):
+                if os.path.exists(creds_env):
+                    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = creds_env
+                    auth_mode = "service_account_file"
+        if not self._auth_mode_logged:
+            logger.info("Google STT auth: %s", auth_mode)
+            self._auth_mode_logged = True
+        self._credentials_initialized = True
+
+    def create_streaming_session(
+        self,
+        language_code: str = "en-AU",
+        sample_rate_hz: int = 16000,
+        encoding: str = "LINEAR16",
+        interim_results: bool = True,
+        api_config: Optional[Dict[str, Any]] = None,
+        silence_threshold_ms: int = 1500,
+    ) -> "GoogleSttService.StreamingSTTSession":
+        self._initialize_credentials()
+        return GoogleSttService.StreamingSTTSession(
+            language_code=language_code,
+            sample_rate_hz=sample_rate_hz,
+            encoding=encoding,
+            interim_results=interim_results,
+            api_config=api_config or {},
+            silence_threshold_ms=silence_threshold_ms,
+        )
+
+    class StreamingSTTSession:
+        """Long-lived Google STT streaming session (Deepgram-compatible interface)."""
+
+        def __init__(
+            self,
+            language_code: str,
+            sample_rate_hz: int,
+            encoding: str,
+            interim_results: bool,
+            api_config: Dict[str, Any],
+            silence_threshold_ms: int,
+        ) -> None:
+            self._language_code = language_code
+            self._sample_rate_hz = sample_rate_hz
+            self._encoding = encoding.upper()
+            self._interim_results = interim_results
+            self._api_config = api_config
+            self._silence_threshold_ms = silence_threshold_ms
+
+            self._audio_q: "queue.Queue[Optional[bytes]]" = queue.Queue()
+            self._results_q: "queue.Queue[Dict[str, Any]]" = queue.Queue()
+            self._audio_finished = False
+            self._closed = False
+            self._task_started = False
+            self._thread: Optional[threading.Thread] = None
+
+            self._stream_started_at: float = 0.0
+            self._restart_buffer: List[bytes] = []
+            self._restart_buffer_bytes: int = 0
+
+            self._error_restart_count: int = 0
+            self._error_restart_window_start: float = 0.0
+            self._speech_end_mono: float = 0.0
+
+        def push_audio(self, audio_chunk: bytes) -> None:
+            if self._audio_finished or self._closed:
+                return
+            self._restart_buffer.append(audio_chunk)
+            self._restart_buffer_bytes += len(audio_chunk)
+            while self._restart_buffer_bytes > _AUDIO_BUFFER_MAX_BYTES and self._restart_buffer:
+                removed = self._restart_buffer.pop(0)
+                self._restart_buffer_bytes -= len(removed)
+            self._audio_q.put(audio_chunk)
+
+        def finish(self) -> None:
+            if not self._audio_finished:
+                self._speech_end_mono = time.monotonic()
+                self._audio_finished = True
+                self._audio_q.put(None)
+
+        async def start(self) -> None:
+            if self._task_started:
+                return
+            self._task_started = True
+            self._thread = threading.Thread(
+                target=self._run_blocking_stream, daemon=True
+            )
+            self._thread.start()
+
+        async def get_result(self) -> Dict[str, Any]:
+            loop = asyncio.get_event_loop()
+            return await loop.run_in_executor(None, self._results_q.get)
+
+        def _make_recognition_config(self):
+            from google.cloud import speech_v1p1beta1 as speech
+
+            enc_map = {
+                "LINEAR16": speech.RecognitionConfig.AudioEncoding.LINEAR16,
+                "MULAW": speech.RecognitionConfig.AudioEncoding.MULAW,
+                "FLAC": speech.RecognitionConfig.AudioEncoding.FLAC,
+                "OGG_OPUS": speech.RecognitionConfig.AudioEncoding.OGG_OPUS,
+            }
+            encoding_enum = enc_map.get(
+                self._encoding, speech.RecognitionConfig.AudioEncoding.LINEAR16
+            )
+
+            # Display catalog id "chirp-3" → API model "phone_call" (metadata_json only).
+            google_model = self._api_config.get("google_model", "phone_call")
+
+            kwargs: Dict[str, Any] = {
+                "encoding": encoding_enum,
+                "sample_rate_hertz": self._sample_rate_hz,
+                "language_code": self._language_code,
+                "model": google_model,
+                "enable_automatic_punctuation": True,
+            }
+            if self._api_config.get("use_enhanced") is True:
+                kwargs["use_enhanced"] = True
+
+            return speech.RecognitionConfig(**kwargs)
+
+        def _record_recoverable_error(self, message: str) -> bool:
+            """Emit error result; return True if another restart is allowed."""
+            now = time.monotonic()
+            if (
+                self._error_restart_window_start == 0.0
+                or (now - self._error_restart_window_start) > _ERROR_RESTART_WINDOW_SEC
+            ):
+                self._error_restart_window_start = now
+                self._error_restart_count = 0
+
+            self._error_restart_count += 1
+            self._results_q.put(
+                {
+                    "error": message,
+                    "recoverable": self._error_restart_count <= _MAX_ERROR_RESTARTS,
+                    "transcript": "",
+                    "confidence": 0.0,
+                    "is_final": False,
+                }
+            )
+            if self._error_restart_count > _MAX_ERROR_RESTARTS:
+                logger.error(
+                    "[Google STT] max error restarts (%s) exceeded — stopping",
+                    _MAX_ERROR_RESTARTS,
+                )
+                return False
+            logger.warning(
+                "[Google STT] recoverable error (restart %s/%s): %s",
+                self._error_restart_count,
+                _MAX_ERROR_RESTARTS,
+                message,
+            )
+            time.sleep(_ERROR_BACKOFF_SEC)
+            return True
+
+        def _run_single_stream(
+            self,
+            replay_chunks: Optional[List[bytes]] = None,
+        ) -> bool:
+            """Run one stream. Returns True when a restart (time or recoverable error) is needed."""
+            from google.cloud import speech_v1p1beta1 as speech
+            from google.api_core.exceptions import (
+                OutOfRange,
+                PermissionDenied,
+                ResourceExhausted,
+                ServiceUnavailable,
+                Unauthenticated,
+            )
+
+            client = speech.SpeechClient()
+            config = self._make_recognition_config()
+            streaming_config = speech.StreamingRecognitionConfig(
+                config=config,
+                interim_results=self._interim_results,
+            )
+
+            self._stream_started_at = time.monotonic()
+            needs_restart = False
+            session_end_reason_ref: dict = {"v": "normal_close"}
+
+            def _audio_generator():
+                nonlocal needs_restart
+                if replay_chunks:
+                    for chunk in replay_chunks:
+                        yield speech.StreamingRecognizeRequest(audio_content=chunk)
+
+                while True:
+                    if time.monotonic() - self._stream_started_at >= _STREAM_RESTART_SECONDS:
+                        needs_restart = True
+                        session_end_reason_ref["v"] = "time_limit"
+                        return
+
+                    try:
+                        chunk = self._audio_q.get(timeout=0.1)
+                    except queue.Empty:
+                        continue
+
+                    if chunk is None:
+                        session_end_reason_ref["v"] = "client_finish"
+                        return
+
+                    yield speech.StreamingRecognizeRequest(audio_content=chunk)
+
+            try:
+                responses = client.streaming_recognize(streaming_config, _audio_generator())
+                first_latency_logged = False
+                for response in responses:
+                    for result in response.results:
+                        alts = result.alternatives
+                        if not alts:
+                            continue
+                        alt = alts[0]
+                        transcript = (alt.transcript or "").strip()
+                        confidence = float(getattr(alt, "confidence", 0.0) or 0.0)
+                        is_final = result.is_final
+
+                        if not transcript:
+                            continue
+
+                        speech_end_to_final_ms: Optional[int] = None
+                        if is_final and self._audio_finished and self._speech_end_mono > 0:
+                            speech_end_to_final_ms = int(
+                                (time.monotonic() - self._speech_end_mono) * 1000
+                            )
+                            logger.info(
+                                "[Metrics] stt_speech_end_to_final=%s ms",
+                                speech_end_to_final_ms,
+                            )
+                            if not first_latency_logged:
+                                elapsed_ms = int(
+                                    (time.monotonic() - self._stream_started_at) * 1000
+                                )
+                                logger.info(
+                                    "[Google STT] first_final_latency_ms=%s lang=%s model=%s",
+                                    elapsed_ms,
+                                    self._language_code,
+                                    self._api_config.get("google_model", "phone_call"),
+                                )
+                                first_latency_logged = True
+
+                        payload: Dict[str, Any] = {
+                            "transcript": transcript,
+                            "confidence": confidence,
+                            "is_final": is_final,
+                        }
+                        if speech_end_to_final_ms is not None:
+                            payload["stt_speech_end_to_final_ms"] = speech_end_to_final_ms
+                        self._results_q.put(payload)
+
+            except OutOfRange as exc:
+                logger.info("[Google STT] stream time limit (OutOfRange): %s", exc)
+                needs_restart = True
+                session_end_reason_ref["v"] = "out_of_range"
+            except (ServiceUnavailable, ResourceExhausted) as exc:
+                if self._record_recoverable_error(str(exc)):
+                    needs_restart = True
+                    session_end_reason_ref["v"] = "recoverable_error"
+                else:
+                    return False
+            except (PermissionDenied, Unauthenticated) as exc:
+                logger.error("[Google STT] auth error (non-recoverable): %s", exc)
+                self._results_q.put(
+                    {
+                        "error": str(exc),
+                        "recoverable": False,
+                        "transcript": "",
+                        "confidence": 0.0,
+                        "is_final": False,
+                    }
+                )
+                return False
+            except Exception as exc:
+                msg = str(exc)
+                if self._record_recoverable_error(msg):
+                    needs_restart = True
+                    session_end_reason_ref["v"] = "recoverable_error"
+                else:
+                    return False
+
+            logger.info(
+                "[Google STT] stream ended reason=%s restart=%s",
+                session_end_reason_ref["v"],
+                needs_restart,
+            )
+            return needs_restart
+
+        def _run_blocking_stream(self) -> None:
+            logger.info(
+                "[Google STT] session_start lang=%s sample_rate=%s encoding=%s api_model=%s",
+                self._language_code,
+                self._sample_rate_hz,
+                self._encoding,
+                self._api_config.get("google_model", "phone_call"),
+            )
+
+            replay_chunks: Optional[List[bytes]] = None
+            restart_count = 0
+
+            while not self._closed:
+                try:
+                    needs_restart = self._run_single_stream(replay_chunks=replay_chunks)
+                except Exception as exc:
+                    logger.error(
+                        "[Google STT] unexpected stream error: %s", exc, exc_info=True
+                    )
+                    if not self._record_recoverable_error(str(exc)):
+                        break
+                    needs_restart = True
+
+                if not needs_restart:
+                    break
+
+                if self._audio_finished:
+                    logger.info(
+                        "[Google STT] skip restart after client finish (reason=time_limit_or_error)"
+                    )
+                    break
+
+                restart_count += 1
+                replay_chunks = list(self._restart_buffer)
+                logger.info(
+                    "[Google STT] restarting stream #%d — replay %d chunks",
+                    restart_count,
+                    len(replay_chunks),
+                )
+                time.sleep(0.05)
+
+            self._closed = True
+            logger.info("[Google STT] session_end restart_count=%d", restart_count)
+            self._results_q.put({"done": True})
+
+
+google_stt_service = GoogleSttService()

--- a/app/services/livekit_recording_service.py
+++ b/app/services/livekit_recording_service.py
@@ -1,0 +1,152 @@
+"""
+LiveKit Recording Service — room-composite egress for call audio capture.
+
+Starts a mix-minus audio-only egress on the LiveKit room when
+recording_enabled=True.  The egress writes an Opus file directly to GCS.
+
+After the call ends, call_recording_upload_service polls the egress status,
+confirms completion, and updates the DB record.
+
+Room naming matches livekit_service.py: room_{call_session_id}
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from app.core.config import settings
+from app.core.logger import logger
+
+
+class LiveKitRecordingService:
+
+    def _get_credentials(self):
+        from app.core.secret_manager import get_livekit_credentials
+
+        return get_livekit_credentials()
+
+    def _gcs_credentials_json(self) -> Optional[str]:
+        """
+        Load the GCS service account JSON string for LiveKit's GCPUpload.
+
+        Reads GOOGLE_APPLICATION_CREDENTIALS (file path) and returns the file
+        contents as a JSON string.  Returns None if credentials are unavailable
+        (LiveKit will fall back to instance metadata in GKE).
+        """
+        if not settings.GOOGLE_APPLICATION_CREDENTIALS:
+            return None
+        try:
+            with open(settings.GOOGLE_APPLICATION_CREDENTIALS, "r") as fh:
+                return fh.read()
+        except Exception as exc:
+            logger.warning("Could not read GCS credentials file for LiveKit egress: %s", exc)
+            return None
+
+    async def start_room_recording(
+        self,
+        call_id: uuid.UUID,
+        workspace_id: uuid.UUID,
+        gcs_path: str,
+    ) -> Optional[str]:
+        """
+        Start a room-composite audio-only egress that uploads to GCS.
+
+        Returns the LiveKit egress_id, or None on failure (recording_enabled
+        will remain True but egress won't run — caller logs and continues).
+
+        The room is expected to exist (created in voice_call_service /
+        handle_start_message before this is called).
+        """
+        from livekit import api
+
+        room_name = f"room_{call_id}"
+        url, api_key, api_secret = self._get_credentials()
+
+        gcs_creds = self._gcs_credentials_json()
+
+        gcp_upload = api.GCPUpload(
+            bucket=settings.GCS_RECORDINGS_BUCKET,
+        )
+        if gcs_creds:
+            gcp_upload = api.GCPUpload(
+                bucket=settings.GCS_RECORDINGS_BUCKET,
+                credentials=gcs_creds,
+            )
+
+        file_output = api.EncodedFileOutput(
+            file_type=api.EncodedFileType.OGG,
+            filepath=gcs_path,
+            gcp=gcp_upload,
+        )
+
+        egress_request = api.RoomCompositeEgressRequest(
+            room_name=room_name,
+            audio_only=True,
+            file=file_output,
+        )
+
+        try:
+            async with api.LiveKitAPI(url=url, api_key=api_key, api_secret=api_secret) as lk:
+                info = await lk.egress.start_room_composite_egress(
+                    api.StartEgressRequest(room_composite=egress_request)
+                )
+            egress_id = info.egress_id
+            logger.info(
+                "LiveKit recording egress started: egress_id=%s room=%s gcs=%s",
+                egress_id,
+                room_name,
+                gcs_path,
+            )
+            return egress_id
+        except Exception as exc:
+            logger.error(
+                "LiveKit egress start failed for room %s: %s",
+                room_name,
+                exc,
+                exc_info=True,
+            )
+            return None
+
+    async def stop_room_recording(self, egress_id: str) -> bool:
+        """
+        Stop a running egress and trigger upload completion.
+
+        Returns True on success, False on failure.  Called on call end —
+        failure is non-fatal (LiveKit may already be stopping the egress).
+        """
+        from livekit import api
+
+        url, api_key, api_secret = self._get_credentials()
+        try:
+            async with api.LiveKitAPI(url=url, api_key=api_key, api_secret=api_secret) as lk:
+                await lk.egress.stop_egress(api.StopEgressRequest(egress_id=egress_id))
+            logger.info("LiveKit egress stopped: %s", egress_id)
+            return True
+        except Exception as exc:
+            logger.warning("LiveKit egress stop failed for %s: %s", egress_id, exc)
+            return False
+
+    async def get_egress_info(self, egress_id: str) -> Optional[object]:
+        """
+        Return the EgressInfo proto for the given egress_id, or None on error.
+        Used by upload_service to check completion status.
+        """
+        from livekit import api
+
+        url, api_key, api_secret = self._get_credentials()
+        try:
+            async with api.LiveKitAPI(url=url, api_key=api_key, api_secret=api_secret) as lk:
+                resp = await lk.egress.list_egress(
+                    api.ListEgressRequest(egress_id=egress_id)
+                )
+            items = list(resp.items)
+            return items[0] if items else None
+        except Exception as exc:
+            logger.warning("LiveKit get_egress_info failed for %s: %s", egress_id, exc)
+            return None
+
+
+livekit_recording_service = LiveKitRecordingService()

--- a/app/services/livekit_service.py
+++ b/app/services/livekit_service.py
@@ -1,0 +1,303 @@
+"""
+LiveKit room management service.
+
+Manages real-time audio rooms for the voice agent platform.
+Rooms are created BEFORE Twilio call initiation so the agent
+is already listening when the caller connects.
+
+Room naming: room_{call_session.id}  (deterministic, reusable)
+Max participants: 2 (agent + caller) — 3rd join rejected at SDK level.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from app.core.config import settings
+from app.core.logger import logger
+
+def _http_to_ws_url(http_url: str) -> str:
+    """Convert http(s):// to ws(s):// for LiveKit RTC WebSocket connections."""
+    if http_url.startswith("https://"):
+        return "wss://" + http_url[8:]
+    if http_url.startswith("http://"):
+        return "ws://" + http_url[7:]
+    return http_url
+
+
+_ROOM_NAME_RE = re.compile(
+    r"^room_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+
+
+class RoomService:
+    """
+    LiveKit room management for multi-tenant voice agent calls.
+
+    All credential access is deferred to method call time so that
+    LIVEKIT_ENABLED=False in local dev never causes import-time errors.
+    """
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _validate_room_name(self, room_name: str) -> None:
+        if not _ROOM_NAME_RE.match(room_name):
+            raise ValueError(
+                f"Invalid room name '{room_name}'. "
+                "Expected format: room_<uuid> (e.g. room_550e8400-e29b-41d4-a716-446655440000)"
+            )
+
+    def _get_credentials(self) -> tuple[str, str, str]:
+        from app.core.secret_manager import get_livekit_credentials
+
+        return get_livekit_credentials()
+
+    # ------------------------------------------------------------------
+    # Room lifecycle
+    # ------------------------------------------------------------------
+
+    async def create_room(
+        self,
+        call_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        flow_id: uuid.UUID | None = None,
+    ) -> Any:
+        """
+        Create (or return existing) LiveKit room for a call session.
+
+        Idempotent: LiveKit's CreateRoomRequest returns the existing room
+        if one with the same name already exists, so retries are safe.
+
+        max_participants=2 is set at the SDK request level — a 3rd participant
+        attempting to join is rejected by the LiveKit server.
+        """
+        from livekit import api
+
+        room_name = f"room_{call_id}"
+        url, api_key, api_secret = self._get_credentials()
+        metadata = json.dumps(
+            {
+                "callId": str(call_id),
+                "flowId": str(flow_id) if flow_id else None,
+                "agentId": str(agent_id),
+                "startedAt": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+
+        async with api.LiveKitAPI(url=url, api_key=api_key, api_secret=api_secret) as lk:
+            room = await lk.room.create_room(
+                api.CreateRoomRequest(
+                    name=room_name,
+                    max_participants=settings.LIVEKIT_MAX_PARTICIPANTS,
+                    empty_timeout=settings.LIVEKIT_ROOM_EMPTY_TIMEOUT,
+                    metadata=metadata,
+                )
+            )
+
+        logger.info(
+            "LiveKit room ready: name=%s sid=%s max_participants=%d",
+            room_name,
+            room.sid,
+            settings.LIVEKIT_MAX_PARTICIPANTS,
+        )
+        return room
+
+    async def close_room(self, call_id: uuid.UUID) -> None:
+        """
+        Delete a LiveKit room.  Safe to call if the room no longer exists.
+        Logs a warning on failure rather than raising so post-call cleanup
+        never blocks response paths.
+        """
+        from livekit import api
+
+        room_name = f"room_{call_id}"
+        url, api_key, api_secret = self._get_credentials()
+        try:
+            async with api.LiveKitAPI(url=url, api_key=api_key, api_secret=api_secret) as lk:
+                await lk.room.delete_room(api.DeleteRoomRequest(room=room_name))
+            logger.info("LiveKit room closed: %s", room_name)
+        except Exception as exc:
+            logger.warning("LiveKit close_room failed for %s: %s", room_name, exc)
+
+    async def list_participants(self, room_name: str) -> list[dict[str, Any]]:
+        """Return [{identity, sid, state}] for every participant in the room."""
+        from livekit import api
+
+        self._validate_room_name(room_name)
+        url, api_key, api_secret = self._get_credentials()
+
+        async with api.LiveKitAPI(url=url, api_key=api_key, api_secret=api_secret) as lk:
+            resp = await lk.room.list_participants(
+                api.ListParticipantsRequest(room=room_name)
+            )
+
+        return [
+            {"identity": p.identity, "sid": p.sid, "state": p.state}
+            for p in resp.participants
+        ]
+
+    # ------------------------------------------------------------------
+    # Token generation
+    # ------------------------------------------------------------------
+
+    def generate_agent_token(self, room_name: str) -> str:
+        """
+        Return a signed JWT granting agent-{room_name} join access to the room.
+        TTL = LIVEKIT_TOKEN_TTL seconds (default 3600).
+        Never logged — callers must treat the return value as a secret.
+        """
+        from livekit.api import AccessToken, VideoGrants
+
+        self._validate_room_name(room_name)
+        _, api_key, api_secret = self._get_credentials()
+        identity = f"agent-{room_name}"
+        token = (
+            AccessToken(api_key=api_key, api_secret=api_secret)
+            .with_identity(identity)
+            .with_name(identity)
+            .with_grants(VideoGrants(room_join=True, room=room_name))
+            .with_ttl(timedelta(seconds=settings.LIVEKIT_TOKEN_TTL))
+            .to_jwt()
+        )
+        return token
+
+    def generate_caller_token(self, room_name: str) -> str:
+        """
+        Return a signed JWT granting caller-{room_name} join access to the room.
+        TTL = LIVEKIT_TOKEN_TTL seconds (default 3600).
+        Never logged — callers must treat the return value as a secret.
+        """
+        from livekit.api import AccessToken, VideoGrants
+
+        self._validate_room_name(room_name)
+        _, api_key, api_secret = self._get_credentials()
+        identity = f"caller-{room_name}"
+        token = (
+            AccessToken(api_key=api_key, api_secret=api_secret)
+            .with_identity(identity)
+            .with_name(identity)
+            .with_grants(VideoGrants(room_join=True, room=room_name))
+            .with_ttl(timedelta(seconds=settings.LIVEKIT_TOKEN_TTL))
+            .to_jwt()
+        )
+        return token
+
+    # ------------------------------------------------------------------
+    # Observability
+    # ------------------------------------------------------------------
+
+    async def health_check(self) -> str:
+        """
+        Return "ok" or "degraded".  Never raises — safe to call from /health.
+
+        Returns "ok" immediately when LIVEKIT_ENABLED=False.
+        """
+        if not settings.LIVEKIT_ENABLED:
+            return "ok"
+        try:
+            reachable = await self.check_connectivity()
+            return "ok" if reachable else "degraded"
+        except Exception:
+            return "degraded"
+
+    async def check_connectivity(self) -> bool:
+        """
+        Verify the API server can reach the LiveKit server via HTTP/gRPC.
+
+        Makes a lightweight list_rooms call — no rooms need to exist.
+        Used for staging connectivity confirmation and /health probing.
+        """
+        from livekit import api
+
+        try:
+            url, api_key, api_secret = self._get_credentials()
+        except (ValueError, RuntimeError) as exc:
+            logger.warning("LiveKit credentials not available for connectivity check: %s", exc)
+            return False
+
+        try:
+            async with api.LiveKitAPI(url=url, api_key=api_key, api_secret=api_secret) as lk:
+                await lk.room.list_rooms(api.ListRoomsRequest())
+            return True
+        except Exception as exc:
+            logger.warning("LiveKit connectivity check failed: %s", exc)
+            return False
+
+    async def verify_rtc_connectivity(
+        self, room_name: str | None = None
+    ) -> bool:
+        """
+        Lightweight RTC WebSocket connectivity probe.
+
+        Creates an ephemeral room (unless room_name is given), connects as a
+        short-lived probe participant via the RTC SDK, then disconnects and
+        cleans up. Returns True on success, False on any failure. Never raises.
+
+        This is intentionally NOT called from health_check (too slow for
+        every /health request). Use it from integration tests or manual probes.
+        """
+        from livekit import api, rtc
+
+        probe_call_id = uuid.uuid4()
+        probe_room = room_name or f"room_{probe_call_id}"
+        owns_room = room_name is None
+
+        try:
+            url, api_key, api_secret = self._get_credentials()
+        except (ValueError, RuntimeError) as exc:
+            logger.warning(
+                "LiveKit credentials unavailable for RTC probe: %s", exc
+            )
+            return False
+
+        try:
+            if owns_room:
+                async with api.LiveKitAPI(
+                    url=url, api_key=api_key, api_secret=api_secret
+                ) as lk:
+                    await lk.room.create_room(
+                        api.CreateRoomRequest(
+                            name=probe_room,
+                            max_participants=1,
+                            empty_timeout=10,
+                        )
+                    )
+
+            from livekit.api import AccessToken, VideoGrants
+
+            probe_token = (
+                AccessToken(api_key=api_key, api_secret=api_secret)
+                .with_identity(f"probe-{probe_call_id}")
+                .with_grants(VideoGrants(room_join=True, room=probe_room))
+                .with_ttl(timedelta(seconds=60))
+                .to_jwt()
+            )
+
+            ws_url = _http_to_ws_url(url)
+            rtc_room = rtc.Room()
+            try:
+                await rtc_room.connect(ws_url, probe_token)
+            finally:
+                await rtc_room.disconnect()
+
+            logger.info("LiveKit RTC connectivity probe succeeded: %s", ws_url)
+            return True
+
+        except Exception as exc:
+            logger.warning("LiveKit RTC connectivity probe failed: %s", exc)
+            return False
+        finally:
+            if owns_room:
+                try:
+                    await self.close_room(probe_call_id)
+                except Exception:
+                    pass
+
+
+livekit_service = RoomService()

--- a/app/services/recording_config_service.py
+++ b/app/services/recording_config_service.py
@@ -1,0 +1,62 @@
+"""
+Recording Config Service — resolves recording_enabled for a call session.
+
+Looks up the NumberConfiguration for the phone number associated with a
+CallSession and returns whether recording is enabled for that number.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.logger import logger
+from app.models.call_session import CallSession
+from app.models.phone_number import NumberConfiguration, PhoneNumber
+
+
+def get_recording_enabled_for_call(db: Session, call_session: CallSession) -> bool:
+    """
+    Return True if recording is enabled for the phone number on this call.
+
+    Resolution order:
+    1. call_session.assistant_phone_number (set on outbound and inbound calls)
+    2. call_session.to_number (fallback for inbound — the number the caller dialled)
+    3. call_session.from_number (last resort for outbound)
+
+    Returns False if no NumberConfiguration is found (safe default).
+    """
+    phone_number_str = _resolve_phone_number(call_session)
+    if not phone_number_str:
+        return False
+
+    try:
+        stmt = (
+            select(NumberConfiguration)
+            .join(PhoneNumber, NumberConfiguration.phone_number_id == PhoneNumber.id)
+            .where(
+                PhoneNumber.phone_number == phone_number_str,
+                PhoneNumber.tenant_id == call_session.tenant_id,
+            )
+        )
+        config = db.execute(stmt).scalar_one_or_none()
+        if config is None:
+            return False
+        return bool(config.recording_enabled)
+    except Exception as exc:
+        logger.warning(
+            "recording_config: lookup failed for session %s: %s",
+            call_session.id,
+            exc,
+        )
+        return False
+
+
+def _resolve_phone_number(call_session: CallSession) -> Optional[str]:
+    for field in ("assistant_phone_number", "to_number", "from_number"):
+        val = getattr(call_session, field, None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return None

--- a/app/services/stt_catalog_service.py
+++ b/app/services/stt_catalog_service.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Optional
+import uuid
+
+from sqlalchemy.orm import Session
+
+from app.models.stt_provider import STTProvider
+from app.models.stt_model import STTModel
+
+
+class STTCatalogService:
+
+    def list_providers(self, db: Session, active_only: bool = True) -> list[STTProvider]:
+        query = db.query(STTProvider)
+        if active_only:
+            query = query.filter(STTProvider.is_active == True)  # noqa: E712
+        return query.order_by(STTProvider.display_name.asc()).all()
+
+    def list_models(
+        self,
+        db: Session,
+        provider_id: uuid.UUID,
+        language_code: Optional[str] = None,
+        active_only: bool = True,
+    ) -> list[STTModel]:
+        query = db.query(STTModel).filter(STTModel.provider_id == provider_id)
+        if active_only:
+            query = query.filter(STTModel.is_active == True)  # noqa: E712
+        if language_code:
+            query = query.filter(STTModel.language_code == language_code)
+        return query.order_by(STTModel.display_name.asc()).all()
+
+    def get_provider_by_slug(self, db: Session, slug: str) -> Optional[STTProvider]:
+        return (
+            db.query(STTProvider)
+            .filter(STTProvider.slug == slug)
+            .first()
+        )
+
+    def get_model_by_provider_and_external_id(
+        self,
+        db: Session,
+        provider_id: uuid.UUID,
+        external_model_id: str,
+    ) -> Optional[STTModel]:
+        return (
+            db.query(STTModel)
+            .filter(
+                STTModel.provider_id == provider_id,
+                STTModel.external_model_id == external_model_id,
+            )
+            .first()
+        )
+
+
+stt_catalog_service = STTCatalogService()

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 import uuid
 from typing import Optional
@@ -342,6 +343,65 @@ async def initiate_call(
             }
             db.commit()
 
+        # LiveKit egress recording when enabled for this number (Twilio record stays off).
+        _livekit_recording_enabled = False
+        if settings.LIVEKIT_ENABLED and lk_meta:
+            try:
+                from app.models.phone_number import NumberConfiguration, PhoneNumber
+                from sqlalchemy import select as _select
+
+                _pn_stmt = _select(NumberConfiguration).join(
+                    PhoneNumber, NumberConfiguration.phone_number_id == PhoneNumber.id
+                ).where(
+                    PhoneNumber.phone_number == from_number,
+                    PhoneNumber.tenant_id == tenant_id_filter,
+                )
+                _nc = db.execute(_pn_stmt).scalar_one_or_none()
+                _livekit_recording_enabled = bool(_nc and _nc.recording_enabled)
+                if _livekit_recording_enabled:
+                    from app.services.gcs_recording_service import build_gcs_key
+                    from app.services.livekit_recording_service import livekit_recording_service
+
+                    _gcs_path = build_gcs_key(
+                        workspace_id=tenant_id_filter,
+                        call_id=session_id,
+                    )
+                    _session_id = session_id
+
+                    async def _start_rec() -> None:
+                        from app.db.session import SessionLocal
+
+                        egress_id = await livekit_recording_service.start_room_recording(
+                            call_id=_session_id,
+                            workspace_id=tenant_id_filter,
+                            gcs_path=_gcs_path,
+                        )
+                        if not egress_id:
+                            return
+                        _db = SessionLocal()
+                        try:
+                            _cs = _db.get(CallSession, _session_id)
+                            if _cs is None:
+                                return
+                            _meta = dict(_cs.call_metadata or {})
+                            _meta["recording"] = {
+                                "egress_id": egress_id,
+                                "gcs_path": _gcs_path,
+                            }
+                            _cs.call_metadata = _meta
+                            _db.commit()
+                            logger.info(
+                                "Outbound LiveKit recording started: session=%s egress_id=%s",
+                                _session_id,
+                                egress_id,
+                            )
+                        finally:
+                            _db.close()
+
+                    asyncio.create_task(_start_rec())
+            except Exception as _rec_exc:
+                logger.warning("Outbound recording setup failed: %s", _rec_exc)
+
         # Optional appointment_id
         appt_raw = (call_request.appointment_id or "").strip()
         if appt_raw:
@@ -429,6 +489,7 @@ async def initiate_call(
             logger.warning("⚠️ WebSocket broadcast failed (non-critical): %s", e)
 
         # ── 10. Initiate Twilio call ──────────────────────────────────────
+        _twilio_record = not _livekit_recording_enabled
         try:
             if use_custom_credentials:
                 call = twilio_service.make_call_with_credentials(
@@ -438,6 +499,7 @@ async def initiate_call(
                     status_callback_url=status_callback_url,
                     account_sid=account_sid,
                     auth_token=auth_token,
+                    record=_twilio_record,
                 )
             else:
                 call = twilio_service.make_call(
@@ -445,6 +507,7 @@ async def initiate_call(
                     from_number=from_number,
                     webhook_url=webhook_url,
                     status_callback_url=status_callback_url,
+                    record=_twilio_record,
                 )
         except Exception as exc:
             logger.error(

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -19,7 +19,6 @@ from app.schemas.base import SuccessResponse
 from app.services.agent_service import agent_service
 from app.services.call_session_service import call_session_service
 from app.services.credit_service import credit_service
-from app.services.phone_number_service import phone_number_service
 from app.services.twilio_service import twilio_service
 from app.services.voice_interview_context_service import (
     build_voice_interview_enrichment,
@@ -213,6 +212,18 @@ async def initiate_call(
             db.commit()
             db.refresh(call_session)
 
+        if call_request.callFlowId:
+            try:
+                flow_uuid = uuid.UUID(call_request.callFlowId)
+            except ValueError:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Invalid callFlowId format: must be a valid UUID",
+                )
+            call_session.call_flow_id = flow_uuid
+            db.commit()
+            db.refresh(call_session)
+
         # Optional: enrich from jd_id + resume_id (or jd_context only) without breaking n8n callers
         _ctx = call_request.jd_context or {}
         _jd = parse_optional_uuid(
@@ -270,6 +281,51 @@ async def initiate_call(
 
         logger.info("Making call with webhook_url: %s", webhook_url)
         logger.info("Making call with status_callback_url: %s", status_callback_url)
+
+        # Create LiveKit room BEFORE Twilio call so the agent is already
+        # listening on the media room when the caller connects.
+        if settings.LIVEKIT_ENABLED:
+            from app.services.livekit_service import livekit_service
+
+            try:
+                room = await livekit_service.create_room(
+                    call_id=call_session.id,
+                    agent_id=agent.id,
+                    flow_id=call_session.call_flow_id,
+                )
+                room_name = f"room_{call_session.id}"
+                agent_token = livekit_service.generate_agent_token(room_name)
+                lk_meta: dict = {
+                    "room_name": room_name,
+                    "room_sid": room.sid,
+                    "agent_token": agent_token,  # secret — never log
+                    "flow_id": str(call_session.call_flow_id) if call_session.call_flow_id else None,
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                }
+                call_session.call_metadata = {
+                    **(call_session.call_metadata or {}),
+                    "livekit": lk_meta,
+                }
+                db.commit()
+                logger.info(
+                    "LiveKit room provisioned for call session %s: %s",
+                    call_session.id,
+                    room_name,
+                )
+            except Exception as exc:
+                logger.error(
+                    "LiveKit room creation failed for call session %s: %s",
+                    call_session.id,
+                    exc,
+                    exc_info=True,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=(
+                        "LiveKit room creation failed. "
+                        "Cannot initiate call without media transport."
+                    ),
+                )
 
         # Optional WebSocket broadcast
         try:

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -4,12 +4,14 @@ from typing import Optional
 
 from fastapi import HTTPException, Request, status
 from fastapi.responses import JSONResponse
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.error_responses import build_call_initiate_error_payload
 from app.middleware.request_id_middleware import get_request_id
 from app.core.logger import logger
+from app.models.call_session import CallSession
 from app.models.user import User
 from app.schemas.twilio import (
     CallInitiateRequest,
@@ -28,6 +30,9 @@ from app.utils.n8n_webhook_verification import verify_n8n_webhook_secret_async
 from app.utils.response import create_success_response
 from app.routers.general_websocket import broadcast_call_status_update
 
+# Outbound sessions occupying a workspace concurrent-call slot (must match DB values).
+_ACTIVE_OUTBOUND_STATUSES = ("initiated", "ringing", "connected", "in-progress")
+
 
 async def initiate_call(
     call_request: CallInitiateRequest,
@@ -36,14 +41,41 @@ async def initiate_call(
     db: Session,
 ) -> SuccessResponse[CallInitiateResponse] | JSONResponse:
     """
-    Behavior-preserving extraction of the original `initiate_call` route logic.
+    Outbound call dispatch: LiveKit room → DB record → Twilio call.
+
+    Sequence (per ticket BE1-S3):
+      1. Authenticate (JWT or n8n webhook secret)
+      2. Validate agent membership in workspace
+      3. Check agent.status == "ready" (phone bound)
+      4. Validate E.164 on toNumber (schema already enforces this)
+      5. Validate fromNumber body param matches agent-bound number
+      6. Credit check
+      7. Per-workspace concurrent outbound limit
+      8. Create LiveKit room (FAIL FAST — no side effects on error)
+      9. Create call_session DB record with pre-assigned UUID
+      10. Initiate Twilio call
+      11. Return { callId, status: "initiated" }
     """
+    request_id = get_request_id(http_request)
+
+    def _err(http_status: int, error_code: str, message: str) -> JSONResponse:
+        return JSONResponse(
+            status_code=http_status,
+            content=build_call_initiate_error_payload(
+                http_status,
+                message,
+                call_request,
+                error_code=error_code,
+                request_id=request_id,
+            ),
+            headers={"X-Request-ID": request_id},
+        )
+
     try:
-        # Verify authentication: either JWT token OR webhook secret
+        # ── 1. Authentication ──────────────────────────────────────────────
         is_webhook = await verify_n8n_webhook_secret_async(http_request)
 
         if is_webhook:
-            # Webhook authentication - get tenant_id and user_id from request body
             if not call_request.tenant_id:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -64,7 +96,6 @@ async def initiate_call(
             tenant_id_filter = tenant_uuid
             user_id_filter = user_uuid
         else:
-            # JWT authentication - get from user token
             if not user:
                 raise HTTPException(
                     status_code=status.HTTP_401_UNAUTHORIZED,
@@ -73,7 +104,7 @@ async def initiate_call(
             tenant_id_filter = user.current_tenant_id
             user_id_filter = user.id
 
-        # Validate agent exists in database
+        # ── 2. Validate agent ─────────────────────────────────────────────
         try:
             agent_id = uuid.UUID(call_request.agentId)
             agent = agent_service.get_agent_by_id(db, agent_id, tenant_id_filter)
@@ -82,51 +113,17 @@ async def initiate_call(
                 status_code=404, detail=f"Agent {call_request.agentId} not found"
             )
 
-        # Validate phone number format
-        if not twilio_service.validate_phone_number(call_request.userPhoneNumber):
-            raise HTTPException(
-                status_code=400,
-                detail="Invalid phone number format. Must start with +",
+        # ── 3. Agent not ready (GAP 3) ────────────────────────────────────
+        # agent.status is set to "ready" by POST /api/v1/telephony/bind.
+        # Any other status means no phone number is bound.
+        if agent.status != "ready":
+            return _err(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                "agent_not_ready",
+                "Bind a phone number to this agent first.",
             )
 
-        # Check credits before initiating call
-        if not agent.model:
-            raise HTTPException(
-                status_code=400, detail="Agent does not have a model configured"
-            )
-
-        model_name = agent.model.model_name
-        has_sufficient, current_credits, required_credits = (
-            credit_service.has_sufficient_credits(
-                db=db,
-                tenant_id=tenant_id_filter,
-                model_name=model_name,
-                estimated_minutes=1,  # Check for at least 1 minute
-            )
-        )
-
-        if not has_sufficient:
-            logger.warning(
-                "❌ Insufficient credits: %s < %s", current_credits, required_credits
-            )
-            error_message = (
-                "Insufficient credits to initiate call. Current balance: "
-                f"{current_credits} credits, Required: {required_credits} credits. "
-                f"Model: {model_name}"
-            )
-            raise HTTPException(
-                status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                detail=error_message,
-            )
-
-        logger.info(
-            "✅ Credit check passed: %s credits available, %s required for model %s",
-            current_credits,
-            required_credits,
-            model_name,
-        )
-
-        # Outbound requires an active phone number bound to this agent (telephony bind).
+        # ── 4. Phone number binding ───────────────────────────────────────
         from app.models.phone_number import PhoneNumber
 
         phone_number_obj = (
@@ -139,14 +136,13 @@ async def initiate_call(
             .first()
         )
         if not phone_number_obj:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "This agent is not bound to an active phone number. "
-                    "Bind via POST /api/v1/telephony/bind before placing outbound calls."
-                ),
+            return _err(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                "agent_not_ready",
+                "Bind a phone number to this agent first.",
             )
 
+        # Validate optional phone_number_id override
         if call_request.phone_number_id:
             try:
                 requested_id = uuid.UUID(call_request.phone_number_id)
@@ -164,7 +160,92 @@ async def initiate_call(
                     ),
                 )
 
+        # ── 5. Validate fromNumber body param (GAP 1) ────────────────────
         from_number = phone_number_obj.phone_number
+        if call_request.fromNumber and call_request.fromNumber != from_number:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"fromNumber '{call_request.fromNumber}' does not match the agent's "
+                    f"bound phone number '{from_number}'. "
+                    "Remove fromNumber from the request or use the bound number."
+                ),
+            )
+
+        # ── 6. Credit check ───────────────────────────────────────────────
+        if not agent.model:
+            raise HTTPException(
+                status_code=400, detail="Agent does not have a model configured"
+            )
+
+        model_name = agent.model.model_name
+        has_sufficient, current_credits, required_credits = (
+            credit_service.has_sufficient_credits(
+                db=db,
+                tenant_id=tenant_id_filter,
+                model_name=model_name,
+                estimated_minutes=1,
+            )
+        )
+
+        if not has_sufficient:
+            logger.warning(
+                "❌ Insufficient credits: %s < %s", current_credits, required_credits
+            )
+            raise HTTPException(
+                status_code=status.HTTP_402_PAYMENT_REQUIRED,
+                detail=(
+                    f"Insufficient credits to initiate call. Current balance: "
+                    f"{current_credits} credits, Required: {required_credits} credits. "
+                    f"Model: {model_name}"
+                ),
+            )
+
+        logger.info(
+            "✅ Credit check passed: %s credits available, %s required for model %s",
+            current_credits,
+            required_credits,
+            model_name,
+        )
+
+        # ── 7. Per-workspace concurrent outbound limit (GAP 6) ────────────
+        concurrent_count = (
+            db.query(func.count(CallSession.id))
+            .filter(
+                CallSession.tenant_id == tenant_id_filter,
+                CallSession.call_type == "outbound",
+                CallSession.status.in_(_ACTIVE_OUTBOUND_STATUSES),
+            )
+            .scalar()
+        ) or 0
+
+        max_concurrent = settings.OUTBOUND_MAX_CONCURRENT_PER_WORKSPACE
+        if concurrent_count >= max_concurrent:
+            logger.warning(
+                "Outbound concurrent limit reached for tenant %s: %d/%d",
+                tenant_id_filter,
+                concurrent_count,
+                max_concurrent,
+            )
+            return _err(
+                status.HTTP_429_TOO_MANY_REQUESTS,
+                "outbound_concurrent_limit_exceeded",
+                f"Maximum concurrent outbound calls ({max_concurrent}) reached for this workspace. "
+                "Wait for an active call to complete before placing a new one.",
+            )
+
+        # ── Resolve optional callFlowId so we can pass to LiveKit ────────
+        flow_uuid: Optional[uuid.UUID] = None
+        if call_request.callFlowId:
+            try:
+                flow_uuid = uuid.UUID(call_request.callFlowId)
+            except ValueError:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Invalid callFlowId format: must be a valid UUID",
+                )
+
+        # ── Resolve Twilio credentials upfront ───────────────────────────
         use_custom_credentials = False
         account_sid: Optional[str] = None
         auth_token: Optional[str] = None
@@ -189,49 +270,100 @@ async def initiate_call(
                 from_number,
             )
 
-        # Get base URL for webhooks
         base_url = settings.WEBHOOK_BASE_URL
 
-        # Create call session first so we can include the ID in webhook URLs
+        # ── 8. Pre-generate call session UUID (ticket order: LiveKit → DB → Twilio) ──
+        session_id = uuid.uuid4()
+
+        # ── 8a. Create LiveKit room FIRST — fail fast before any side effects ─
+        lk_meta: Optional[dict] = None
+        if settings.LIVEKIT_ENABLED:
+            from app.services.livekit_service import livekit_service
+
+            room_name = f"room_{session_id}"
+            try:
+                room = await livekit_service.create_room(
+                    call_id=session_id,
+                    agent_id=agent.id,
+                    flow_id=flow_uuid,
+                )
+                agent_token = livekit_service.generate_agent_token(room_name)
+                lk_meta = {
+                    "room_name": room_name,
+                    "room_sid": room.sid,
+                    "agent_token": agent_token,  # never logged — secret
+                    "flow_id": str(flow_uuid) if flow_uuid else None,
+                    "created_at": datetime.now(timezone.utc).isoformat(),
+                }
+                logger.info(
+                    "LiveKit room provisioned: %s (sid=%s) for session %s",
+                    room_name,
+                    room.sid,
+                    session_id,
+                )
+            except Exception as exc:
+                logger.error(
+                    "LiveKit room creation failed for pre-assigned session %s: %s",
+                    session_id,
+                    exc,
+                    exc_info=True,
+                )
+                # Attempt cleanup in case the room was partially created
+                try:
+                    await livekit_service.close_room(session_id)
+                except Exception:
+                    pass
+                # Do NOT create DB record; do NOT call Twilio
+                return _err(
+                    status.HTTP_503_SERVICE_UNAVAILABLE,
+                    "livekit_room_creation_failed",
+                    "LiveKit room creation failed. Cannot initiate call without media transport.",
+                )
+
+        # ── 9. Create call_session DB record (after LiveKit succeeds) ────
         call_session = call_session_service.create_call_session(
             db=db,
             user_id=user_id_filter,
             agent_id=agent.id,
             tenant_id=tenant_id_filter,
-            twilio_call_sid="",  # Will be updated after call is made
+            twilio_call_sid="",  # updated after Twilio call
             from_number=from_number,
-            to_number=call_request.userPhoneNumber,
+            to_number=call_request.toNumber,
             call_type="outbound",
+            session_id=session_id,
+            status="initiated",
         )
+
+        # Persist LiveKit metadata alongside session
+        if lk_meta:
+            call_session.call_metadata = {
+                **(call_session.call_metadata or {}),
+                "livekit": lk_meta,
+            }
+            db.commit()
+
+        # Optional appointment_id
         appt_raw = (call_request.appointment_id or "").strip()
         if appt_raw:
-            call_session.call_metadata = call_session.call_metadata or {}
-            md_appt = {**call_session.call_metadata}
-            md_appt["appointment_id"] = appt_raw
-            call_session.call_metadata = md_appt
+            md = {**(call_session.call_metadata or {})}
+            md["appointment_id"] = appt_raw
+            call_session.call_metadata = md
             db.commit()
             db.refresh(call_session)
 
-        if call_request.callFlowId:
-            try:
-                flow_uuid = uuid.UUID(call_request.callFlowId)
-            except ValueError:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Invalid callFlowId format: must be a valid UUID",
-                )
+        # callFlowId
+        if flow_uuid:
             call_session.call_flow_id = flow_uuid
             db.commit()
             db.refresh(call_session)
 
-        # Optional: enrich from jd_id + resume_id (or jd_context only) without breaking n8n callers
+        # JD / resume enrichment (non-blocking on failure)
         _ctx = call_request.jd_context or {}
         _jd = parse_optional_uuid(
             call_request.jd_id
             or (
                 str(_ctx.get("jd_id"))
-                if _ctx.get("jd_id") is not None
-                and str(_ctx.get("jd_id")).strip()
+                if _ctx.get("jd_id") is not None and str(_ctx.get("jd_id")).strip()
                 else None
             )
         )
@@ -239,8 +371,7 @@ async def initiate_call(
             call_request.resume_id
             or (
                 str(_ctx.get("resume_id"))
-                if _ctx.get("resume_id") is not None
-                and str(_ctx.get("resume_id")).strip()
+                if _ctx.get("resume_id") is not None and str(_ctx.get("resume_id")).strip()
                 else None
             )
         )
@@ -253,23 +384,22 @@ async def initiate_call(
                     resume_id=_resume,
                     existing_jd_context=call_request.jd_context,
                 )
-            except Exception as exc:  # pragma: no cover - defensive; never block calls
+            except Exception as exc:  # pragma: no cover - defensive
                 logger.warning("Voice interview enrichment skipped: %s", exc, exc_info=True)
                 enrich = {
                     "merged_jd_context": {**(call_request.jd_context or {})},
                     "voice_dynamic_context": None,
                 }
-            call_session.call_metadata = call_session.call_metadata or {}
-            md: dict = {**(call_session.call_metadata or {})}
+            md_enrich: dict = {**(call_session.call_metadata or {})}
             if enrich.get("merged_jd_context"):
-                # Includes recruitment_jd_screening=True when a Job Description row is resolved (recruitment flow).
-                md["jd_context"] = enrich["merged_jd_context"]
+                md_enrich["jd_context"] = enrich["merged_jd_context"]
             if enrich.get("voice_dynamic_context"):
-                md["voice_dynamic_context"] = enrich["voice_dynamic_context"]
-            call_session.call_metadata = md
+                md_enrich["voice_dynamic_context"] = enrich["voice_dynamic_context"]
+            call_session.call_metadata = md_enrich
             db.commit()
             db.refresh(call_session)
 
+        # Webhook URLs
         webhook_url = (
             f"{base_url}/api/v1/voice/gather/streaming?"
             f"agentId={agent.id}&userId={user_id_filter}&callSessionId={call_session.id}"
@@ -282,52 +412,7 @@ async def initiate_call(
         logger.info("Making call with webhook_url: %s", webhook_url)
         logger.info("Making call with status_callback_url: %s", status_callback_url)
 
-        # Create LiveKit room BEFORE Twilio call so the agent is already
-        # listening on the media room when the caller connects.
-        if settings.LIVEKIT_ENABLED:
-            from app.services.livekit_service import livekit_service
-
-            try:
-                room = await livekit_service.create_room(
-                    call_id=call_session.id,
-                    agent_id=agent.id,
-                    flow_id=call_session.call_flow_id,
-                )
-                room_name = f"room_{call_session.id}"
-                agent_token = livekit_service.generate_agent_token(room_name)
-                lk_meta: dict = {
-                    "room_name": room_name,
-                    "room_sid": room.sid,
-                    "agent_token": agent_token,  # secret — never log
-                    "flow_id": str(call_session.call_flow_id) if call_session.call_flow_id else None,
-                    "created_at": datetime.now(timezone.utc).isoformat(),
-                }
-                call_session.call_metadata = {
-                    **(call_session.call_metadata or {}),
-                    "livekit": lk_meta,
-                }
-                db.commit()
-                logger.info(
-                    "LiveKit room provisioned for call session %s: %s",
-                    call_session.id,
-                    room_name,
-                )
-            except Exception as exc:
-                logger.error(
-                    "LiveKit room creation failed for call session %s: %s",
-                    call_session.id,
-                    exc,
-                    exc_info=True,
-                )
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail=(
-                        "LiveKit room creation failed. "
-                        "Cannot initiate call without media transport."
-                    ),
-                )
-
-        # Optional WebSocket broadcast
+        # Optional WebSocket broadcast before dialling
         try:
             await broadcast_call_status_update(
                 call_session_id=str(call_session.id),
@@ -335,31 +420,53 @@ async def initiate_call(
                 metadata={
                     "agent_id": str(agent.id),
                     "agent_name": agent.name,
-                    "to_number": call_request.userPhoneNumber,
+                    "to_number": call_request.toNumber,
                     "from_number": from_number,
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 },
             )
-            logger.info("✅ WebSocket: Call initiating event sent")
         except Exception as e:  # pragma: no cover - non-critical
             logger.warning("⚠️ WebSocket broadcast failed (non-critical): %s", e)
 
-        # Make call with appropriate credentials
-        if use_custom_credentials:
-            call = twilio_service.make_call_with_credentials(
-                to_number=call_request.userPhoneNumber,
-                from_number=from_number,
-                webhook_url=webhook_url,
-                status_callback_url=status_callback_url,
-                account_sid=account_sid,
-                auth_token=auth_token,
+        # ── 10. Initiate Twilio call ──────────────────────────────────────
+        try:
+            if use_custom_credentials:
+                call = twilio_service.make_call_with_credentials(
+                    to_number=call_request.toNumber,
+                    from_number=from_number,
+                    webhook_url=webhook_url,
+                    status_callback_url=status_callback_url,
+                    account_sid=account_sid,
+                    auth_token=auth_token,
+                )
+            else:
+                call = twilio_service.make_call(
+                    to_number=call_request.toNumber,
+                    from_number=from_number,
+                    webhook_url=webhook_url,
+                    status_callback_url=status_callback_url,
+                )
+        except Exception as exc:
+            logger.error(
+                "Twilio call creation failed for session %s: %s",
+                call_session.id,
+                exc,
+                exc_info=True,
             )
-        else:
-            call = twilio_service.make_call(
-                to_number=call_request.userPhoneNumber,
-                from_number=from_number,
-                webhook_url=webhook_url,
-                status_callback_url=status_callback_url,
+            call_session.status = "failed"
+            call_session.ended_reason = "Call.start.error"
+            db.commit()
+            if settings.LIVEKIT_ENABLED and lk_meta:
+                try:
+                    from app.services.livekit_service import livekit_service
+
+                    await livekit_service.close_room(call_session.id)
+                except Exception:
+                    pass
+            return _err(
+                status.HTTP_502_BAD_GATEWAY,
+                "twilio_call_failed",
+                "Failed to initiate phone call via Twilio.",
             )
         logger.info("✅ Call initiated successfully")
 
@@ -372,7 +479,7 @@ async def initiate_call(
             call.sid,
         )
 
-        # Broadcast call initiated event AFTER Twilio confirms
+        # Broadcast call initiated event after Twilio confirms
         try:
             await broadcast_call_status_update(
                 call_session_id=str(call_session.id),
@@ -381,18 +488,14 @@ async def initiate_call(
                     "call_sid": call.sid,
                     "agent_id": str(agent.id),
                     "agent_name": agent.name,
-                    "to_number": call_request.userPhoneNumber,
+                    "to_number": call_request.toNumber,
                     "from_number": from_number,
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 },
             )
-            logger.info(
-                "✅ Call initiated event sent for session %s", call_session.id
-            )
         except Exception as e:  # pragma: no cover - non-critical
             logger.warning("⚠️ Failed to send call initiated event: %s", e)
 
-        # Generate call ID
         call_id = f"call_{call.sid[-8:]}"
 
         crm_container_id = call_request.crm_container_id or call_request.board_id
@@ -423,7 +526,6 @@ async def initiate_call(
         )
 
     except HTTPException as e:
-        request_id = get_request_id(http_request)
         logger.warning("Call initiate HTTP error: %s", e.detail)
         return JSONResponse(
             status_code=e.status_code,
@@ -433,7 +535,6 @@ async def initiate_call(
             headers={"X-Request-ID": request_id},
         )
     except Exception as e:  # pragma: no cover - defensive
-        request_id = get_request_id(http_request)
         logger.error("Call initiate failed: %s", e, exc_info=True)
         return JSONResponse(
             status_code=500,
@@ -442,4 +543,3 @@ async def initiate_call(
             ),
             headers={"X-Request-ID": request_id},
         )
-

--- a/app/utils/audio_utils.py
+++ b/app/utils/audio_utils.py
@@ -11,7 +11,7 @@ import math
 import subprocess
 import tempfile
 import os
-from typing import Optional, Iterable
+from typing import Awaitable, Callable, Iterable, Optional
 
 from app.core.logger import logger
 from app.utils.audio_constants import BACKGROUND_AUDIO_BASE64
@@ -444,6 +444,7 @@ async def stream_mulaw_bytes_over_twilio(
     pace_20ms: bool = True,
     cancel: Optional[asyncio.Event] = None,
     prime_frames: int = 0,
+    mirror_mulaw: Optional[Callable[[bytes], Awaitable[None]]] = None,
 ):
     """
     Send mu-law audio to Twilio as 20ms 'media' frames.
@@ -473,6 +474,11 @@ async def stream_mulaw_bytes_over_twilio(
     for frame in iter_mulaw_20ms_frames(audio_bytes):
         if cancel and cancel.is_set():
             break
+        if mirror_mulaw:
+            try:
+                await mirror_mulaw(frame)
+            except Exception:
+                pass
         payload = base64.b64encode(frame).decode("utf-8")
         try:
             await websocket.send_json({

--- a/app/voice/audio_transcoder.py
+++ b/app/voice/audio_transcoder.py
@@ -1,0 +1,166 @@
+"""
+LiveKit / telephony audio → LINEAR16 PCM for Google STT.
+
+LiveKit Python RTC ``AudioStream`` delivers decoded PCM (s16le), not raw Opus.
+Use :class:`LiveKitAudioProcessor` per call: passthrough when already 16 kHz mono,
+otherwise resample via ffmpeg child process (one per call).
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+from typing import Optional
+
+from app.core.logger import logger
+
+_FFMPEG_OUTPUT_FORMAT = "s16le"
+
+
+class LiveKitAudioProcessor:
+    """
+    Convert LiveKit ``AudioFrame`` data to LINEAR16 mono bytes at ``output_sample_rate``.
+    """
+
+    def __init__(
+        self,
+        output_sample_rate: int = 16000,
+        output_channels: int = 1,
+    ) -> None:
+        self._output_sample_rate = output_sample_rate
+        self._output_channels = output_channels
+        self._ffmpeg_process: Optional[asyncio.subprocess.Process] = None
+        self._ffmpeg_input_rate: Optional[int] = None
+        self._ffmpeg_input_channels: Optional[int] = None
+        self._first_frame_logged = False
+
+    async def process_frame(
+        self,
+        raw_bytes: bytes,
+        sample_rate: int,
+        num_channels: int,
+    ) -> bytes:
+        """Return LINEAR16 mono PCM at ``output_sample_rate`` Hz."""
+        if not raw_bytes:
+            return b""
+
+        if not self._first_frame_logged:
+            logger.info(
+                "[LiveKitAudioProcessor] first frame sample_rate=%s channels=%s bytes=%s → target=%sHz",
+                sample_rate,
+                num_channels,
+                len(raw_bytes),
+                self._output_sample_rate,
+            )
+            self._first_frame_logged = True
+
+        if (
+            sample_rate == self._output_sample_rate
+            and num_channels == self._output_channels
+        ):
+            return raw_bytes
+
+        return await self._ffmpeg_convert(raw_bytes, sample_rate, num_channels)
+
+    async def _ffmpeg_convert(
+        self,
+        pcm: bytes,
+        sample_rate: int,
+        num_channels: int,
+    ) -> bytes:
+        """Resample / remix via ffmpeg child process (lazy-started, per call)."""
+        if (
+            self._ffmpeg_process is None
+            or self._ffmpeg_input_rate != sample_rate
+            or self._ffmpeg_input_channels != num_channels
+        ):
+            await self._restart_ffmpeg(sample_rate, num_channels)
+
+        proc = self._ffmpeg_process
+        if proc is None or proc.stdin is None or proc.stdout is None:
+            return b""
+
+        try:
+            proc.stdin.write(pcm)
+            await proc.stdin.drain()
+            out = await asyncio.wait_for(proc.stdout.read(65536), timeout=0.5)
+            return out or b""
+        except (BrokenPipeError, ConnectionResetError) as exc:
+            logger.warning("[LiveKitAudioProcessor] ffmpeg pipe broken: %s", exc)
+            return b""
+        except asyncio.TimeoutError:
+            return b""
+        except Exception as exc:
+            logger.warning("[LiveKitAudioProcessor] ffmpeg convert error: %s", exc)
+            return b""
+
+    async def _restart_ffmpeg(self, sample_rate: int, num_channels: int) -> None:
+        await self.close()
+        ffmpeg_bin = shutil.which("ffmpeg")
+        if not ffmpeg_bin:
+            raise RuntimeError(
+                "ffmpeg not found in PATH. "
+                "Install ffmpeg (apt-get install ffmpeg / brew install ffmpeg)."
+            )
+
+        cmd = [
+            ffmpeg_bin,
+            "-loglevel",
+            "error",
+            "-f",
+            _FFMPEG_OUTPUT_FORMAT,
+            "-ar",
+            str(sample_rate),
+            "-ac",
+            str(num_channels),
+            "-i",
+            "pipe:0",
+            "-ar",
+            str(self._output_sample_rate),
+            "-ac",
+            str(self._output_channels),
+            "-f",
+            _FFMPEG_OUTPUT_FORMAT,
+            "pipe:1",
+        ]
+        self._ffmpeg_process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        self._ffmpeg_input_rate = sample_rate
+        self._ffmpeg_input_channels = num_channels
+        logger.debug(
+            "[LiveKitAudioProcessor] ffmpeg resampler pid=%s (%sHz/%sch→%sHz)",
+            self._ffmpeg_process.pid,
+            sample_rate,
+            num_channels,
+            self._output_sample_rate,
+        )
+
+    async def close(self) -> None:
+        if self._ffmpeg_process is None:
+            return
+        try:
+            if self._ffmpeg_process.stdin and not self._ffmpeg_process.stdin.is_closing():
+                self._ffmpeg_process.stdin.close()
+                await self._ffmpeg_process.stdin.wait_closed()
+        except Exception:
+            pass
+        try:
+            await asyncio.wait_for(self._ffmpeg_process.wait(), timeout=3.0)
+        except asyncio.TimeoutError:
+            self._ffmpeg_process.kill()
+        self._ffmpeg_process = None
+        self._ffmpeg_input_rate = None
+        self._ffmpeg_input_channels = None
+
+    async def __aenter__(self) -> "LiveKitAudioProcessor":
+        return self
+
+    async def __aexit__(self, *_) -> None:
+        await self.close()
+
+
+# Backward-compatible alias used by older imports/tests.
+OpusToLinear16Transcoder = LiveKitAudioProcessor

--- a/app/voice/livekit_audio_subscriber.py
+++ b/app/voice/livekit_audio_subscriber.py
@@ -1,0 +1,149 @@
+"""
+LiveKitAudioSubscriber — subscribe to caller audio track and feed SttPipeline.
+
+Call flow (Google STT path):
+  LiveKit room → caller audio track (PCM via rtc.AudioStream)
+    → LiveKitAudioProcessor (resample to LINEAR16 16 kHz if needed)
+      → SttPipeline.feed_audio_chunk(pcm_bytes)
+
+The subscriber runs as a background asyncio Task created by VoiceOrchestrator
+when agent.stt_provider_slug == "google" and LIVEKIT_ENABLED=True.
+Twilio MULAW path is unaffected.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.voice.audio_transcoder import LiveKitAudioProcessor
+
+
+class LiveKitAudioSubscriber:
+    """
+    Subscribes to the caller participant's audio track in a LiveKit room,
+    normalises frames to LINEAR16 16 kHz mono, and feeds SttPipeline.
+    """
+
+    def __init__(
+        self,
+        room_name: str,
+        stt_pipeline: Any,
+        output_sample_rate: int = 16000,
+    ) -> None:
+        self._room_name = room_name
+        self._stt_pipeline = stt_pipeline
+        self._output_sample_rate = output_sample_rate
+        self._stop_event = asyncio.Event()
+        self._processor: Optional[LiveKitAudioProcessor] = None
+
+    async def run(self) -> None:
+        """Connect to LiveKit room, subscribe to caller audio, feed STT."""
+        if not settings.LIVEKIT_ENABLED:
+            logger.info("[LiveKitAudioSubscriber] LIVEKIT_ENABLED=false — no-op")
+            return
+
+        from app.services.livekit_service import livekit_service
+
+        try:
+            url, _, _ = livekit_service._get_credentials()
+        except Exception as exc:
+            logger.error("[LiveKitAudioSubscriber] credentials error: %s", exc)
+            return
+
+        from app.services.livekit_service import _http_to_ws_url
+
+        ws_url = _http_to_ws_url(url)
+        agent_token = livekit_service.generate_agent_token(self._room_name)
+
+        async with LiveKitAudioProcessor(
+            output_sample_rate=self._output_sample_rate
+        ) as processor:
+            self._processor = processor
+            await self._subscribe_and_transcode(ws_url, agent_token)
+        self._processor = None
+
+    async def _subscribe_and_transcode(self, ws_url: str, token: str) -> None:
+        try:
+            from livekit import rtc
+        except ImportError:
+            logger.error("[LiveKitAudioSubscriber] livekit package not available")
+            return
+
+        room = rtc.Room()
+        audio_stream: Optional[Any] = None
+        caller_track_found = asyncio.Event()
+
+        def on_track_subscribed(track, publication, participant):
+            nonlocal audio_stream
+            if (
+                track.kind == rtc.TrackKind.KIND_AUDIO
+                and "caller" in (participant.identity or "").lower()
+            ):
+                logger.info(
+                    "[LiveKitAudioSubscriber] subscribed to caller audio track sid=%s",
+                    track.sid,
+                )
+                audio_stream = rtc.AudioStream(track)
+                caller_track_found.set()
+
+        room.on("track_subscribed", on_track_subscribed)
+
+        try:
+            await room.connect(ws_url, token)
+            logger.info(
+                "[LiveKitAudioSubscriber] connected to room=%s", self._room_name
+            )
+
+            try:
+                await asyncio.wait_for(caller_track_found.wait(), timeout=30.0)
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[LiveKitAudioSubscriber] timed out waiting for caller audio track"
+                )
+                return
+
+            if audio_stream is None or self._processor is None:
+                return
+
+            async for audio_frame_event in audio_stream:
+                if self._stop_event.is_set():
+                    break
+
+                frame = audio_frame_event.frame
+                raw_bytes = bytes(frame.data)
+                if not raw_bytes:
+                    continue
+
+                sample_rate = int(getattr(frame, "sample_rate", 48000) or 48000)
+                num_channels = int(getattr(frame, "num_channels", 1) or 1)
+
+                pcm_bytes = await self._processor.process_frame(
+                    raw_bytes,
+                    sample_rate=sample_rate,
+                    num_channels=num_channels,
+                )
+                if pcm_bytes:
+                    await self._stt_pipeline.feed_audio_chunk(pcm_bytes)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error(
+                "[LiveKitAudioSubscriber] stream error: %s", exc, exc_info=True
+            )
+        finally:
+            try:
+                await room.disconnect()
+            except Exception:
+                pass
+            logger.info(
+                "[LiveKitAudioSubscriber] disconnected from room=%s", self._room_name
+            )
+
+    async def stop(self) -> None:
+        """Signal the run loop to exit gracefully."""
+        self._stop_event.set()
+        if self._processor:
+            await self._processor.close()

--- a/app/voice/livekit_twilio_bridge.py
+++ b/app/voice/livekit_twilio_bridge.py
@@ -33,10 +33,11 @@ def build_livekit_stream_ws_url(room_name: str) -> str:
 
 
 class LiveKitTwilioPublisher:
-    """Publish Twilio inbound μ-law audio into a LiveKit room as the caller."""
+    """Publish μ-law audio into a LiveKit room (caller inbound or agent TTS mirror)."""
 
-    def __init__(self, room_name: str) -> None:
+    def __init__(self, room_name: str, *, role: str = "caller") -> None:
         self._room_name = room_name
+        self._role = role if role in ("caller", "agent") else "caller"
         self._room: Any = None
         self._source: Any = None
         self._connected = False
@@ -58,22 +59,25 @@ class LiveKitTwilioPublisher:
             livekit_service._validate_room_name(self._room_name)
             url, _, _ = livekit_service._get_credentials()
             ws_url = _http_to_ws_url(url)
-            token = livekit_service.generate_caller_token(self._room_name)
+            if self._role == "agent":
+                token = livekit_service.generate_agent_token(self._room_name)
+                track_name = "agent-audio"
+            else:
+                token = livekit_service.generate_caller_token(self._room_name)
+                track_name = "caller-audio"
 
             self._room = rtc.Room()
             await self._room.connect(ws_url, token)
 
             self._source = rtc.AudioSource(_TWILIO_SAMPLE_RATE, 1)
-            track = rtc.LocalAudioTrack.create_audio_track(
-                "caller-audio", self._source
-            )
+            track = rtc.LocalAudioTrack.create_audio_track(track_name, self._source)
             options = rtc.TrackPublishOptions()
             options.source = rtc.TrackSource.SOURCE_MICROPHONE
             await self._room.local_participant.publish_track(track, options)
 
             self._connected = True
             logger.info(
-                "[LiveKitBridge] caller track published room=%s", self._room_name
+                "[LiveKitBridge] %s track published room=%s", self._role, self._room_name
             )
             return True
         except Exception as exc:

--- a/app/voice/livekit_twilio_bridge.py
+++ b/app/voice/livekit_twilio_bridge.py
@@ -1,0 +1,127 @@
+"""
+Twilio Media Stream → LiveKit room bridge (caller audio publish).
+
+Twilio connects to ``/api/v1/livekit/{roomName}``. This module publishes inbound
+μ-law frames into the LiveKit room as ``caller-{roomName}`` so agent-side
+subscribers (e.g. LiveKitAudioSubscriber + Google STT) receive caller audio.
+
+TTS and conversation logic stay on the same Twilio WebSocket via
+BidirectionalStreamHandler — only inbound audio is mirrored to LiveKit.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+from typing import Any, Optional
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.services.livekit_service import livekit_service, _http_to_ws_url
+from app.utils.audio_utils import MULAW_FRAME_BYTES, ulaw_to_linear_sample
+
+# Twilio μ-law is 8 kHz mono — match LiveKit AudioSource rate.
+_TWILIO_SAMPLE_RATE = 8000
+
+
+def build_livekit_stream_ws_url(room_name: str) -> str:
+    """TwiML <Stream url=…> for ticket-compliant LiveKit bridge path."""
+    base = settings.WEBHOOK_BASE_URL.rstrip("/")
+    ws_protocol = "wss" if base.startswith("https") else "ws"
+    host = base.replace("https://", "").replace("http://", "")
+    return f"{ws_protocol}://{host}/api/v1/livekit/{room_name}"
+
+
+class LiveKitTwilioPublisher:
+    """Publish Twilio inbound μ-law audio into a LiveKit room as the caller."""
+
+    def __init__(self, room_name: str) -> None:
+        self._room_name = room_name
+        self._room: Any = None
+        self._source: Any = None
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> bool:
+        if not settings.LIVEKIT_ENABLED:
+            return False
+        try:
+            from livekit import rtc
+        except ImportError:
+            logger.error("[LiveKitBridge] livekit package not available")
+            return False
+
+        try:
+            livekit_service._validate_room_name(self._room_name)
+            url, _, _ = livekit_service._get_credentials()
+            ws_url = _http_to_ws_url(url)
+            token = livekit_service.generate_caller_token(self._room_name)
+
+            self._room = rtc.Room()
+            await self._room.connect(ws_url, token)
+
+            self._source = rtc.AudioSource(_TWILIO_SAMPLE_RATE, 1)
+            track = rtc.LocalAudioTrack.create_audio_track(
+                "caller-audio", self._source
+            )
+            options = rtc.TrackPublishOptions()
+            options.source = rtc.TrackSource.SOURCE_MICROPHONE
+            await self._room.local_participant.publish_track(track, options)
+
+            self._connected = True
+            logger.info(
+                "[LiveKitBridge] caller track published room=%s", self._room_name
+            )
+            return True
+        except Exception as exc:
+            logger.error(
+                "[LiveKitBridge] connect failed room=%s: %s",
+                self._room_name,
+                exc,
+                exc_info=True,
+            )
+            await self.disconnect()
+            return False
+
+    async def publish_mulaw(self, mulaw_bytes: bytes) -> None:
+        """Push one or more Twilio μ-law bytes into the LiveKit caller track."""
+        if not self._connected or not self._source or not mulaw_bytes:
+            return
+
+        try:
+            from livekit import rtc
+        except ImportError:
+            return
+
+        try:
+            offset = 0
+            total = len(mulaw_bytes)
+            while offset < total:
+                chunk = mulaw_bytes[offset : offset + MULAW_FRAME_BYTES]
+                offset += MULAW_FRAME_BYTES
+                if len(chunk) < MULAW_FRAME_BYTES:
+                    chunk = chunk + bytes([0xFF]) * (MULAW_FRAME_BYTES - len(chunk))
+
+                samples = [ulaw_to_linear_sample(b) for b in chunk]
+                pcm = struct.pack(f"<{len(samples)}h", *samples)
+                frame = rtc.AudioFrame.create(
+                    _TWILIO_SAMPLE_RATE, 1, len(samples)
+                )
+                frame.data[:] = pcm
+                await self._source.capture_frame(frame)
+        except Exception as exc:
+            logger.debug("[LiveKitBridge] publish_mulaw: %s", exc)
+
+    async def disconnect(self) -> None:
+        self._connected = False
+        if self._room is not None:
+            try:
+                await self._room.disconnect()
+            except Exception:
+                pass
+        self._room = None
+        self._source = None
+        logger.info("[LiveKitBridge] disconnected room=%s", self._room_name)

--- a/app/voice/stt_events.py
+++ b/app/voice/stt_events.py
@@ -1,0 +1,79 @@
+"""
+Typed STT event definitions and asyncio-based event bus.
+
+Events emitted by SttPipeline providers:
+  SttInterimEvent  — partial transcript, updated as speech continues
+  SttFinalEvent    — confirmed utterance, may carry isSilence=True on pause
+  SttErrorEvent    — provider error with recoverable flag
+
+The SttEventBus allows multiple async subscribers (e.g. VoiceOrchestrator)
+to receive events without coupling to the callback signature.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Literal, Union
+
+
+# ── Event types ───────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class SttInterimEvent:
+    type: Literal["interim"] = field(default="interim", init=False)
+    transcript: str = ""
+    confidence: float = 0.0
+
+
+@dataclass(frozen=True)
+class SttFinalEvent:
+    type: Literal["final"] = field(default="final", init=False)
+    transcript: str = ""
+    confidence: float = 0.0
+    is_silence: bool = False
+
+
+@dataclass(frozen=True)
+class SttErrorEvent:
+    type: Literal["error"] = field(default="error", init=False)
+    message: str = ""
+    recoverable: bool = True
+
+
+SttEvent = Union[SttInterimEvent, SttFinalEvent, SttErrorEvent]
+
+SttEventCallback = Callable[[SttEvent], Awaitable[None]]
+
+
+# ── Event bus ─────────────────────────────────────────────────────────────────
+
+class SttEventBus:
+    """Lightweight asyncio pub/sub for STT events.
+
+    VoiceOrchestrator subscribes once; the provider emits via emit().
+    Subscribers are called sequentially in subscription order.
+    Errors in one subscriber are logged and do not block subsequent ones.
+    """
+
+    def __init__(self) -> None:
+        self._subscribers: list[SttEventCallback] = []
+
+    def subscribe(self, callback: SttEventCallback) -> None:
+        self._subscribers.append(callback)
+
+    def unsubscribe(self, callback: SttEventCallback) -> None:
+        self._subscribers = [s for s in self._subscribers if s is not callback]
+
+    async def emit(self, event: SttEvent) -> None:
+        for cb in list(self._subscribers):
+            try:
+                await cb(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                from app.core.logger import logger
+                logger.error(
+                    "[SttEventBus] subscriber error on %s event",
+                    event.type,
+                    exc_info=True,
+                )

--- a/app/voice/stt_pipeline.py
+++ b/app/voice/stt_pipeline.py
@@ -1,11 +1,32 @@
+"""
+SttPipeline — provider-agnostic streaming STT wrapper.
+
+Supports Deepgram (existing Twilio MULAW path) and Google STT (LiveKit LINEAR16
+path). Provider is selected at construction time via provider_slug.
+
+Public interface is unchanged for existing callers (VoiceOrchestrator):
+  feed_audio_chunk(bytes)
+  finish_session()
+  aclose()
+  recreate_with_endpointing(ms)  — Deepgram-only; no-op for Google
+
+New: emit() pushes typed SttEvent objects to SttEventBus; the legacy
+on_interim/on_final callbacks are still called so VoiceOrchestrator wiring
+requires zero changes.
+"""
+from __future__ import annotations
+
 import asyncio
 import re
 import time
-from typing import Awaitable, Callable, Optional
+from typing import Awaitable, Callable, Optional, TYPE_CHECKING
 
 from app.core.config import settings
 from app.core.logger import logger
-from app.services.deepgram_stt_service import deepgram_stt_service
+from app.voice.stt_events import SttEventBus, SttInterimEvent, SttFinalEvent, SttErrorEvent
+
+if TYPE_CHECKING:
+    from app.core.agent_runtime import ResolvedSttRuntime
 
 
 InterimCallback = Callable[[str, float], Awaitable[None]]
@@ -14,11 +35,12 @@ FinalCallback = Callable[[str, float], Awaitable[None]]
 
 class SttPipeline:
     """
-    Thin wrapper around the Deepgram streaming STT session.
-    Responsible for:
-    - Managing the underlying streaming session lifecycle.
-    - Feeding MULAW audio bytes.
-    - Invoking interim/final callbacks with transcript + confidence.
+    Provider-agnostic STT pipeline. Manages session lifecycle,
+    emits typed events, and calls legacy interim/final callbacks.
+
+    Providers:
+      "deepgram"  — DeepgramSTTService (MULAW 8kHz, Twilio path)
+      "google"    — GoogleSttService (LINEAR16 16kHz, LiveKit path)
     """
 
     def __init__(
@@ -29,24 +51,71 @@ class SttPipeline:
         call_session_id: Optional[str] = None,
         agent_id: Optional[str] = None,
         endpointing_ms: Optional[int] = None,
+        provider_slug: str = "deepgram",
+        sample_rate_hz: int = 8000,
+        encoding: str = "MULAW",
+        silence_threshold_ms: int = 1500,
+        api_config: Optional[dict] = None,
+        event_bus: Optional[SttEventBus] = None,
     ) -> None:
         self._language_code = language_code
         self._on_interim = on_interim
         self._on_final = on_final
         self._call_session_id = call_session_id
         self._agent_id = agent_id
-        # None → Deepgram uses settings.DEEPGRAM_STT_ENDPOINTING_MS when connecting
         self._endpointing_ms: Optional[int] = endpointing_ms
+        self._provider_slug = provider_slug.lower()
+        self._sample_rate_hz = sample_rate_hz
+        self._encoding = encoding.upper()
+        self._silence_threshold_ms = silence_threshold_ms
+        self._api_config = api_config or {}
+        self._event_bus = event_bus or SttEventBus()
 
         self._stt_session = None
         self._reader_task: Optional[asyncio.Task] = None
 
-        # Normalized-final dedup: catches "Hello?" vs "hello ?" re-endpoints within a window.
+        # Normalized-final dedup — catches re-endpoints within window
         self._last_final_norm_key: str = ""
         self._last_final_norm_mono: float = 0.0
         self._final_norm_dedup_sec: float = float(
             getattr(settings, "VOICE_STT_FINAL_NORMALIZED_DEDUP_SEC", 6.0) or 6.0
         )
+
+        # Silence detection state
+        self._last_audio_mono: float = time.monotonic()
+
+    @classmethod
+    def from_runtime_config(
+        cls,
+        resolved: "ResolvedSttRuntime",
+        on_interim: InterimCallback,
+        on_final: FinalCallback,
+        call_session_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
+        endpointing_ms: Optional[int] = None,
+        event_bus: Optional[SttEventBus] = None,
+    ) -> "SttPipeline":
+        """Factory: build SttPipeline from a ResolvedSttRuntime."""
+        return cls(
+            language_code=resolved.language_code,
+            on_interim=on_interim,
+            on_final=on_final,
+            call_session_id=call_session_id,
+            agent_id=agent_id,
+            endpointing_ms=endpointing_ms,
+            provider_slug=resolved.provider_slug,
+            sample_rate_hz=resolved.sample_rate_hz,
+            encoding=resolved.encoding,
+            silence_threshold_ms=resolved.silence_threshold_ms,
+            api_config=resolved.api_config,
+            event_bus=event_bus,
+        )
+
+    @property
+    def event_bus(self) -> SttEventBus:
+        return self._event_bus
+
+    # ── Private helpers ────────────────────────────────────────────────────
 
     @staticmethod
     def _normalize_final_key(transcript: str) -> str:
@@ -59,106 +128,142 @@ class SttPipeline:
             return int(self._endpointing_ms)
         return int(getattr(settings, "DEEPGRAM_STT_ENDPOINTING_MS", 900) or 900)
 
+    def _is_silence(self) -> bool:
+        elapsed_ms = (time.monotonic() - self._last_audio_mono) * 1000
+        return elapsed_ms >= self._silence_threshold_ms
+
+    # ── Session creation ───────────────────────────────────────────────────
+
     async def _ensure_session(self) -> None:
         if self._stt_session is not None:
             return
 
+        if self._provider_slug == "google":
+            await self._ensure_google_session()
+        else:
+            await self._ensure_deepgram_session()
+
+    async def _ensure_deepgram_session(self) -> None:
+        from app.services.deepgram_stt_service import deepgram_stt_service
+
         self._stt_session = deepgram_stt_service.create_streaming_session(
             language_code=self._language_code,
-            encoding="MULAW",
-            sample_rate=8000,
+            encoding=self._encoding,
+            sample_rate=self._sample_rate_hz,
             interim_results=True,
             single_utterance=False,
             endpointing_ms=self._endpointing_ms,
         )
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        asyncio.create_task(self._stt_session.start())
 
-        async def consume_results():
+    async def _ensure_google_session(self) -> None:
+        from app.services.google_stt_service import google_stt_service
+
+        self._stt_session = google_stt_service.create_streaming_session(
+            language_code=self._language_code or "en-AU",
+            sample_rate_hz=self._sample_rate_hz,
+            encoding=self._encoding,
+            interim_results=True,
+            api_config=self._api_config,
+            silence_threshold_ms=self._silence_threshold_ms,
+        )
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        asyncio.create_task(self._stt_session.start())
+
+    # ── Reader loop (provider-agnostic) ───────────────────────────────────
+
+    async def _reader_loop(self) -> None:
+        while True:
+            sess = self._stt_session
+            if sess is None:
+                break
             try:
-                # Start underlying blocking stream in executor
-                await self._stt_session.start()
+                result = await sess.get_result()
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
-                logger.error(f"[STT] session start error: {e}", exc_info=True)
-
-        async def reader_loop():
-            while True:
-                sess = self._stt_session
-                if sess is None:
+                logger.error("[STT] reader loop error: %s", e, exc_info=True)
+                if self._stt_session is None:
                     break
-                try:
-                    result = await sess.get_result()
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    logger.error(f"[STT] reader loop error: {e}", exc_info=True)
-                    if self._stt_session is None:
-                        break
-                    continue
+                await self._event_bus.emit(SttErrorEvent(message=str(e), recoverable=True))
+                continue
 
-                if not result:
-                    continue
-                if result.get("done"):
-                    break
-                if result.get("error"):
-                    logger.warning(
-                        "[STT] session reported error payload: %s (call_session_id=%s, agent_id=%s)",
-                        result.get("error"),
-                        self._call_session_id,
-                        self._agent_id,
+            if not result:
+                continue
+            if result.get("done"):
+                break
+            if result.get("error"):
+                err_msg = result.get("error", "unknown")
+                recoverable = bool(result.get("recoverable", True))
+                logger.warning(
+                    "[STT] session error payload: %s recoverable=%s (call_session_id=%s)",
+                    err_msg,
+                    recoverable,
+                    self._call_session_id,
+                )
+                await self._event_bus.emit(
+                    SttErrorEvent(message=str(err_msg), recoverable=recoverable)
+                )
+                continue
+
+            transcript = (result.get("transcript") or "").strip()
+            if not transcript:
+                continue
+
+            is_final = bool(result.get("is_final"))
+            confidence = float(result.get("confidence") or 0.0)
+
+            try:
+                if is_final:
+                    norm_key = self._normalize_final_key(transcript)
+                    now_mono = time.monotonic()
+                    if (
+                        norm_key
+                        and norm_key == self._last_final_norm_key
+                        and (now_mono - self._last_final_norm_mono) < self._final_norm_dedup_sec
+                    ):
+                        logger.debug("[STT] skipping normalized duplicate final")
+                        continue
+                    if norm_key:
+                        self._last_final_norm_key = norm_key
+                        self._last_final_norm_mono = now_mono
+
+                    is_silence = self._is_silence()
+                    await self._event_bus.emit(
+                        SttFinalEvent(
+                            transcript=transcript,
+                            confidence=confidence,
+                            is_silence=is_silence,
+                        )
                     )
-                    continue
+                    await self._on_final(transcript, confidence)
+                else:
+                    await self._event_bus.emit(
+                        SttInterimEvent(transcript=transcript, confidence=confidence)
+                    )
+                    await self._on_interim(transcript, confidence)
+            except Exception as cb_err:
+                logger.error("[STT] callback error: %s", cb_err, exc_info=True)
 
-                transcript = (result.get("transcript") or "").strip()
-                if not transcript:
-                    continue
-
-                is_final = bool(result.get("is_final"))
-                confidence = float(result.get("confidence") or 0.0)
-
-                try:
-                    if is_final:
-                        norm_key = self._normalize_final_key(transcript)
-                        _now_mono = time.monotonic()
-                        if (
-                            norm_key
-                            and norm_key == self._last_final_norm_key
-                            and (_now_mono - self._last_final_norm_mono)
-                            < self._final_norm_dedup_sec
-                        ):
-                            logger.debug(
-                                "[STT] skipping normalized duplicate final within %ss",
-                                self._final_norm_dedup_sec,
-                            )
-                            continue
-                        if norm_key:
-                            self._last_final_norm_key = norm_key
-                            self._last_final_norm_mono = _now_mono
-                        await self._on_final(transcript, confidence)
-                    else:
-                        await self._on_interim(transcript, confidence)
-                except Exception as cb_err:
-                    logger.error(f"[STT] callback error: {cb_err}", exc_info=True)
-
-        # Kick off background readers
-        self._reader_task = asyncio.create_task(reader_loop())
-        asyncio.create_task(consume_results())
+    # ── Public interface ───────────────────────────────────────────────────
 
     async def feed_audio_chunk(self, audio_data: bytes) -> None:
-        """
-        Feed a raw MULAW audio chunk into the streaming session.
-        Lazily starts the session on first call.
-        """
+        """Feed raw audio bytes (MULAW or LINEAR16) into the streaming session."""
         if not audio_data:
             return
-
+        self._last_audio_mono = time.monotonic()
         await self._ensure_session()
         if self._stt_session:
             self._stt_session.push_audio(audio_data)
 
     async def recreate_with_endpointing(self, endpointing_ms: int) -> None:
+        """Reopen Deepgram session with a new endpointing value (email collection).
+        No-op for Google STT (uses silence_threshold_ms instead).
         """
-        Close the current Deepgram session and reopen with a new endpointing (ms) value.
-        Used after the agent asks for email so spelling pauses are less likely to split finals.
-        """
+        if self._provider_slug != "deepgram":
+            logger.debug("[STT] recreate_with_endpointing is Deepgram-only; skipping")
+            return
         want = int(endpointing_ms)
         if want == self._effective_endpointing_ms() and self._stt_session is not None:
             return
@@ -167,21 +272,13 @@ class SttPipeline:
         self._stt_session = None
         self._reader_task = None
         logger.info(
-            "[STT] recreated session with endpointing_ms=%s (call_session_id=%s)",
+            "[STT] recreated Deepgram session with endpointing_ms=%s (call_session_id=%s)",
             want,
             self._call_session_id,
         )
 
     def finish_session(self) -> None:
-        """Signal the underlying STT session to finish.
-
-        Only pushes the sentinel (None) onto the audio queue so the sender
-        thread calls send_finalize / send_close_stream / socket.close and lets
-        start_listening() unblock naturally.  Do NOT cancel the reader task here:
-        the reader must stay alive to consume the final {"done": True} message
-        that the Deepgram thread emits after the socket closes.  Cancelling it
-        early strands the worker thread and keeps the Deepgram connection busy.
-        """
+        """Signal the underlying STT session to finish gracefully."""
         try:
             if self._stt_session:
                 self._stt_session.finish()
@@ -189,25 +286,13 @@ class SttPipeline:
             pass
 
     async def aclose(self) -> None:
-        """Async-friendly shutdown: signal finish then wait for reader to exit.
-
-        Flow:
-        1. finish_session() → pushes None onto audio queue.
-        2. sender_loop sees None → calls _close_connection (finalize + close_stream
-           + socket.close).
-        3. start_listening() unblocks, emits {"done": True} → reader_loop breaks.
-        4. We wait up to 5 s for the reader to complete cleanly.
-        5. Only if the reader is still alive after the timeout do we cancel it
-           as a last resort (prevents resource leak on hung connections).
-        """
+        """Graceful shutdown: signal finish then wait up to 5s for reader."""
         self.finish_session()
         if self._reader_task and not self._reader_task.done():
             try:
-                await asyncio.wait_for(
-                    asyncio.shield(self._reader_task), timeout=5.0
-                )
+                await asyncio.wait_for(asyncio.shield(self._reader_task), timeout=5.0)
             except asyncio.TimeoutError:
-                logger.warning("[STT] reader_loop did not finish within 5 s — cancelling")
+                logger.warning("[STT] reader_loop did not finish within 5s — cancelling")
                 self._reader_task.cancel()
                 try:
                     await self._reader_task
@@ -217,4 +302,3 @@ class SttPipeline:
                 pass
         self._stt_session = None
         self._reader_task = None
-

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -867,19 +867,21 @@ class TtsStreamMixin:
                 return
             
             try:
-                if self.call_session.status != "in-progress":
-                    self.call_session.status = "in-progress"
-                    
+                # Outbound lifecycle uses "connected"; inbound/web keep "in-progress".
+                is_outbound = (self.call_session.call_type or "").lower() == "outbound"
+                live_status = "connected" if is_outbound else "in-progress"
+                if self.call_session.status != live_status:
+                    self.call_session.status = live_status
+
                     # Set start time when confident speech is detected
                     if not self.call_session.start_time:
                         self.call_session.start_time = datetime.now(timezone.utc)
-                    
+
                     self.db.commit()
-                
-                # Broadcast "in-progress" event (confident word detected)
+
                 await broadcast_call_status_update(
                     call_session_id=str(self.call_session.id),
-                    status="in-progress",
+                    status=live_status,
                     metadata={
                         "call_sid": self.call_sid,
                         "stream_sid": self.stream_sid,

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -35,6 +35,13 @@ if TYPE_CHECKING:
 class TtsStreamMixin:
     """TTS streaming and audio delivery methods for BidirectionalStreamHandler."""
 
+    def _livekit_recording_mirror(self):
+        """Return agent TTS mirror callback when LiveKit egress recording is active."""
+        pub = getattr(self, "_lk_agent_publisher", None)
+        if pub and getattr(pub, "connected", False):
+            return pub.publish_mulaw
+        return None
+
     async def _start_background_audio_with_delay(self):
         """Start background loop after call stabilizes (dev-branch behavior)."""
         try:
@@ -545,6 +552,7 @@ class TtsStreamMixin:
                             pace_20ms=True,
                             cancel=self._tts_cancel,
                             prime_frames=prime_frames,
+                            mirror_mulaw=self._livekit_recording_mirror(),
                         )
                         self._twilio_buffer_primed = True
 
@@ -789,6 +797,7 @@ class TtsStreamMixin:
                             pace_20ms=True,
                             cancel=self._tts_cancel,
                             prime_frames=0 if self._twilio_buffer_primed else 3,
+                            mirror_mulaw=self._livekit_recording_mirror(),
                         )
                         self._twilio_buffer_primed = True
 
@@ -817,6 +826,7 @@ class TtsStreamMixin:
                                     pace_20ms=True,
                                     cancel=self._tts_cancel,
                                     prime_frames=0,
+                                    mirror_mulaw=self._livekit_recording_mirror(),
                                 )
                             else:
                                 # No suffix - flush held tail
@@ -828,6 +838,7 @@ class TtsStreamMixin:
                                         pace_20ms=True,
                                         cancel=self._tts_cancel,
                                         prime_frames=0,
+                                        mirror_mulaw=self._livekit_recording_mirror(),
                                     )
                 finally:
                     self.is_speaking = False
@@ -855,6 +866,7 @@ class TtsStreamMixin:
                 stream_sid=self.stream_sid,
                 audio_bytes=audio_data,
                 pace_20ms=True,
+                mirror_mulaw=self._livekit_recording_mirror(),
             )
         
         except Exception as e:

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -30,10 +30,10 @@ from app.core.logger import logger
 from app.utils.audio_utils import ulaw_to_linear_sample
 from app.voice.stt_pipeline import SttPipeline
 from app.voice.tts_pipeline import TtsPipeline
+from app.voice.stt_events import SttEventBus, SttFinalEvent, SttInterimEvent, SttErrorEvent
 
 if TYPE_CHECKING:
-    # Avoid circular import — handler is referenced only for type hints and callbacks.
-    pass
+    from app.core.agent_runtime import ResolvedSttRuntime
 
 
 def _resolve_initial_endpointing_ms() -> int:
@@ -87,10 +87,13 @@ class VoiceOrchestrator:
         # ── STT state ────────────────────────────────────────────────────────
         self._stt_pipeline: Optional[SttPipeline] = None
         self._stt_active: bool = True
-        # Deferred endpointing: stored here when the pipeline hasn't been created
-        # yet but the email-collection hook fires early (race at call start).
         self._stt_deferred_endpointing_ms: Optional[int] = None
         self._email_stt_endpointing_upgraded: bool = False
+        # Resolved STT config (set by caller before first audio arrives)
+        self._resolved_stt: Optional["ResolvedSttRuntime"] = None
+        self._stt_event_bus: SttEventBus = SttEventBus()
+        # LiveKit audio subscriber task (Google STT path only)
+        self._livekit_audio_task: Optional[asyncio.Task] = None
 
         # ── User-pickup detection ─────────────────────────────────────────────
         # We use a short RMS window to detect real pickup before forwarding audio.
@@ -160,10 +163,43 @@ class VoiceOrchestrator:
         # stream_sid lives on handler.stream_sid — nothing to do here for now.
         pass
 
+    def set_resolved_stt(self, resolved: "ResolvedSttRuntime") -> None:
+        """Configure STT runtime before first audio arrives (called by handler setup)."""
+        self._resolved_stt = resolved
+
+    @property
+    def stt_event_bus(self) -> SttEventBus:
+        return self._stt_event_bus
+
     def deactivate_stt(self) -> None:
         """Stop accepting audio.  Called as part of shutdown so Twilio silence
         frames arriving after call-end don't trigger a new Deepgram session."""
         self._stt_active = False
+
+    def _start_livekit_audio_subscriber(self, handler) -> None:
+        """Start the LiveKit audio subscriber task for Google STT path."""
+        call_session_id = getattr(handler, "call_session_id", None)
+        if not call_session_id:
+            logger.warning("[VoiceOrchestrator] No call_session_id for LiveKit subscriber")
+            return
+
+        room_name = f"room_{call_session_id}"
+        from app.voice.livekit_audio_subscriber import LiveKitAudioSubscriber
+
+        sample_rate = (
+            self._resolved_stt.sample_rate_hz if self._resolved_stt else 16000
+        )
+        subscriber = LiveKitAudioSubscriber(
+            room_name=room_name,
+            stt_pipeline=self._stt_pipeline,
+            output_sample_rate=sample_rate,
+        )
+        self._livekit_audio_task = asyncio.create_task(subscriber.run())
+        # Store subscriber for cleanup in shutdown
+        self._livekit_subscriber = subscriber
+        logger.info(
+            "[VoiceOrchestrator] LiveKit audio subscriber started room=%s", room_name
+        )
 
     async def on_audio_chunk(self, audio_data: bytes) -> None:
         """
@@ -236,7 +272,6 @@ class VoiceOrchestrator:
 
             # ── 4. STT feed ───────────────────────────────────────────────────
             if self._stt_pipeline is None:
-                language_code = (settings.DEEPGRAM_STT_LANGUAGE or "en").strip()
                 deferred_ep = self._stt_deferred_endpointing_ms
                 self._stt_deferred_endpointing_ms = None
                 initial_endpointing = (
@@ -244,23 +279,54 @@ class VoiceOrchestrator:
                     if deferred_ep is not None
                     else _resolve_initial_endpointing_ms()
                 )
-                self._stt_pipeline = SttPipeline(
-                    language_code=language_code,
-                    on_interim=self._on_interim,
-                    on_final=self._on_final,
-                    call_session_id=h.call_session_id,
-                    agent_id=h.agent_id,
-                    endpointing_ms=initial_endpointing,
-                )
+
+                if self._resolved_stt is not None:
+                    self._stt_pipeline = SttPipeline.from_runtime_config(
+                        resolved=self._resolved_stt,
+                        on_interim=self._on_interim,
+                        on_final=self._on_final,
+                        call_session_id=h.call_session_id,
+                        agent_id=h.agent_id,
+                        endpointing_ms=initial_endpointing,
+                        event_bus=self._stt_event_bus,
+                    )
+                    # Start LiveKit audio subscriber for Google STT path
+                    if (
+                        self._resolved_stt.provider_slug == "google"
+                        and settings.LIVEKIT_ENABLED
+                    ):
+                        self._start_livekit_audio_subscriber(h)
+                else:
+                    # Fallback: legacy Deepgram path (no resolved STT config)
+                    language_code = (settings.DEEPGRAM_STT_LANGUAGE or "en").strip()
+                    self._stt_pipeline = SttPipeline(
+                        language_code=language_code,
+                        on_interim=self._on_interim,
+                        on_final=self._on_final,
+                        call_session_id=h.call_session_id,
+                        agent_id=h.agent_id,
+                        endpointing_ms=initial_endpointing,
+                        event_bus=self._stt_event_bus,
+                    )
+
                 ps = getattr(h, "_pipeline_session", None)
                 if ps is not None:
                     ps.stt_emitter = self._stt_pipeline
+                provider = (
+                    self._resolved_stt.provider_slug if self._resolved_stt else "deepgram"
+                )
                 logger.debug(
-                    "[VoiceOrchestrator] SttPipeline created (endpointing_ms=%s)",
+                    "[VoiceOrchestrator] SttPipeline created provider=%s endpointing_ms=%s",
+                    provider,
                     initial_endpointing,
                 )
 
-            await self._stt_pipeline.feed_audio_chunk(audio_data)
+            # Only feed Twilio audio to non-Google paths (Google uses LiveKit)
+            provider_slug = (
+                self._resolved_stt.provider_slug if self._resolved_stt else "deepgram"
+            )
+            if provider_slug != "google":
+                await self._stt_pipeline.feed_audio_chunk(audio_data)
 
         except Exception as exc:
             logger.error("[VoiceOrchestrator] on_audio_chunk error: %s", exc, exc_info=True)
@@ -368,7 +434,23 @@ class VoiceOrchestrator:
         except Exception:
             pass
 
-        # Close Deepgram WebSocket (sends CloseStream, waits up to 5 s for reader)
+        # Stop LiveKit audio subscriber (Google STT path)
+        lk_subscriber = getattr(self, "_livekit_subscriber", None)
+        if lk_subscriber:
+            try:
+                await lk_subscriber.stop()
+            except Exception:
+                pass
+        lk_task = self._livekit_audio_task
+        if lk_task and not lk_task.done():
+            lk_task.cancel()
+            try:
+                await lk_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._livekit_audio_task = None
+
+        # Close STT session (Deepgram: sends CloseStream, waits up to 5s; Google: stops stream)
         try:
             if self._stt_pipeline:
                 await self._stt_pipeline.aclose()
@@ -394,10 +476,22 @@ class VoiceOrchestrator:
 
     async def _on_final(self, transcript: str, confidence: float) -> None:
         """
-        Deepgram final result callback.
-        Routed to the handler's _process_transcript which handles dedup,
-        goodbye detection, voicemail detection, and LLM trigger.
+        STT final result callback.
+        1. Log with PII redaction for audit trail.
+        2. Route to handler._process_transcript (dedup, goodbye, LLM trigger).
         """
+        try:
+            from app.core.pii_redactor import redact_pii
+            redacted = redact_pii(transcript)
+            logger.info(
+                "[STT final] transcript=%r confidence=%.2f call_session_id=%s",
+                redacted,
+                confidence,
+                self._h.call_session_id,
+            )
+        except Exception:
+            pass
+
         try:
             h = self._h
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1954,6 +1954,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/phone-numbers/{phone_number_id}/configuration:
+    put:
+      tags:
+      - Phone Numbers
+      summary: Upsert Number Configuration
+      description: Update or create the per-number configuration (recording, duration,
+        hours).
+      operationId: upsert_number_configuration_api_v1_phone_numbers__phone_number_id__configuration_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: phone_number_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Phone Number Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NumberConfigurationRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_NumberConfigurationResponse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Phone Numbers
+      summary: Get Number Configuration
+      description: Retrieve the per-number configuration.
+      operationId: get_number_configuration_api_v1_phone_numbers__phone_number_id__configuration_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: phone_number_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Phone Number Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_NumberConfigurationResponse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/telephony/bindings:
     get:
       tags:
@@ -6008,6 +6074,40 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse_RecruitmentDashboardData_'
       security:
       - HTTPBearer: []
+  /api/v1/recordings/{call_id}:
+    get:
+      tags:
+      - Call Recordings
+      summary: Get Recording
+      description: 'Return a signed GCS URL for the call recording.
+
+
+        URL expires in {GCS_RECORDINGS_SIGNED_URL_EXPIRY_SECONDS} seconds (default
+        3600).'
+      operationId: get_recording_api_v1_recordings__call_id__get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: call_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Call Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_RecordingResponse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /health:
     get:
       summary: Health Check
@@ -7041,6 +7141,22 @@ components:
       - timezone
       - slot_duration_minutes
       title: BusinessHoursOut
+    BusinessHoursSchema:
+      properties:
+        timezone:
+          type: string
+          title: Timezone
+          description: IANA timezone e.g. Australia/Sydney
+        schedule:
+          items:
+            $ref: '#/components/schemas/ScheduleEntry'
+          type: array
+          title: Schedule
+      type: object
+      required:
+      - timezone
+      - schedule
+      title: BusinessHoursSchema
     BusinessHoursUpsert:
       properties:
         day_of_week:
@@ -9061,6 +9177,60 @@ components:
       type: object
       title: ModelUpdate
       description: Schema for updating a model
+    NumberConfigurationRequest:
+      properties:
+        recording_enabled:
+          type: boolean
+          title: Recording Enabled
+          default: false
+        max_duration_seconds:
+          type: integer
+          maximum: 86400.0
+          minimum: 60.0
+          title: Max Duration Seconds
+          default: 3600
+        business_hours:
+          allOf:
+          - $ref: '#/components/schemas/BusinessHoursSchema'
+          nullable: true
+      type: object
+      title: NumberConfigurationRequest
+    NumberConfigurationResponse:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        phone_number_id:
+          type: string
+          format: uuid
+          title: Phone Number Id
+        recording_enabled:
+          type: boolean
+          title: Recording Enabled
+        max_duration_seconds:
+          type: integer
+          title: Max Duration Seconds
+        business_hours:
+          additionalProperties: true
+          type: object
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - id
+      - phone_number_id
+      - recording_enabled
+      - max_duration_seconds
+      - created_at
+      title: NumberConfigurationResponse
     ParseMode:
       type: string
       enum:
@@ -9623,6 +9793,23 @@ components:
       - created_at
       - message
       title: PurchasePhoneNumberResponse
+    RecordingResponse:
+      properties:
+        url:
+          type: string
+          title: Url
+          description: GCS signed URL (expires in 1 hour)
+        duration:
+          type: integer
+          nullable: true
+        size:
+          type: integer
+          nullable: true
+      type: object
+      required:
+      - url
+      title: RecordingResponse
+      description: Response for GET /api/v1/recordings/{call_id}.
     RecruitmentDashboardData:
       properties:
         summary:
@@ -10501,6 +10688,28 @@ components:
       - is_active
       - supports_streaming
       title: STTProviderOut
+    ScheduleEntry:
+      properties:
+        day:
+          type: integer
+          maximum: 6.0
+          minimum: 0.0
+          title: Day
+          description: 0=Monday … 6=Sunday
+        open:
+          type: string
+          title: Open
+          description: HH:mm open time
+        close:
+          type: string
+          title: Close
+          description: HH:mm close time
+      type: object
+      required:
+      - day
+      - open
+      - close
+      title: ScheduleEntry
     ScheduleFromCallSessionRequest:
       properties:
         call_session_id:
@@ -11186,6 +11395,22 @@ components:
       required:
       - data
       title: SuccessResponse[ModelResponse]
+    SuccessResponse_NumberConfigurationResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/NumberConfigurationResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[NumberConfigurationResponse]
     SuccessResponse_PendingCountResponse_:
       properties:
         data:
@@ -11330,6 +11555,22 @@ components:
       required:
       - data
       title: SuccessResponse[PurchasePhoneNumberResponse]
+    SuccessResponse_RecordingResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/RecordingResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[RecordingResponse]
     SuccessResponse_RecruitmentDashboardData_:
       properties:
         data:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -794,7 +794,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/AgentOut'
         '422':
           description: Validation Error
           content:
@@ -871,7 +872,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/AgentOut'
         '422':
           description: Validation Error
           content:
@@ -905,7 +907,8 @@ paths:
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/AgentOut'
         '422':
           description: Validation Error
           content:
@@ -3612,6 +3615,65 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/internal/stt/providers:
+    get:
+      tags:
+      - Internal STT
+      summary: List Stt Providers
+      description: List active STT providers for agent configuration dropdowns.
+      operationId: list_stt_providers_api_v1_internal_stt_providers_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/STTProviderOut'
+                type: array
+                title: Response List Stt Providers Api V1 Internal Stt Providers Get
+      security:
+      - HTTPBearer: []
+  /api/v1/internal/stt/providers/{provider_id}/models:
+    get:
+      tags:
+      - Internal STT
+      summary: List Stt Models
+      description: List active STT models for a provider, optionally filtered by language_code.
+      operationId: list_stt_models_api_v1_internal_stt_providers__provider_id__models_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: provider_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Provider Id
+      - name: language_code
+        in: query
+        required: false
+        schema:
+          type: string
+          nullable: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/STTModelOut'
+                title: Response List Stt Models Api V1 Internal Stt Providers  Provider
+                  Id  Models Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/schedule:
     post:
       tags:
@@ -6021,6 +6083,14 @@ components:
           title: Llmmodel
         ttsModel:
           $ref: '#/components/schemas/TtsModelSchema'
+        sttModel:
+          allOf:
+          - $ref: '#/components/schemas/SttModelSchema'
+          nullable: true
+        sttSettings:
+          allOf:
+          - $ref: '#/components/schemas/SttSettingsJsonSchema'
+          nullable: true
         status:
           $ref: '#/components/schemas/AgentStatusEnum'
           default: pending
@@ -6115,6 +6185,10 @@ components:
           allOf:
           - $ref: '#/components/schemas/TtsModelSchema'
           nullable: true
+        sttModel:
+          allOf:
+          - $ref: '#/components/schemas/SttModelSchema'
+          nullable: true
         status:
           $ref: '#/components/schemas/AgentStatusEnum'
         createdAt:
@@ -6178,6 +6252,14 @@ components:
         ttsModel:
           allOf:
           - $ref: '#/components/schemas/TtsModelSchema'
+          nullable: true
+        sttModel:
+          allOf:
+          - $ref: '#/components/schemas/SttModelSchema'
+          nullable: true
+        sttSettings:
+          allOf:
+          - $ref: '#/components/schemas/SttSettingsJsonSchema'
           nullable: true
         status:
           allOf:
@@ -7460,6 +7542,9 @@ components:
           type: string
           nullable: true
         crm_type:
+          type: string
+          nullable: true
+        callFlowId:
           type: string
           nullable: true
       type: object
@@ -10316,6 +10401,73 @@ components:
       - id
       - created_at
       title: RoleOut
+    STTModelOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        providerId:
+          type: string
+          format: uuid
+          title: Providerid
+        modelId:
+          type: string
+          title: Modelid
+        displayName:
+          type: string
+          title: Displayname
+        languageCode:
+          type: string
+          title: Languagecode
+        sampleRateHz:
+          type: integer
+          title: Sampleratehz
+        encoding:
+          type: string
+          title: Encoding
+        isActive:
+          type: boolean
+          title: Isactive
+      type: object
+      required:
+      - id
+      - providerId
+      - modelId
+      - displayName
+      - languageCode
+      - sampleRateHz
+      - encoding
+      - isActive
+      title: STTModelOut
+      description: Public STT model projection — never exposes metadata_json (internal
+        API params).
+    STTProviderOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        slug:
+          type: string
+          title: Slug
+        display_name:
+          type: string
+          title: Display Name
+        is_active:
+          type: boolean
+          title: Is Active
+        supports_streaming:
+          type: boolean
+          title: Supports Streaming
+      type: object
+      required:
+      - id
+      - slug
+      - display_name
+      - is_active
+      - supports_streaming
+      title: STTProviderOut
     ScheduleFromCallSessionRequest:
       properties:
         call_session_id:
@@ -10372,6 +10524,47 @@ components:
       - crm_type
       - message
       title: SingleCallResponse
+    SttModelSchema:
+      properties:
+        provider:
+          $ref: '#/components/schemas/SttProviderEnum'
+        modelId:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Modelid
+        languageCode:
+          type: string
+          maxLength: 20
+          minLength: 2
+          title: Languagecode
+      additionalProperties: false
+      type: object
+      required:
+      - provider
+      - modelId
+      - languageCode
+      title: SttModelSchema
+      description: Ticket ``sttModel`` fragment — validated against STT catalog in
+        service layer.
+    SttProviderEnum:
+      type: string
+      enum:
+      - deepgram
+      - google
+      - elevenlabs
+      title: SttProviderEnum
+    SttSettingsJsonSchema:
+      properties:
+        silenceThresholdMs:
+          type: integer
+          maximum: 5000.0
+          minimum: 300.0
+          nullable: true
+      additionalProperties: true
+      type: object
+      title: SttSettingsJsonSchema
+      description: Optional STT tuning stored on ``agent.stt_settings_json``.
     SuccessResponse_ApiKeyCreated_:
       properties:
         data:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1418,14 +1418,44 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/voice/call/initiate/send:
+    post:
+      tags:
+      - Voice Calls
+      summary: Initiate Call
+      description: 'Initiate an outbound voice call.
+
+        /call/initiate/send is an alias for backward compatibility and direct dispatch.'
+      operationId: initiate_call_api_v1_voice_call_initiate_send_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallInitiateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_CallInitiateResponse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /api/v1/voice/call/initiate:
     post:
       tags:
       - Voice Calls
       summary: Initiate Call
-      description: 'Endpoint to initiate a voice call using Twilio.
+      description: 'Initiate an outbound voice call.
 
-        Thin wrapper around `voice_call_service.initiate_call`.'
+        /call/initiate/send is an alias for backward compatibility and direct dispatch.'
       operationId: initiate_call_api_v1_voice_call_initiate_post
       requestBody:
         content:
@@ -3858,8 +3888,8 @@ paths:
         `Appointment ID: <uuid>` in the card description. Pass that value as `appointment_id`
         in the initiate
 
-        JSON body (with `agentId`, `userPhoneNumber`, `tenant_id`, `user_id`, and
-        CRM fields) so the outbound
+        JSON body (with `agentId`, `toNumber`, `tenant_id`, `user_id`, and CRM fields)
+        so the outbound
 
         call runs the follow-up confirmation flow.'
       operationId: create_single_scheduled_call_api_v1_schedule_single_call_post
@@ -7492,9 +7522,12 @@ components:
         agentId:
           type: string
           title: Agentid
-        userPhoneNumber:
+        toNumber:
           type: string
-          title: Userphonenumber
+          title: Tonumber
+        fromNumber:
+          type: string
+          nullable: true
         phone_number_id:
           type: string
           nullable: true
@@ -7550,7 +7583,7 @@ components:
       type: object
       required:
       - agentId
-      - userPhoneNumber
+      - toNumber
       title: CallInitiateRequest
     CallInitiateResponse:
       properties:

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ google-auth
 google-auth-oauthlib
 deepgram-sdk
 google-cloud-texttospeech
+google-cloud-speech>=2.27.0
 sendgrid
 geopy
 timezonefinder

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,3 +47,4 @@ PyYAML
 openapi-spec-validator>=0.7.1
 livekit-api==1.1.0
 livekit==1.1.2
+google-cloud-storage>=2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,5 @@ python-docx
 nanoid
 PyYAML
 openapi-spec-validator>=0.7.1
+livekit-api==1.1.0
+livekit==1.1.2

--- a/scripts/generate_stt_fixture.py
+++ b/scripts/generate_stt_fixture.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Generate tests/integration/fixtures/hello_world_16k_3s.raw (LINEAR16 16kHz, 3s).
+
+Uses Google Cloud Text-to-Speech with the same credentials as STT (ADC / .env JSON).
+Requires: google-cloud-texttospeech, GOOGLE_APPLICATION_CREDENTIALS in .env
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from dotenv import load_dotenv
+
+load_dotenv(ROOT / ".env")
+
+creds = (os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or "").strip()
+if creds.startswith("{"):
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
+        f.write(creds)
+        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = f.name
+
+from google.cloud import texttospeech
+
+TARGET_BYTES = 16000 * 2 * 3  # 3 seconds mono LINEAR16
+OUT = ROOT / "tests" / "integration" / "fixtures" / "hello_world_16k_3s.raw"
+
+
+def main() -> None:
+    client = texttospeech.TextToSpeechClient()
+    resp = client.synthesize_speech(
+        input=texttospeech.SynthesisInput(text="hello world"),
+        voice=texttospeech.VoiceSelectionParams(language_code="en-AU"),
+        audio_config=texttospeech.AudioConfig(
+            audio_encoding=texttospeech.AudioEncoding.LINEAR16,
+            sample_rate_hertz=16000,
+        ),
+    )
+    pcm = resp.audio_content
+    if len(pcm) < TARGET_BYTES:
+        pcm = pcm + b"\x00" * (TARGET_BYTES - len(pcm))
+    else:
+        pcm = pcm[:TARGET_BYTES]
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_bytes(pcm)
+    print(f"Wrote {len(pcm)} bytes ({len(pcm) / 32000:.2f}s) → {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stt_latency_p95.py
+++ b/scripts/stt_latency_p95.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+STT latency p95 measurement tool (ticket acceptance: p95 < 400 ms staging).
+
+Metric: stt_speech_end_to_final
+  Boundary: caller speech end (finish() / last audio) → first final transcript from Google STT.
+
+Parse application logs for lines emitted by google_stt_service.py:
+  [Metrics] stt_speech_end_to_final=NNN ms
+
+Usage:
+  python scripts/stt_latency_p95.py --log /var/log/voiceagent/app.log
+  kubectl logs -f deployment/tgs-agent-be | python scripts/stt_latency_p95.py --stdin
+  python scripts/stt_latency_p95.py --log app.log --threshold 400 --min-samples 20
+
+Exit codes:
+  0  p95 < threshold (pass)
+  1  p95 >= threshold (fail)
+  2  not enough samples
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import sys
+from typing import List
+
+P95_THRESHOLD_MS = 400.0
+MIN_SAMPLES_DEFAULT = 10
+
+_METRIC_RE = re.compile(
+    r"\[Metrics\]\s+stt_speech_end_to_final=([\d.]+)\s*ms",
+)
+
+
+def _parse_latencies(lines: List[str]) -> List[float]:
+    values: List[float] = []
+    for line in lines:
+        m = _METRIC_RE.search(line)
+        if m:
+            try:
+                values.append(float(m.group(1)))
+            except ValueError:
+                pass
+    return values
+
+
+def _percentile(data: List[float], pct: float) -> float:
+    if not data:
+        return 0.0
+    sorted_data = sorted(data)
+    k = (len(sorted_data) - 1) * pct / 100.0
+    lo, hi = int(k), min(int(k) + 1, len(sorted_data) - 1)
+    return sorted_data[lo] + (sorted_data[hi] - sorted_data[lo]) * (k - lo)
+
+
+def _report(latencies: List[float], threshold: float = P95_THRESHOLD_MS) -> int:
+    n = len(latencies)
+    mn = min(latencies)
+    mx = max(latencies)
+    mean = statistics.mean(latencies)
+    p50 = _percentile(latencies, 50)
+    p95 = _percentile(latencies, 95)
+    p99 = _percentile(latencies, 99)
+
+    verdict = "✓ PASS" if p95 < threshold else "✗ FAIL"
+    print(f"Metric  : stt_speech_end_to_final")
+    print(f"Samples : {n}")
+    print(f"Min     : {mn:6.0f} ms")
+    print(f"Mean    : {mean:6.0f} ms")
+    print(f"p50     : {p50:6.0f} ms")
+    print(f"p95     : {p95:6.0f} ms   {verdict} (threshold: {threshold:.0f} ms)")
+    print(f"p99     : {p99:6.0f} ms")
+    print(f"Max     : {mx:6.0f} ms")
+
+    return 0 if p95 < threshold else 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute p95 STT speech-end→final latency from application logs."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--log", metavar="FILE", help="Path to log file")
+    group.add_argument("--stdin", action="store_true", help="Read from stdin")
+    parser.add_argument(
+        "--min-samples",
+        type=int,
+        default=MIN_SAMPLES_DEFAULT,
+        metavar="N",
+        help=f"Minimum samples required (default: {MIN_SAMPLES_DEFAULT})",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=P95_THRESHOLD_MS,
+        metavar="MS",
+        help=f"p95 pass threshold in ms (default: {P95_THRESHOLD_MS})",
+    )
+    args = parser.parse_args()
+
+    if args.stdin:
+        lines = sys.stdin.readlines()
+    else:
+        try:
+            with open(args.log, "r", encoding="utf-8", errors="replace") as f:
+                lines = f.readlines()
+        except FileNotFoundError:
+            print(f"ERROR: log file not found: {args.log}", file=sys.stderr)
+            return 2
+
+    latencies = _parse_latencies(lines)
+    if len(latencies) < args.min_samples:
+        print(
+            f"ERROR: only {len(latencies)} samples found (need {args.min_samples}). "
+            "Run more Google STT test calls or lower --min-samples.",
+            file=sys.stderr,
+        )
+        return 2
+
+    return _report(latencies, threshold=args.threshold)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/api/test_call_recordings.py
+++ b/tests/api/test_call_recordings.py
@@ -1,0 +1,463 @@
+"""
+Tests for the call recordings API and supporting services.
+
+Covers:
+  GET /api/v1/recordings/{call_id}
+  PUT /api/v1/phone-numbers/{id}/configuration
+  GET /api/v1/phone-numbers/{id}/configuration
+  get_recording_enabled_for_call() helper
+  call_recording_upload_service error path
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.middleware.api_key_middleware import _attach_workspace_context
+from app.models.agent import Agent
+from app.models.call_session import CallSession
+from app.models.phone_number import NumberConfiguration, PhoneNumber
+from app.models.tenant import Tenant
+from app.services.recording_config_service import get_recording_enabled_for_call
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payload_for(tenant: Tenant) -> Dict[str, Any]:
+    return {
+        "api_key_id": str(uuid.uuid4()),
+        "tenant_id": str(tenant.id),
+        "key_is_active": True,
+        "workspace": {
+            "id": str(tenant.id),
+            "name": tenant.name,
+            "schema_name": getattr(tenant, "schema_name", "test"),
+            "status": "active",
+        },
+    }
+
+
+def _headers(tenant: Tenant) -> Dict[str, str]:
+    return {"X-API-Key": "test-rec-key", "X-Workspace-ID": str(tenant.id)}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rec_tenant(db):
+    t = Tenant(name="Recording Tenant", schema_name="rec_test", status="active")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    yield t
+    db.query(CallSession).filter(CallSession.tenant_id == t.id).delete()
+    db.query(PhoneNumber).filter(PhoneNumber.tenant_id == t.id).delete()
+    db.query(Agent).filter(Agent.tenant_id == t.id).delete()
+    db.delete(t)
+    db.commit()
+
+
+@pytest.fixture
+def rec_agent(db, rec_tenant):
+    agent = Agent(name="Rec Agent", tenant_id=rec_tenant.id, status="ready")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+@pytest.fixture
+def rec_phone(db, rec_tenant, rec_agent):
+    pn = PhoneNumber(
+        phone_number="+61298765432",
+        tenant_id=rec_tenant.id,
+        assistant_id=rec_agent.id,
+        status="active",
+    )
+    db.add(pn)
+    db.commit()
+    db.refresh(pn)
+    return pn
+
+
+@pytest.fixture
+def rec_phone_with_recording_enabled(db, rec_phone):
+    config = NumberConfiguration(phone_number_id=rec_phone.id, recording_enabled=True)
+    db.add(config)
+    db.commit()
+    db.refresh(config)
+    return rec_phone
+
+
+@pytest.fixture
+def rec_phone_recording_disabled(db, rec_phone):
+    config = NumberConfiguration(phone_number_id=rec_phone.id, recording_enabled=False)
+    db.add(config)
+    db.commit()
+    return rec_phone
+
+
+@pytest.fixture
+def call_session_with_recording(db, rec_tenant, rec_agent, rec_phone_with_recording_enabled):
+    session = CallSession(
+        user_id=uuid.uuid4(),
+        agent_id=rec_agent.id,
+        tenant_id=rec_tenant.id,
+        start_time=__import__("datetime").datetime.utcnow(),
+        status="completed",
+        call_type="outbound",
+        duration=120,
+        assistant_phone_number=rec_phone_with_recording_enabled.phone_number,
+        recording_gcs_path="recordings/tenant1/call1/20260609.opus",
+        recording_error=False,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    yield session
+    db.delete(session)
+    db.commit()
+
+
+@pytest.fixture
+def call_session_no_recording(db, rec_tenant, rec_agent, rec_phone_recording_disabled):
+    session = CallSession(
+        user_id=uuid.uuid4(),
+        agent_id=rec_agent.id,
+        tenant_id=rec_tenant.id,
+        start_time=__import__("datetime").datetime.utcnow(),
+        status="completed",
+        call_type="outbound",
+        duration=90,
+        assistant_phone_number=rec_phone_recording_disabled.phone_number,
+        recording_gcs_path=None,
+        recording_error=False,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    yield session
+    db.delete(session)
+    db.commit()
+
+
+@pytest.fixture
+def authed_client(client: TestClient, rec_tenant: Tenant):
+    payload = _payload_for(rec_tenant)
+
+    async def _resolve(_key_hash, _workspace_id):
+        return payload
+
+    with patch(
+        "app.middleware.api_key_middleware._resolve_api_key",
+        side_effect=_resolve,
+    ):
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# get_recording_enabled_for_call
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecordingEnabledForCall:
+    def test_recording_enabled_true(self, db, rec_tenant, rec_agent, rec_phone_with_recording_enabled):
+        session = CallSession(
+            user_id=uuid.uuid4(),
+            agent_id=rec_agent.id,
+            tenant_id=rec_tenant.id,
+            start_time=__import__("datetime").datetime.utcnow(),
+            status="completed",
+            call_type="outbound",
+            assistant_phone_number=rec_phone_with_recording_enabled.phone_number,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+        result = get_recording_enabled_for_call(db, session)
+        assert result is True
+
+        db.delete(session)
+        db.commit()
+
+    def test_recording_enabled_false(self, db, rec_tenant, rec_agent, rec_phone_recording_disabled):
+        session = CallSession(
+            user_id=uuid.uuid4(),
+            agent_id=rec_agent.id,
+            tenant_id=rec_tenant.id,
+            start_time=__import__("datetime").datetime.utcnow(),
+            status="completed",
+            call_type="outbound",
+            assistant_phone_number=rec_phone_recording_disabled.phone_number,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+        result = get_recording_enabled_for_call(db, session)
+        assert result is False
+
+        db.delete(session)
+        db.commit()
+
+    def test_no_phone_number_returns_false(self, db, rec_tenant, rec_agent):
+        session = CallSession(
+            user_id=uuid.uuid4(),
+            agent_id=rec_agent.id,
+            tenant_id=rec_tenant.id,
+            start_time=__import__("datetime").datetime.utcnow(),
+            status="completed",
+            call_type="web",
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+        result = get_recording_enabled_for_call(db, session)
+        assert result is False
+
+        db.delete(session)
+        db.commit()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/recordings/{call_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecording:
+    def test_returns_signed_url_when_recording_available(
+        self, authed_client: TestClient, rec_tenant: Tenant, call_session_with_recording
+    ):
+        mock_url = "https://storage.googleapis.com/bucket/recordings/xyz?X-Goog-Signature=abc"
+        with (
+            patch(
+                "app.services.gcs_recording_service.generate_signed_url",
+                return_value=mock_url,
+            ),
+            patch(
+                "app.services.gcs_recording_service.get_object_size",
+                return_value=204800,
+            ),
+        ):
+            resp = authed_client.get(
+                f"/api/v1/recordings/{call_session_with_recording.id}",
+                headers=_headers(rec_tenant),
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["data"]["url"] == mock_url
+        assert body["data"]["duration"] == 120
+        assert body["data"]["size"] == 204800
+
+    def test_returns_404_when_recording_disabled(
+        self, authed_client: TestClient, rec_tenant: Tenant, call_session_no_recording
+    ):
+        resp = authed_client.get(
+            f"/api/v1/recordings/{call_session_no_recording.id}",
+            headers=_headers(rec_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_returns_404_for_wrong_tenant(
+        self, authed_client: TestClient, rec_tenant: Tenant, call_session_with_recording
+    ):
+        # Use a different tenant header — the tenant_id won't match the session
+        other_tenant_id = str(uuid.uuid4())
+        resp = authed_client.get(
+            f"/api/v1/recordings/{call_session_with_recording.id}",
+            headers={"X-API-Key": "test-rec-key", "X-Workspace-ID": other_tenant_id},
+        )
+        assert resp.status_code in (401, 403, 404)
+
+    def test_returns_404_when_call_not_found(
+        self, authed_client: TestClient, rec_tenant: Tenant
+    ):
+        resp = authed_client.get(
+            f"/api/v1/recordings/{uuid.uuid4()}",
+            headers=_headers(rec_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_returns_404_when_recording_error_and_no_path(
+        self, db, authed_client: TestClient, rec_tenant: Tenant, rec_agent, rec_phone_with_recording_enabled
+    ):
+        session = CallSession(
+            user_id=uuid.uuid4(),
+            agent_id=rec_agent.id,
+            tenant_id=rec_tenant.id,
+            start_time=__import__("datetime").datetime.utcnow(),
+            status="completed",
+            call_type="outbound",
+            assistant_phone_number=rec_phone_with_recording_enabled.phone_number,
+            recording_gcs_path=None,
+            recording_error=True,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+        resp = authed_client.get(
+            f"/api/v1/recordings/{session.id}",
+            headers=_headers(rec_tenant),
+        )
+        assert resp.status_code == 404
+
+        db.delete(session)
+        db.commit()
+
+
+# ---------------------------------------------------------------------------
+# PUT /GET /api/v1/phone-numbers/{id}/configuration
+# ---------------------------------------------------------------------------
+
+
+class TestPhoneNumberConfiguration:
+    def test_put_enables_recording(
+        self, authed_client: TestClient, rec_tenant: Tenant, rec_phone
+    ):
+        resp = authed_client.put(
+            f"/api/v1/phone-numbers/{rec_phone.id}/configuration",
+            json={"recording_enabled": True, "max_duration_seconds": 1800},
+            headers=_headers(rec_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["data"]["recording_enabled"] is True
+        assert body["data"]["max_duration_seconds"] == 1800
+
+    def test_put_disables_recording(
+        self, authed_client: TestClient, rec_tenant: Tenant, rec_phone
+    ):
+        resp = authed_client.put(
+            f"/api/v1/phone-numbers/{rec_phone.id}/configuration",
+            json={"recording_enabled": False, "max_duration_seconds": 3600},
+            headers=_headers(rec_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["data"]["recording_enabled"] is False
+
+    def test_get_configuration(
+        self, authed_client: TestClient, rec_tenant: Tenant, rec_phone_with_recording_enabled
+    ):
+        resp = authed_client.get(
+            f"/api/v1/phone-numbers/{rec_phone_with_recording_enabled.id}/configuration",
+            headers=_headers(rec_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["data"]["recording_enabled"] is True
+
+    def test_get_configuration_not_found(
+        self, authed_client: TestClient, rec_tenant: Tenant, rec_phone
+    ):
+        # rec_phone has no configuration row yet
+        resp = authed_client.get(
+            f"/api/v1/phone-numbers/{rec_phone.id}/configuration",
+            headers=_headers(rec_tenant),
+        )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Upload service — error path
+# ---------------------------------------------------------------------------
+
+
+class TestCallRecordingUploadService:
+    def test_upload_failure_sets_recording_error(self, db, rec_tenant, rec_agent, rec_phone_with_recording_enabled):
+        """When LiveKit egress fails, recording_error must be set to True."""
+        from app.services.call_recording_upload_service import _check_and_finalize
+
+        session = CallSession(
+            user_id=uuid.uuid4(),
+            agent_id=rec_agent.id,
+            tenant_id=rec_tenant.id,
+            start_time=__import__("datetime").datetime.utcnow(),
+            status="completed",
+            call_type="outbound",
+            assistant_phone_number=rec_phone_with_recording_enabled.phone_number,
+            recording_gcs_path=None,
+            recording_error=False,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+        # EGRESS_FAILED = 4 (livekit.api integer constant — avoid importing livekit in
+        # tests because conftest mocks 'google' which breaks protobuf)
+        mock_egress_info = MagicMock()
+        mock_egress_info.status = 4  # EGRESS_FAILED
+
+        with patch(
+            "app.services.call_recording_upload_service._fetch_egress_info_async",
+            return_value=mock_egress_info,
+        ):
+            _check_and_finalize(db, session, "egress-id-123", "recordings/ws/call/20260609.opus")
+
+        db.refresh(session)
+        assert session.recording_error is True
+        assert session.recording_gcs_path is None
+
+        db.delete(session)
+        db.commit()
+
+    def test_upload_success_sets_gcs_path(self, db, rec_tenant, rec_agent, rec_phone_with_recording_enabled):
+        """When LiveKit egress completes, recording_gcs_path must be set."""
+        from app.services.call_recording_upload_service import _check_and_finalize
+
+        session = CallSession(
+            user_id=uuid.uuid4(),
+            agent_id=rec_agent.id,
+            tenant_id=rec_tenant.id,
+            start_time=__import__("datetime").datetime.utcnow(),
+            status="completed",
+            call_type="outbound",
+            assistant_phone_number=rec_phone_with_recording_enabled.phone_number,
+            recording_gcs_path=None,
+            recording_error=False,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+
+        # EGRESS_COMPLETE = 3
+        mock_egress_info = MagicMock()
+        mock_egress_info.status = 3  # EGRESS_COMPLETE
+
+        gcs_path = f"recordings/{rec_tenant.id}/{session.id}/20260609.opus"
+
+        with (
+            patch(
+                "app.services.call_recording_upload_service._stop_egress_async",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "app.services.call_recording_upload_service._fetch_egress_info_async",
+                return_value=mock_egress_info,
+            ),
+            patch("app.services.call_recording_upload_service.asyncio.sleep", new_callable=AsyncMock),
+            patch("app.services.gcs_recording_service.update_object_metadata"),
+        ):
+            _check_and_finalize(db, session, "egress-id-456", gcs_path)
+
+        db.refresh(session)
+        assert session.recording_gcs_path == gcs_path
+        assert session.recording_error is False
+
+        db.delete(session)
+        db.commit()

--- a/tests/api/test_outbound_call_dispatch.py
+++ b/tests/api/test_outbound_call_dispatch.py
@@ -1,0 +1,583 @@
+"""
+Integration tests for the outbound call dispatch endpoint.
+
+Tests the `voice_call_service.initiate_call` service function directly with all
+external dependencies (Twilio, LiveKit, DB, credits) mocked — no real servers.
+
+Run:
+    pytest tests/api/test_outbound_call_dispatch.py tests/services/test_voice_call_livekit.py -v
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import status as http_status
+from fastapi.responses import JSONResponse
+
+
+# ---------------------------------------------------------------------------
+# Fixed UUIDs
+# ---------------------------------------------------------------------------
+
+_AGENT_ID = uuid.UUID("aa000000-0000-0000-0000-000000000001")
+_TENANT_ID = uuid.UUID("bb000000-0000-0000-0000-000000000002")
+_SESSION_ID = uuid.UUID("cc000000-0000-0000-0000-000000000003")
+_USER_ID = uuid.UUID("dd000000-0000-0000-0000-000000000004")
+_TWILIO_SID = "CA12345678901234567890123456789012"
+
+
+# ---------------------------------------------------------------------------
+# Object builders
+# ---------------------------------------------------------------------------
+
+
+def _request(overrides: dict | None = None):
+    from app.schemas.twilio import CallInitiateRequest
+
+    defaults = dict(agentId=str(_AGENT_ID), toNumber="+15555550001")
+    if overrides:
+        defaults.update(overrides)
+    return CallInitiateRequest(**defaults)
+
+
+def _agent(*, status: str = "ready"):
+    ag = MagicMock()
+    ag.id = _AGENT_ID
+    ag.name = "Test Agent"
+    ag.status = status
+    ag.model = MagicMock(model_name="gpt-4o")
+    return ag
+
+
+def _phone_number():
+    pn = MagicMock()
+    pn.id = uuid.uuid4()
+    pn.phone_number = "+15555550000"
+    pn.assistant_id = _AGENT_ID
+    pn.twilio_account_sid = None
+    pn.twilio_auth_token = None
+    pn.status = "active"
+    return pn
+
+
+def _call_session(*, sid: uuid.UUID = _SESSION_ID):
+    cs = MagicMock()
+    cs.id = sid
+    cs.call_flow_id = None
+    cs.call_metadata = None
+    cs.status = "initiated"
+    cs.twilio_call_sid = ""
+    return cs
+
+
+def _db(phone: MagicMock | None = None, active_outbound: int = 0):
+    """Mock DB that returns a bound phone number and a scalar count for concurrent limit."""
+    db = MagicMock()
+    phone_obj = phone or _phone_number()
+
+    # query(PhoneNumber).filter().first() → phone_obj
+    # query(func.count()).filter().scalar() → active_outbound
+    def _query(model):
+        q = MagicMock()
+        q.filter.return_value.first.return_value = phone_obj
+        q.filter.return_value.scalar.return_value = active_outbound
+        return q
+
+    db.query.side_effect = _query
+    return db
+
+
+def _mock_settings(*, livekit_enabled: bool = True, max_concurrent: int = 10):
+    s = MagicMock()
+    s.LIVEKIT_ENABLED = livekit_enabled
+    s.WEBHOOK_BASE_URL = "http://test.local"
+    s.OUTBOUND_MAX_CONCURRENT_PER_WORKSPACE = max_concurrent
+    return s
+
+
+def _mock_http_request():
+    req = MagicMock()
+    req.headers = {}
+    req.state = MagicMock()
+    req.state.request_id = "test-req-id"
+    return req
+
+
+def _mock_user():
+    u = MagicMock()
+    u.current_tenant_id = _TENANT_ID
+    u.id = _USER_ID
+    return u
+
+
+# ---------------------------------------------------------------------------
+# Core runner
+# ---------------------------------------------------------------------------
+
+
+async def _run(
+    req,
+    *,
+    agent_status: str = "ready",
+    livekit_enabled: bool = True,
+    max_concurrent: int = 10,
+    active_outbound: int = 0,
+    livekit_create_room=None,
+    twilio_make_call=None,
+    call_session_obj=None,
+    phone_obj=None,
+):
+    from app.services.voice_call_service import initiate_call
+
+    cs = call_session_obj or _call_session()
+    lk_create = livekit_create_room or AsyncMock(
+        return_value=SimpleNamespace(sid="RM_test_sid")
+    )
+    twilio_call = twilio_make_call or MagicMock(
+        return_value=SimpleNamespace(sid=_TWILIO_SID)
+    )
+
+    mock_livekit = MagicMock()
+    mock_livekit.create_room = lk_create
+    mock_livekit.generate_agent_token = MagicMock(return_value="token.payload.sig")
+    mock_livekit.close_room = AsyncMock()
+
+    db = _db(phone=phone_obj, active_outbound=active_outbound)
+
+    with (
+        patch(
+            "app.services.voice_call_service.verify_n8n_webhook_secret_async",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.voice_call_service.agent_service",
+            MagicMock(get_agent_by_id=MagicMock(return_value=_agent(status=agent_status))),
+        ),
+        patch(
+            "app.services.voice_call_service.twilio_service",
+            MagicMock(
+                validate_phone_number=MagicMock(return_value=True),
+                make_call_with_credentials=twilio_call,
+                make_call=twilio_call,
+            ),
+        ),
+        patch(
+            "app.services.voice_call_service.credit_service",
+            MagicMock(has_sufficient_credits=MagicMock(return_value=(True, 100, 10))),
+        ),
+        patch(
+            "app.services.voice_call_service.call_session_service",
+            MagicMock(create_call_session=MagicMock(return_value=cs)),
+        ),
+        patch(
+            "app.services.voice_call_service.broadcast_call_status_update",
+            AsyncMock(),
+        ),
+        patch("app.services.livekit_service.livekit_service", mock_livekit),
+        patch(
+            "app.services.voice_call_service.settings",
+            _mock_settings(
+                livekit_enabled=livekit_enabled, max_concurrent=max_concurrent
+            ),
+        ),
+        patch(
+            "app.core.secret_manager.get_twilio_credentials",
+            MagicMock(return_value=("AC_test", "token_test")),
+        ),
+    ):
+        result = await initiate_call(req, _mock_http_request(), _mock_user(), db)
+
+    return result, mock_livekit, twilio_call, db
+
+
+# ---------------------------------------------------------------------------
+# Test: Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_response_status_is_initiated(self):
+        """Successful call → response contains status='initiated'."""
+        req = _request()
+        result, _, _, _ = await _run(req)
+
+        # result is a SuccessResponse wrapping CallInitiateResponse
+        assert hasattr(result, "data"), f"Unexpected result type: {type(result)}"
+        assert result.data.status == "initiated"
+
+    @pytest.mark.asyncio
+    async def test_livekit_create_room_called_once(self):
+        """LiveKit room creation is called once with correct call_id."""
+        req = _request()
+        _, mock_livekit, _, _ = await _run(req)
+
+        mock_livekit.create_room.assert_awaited_once()
+        _, kwargs = mock_livekit.create_room.await_args
+        assert isinstance(kwargs.get("call_id"), uuid.UUID)
+
+    @pytest.mark.asyncio
+    async def test_twilio_make_call_called_once(self):
+        """Twilio make_call is invoked exactly once on the happy path."""
+        req = _request()
+        _, _, twilio_call, _ = await _run(req)
+
+        twilio_call.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_call_session_created_with_initiated_status(self):
+        """create_call_session is called with status='initiated' (not 'active')."""
+        req = _request()
+        _, _, _, db = await _run(req)
+
+        # Find the create_call_session call args in patched service
+        # (We confirm via response; the DB mock isn't the real DB so we check indirectly)
+        result, _, _, _ = await _run(req)
+        assert result.data.status == "initiated"
+
+    @pytest.mark.asyncio
+    async def test_response_contains_call_session_id(self):
+        """callSessionId in response matches the created session."""
+        cs = _call_session(sid=_SESSION_ID)
+        req = _request()
+        result, _, _, _ = await _run(req, call_session_obj=cs)
+
+        assert result.data.callSessionId == str(_SESSION_ID)
+
+    @pytest.mark.asyncio
+    async def test_response_contains_twilio_call_sid(self):
+        """twilioCallSid in response matches Twilio's returned SID."""
+        req = _request()
+        result, _, _, _ = await _run(req)
+
+        assert result.data.twilioCallSid == _TWILIO_SID
+
+    @pytest.mark.asyncio
+    async def test_from_number_matching_bound_number_accepted(self):
+        """fromNumber that matches the agent's bound phone is accepted."""
+        phone = _phone_number()
+        phone.phone_number = "+15555550000"
+        req = _request({"fromNumber": "+15555550000"})
+        result, _, _, _ = await _run(req, phone_obj=phone)
+        assert result.data.status == "initiated"
+
+
+# ---------------------------------------------------------------------------
+# Test: agent_not_ready
+# ---------------------------------------------------------------------------
+
+
+class TestAgentNotReady:
+    @pytest.mark.asyncio
+    async def test_pending_agent_returns_422(self):
+        """Agent with status='pending' returns 422 with agent_not_ready code."""
+        req = _request()
+        result, _, _, _ = await _run(req, agent_status="pending")
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_pending_agent_error_code(self):
+        """422 response body contains error.code='agent_not_ready'."""
+        import json
+
+        req = _request()
+        result, _, _, _ = await _run(req, agent_status="pending")
+
+        body = json.loads(result.body)
+        assert body["error"]["code"] == "agent_not_ready"
+
+    @pytest.mark.asyncio
+    async def test_pending_agent_livekit_not_called(self):
+        """LiveKit create_room is NOT called when agent is not ready."""
+        req = _request()
+        _, mock_livekit, _, _ = await _run(req, agent_status="pending")
+
+        mock_livekit.create_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pending_agent_twilio_not_called(self):
+        """Twilio make_call is NOT called when agent is not ready."""
+        req = _request()
+        _, _, twilio_call, _ = await _run(req, agent_status="pending")
+
+        twilio_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_from_number_mismatch_returns_400(self):
+        """fromNumber that does NOT match the bound number returns 400."""
+        import json
+
+        phone = _phone_number()
+        phone.phone_number = "+15555550000"
+        # fromNumber differs from bound number
+        req = _request({"fromNumber": "+19998887777"})
+        result, _, _, _ = await _run(req, phone_obj=phone)
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_400_BAD_REQUEST
+
+
+# ---------------------------------------------------------------------------
+# Test: concurrent outbound limit
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentLimit:
+    @pytest.mark.asyncio
+    async def test_limit_exceeded_returns_429(self):
+        """10 active outbound calls → next call returns 429."""
+        req = _request()
+        result, _, _, _ = await _run(req, active_outbound=10, max_concurrent=10)
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_429_TOO_MANY_REQUESTS
+
+    @pytest.mark.asyncio
+    async def test_limit_exceeded_error_code(self):
+        """429 body has error.code='outbound_concurrent_limit_exceeded'."""
+        import json
+
+        req = _request()
+        result, _, _, _ = await _run(req, active_outbound=10, max_concurrent=10)
+
+        body = json.loads(result.body)
+        assert body["error"]["code"] == "outbound_concurrent_limit_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_limit_not_exceeded_proceeds(self):
+        """9 active calls with limit=10 → call proceeds normally."""
+        req = _request()
+        result, _, _, _ = await _run(req, active_outbound=9, max_concurrent=10)
+
+        assert not isinstance(result, JSONResponse)
+        assert result.data.status == "initiated"
+
+    @pytest.mark.asyncio
+    async def test_limit_exceeded_livekit_not_called(self):
+        """LiveKit is NOT called when concurrent limit is exceeded."""
+        req = _request()
+        _, mock_livekit, _, _ = await _run(req, active_outbound=10, max_concurrent=10)
+
+        mock_livekit.create_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_limit_exceeded_twilio_not_called(self):
+        """Twilio is NOT called when concurrent limit is exceeded."""
+        req = _request()
+        _, _, twilio_call, _ = await _run(req, active_outbound=10, max_concurrent=10)
+
+        twilio_call.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: LiveKit room creation failure (GAP 2b)
+# ---------------------------------------------------------------------------
+
+
+class TestLivekitRoomCreationFailure:
+    @pytest.mark.asyncio
+    async def test_livekit_failure_returns_503(self):
+        """create_room raising → 503 response, no DB record, no Twilio call."""
+        lk_fail = AsyncMock(side_effect=Exception("LiveKit server unreachable"))
+        req = _request()
+
+        result, mock_livekit, twilio_call, _ = await _run(
+            req, livekit_create_room=lk_fail
+        )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_503_SERVICE_UNAVAILABLE
+
+    @pytest.mark.asyncio
+    async def test_livekit_failure_error_code(self):
+        """503 body has error.code='livekit_room_creation_failed'."""
+        import json
+
+        lk_fail = AsyncMock(side_effect=Exception("LiveKit server unreachable"))
+        req = _request()
+        result, _, _, _ = await _run(req, livekit_create_room=lk_fail)
+
+        body = json.loads(result.body)
+        assert body["error"]["code"] == "livekit_room_creation_failed"
+
+    @pytest.mark.asyncio
+    async def test_livekit_failure_twilio_not_called(self):
+        """Twilio make_call is NOT invoked when LiveKit room creation fails."""
+        lk_fail = AsyncMock(side_effect=Exception("LiveKit server unreachable"))
+        req = _request()
+
+        _, _, twilio_call, _ = await _run(req, livekit_create_room=lk_fail)
+
+        twilio_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_livekit_failure_db_not_committed(self):
+        """create_call_session is NOT called when LiveKit room creation fails."""
+        lk_fail = AsyncMock(side_effect=Exception("LiveKit server unreachable"))
+        req = _request()
+
+        # Patch call_session_service explicitly to confirm it is not called
+        mock_css = MagicMock()
+        mock_css.create_call_session = MagicMock(return_value=_call_session())
+        lk_create = lk_fail
+
+        mock_livekit = MagicMock()
+        mock_livekit.create_room = lk_create
+        mock_livekit.generate_agent_token = MagicMock(return_value="t")
+        mock_livekit.close_room = AsyncMock()
+
+        with (
+            patch(
+                "app.services.voice_call_service.verify_n8n_webhook_secret_async",
+                AsyncMock(return_value=False),
+            ),
+            patch(
+                "app.services.voice_call_service.agent_service",
+                MagicMock(get_agent_by_id=MagicMock(return_value=_agent())),
+            ),
+            patch(
+                "app.services.voice_call_service.twilio_service",
+                MagicMock(
+                    validate_phone_number=MagicMock(return_value=True),
+                    make_call_with_credentials=MagicMock(),
+                ),
+            ),
+            patch(
+                "app.services.voice_call_service.credit_service",
+                MagicMock(has_sufficient_credits=MagicMock(return_value=(True, 100, 10))),
+            ),
+            patch("app.services.voice_call_service.call_session_service", mock_css),
+            patch(
+                "app.services.voice_call_service.broadcast_call_status_update",
+                AsyncMock(),
+            ),
+            patch("app.services.livekit_service.livekit_service", mock_livekit),
+            patch(
+                "app.services.voice_call_service.settings",
+                _mock_settings(livekit_enabled=True),
+            ),
+            patch(
+                "app.core.secret_manager.get_twilio_credentials",
+                MagicMock(return_value=("AC_test", "tok")),
+            ),
+        ):
+            result = await _run_direct(req)
+
+        # create_call_session must NOT have been called
+        mock_css.create_call_session.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_livekit_disabled_skips_create_room(self):
+        """When LIVEKIT_ENABLED=False, create_room is never called."""
+        req = _request()
+        _, mock_livekit, _, _ = await _run(req, livekit_enabled=False)
+
+        mock_livekit.create_room.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_livekit_disabled_call_still_succeeds(self):
+        """Call proceeds normally when LIVEKIT_ENABLED=False."""
+        req = _request()
+        result, _, _, _ = await _run(req, livekit_enabled=False)
+
+        assert not isinstance(result, JSONResponse)
+        assert result.data.status == "initiated"
+
+
+# ---------------------------------------------------------------------------
+# Test: E.164 validation
+# ---------------------------------------------------------------------------
+
+
+class TestE164Validation:
+    def test_invalid_to_number_raises(self):
+        """Non-E.164 toNumber raises validation error at schema level."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            from app.schemas.twilio import CallInitiateRequest
+
+            CallInitiateRequest(agentId=str(_AGENT_ID), toNumber="5551234567")
+
+    def test_missing_to_number_raises(self):
+        """toNumber is required."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            from app.schemas.twilio import CallInitiateRequest
+
+            CallInitiateRequest(agentId=str(_AGENT_ID))
+
+    def test_invalid_from_number_raises(self):
+        """Non-E.164 fromNumber raises validation error at schema level."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            from app.schemas.twilio import CallInitiateRequest
+
+            CallInitiateRequest(
+                agentId=str(_AGENT_ID),
+                toNumber="+15551234567",
+                fromNumber="not_a_number",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: Twilio call failure cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestTwilioCallFailure:
+    @pytest.mark.asyncio
+    async def test_twilio_failure_returns_502(self):
+        twilio_fail = MagicMock(side_effect=Exception("Twilio API error"))
+        req = _request()
+        result, _, _, _ = await _run(req, twilio_make_call=twilio_fail)
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_502_BAD_GATEWAY
+
+    @pytest.mark.asyncio
+    async def test_twilio_failure_error_code(self):
+        import json
+
+        twilio_fail = MagicMock(side_effect=Exception("Twilio API error"))
+        req = _request()
+        result, _, _, _ = await _run(req, twilio_make_call=twilio_fail)
+
+        body = json.loads(result.body)
+        assert body["error"]["code"] == "twilio_call_failed"
+
+    @pytest.mark.asyncio
+    async def test_twilio_failure_closes_livekit_room(self):
+        twilio_fail = MagicMock(side_effect=Exception("Twilio API error"))
+        req = _request()
+        _, mock_livekit, _, _ = await _run(req, twilio_make_call=twilio_fail)
+
+        mock_livekit.close_room.assert_awaited()
+
+
+class TestActiveOutboundStatuses:
+    def test_concurrent_limit_includes_connected_and_in_progress(self):
+        from app.services.voice_call_service import _ACTIVE_OUTBOUND_STATUSES
+
+        assert "connected" in _ACTIVE_OUTBOUND_STATUSES
+        assert "in-progress" in _ACTIVE_OUTBOUND_STATUSES
+
+
+# ---------------------------------------------------------------------------
+# Helper: run initiate_call directly (for isolated sub-tests)
+# ---------------------------------------------------------------------------
+
+
+async def _run_direct(req):
+    """Thin wrapper used by tests that need to inject specific mocks directly."""
+    from app.services.voice_call_service import initiate_call
+
+    return await initiate_call(req, _mock_http_request(), _mock_user(), _db())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,26 +11,31 @@ os.environ.setdefault(
     "test-elevenlabs-encryption-key-for-pytest-only",
 )
 
-# Mock google submodules recursively to avoid ImportError
-# We must mock every level that is imported
-sys.modules["google"] = MagicMock()
-sys.modules["google.genai"] = MagicMock()
-sys.modules["google.oauth2"] = MagicMock()
-sys.modules["google.oauth2"].id_token = MagicMock()
-sys.modules["google.auth"] = MagicMock()
-sys.modules["google.auth"].transport = MagicMock()
-sys.modules["google.auth.transport"] = MagicMock()
-sys.modules["google.auth.transport"].requests = MagicMock()
-sys.modules["google.auth.transport.requests"] = MagicMock()
-sys.modules["google.cloud"] = MagicMock()
-sys.modules["google.cloud"].speech = MagicMock()
-sys.modules["google.cloud.speech_v1p1beta1"] = MagicMock()
-sys.modules["google.cloud.speech_v1p1beta1"].types = MagicMock()
-sys.modules["google.api_core"] = MagicMock()
-sys.modules["google.api_core"].exceptions = MagicMock()
-sys.modules["google.api_core.client_options"] = MagicMock()
-sys.modules["google.api_core.client_options"].ClientOptions = MagicMock()
-sys.modules["google.api_core.exceptions"] = MagicMock()
+# Mock google submodules recursively to avoid ImportError in unit tests.
+# Live Google STT integration tests set RUN_GOOGLE_STT_INTEGRATION=1 to skip mocks.
+_RUN_GOOGLE_STT_INTEGRATION = os.environ.get(
+    "RUN_GOOGLE_STT_INTEGRATION", ""
+).lower() in ("1", "true", "yes")
+
+if not _RUN_GOOGLE_STT_INTEGRATION:
+    sys.modules["google"] = MagicMock()
+    sys.modules["google.genai"] = MagicMock()
+    sys.modules["google.oauth2"] = MagicMock()
+    sys.modules["google.oauth2"].id_token = MagicMock()
+    sys.modules["google.auth"] = MagicMock()
+    sys.modules["google.auth"].transport = MagicMock()
+    sys.modules["google.auth.transport"] = MagicMock()
+    sys.modules["google.auth.transport"].requests = MagicMock()
+    sys.modules["google.auth.transport.requests"] = MagicMock()
+    sys.modules["google.cloud"] = MagicMock()
+    sys.modules["google.cloud"].speech = MagicMock()
+    sys.modules["google.cloud.speech_v1p1beta1"] = MagicMock()
+    sys.modules["google.cloud.speech_v1p1beta1"].types = MagicMock()
+    sys.modules["google.api_core"] = MagicMock()
+    sys.modules["google.api_core"].exceptions = MagicMock()
+    sys.modules["google.api_core.client_options"] = MagicMock()
+    sys.modules["google.api_core.client_options"].ClientOptions = MagicMock()
+    sys.modules["google.api_core.exceptions"] = MagicMock()
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -56,6 +61,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "integration: tests that require a live PostgreSQL database",
+    )
+    config.addinivalue_line(
+        "markers",
+        "google_stt_live: live Google Cloud STT tests (RUN_GOOGLE_STT_INTEGRATION=1)",
     )
 
 

--- a/tests/integration/google_stt_helpers.py
+++ b/tests/integration/google_stt_helpers.py
@@ -1,0 +1,124 @@
+"""Shared helpers for live Google STT integration tests."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "hello_world_16k_3s.raw"
+EXPECTED_PHRASE = "hello"
+
+
+def google_stt_credentials_configured() -> bool:
+    """True when GOOGLE_APPLICATION_CREDENTIALS is set (JSON inline or file path)."""
+    raw = (os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or "").strip()
+    if not raw:
+        return False
+    if raw.startswith("{"):
+        try:
+            json.loads(raw)
+            return True
+        except json.JSONDecodeError:
+            return False
+    return Path(raw).expanduser().is_file()
+
+
+def google_cloud_speech_available() -> bool:
+    try:
+        import google.cloud.speech_v1p1beta1  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def load_hello_world_fixture() -> bytes:
+    if not FIXTURE_PATH.is_file():
+        raise FileNotFoundError(
+            f"Missing fixture {FIXTURE_PATH}. "
+            "Run: python scripts/generate_stt_fixture.py"
+        )
+    return FIXTURE_PATH.read_bytes()
+
+
+async def stream_audio_and_collect(
+    audio: bytes,
+    *,
+    language_code: str = "en-AU",
+    chunk_bytes: int = 6400,
+    chunk_delay_sec: float = 0.0,
+    result_timeout_sec: float = 30.0,
+) -> tuple[list[dict[str, Any]], list[int]]:
+    """
+    Push LINEAR16 audio through GoogleSttService streaming session.
+    Returns (final_results, speech_end_to_final_ms_samples).
+
+    Audio is pushed quickly then finish() is called to mimic caller speech end;
+    latency is measured from finish() to the post-end final transcript.
+    """
+    from app.services.google_stt_service import GoogleSttService
+
+    svc = GoogleSttService()
+    sess = svc.create_streaming_session(
+        language_code=language_code,
+        sample_rate_hz=16000,
+        encoding="LINEAR16",
+        interim_results=True,
+        api_config={"google_model": "phone_call"},
+        silence_threshold_ms=1500,
+    )
+
+    await sess.start()
+    await asyncio.sleep(0.05)
+    for offset in range(0, len(audio), chunk_bytes):
+        sess.push_audio(audio[offset : offset + chunk_bytes])
+        if chunk_delay_sec > 0:
+            await asyncio.sleep(chunk_delay_sec)
+    sess.finish()
+
+    finals: list[dict[str, Any]] = []
+    latencies: list[int] = []
+    deadline = time.monotonic() + result_timeout_sec
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            result = await asyncio.wait_for(sess.get_result(), timeout=min(remaining, 5.0))
+        except asyncio.TimeoutError:
+            continue
+        if result.get("done"):
+            break
+        if result.get("error"):
+            if not result.get("recoverable"):
+                raise RuntimeError(f"Google STT error: {result.get('error')}")
+            continue
+        if result.get("is_final") and (result.get("transcript") or "").strip():
+            finals.append(result)
+            ms = result.get("stt_speech_end_to_final_ms")
+            if isinstance(ms, (int, float)) and ms >= 0:
+                latencies.append(int(ms))
+
+    return finals, latencies
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    sorted_vals = sorted(values)
+    k = (len(sorted_vals) - 1) * pct / 100.0
+    lo, hi = int(k), min(int(k) + 1, len(sorted_vals) - 1)
+    return sorted_vals[lo] + (sorted_vals[hi] - sorted_vals[lo]) * (k - lo)
+
+
+def bootstrap_google_credentials_from_env() -> None:
+    """Write inline JSON creds to a temp file so SpeechClient can load them."""
+    raw = (os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") or "").strip()
+    if raw.startswith("{"):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
+            f.write(raw)
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = f.name

--- a/tests/integration/test_call_recording_api.py
+++ b/tests/integration/test_call_recording_api.py
@@ -1,0 +1,116 @@
+"""
+Integration-style test for GET /api/v1/recordings/{call_id}.
+
+Uses mocked GCS signing (no live bucket required). Skips when explicitly
+running only live GCS tests without mocks — see RUN_GCS_RECORDING_INTEGRATION.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.agent import Agent
+from app.models.call_session import CallSession
+from app.models.phone_number import NumberConfiguration, PhoneNumber
+from app.models.tenant import Tenant
+
+_SIGNED_URL_RE = re.compile(
+    r"^https://storage\.googleapis\.com/.+\?X-Goog-.*",
+    re.IGNORECASE,
+)
+
+
+@pytest.mark.integration
+def test_get_recording_returns_signed_url_format(client: TestClient, db):
+    """Ticket: create call with recording path → GET → confirm signed URL format."""
+    if os.environ.get("RUN_GCS_RECORDING_INTEGRATION", "").lower() not in ("1", "true", "yes"):
+        pytest.skip("Set RUN_GCS_RECORDING_INTEGRATION=1 for live GCS signing tests")
+
+    tenant = Tenant(name="Rec Int Tenant", schema_name="rec_int", status="active")
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    agent = Agent(name="Rec Agent", tenant_id=tenant.id, status="ready")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+
+    pn = PhoneNumber(
+        phone_number="+61290000001",
+        tenant_id=tenant.id,
+        assistant_id=agent.id,
+        status="active",
+    )
+    db.add(pn)
+    db.commit()
+    db.refresh(pn)
+
+    db.add(NumberConfiguration(phone_number_id=pn.id, recording_enabled=True))
+    db.commit()
+
+    session = CallSession(
+        user_id=uuid.uuid4(),
+        agent_id=agent.id,
+        tenant_id=tenant.id,
+        start_time=datetime.now(timezone.utc),
+        status="completed",
+        call_type="outbound",
+        duration=60,
+        assistant_phone_number=pn.phone_number,
+        recording_gcs_path=f"recordings/{tenant.id}/{uuid.uuid4()}/20260609.opus",
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    mock_url = (
+        "https://storage.googleapis.com/my-bucket/recordings/x.opus"
+        "?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Signature=abc"
+    )
+    with (
+        patch(
+            "app.services.gcs_recording_service.generate_signed_url",
+            return_value=mock_url,
+        ),
+        patch("app.services.gcs_recording_service.get_object_size", return_value=1024),
+        patch(
+            "app.middleware.api_key_middleware._resolve_api_key",
+            return_value={
+                "api_key_id": str(uuid.uuid4()),
+                "tenant_id": str(tenant.id),
+                "key_is_active": True,
+                "workspace": {
+                    "id": str(tenant.id),
+                    "name": tenant.name,
+                    "schema_name": tenant.schema_name,
+                    "status": "active",
+                },
+            },
+        ),
+    ):
+        resp = client.get(
+            f"/api/v1/recordings/{session.id}",
+            headers={
+                "X-API-Key": "integration-test-key",
+                "X-Workspace-ID": str(tenant.id),
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    url = resp.json()["data"]["url"]
+    assert _SIGNED_URL_RE.match(url), url
+
+    db.delete(session)
+    db.query(NumberConfiguration).filter(NumberConfiguration.phone_number_id == pn.id).delete()
+    db.delete(pn)
+    db.delete(agent)
+    db.delete(tenant)
+    db.commit()

--- a/tests/integration/test_google_stt_live.py
+++ b/tests/integration/test_google_stt_live.py
@@ -1,0 +1,117 @@
+"""
+Live Google STT integration tests — require real Google Cloud credentials.
+
+Run (loads .env automatically via python-dotenv in helpers bootstrap):
+
+    RUN_GOOGLE_STT_INTEGRATION=1 pytest tests/integration/test_google_stt_live.py -v
+
+Optional p95 sample count (default 10):
+
+    RUN_GOOGLE_STT_INTEGRATION=1 GOOGLE_STT_P95_SAMPLES=20 \\
+        pytest tests/integration/test_google_stt_live.py -v
+
+Requires:
+  - google-cloud-speech installed
+  - GOOGLE_APPLICATION_CREDENTIALS in .env (JSON inline or file path)
+  - tests/integration/fixtures/hello_world_16k_3s.raw
+    (generate: python scripts/generate_stt_fixture.py)
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+from tests.integration.google_stt_helpers import (
+    EXPECTED_PHRASE,
+    bootstrap_google_credentials_from_env,
+    google_cloud_speech_available,
+    google_stt_credentials_configured,
+    load_hello_world_fixture,
+    percentile,
+    stream_audio_and_collect,
+)
+
+load_dotenv()
+
+pytestmark = pytest.mark.integration
+
+_SKIP_LIVE = pytest.mark.skipif(
+    os.environ.get("RUN_GOOGLE_STT_INTEGRATION", "").lower() not in ("1", "true", "yes"),
+    reason="Set RUN_GOOGLE_STT_INTEGRATION=1 to run live Google STT tests",
+)
+
+_SKIP_NO_CREDS = pytest.mark.skipif(
+    not google_stt_credentials_configured(),
+    reason="GOOGLE_APPLICATION_CREDENTIALS not set — skipping live Google STT tests",
+)
+
+_SKIP_NO_SDK = pytest.mark.skipif(
+    not google_cloud_speech_available(),
+    reason="google-cloud-speech not installed — pip install google-cloud-speech>=2.27.0",
+)
+
+
+@_SKIP_LIVE
+@_SKIP_NO_CREDS
+@_SKIP_NO_SDK
+class TestGoogleSttLive:
+    @pytest.fixture(autouse=True)
+    def _bootstrap_creds(self):
+        bootstrap_google_credentials_from_env()
+
+    def test_3s_audio_clip_final_transcript_matches(self):
+        """Inject 3s LINEAR16 clip → final transcript contains expected phrase."""
+        audio = load_hello_world_fixture()
+        assert len(audio) == 16000 * 2 * 3
+
+        finals, _ = asyncio.run(stream_audio_and_collect(audio))
+        assert finals, "Expected at least one final transcript from 3s audio clip"
+
+        combined = " ".join(f["transcript"].lower() for f in finals)
+        assert EXPECTED_PHRASE in combined, (
+            f"Expected '{EXPECTED_PHRASE}' in transcript, got: {combined!r}"
+        )
+
+    def test_speech_end_to_final_latency_metric_captured(self):
+        """Verify speech-end→final latency metric is emitted (value varies by network)."""
+        audio = load_hello_world_fixture()
+        finals, latencies = asyncio.run(stream_audio_and_collect(audio))
+        assert finals, "No final transcript received"
+        assert latencies, "No stt_speech_end_to_final_ms metric in results"
+        assert latencies[0] > 0
+
+    def test_speech_end_to_final_latency_p95_under_400ms(self):
+        """
+        Ticket acceptance: p95 speech-end→final < 400ms (staging).
+
+        Skipped locally unless STT_STRICT_LATENCY=1 (enable in staging CI).
+        Override threshold: STT_P95_THRESHOLD_MS=400
+        """
+        if os.environ.get("STT_STRICT_LATENCY", "").lower() not in ("1", "true", "yes"):
+            pytest.skip(
+                "Set STT_STRICT_LATENCY=1 in staging to enforce p95 < 400ms "
+                "(local dev network to Google is often > 400ms)"
+            )
+
+        sample_count = int(os.environ.get("GOOGLE_STT_P95_SAMPLES", "10"))
+        threshold_ms = float(os.environ.get("STT_P95_THRESHOLD_MS", "400"))
+        audio = load_hello_world_fixture()
+
+        all_latencies: list[float] = []
+        for _ in range(sample_count):
+            _, latencies = asyncio.run(stream_audio_and_collect(audio))
+            if latencies:
+                all_latencies.append(float(latencies[0]))
+
+        assert len(all_latencies) >= max(3, sample_count // 2), (
+            f"Only collected {len(all_latencies)}/{sample_count} latency samples"
+        )
+
+        p95 = percentile(all_latencies, 95)
+        assert p95 < threshold_ms, (
+            f"p95 stt_speech_end_to_final={p95:.0f}ms >= {threshold_ms}ms "
+            f"(samples={all_latencies})"
+        )

--- a/tests/integration/test_livekit_integration.py
+++ b/tests/integration/test_livekit_integration.py
@@ -1,0 +1,276 @@
+"""
+Integration tests for LiveKit — require a live server.
+
+Run only when LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET are set.
+
+These tests confirm both HTTP/API-plane and WebSocket/RTC connectivity from
+the API server to the LiveKit server, covering the full room lifecycle:
+
+  create_room → generate_agent_token → generate_caller_token
+  → RTC participant join → list_participants → disconnect
+  → close_room → verify closed
+
+LOCAL DEV — start a throwaway LiveKit server with Docker:
+
+    docker run --rm -p 7880:7880 -p 7881:7881 -p 7882:7882/udp \\
+        -e LIVEKIT_KEYS="devkey: secret" livekit/livekit-server --dev
+
+    Then run:
+
+    LIVEKIT_URL=http://localhost:7880 \\
+    LIVEKIT_API_KEY=devkey \\
+    LIVEKIT_API_SECRET=secret \\
+    pytest tests/integration/test_livekit_integration.py -v -m integration
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Skip entire module if LiveKit env vars are absent
+# ---------------------------------------------------------------------------
+
+_LIVEKIT_URL = os.environ.get("LIVEKIT_URL", "")
+_LIVEKIT_API_KEY = os.environ.get("LIVEKIT_API_KEY", "")
+_LIVEKIT_API_SECRET = os.environ.get("LIVEKIT_API_SECRET", "")
+
+pytestmark = pytest.mark.integration
+
+_skip_unless_livekit = pytest.mark.skipif(
+    not (_LIVEKIT_URL and _LIVEKIT_API_KEY and _LIVEKIT_API_SECRET),
+    reason="LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET not set — skipping integration tests",
+)
+
+# Skip RTC tests if the native livekit package cannot be imported
+# (e.g. no platform wheel available for this Python version).
+try:
+    import livekit.rtc as _rtc  # noqa: F401
+
+    _HAS_RTC = True
+except Exception:
+    _HAS_RTC = False
+
+_skip_unless_rtc = pytest.mark.skipif(
+    not _HAS_RTC,
+    reason="livekit RTC package unavailable — install livekit>=1.1.2",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_service():
+    """Return a RoomService wired to the real LiveKit credentials from env."""
+    from app.services.livekit_service import RoomService
+
+    svc = RoomService()
+    _real_creds = (_LIVEKIT_URL, _LIVEKIT_API_KEY, _LIVEKIT_API_SECRET)
+    svc._get_credentials = lambda: _real_creds  # type: ignore[method-assign]
+    return svc
+
+
+def _livekit_ws_url(http_url: str) -> str:
+    """Convert http(s):// → ws(s):// for LiveKit RTC connections."""
+    from app.services.livekit_service import _http_to_ws_url
+
+    return _http_to_ws_url(http_url)
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle integration test (with RTC participant join)
+# ---------------------------------------------------------------------------
+
+
+@_skip_unless_livekit
+@_skip_unless_rtc
+@pytest.mark.asyncio
+async def test_full_room_lifecycle():
+    """
+    Create → token → RTC participant join → list participants → disconnect
+    → close → verify closed.
+
+    Steps:
+    1.  create_room(call_id, agent_id, flow_id)
+    2.  generate_agent_token(room_name)   — verify JWT structure
+    3.  generate_caller_token(room_name)  — verify JWT structure, distinct from agent token
+    4.  Connect as agent participant using livekit RTC SDK
+    5.  list_participants(room_name) — must contain the joined agent identity
+    6.  Disconnect participant cleanly
+    7.  close_room(call_id)
+    8.  Verify API remains reachable after deletion
+    """
+    from livekit import rtc
+
+    svc = _make_service()
+    call_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    flow_id = uuid.uuid4()
+    room_name = f"room_{call_id}"
+
+    try:
+        # Step 1 — create room (with flow_id so metadata is exercised)
+        room = await svc.create_room(call_id, agent_id, flow_id=flow_id)
+        assert room.sid, "Room SID must be set after creation"
+
+        # Step 2 — agent token
+        agent_token = svc.generate_agent_token(room_name)
+        assert isinstance(agent_token, str)
+        assert len(agent_token.split(".")) == 3, "JWT must be header.payload.signature"
+
+        # Step 3 — caller token (distinct from agent token)
+        caller_token = svc.generate_caller_token(room_name)
+        assert isinstance(caller_token, str)
+        assert len(caller_token.split(".")) == 3
+        assert agent_token != caller_token
+
+        # Step 4 — connect as agent via RTC
+        ws_url = _livekit_ws_url(_LIVEKIT_URL)
+        rtc_room = rtc.Room()
+        try:
+            await rtc_room.connect(ws_url, agent_token)
+
+            # Step 5 — list participants; the connected agent must be visible
+            participants = await svc.list_participants(room_name)
+            identities = [p["identity"] for p in participants]
+            assert f"agent-{room_name}" in identities, (
+                f"agent identity missing from participants list: {identities}"
+            )
+
+        finally:
+            # Step 6 — disconnect cleanly (always runs)
+            await rtc_room.disconnect()
+
+    finally:
+        # Step 7 — close room (always runs)
+        await svc.close_room(call_id)
+
+    # Step 8 — API must remain reachable
+    assert await svc.check_connectivity(), "LiveKit API must remain reachable after room deletion"
+
+
+# ---------------------------------------------------------------------------
+# Idempotent create
+# ---------------------------------------------------------------------------
+
+
+@_skip_unless_livekit
+@pytest.mark.asyncio
+async def test_create_room_idempotent():
+    """Calling create_room twice with the same call_id returns the same room."""
+    svc = _make_service()
+    call_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+
+    try:
+        room1 = await svc.create_room(call_id, agent_id)
+        room2 = await svc.create_room(call_id, agent_id)
+        assert room1.sid == room2.sid, "Idempotent: same room SID on retry"
+    finally:
+        await svc.close_room(call_id)
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+@_skip_unless_livekit
+@pytest.mark.asyncio
+async def test_close_nonexistent_room_does_not_raise():
+    """close_room on a room that doesn't exist must not raise."""
+    svc = _make_service()
+    await svc.close_room(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# HTTP API connectivity
+# ---------------------------------------------------------------------------
+
+
+@_skip_unless_livekit
+@pytest.mark.asyncio
+async def test_check_connectivity_returns_true():
+    """API plane: HTTP/gRPC connectivity to LiveKit must succeed."""
+    svc = _make_service()
+    assert await svc.check_connectivity() is True, "LiveKit must be reachable"
+
+
+# ---------------------------------------------------------------------------
+# RTC WebSocket connectivity (via verify_rtc_connectivity)
+# ---------------------------------------------------------------------------
+
+
+@_skip_unless_livekit
+@_skip_unless_rtc
+@pytest.mark.asyncio
+async def test_rtc_connectivity_returns_true():
+    """WebSocket plane: verify_rtc_connectivity() must return True when server is up."""
+    svc = _make_service()
+    result = await svc.verify_rtc_connectivity()
+    assert result is True, "LiveKit RTC WebSocket connectivity must succeed"
+
+
+# ---------------------------------------------------------------------------
+# Token payload verification
+# ---------------------------------------------------------------------------
+
+
+@_skip_unless_livekit
+@pytest.mark.asyncio
+async def test_token_identity_embedded_in_jwt():
+    """Agent and caller identities must be recoverable from the JWT payload."""
+    import base64
+
+    svc = _make_service()
+    call_id = uuid.uuid4()
+    room_name = f"room_{call_id}"
+
+    try:
+        await svc.create_room(call_id, uuid.uuid4())
+
+        agent_token = svc.generate_agent_token(room_name)
+        caller_token = svc.generate_caller_token(room_name)
+
+        def _decode_payload(token: str) -> str:
+            payload_b64 = token.split(".")[1]
+            padding = 4 - len(payload_b64) % 4
+            if padding != 4:
+                payload_b64 += "=" * padding
+            return base64.urlsafe_b64decode(payload_b64).decode()
+
+        assert f"agent-{room_name}" in _decode_payload(agent_token)
+        assert f"caller-{room_name}" in _decode_payload(caller_token)
+    finally:
+        await svc.close_room(call_id)
+
+
+# ---------------------------------------------------------------------------
+# flow_id in room metadata
+# ---------------------------------------------------------------------------
+
+
+@_skip_unless_livekit
+@pytest.mark.asyncio
+async def test_flow_id_in_room_metadata():
+    """flowId passed to create_room must appear in the LiveKit room metadata."""
+    import json
+
+    svc = _make_service()
+    call_id = uuid.uuid4()
+    flow_id = uuid.uuid4()
+
+    try:
+        room = await svc.create_room(call_id, uuid.uuid4(), flow_id=flow_id)
+        metadata = json.loads(room.metadata)
+        assert metadata["flowId"] == str(flow_id), (
+            f"Expected flowId={flow_id!s}, got {metadata.get('flowId')!r}"
+        )
+    finally:
+        await svc.close_room(call_id)

--- a/tests/routers/test_health.py
+++ b/tests/routers/test_health.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -21,24 +22,89 @@ class TestHealthEndpoint:
         self.client = _client()
 
     def test_status_200(self):
-        resp = self.client.get("/health")
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(return_value="ok"),
+        ):
+            resp = self.client.get("/health")
         assert resp.status_code == 200
 
     def test_response_shape(self):
-        data = self.client.get("/health").json()
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(return_value="ok"),
+        ):
+            data = self.client.get("/health").json()
         assert data["status"] == "ok"
         assert "version" in data
         assert "timestamp" in data
 
     def test_timestamp_is_iso8601_utc(self):
-        data = self.client.get("/health").json()
-        # datetime.fromisoformat raises if the string is not valid ISO-8601.
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(return_value="ok"),
+        ):
+            data = self.client.get("/health").json()
         ts = datetime.fromisoformat(data["timestamp"])
-        # Must carry UTC timezone info.
         assert ts.tzinfo is not None
 
     def test_no_success_response_wrapper(self):
         """Health must NOT be wrapped in { data, message } SuccessResponse."""
-        data = self.client.get("/health").json()
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(return_value="ok"),
+        ):
+            data = self.client.get("/health").json()
         assert "data" not in data
         assert "message" not in data
+
+    def test_livekit_key_present_in_response(self):
+        """Response must include a 'livekit' key."""
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(return_value="ok"),
+        ):
+            data = self.client.get("/health").json()
+        assert "livekit" in data
+
+    def test_livekit_ok_when_livekit_enabled_false(self):
+        """When LIVEKIT_ENABLED=False, health_check() returns 'ok' immediately."""
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(return_value="ok"),
+        ):
+            data = self.client.get("/health").json()
+        assert data["livekit"] == "ok"
+
+    def test_livekit_degraded_when_unreachable(self):
+        """livekit='degraded' when LiveKit server is unreachable."""
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(return_value="degraded"),
+        ):
+            data = self.client.get("/health").json()
+        assert data["livekit"] == "degraded"
+
+    def test_health_never_returns_500_on_livekit_failure(self):
+        """HTTP 500 must never be returned due to LiveKit failure."""
+        with patch(
+            "app.routers.health.livekit_service.health_check",
+            new=AsyncMock(side_effect=Exception("LiveKit completely down")),
+        ):
+            resp = self.client.get("/health")
+        # Even when health_check() raises unexpectedly, the endpoint must return 200
+        # with livekit='degraded' — never propagate a 500.
+        assert resp.status_code == 200
+        assert resp.json()["livekit"] == "degraded"
+
+    def test_status_ok_regardless_of_livekit(self):
+        """top-level 'status' is always 'ok' regardless of LiveKit state."""
+        for lk_status in ("ok", "degraded"):
+            with patch(
+                "app.routers.health.livekit_service.health_check",
+                new=AsyncMock(return_value=lk_status),
+            ):
+                data = self.client.get("/health").json()
+            assert data["status"] == "ok", (
+                f"status must be 'ok' even when livekit='{lk_status}'"
+            )

--- a/tests/services/test_bidirectional_interim_regression.py
+++ b/tests/services/test_bidirectional_interim_regression.py
@@ -100,6 +100,8 @@ def _empty_handler() -> Handler:
     h._barge_in_min_conf_1w = 0.52
     h._barge_in_min_words = 2
     h._barge_in_rejected_while_playing = 0
+    h._tts_play_start_ts = 0.0
+    h._barge_in_dead_zone_ms = 0.0
     h._stt_min_final_confidence = 0.26
     h._enable_soft_final_fallback = True
     h._stt_soft_min_final_confidence = 0.16

--- a/tests/services/test_google_stt.py
+++ b/tests/services/test_google_stt.py
@@ -1,0 +1,563 @@
+"""
+Unit + integration tests for Google STT multi-provider architecture.
+
+Covers all Part C acceptance criteria from the ticket:
+  1. Interim event shape {type, transcript, confidence}
+  2. Final event shape {type, transcript, confidence, isSilence}
+  3. Silence detection (isSilence=True after SILENCE_THRESHOLD_MS)
+  4. Google STT stream restart at 5-min boundary (mock clock)
+  5. Error event + graceful restart on quota/network failure
+  6. _resolve_stt_model validation
+  7. agent_to_out includes sttModel
+  8. resolve_stt_runtime priority (flow > agent > catalog)
+  9. Integration: 3-second audio clip → final transcript
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.voice.stt_events import SttEventBus, SttFinalEvent, SttInterimEvent, SttErrorEvent
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Interim event shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_interim_event_shape():
+    event = SttInterimEvent(transcript="hello", confidence=0.85)
+    assert event.type == "interim"
+    assert event.transcript == "hello"
+    assert event.confidence == 0.85
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Final event shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_final_event_shape():
+    event = SttFinalEvent(transcript="hello world", confidence=0.95, is_silence=False)
+    assert event.type == "final"
+    assert event.transcript == "hello world"
+    assert event.confidence == 0.95
+    assert event.is_silence is False
+
+
+def test_final_event_with_is_silence():
+    event = SttFinalEvent(transcript="", confidence=0.0, is_silence=True)
+    assert event.type == "final"
+    assert event.is_silence is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Silence detection — isSilence=True after SILENCE_THRESHOLD_MS
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_stt_pipeline_silence_detection():
+    """SttPipeline._is_silence() and final event is_silence flag work correctly."""
+    from app.voice.stt_pipeline import SttPipeline
+
+    received_events = []
+
+    async def on_interim(t, c):
+        pass
+
+    async def on_final(t, c):
+        pass
+
+    async def capture(e):
+        received_events.append(e)
+
+    async def _run():
+        bus = SttEventBus()
+        bus.subscribe(capture)
+
+        pipeline = SttPipeline(
+            language_code="en",
+            on_interim=on_interim,
+            on_final=on_final,
+            silence_threshold_ms=100,
+            event_bus=bus,
+        )
+
+        # Simulate: audio was last received 200ms ago → exceeds 100ms threshold
+        pipeline._last_audio_mono = time.monotonic() - 0.2
+        assert pipeline._is_silence() is True, "_is_silence should be True at 200ms > 100ms threshold"
+
+        # Directly emit what the reader loop would produce
+        is_sil = pipeline._is_silence()
+        await bus.emit(SttFinalEvent(transcript="test", confidence=0.9, is_silence=is_sil))
+
+    asyncio.run(_run())
+
+    finals = [e for e in received_events if isinstance(e, SttFinalEvent)]
+    assert finals, "Expected at least one SttFinalEvent"
+    assert any(e.is_silence for e in finals), "Expected is_silence=True in at least one final event"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Google STT stream restart at 5-minute boundary (mock clock)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_google_stt_stream_restart_at_5min():
+    """_run_blocking_stream restarts when _run_single_stream signals needs_restart=True."""
+    from app.services.google_stt_service import GoogleSttService
+
+    sess = GoogleSttService.StreamingSTTSession(
+        language_code="en-AU",
+        sample_rate_hz=16000,
+        encoding="LINEAR16",
+        interim_results=True,
+        api_config={},
+        silence_threshold_ms=1500,
+    )
+
+    call_count = [0]
+
+    def fake_run_single_stream(replay_chunks=None):
+        call_count[0] += 1
+        if call_count[0] == 1:
+            # First stream: simulate 5-min limit reached → needs_restart=True
+            return True
+        # Second stream: normal end
+        return False
+
+    with patch.object(sess, "_run_single_stream", fake_run_single_stream):
+        sess._run_blocking_stream()
+
+    assert call_count[0] == 2, (
+        "Expected _run_single_stream called twice: once at restart, once for normal end"
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Error event + graceful restart on quota/network failure
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_google_stt_error_emits_error_result():
+    """Recoverable errors trigger stream restart (bounded)."""
+    from app.services.google_stt_service import GoogleSttService
+
+    sess = GoogleSttService.StreamingSTTSession(
+        language_code="en-AU",
+        sample_rate_hz=16000,
+        encoding="LINEAR16",
+        interim_results=True,
+        api_config={},
+        silence_threshold_ms=1500,
+    )
+
+    call_count = [0]
+
+    def fake_run_single_stream(replay_chunks=None):
+        call_count[0] += 1
+        sess._results_q.put(
+            {
+                "error": "quota exceeded",
+                "recoverable": True,
+                "transcript": "",
+                "confidence": 0.0,
+                "is_final": False,
+            }
+        )
+        if call_count[0] == 1:
+            return True  # restart after recoverable error
+        return False
+
+    with patch.object(sess, "_run_single_stream", fake_run_single_stream):
+        with patch("app.services.google_stt_service.time.sleep"):
+            sess._run_blocking_stream()
+
+    assert call_count[0] == 2, "Expected restart after recoverable error"
+    results = []
+    while not sess._results_q.empty():
+        results.append(sess._results_q.get_nowait())
+    assert any(r.get("error") for r in results)
+    assert any(r.get("done") for r in results)
+
+
+def test_chirp3_catalog_maps_to_phone_call_api_model():
+    """Display model chirp-3 uses google_model=phone_call for API; API shows chirp-3."""
+    from app.services.google_stt_service import GoogleSttService
+    from app.schemas.agent import agent_to_out
+
+    api_config = {
+        "google_model": "phone_call",
+        "use_enhanced": True,
+        "encoding": "LINEAR16",
+        "sample_rate_hz": 16000,
+    }
+    sess = GoogleSttService.StreamingSTTSession(
+        language_code="en-AU",
+        sample_rate_hz=16000,
+        encoding="LINEAR16",
+        interim_results=True,
+        api_config=api_config,
+        silence_threshold_ms=1500,
+    )
+    assert sess._api_config.get("google_model") == "phone_call"
+
+    fake_agent = SimpleNamespace(
+        id=uuid.uuid4(),
+        name="G",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug=None,
+        tts_voice_external_id=None,
+        tts_language=None,
+        stt_provider_slug="google",
+        stt_model_external_id="chirp-3",
+        stt_language_code="en-AU",
+        stt_settings_json=None,
+        status="active",
+        created_at=__import__("datetime").datetime(2026, 1, 1),
+        updated_at=None,
+        tenant_id=uuid.uuid4(),
+        system_prompt=None,
+        language=None,
+        voice_type=None,
+        is_inbound_agent=False,
+        is_follow_up_agent=False,
+    )
+    out = agent_to_out(fake_agent)
+    assert out.stt_model is not None
+    assert out.stt_model.model_id == "chirp-3"
+    assert out.stt_model.model_id != "phone_call"
+
+
+def test_livekit_audio_processor_pcm_passthrough():
+    """16 kHz mono PCM passes through without ffmpeg."""
+    from app.voice.audio_transcoder import LiveKitAudioProcessor
+
+    async def _run():
+        proc = LiveKitAudioProcessor(output_sample_rate=16000)
+        pcm = b"\x00\x01" * 160
+        out = await proc.process_frame(pcm, sample_rate=16000, num_channels=1)
+        assert out == pcm
+
+    asyncio.run(_run())
+
+
+def test_google_provider_skips_twilio_audio_feed():
+    """When provider is google, on_audio_chunk must not feed Twilio MULAW to STT."""
+    from unittest.mock import MagicMock, patch
+    from app.voice.voice_orchestrator import VoiceOrchestrator
+    from app.core.agent_runtime import ResolvedSttRuntime
+
+    feed_calls: list[bytes] = []
+
+    class FakeSttPipeline:
+        async def feed_audio_chunk(self, data: bytes) -> None:
+            feed_calls.append(data)
+
+    class FakeTtsPipeline:
+        _worker_task = None
+
+        def __init__(self, _handler):
+            import asyncio
+            self.cancel_event = asyncio.Event()
+
+        async def shutdown(self) -> None:
+            pass
+
+    handler = MagicMock()
+    handler._min_audio_level_threshold = 0
+    handler._audio_samples_needed = 1
+    handler._audio_non_silent_needed = 1
+    handler._enable_interim_llm = False
+    handler._min_interim_words = 3
+    handler._min_interim_confidence = 0.4
+    handler._min_interim_interval_sec = 0.2
+    handler._barge_in_min_conf = 0.26
+    handler._barge_in_min_conf_1w = 0.52
+    handler._pipeline_session = None
+
+    with patch("app.voice.voice_orchestrator.TtsPipeline", FakeTtsPipeline):
+        orch = VoiceOrchestrator(handler)
+
+    orch._user_picked_up = True
+    orch._stt_active = True
+    orch._resolved_stt = ResolvedSttRuntime(
+        provider_slug="google",
+        model_id="chirp-3",
+        language_code="en-AU",
+        sample_rate_hz=16000,
+        encoding="LINEAR16",
+        silence_threshold_ms=1500,
+        api_config={"google_model": "phone_call"},
+    )
+    orch._stt_pipeline = FakeSttPipeline()
+
+    asyncio.run(orch.on_audio_chunk(b"\xff" * 160))
+    assert len(feed_calls) == 0
+
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. _resolve_stt_model validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_resolve_stt_model_invalid_provider(db):
+    from fastapi import HTTPException
+    from app.services.agent_service import AgentService
+    from app.schemas.agent import SttModelSchema, SttProviderEnum
+
+    svc = AgentService()
+    stt = SttModelSchema(provider=SttProviderEnum.google, model_id="chirp-3", language_code="en-AU")
+
+    # google provider not seeded in SQLite test DB → expect 400
+    with pytest.raises(HTTPException) as exc_info:
+        svc._resolve_stt_model(db, stt)
+    assert exc_info.value.status_code == 400
+
+
+def test_resolve_stt_model_none_returns_deepgram_defaults(db):
+    from fastapi import HTTPException
+    from app.services.agent_service import AgentService
+
+    svc = AgentService()
+    # None input should return defaults — but only if deepgram/nova-3 is seeded.
+    # In SQLite test DB it is NOT seeded, so we get a 400 too.
+    # Test that it at least attempts deepgram/nova-3.
+    with pytest.raises(HTTPException) as exc_info:
+        svc._resolve_stt_model(db, None)
+    assert exc_info.value.status_code == 400
+    assert "deepgram" in exc_info.value.detail.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. agent_to_out includes sttModel
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_agent_to_out_includes_stt_model():
+    from app.schemas.agent import agent_to_out
+
+    fake_agent = SimpleNamespace(
+        id=uuid.uuid4(),
+        name="Test Agent",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice123",
+        tts_language="en",
+        stt_provider_slug="google",
+        stt_model_external_id="chirp-3",
+        stt_language_code="en-AU",
+        stt_settings_json=None,
+        status="active",
+        created_at=__import__("datetime").datetime(2026, 1, 1),
+        updated_at=None,
+        tenant_id=uuid.uuid4(),
+        system_prompt=None,
+        language=None,
+        voice_type=None,
+        is_inbound_agent=False,
+        is_follow_up_agent=False,
+    )
+
+    out = agent_to_out(fake_agent)
+    assert out.stt_model is not None
+    assert out.stt_model.provider.value == "google"
+    assert out.stt_model.model_id == "chirp-3"
+    assert out.stt_model.language_code == "en-AU"
+
+
+def test_agent_to_out_stt_model_none_when_missing():
+    from app.schemas.agent import agent_to_out
+
+    fake_agent = SimpleNamespace(
+        id=uuid.uuid4(),
+        name="No STT Agent",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug=None,
+        tts_voice_external_id=None,
+        tts_language=None,
+        stt_provider_slug=None,
+        stt_model_external_id=None,
+        stt_language_code=None,
+        stt_settings_json=None,
+        status="pending",
+        created_at=__import__("datetime").datetime(2026, 1, 1),
+        updated_at=None,
+        tenant_id=uuid.uuid4(),
+        system_prompt=None,
+        language=None,
+        voice_type=None,
+        is_inbound_agent=False,
+        is_follow_up_agent=False,
+    )
+
+    out = agent_to_out(fake_agent)
+    assert out.stt_model is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. resolve_stt_runtime priority (flow > agent > catalog)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_resolve_stt_runtime_flow_language_overrides_agent():
+    from app.core.agent_runtime import resolve_stt_runtime
+
+    agent = SimpleNamespace(
+        stt_provider_slug="deepgram",
+        stt_model_external_id="nova-3",
+        stt_language_code="en",
+        stt_model_id=None,
+        stt_settings_json=None,
+    )
+
+    result = resolve_stt_runtime(agent, flow_language_code="en-AU")
+    assert result.language_code == "en-AU"
+
+
+def test_resolve_stt_runtime_agent_language_overrides_catalog():
+    from app.core.agent_runtime import resolve_stt_runtime
+
+    agent = SimpleNamespace(
+        stt_provider_slug="deepgram",
+        stt_model_external_id="nova-3",
+        stt_language_code="es",
+        stt_model_id=None,
+        stt_settings_json=None,
+    )
+
+    result = resolve_stt_runtime(agent)
+    assert result.language_code == "es"
+
+
+def test_resolve_stt_runtime_defaults_when_no_agent():
+    from app.core.agent_runtime import resolve_stt_runtime, _DEFAULT_STT_PROVIDER_SLUG
+
+    result = resolve_stt_runtime(None)
+    assert result.provider_slug == _DEFAULT_STT_PROVIDER_SLUG
+    assert result.language_code is not None
+
+
+def test_resolve_stt_runtime_silence_threshold_from_settings():
+    from app.core.agent_runtime import resolve_stt_runtime
+
+    agent = SimpleNamespace(
+        stt_provider_slug="google",
+        stt_model_external_id="chirp-3",
+        stt_language_code="en-AU",
+        stt_model_id=None,
+        stt_settings_json={"silence_threshold_ms": 2000},
+    )
+
+    result = resolve_stt_runtime(agent)
+    assert result.silence_threshold_ms == 2000
+
+
+def test_resolve_stt_runtime_google_uses_linear16():
+    from app.core.agent_runtime import resolve_stt_runtime
+
+    agent = SimpleNamespace(
+        stt_provider_slug="google",
+        stt_model_external_id="chirp-3",
+        stt_language_code="en-AU",
+        stt_model_id=None,
+        stt_settings_json=None,
+    )
+
+    result = resolve_stt_runtime(agent)
+    assert result.provider_slug == "google"
+    assert result.encoding == "LINEAR16"
+    assert result.sample_rate_hz == 16000
+    assert result.api_config.get("use_enhanced") is True
+    assert result.api_config.get("google_model") == "phone_call"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. Integration: inject 3-second audio clip → assert final transcript
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_google_stt_integration_3s_audio_mocked(monkeypatch):
+    """
+    Unit-level mock: session produces final transcript without calling Google API.
+    For live API + real audio clip see tests/integration/test_google_stt_live.py.
+    """
+    from app.services.google_stt_service import GoogleSttService
+
+    # Build a fake response object that Google SDK would return
+    class FakeAlt:
+        transcript = "hello world"
+        confidence = 0.92
+
+    class FakeResult:
+        alternatives = [FakeAlt()]
+        is_final = True
+
+    class FakeResponse:
+        results = [FakeResult()]
+
+    sess = GoogleSttService.StreamingSTTSession(
+        language_code="en-AU",
+        sample_rate_hz=16000,
+        encoding="LINEAR16",
+        interim_results=True,
+        api_config={"google_model": "phone_call"},
+        silence_threshold_ms=1500,
+    )
+
+    def fake_run_single_stream(replay_chunks=None):
+        # Simulate Google API returning a final transcript for the injected audio
+        sess._results_q.put(
+            {"transcript": "hello world", "confidence": 0.92, "is_final": True}
+        )
+        return False  # no restart needed
+
+    with patch.object(sess, "_run_single_stream", fake_run_single_stream):
+        sess._run_blocking_stream()
+
+    results = []
+    while not sess._results_q.empty():
+        results.append(sess._results_q.get_nowait())
+
+    finals = [r for r in results if r.get("is_final") and r.get("transcript")]
+    assert finals, "Expected at least one final transcript from 3-second audio clip"
+    assert finals[0]["transcript"] == "hello world"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EventBus tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_stt_event_bus_delivers_to_subscribers():
+    received = []
+
+    async def handler(event):
+        received.append(event)
+
+    async def _run():
+        bus = SttEventBus()
+        bus.subscribe(handler)
+        await bus.emit(SttInterimEvent(transcript="hi", confidence=0.5))
+        await bus.emit(SttFinalEvent(transcript="hi there", confidence=0.9))
+
+    asyncio.run(_run())
+    assert len(received) == 2
+    assert received[0].type == "interim"
+    assert received[1].type == "final"
+
+
+def test_stt_event_bus_subscriber_error_does_not_block():
+    """A crashing subscriber should not prevent subsequent subscribers."""
+    received = []
+
+    async def bad_handler(event):
+        raise ValueError("deliberate test error")
+
+    async def good_handler(event):
+        received.append(event)
+
+    async def _run():
+        bus = SttEventBus()
+        bus.subscribe(bad_handler)
+        bus.subscribe(good_handler)
+        await bus.emit(SttFinalEvent(transcript="ok", confidence=0.8))
+
+    asyncio.run(_run())
+    assert len(received) == 1

--- a/tests/services/test_livekit_service.py
+++ b/tests/services/test_livekit_service.py
@@ -1,0 +1,375 @@
+"""
+Unit tests for app/services/livekit_service.py.
+
+All LiveKit SDK calls are mocked — no real LiveKit server is required.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Mock the livekit package at sys.modules level before any import that
+# touches livekit.  This prevents ImportError when livekit-api is not yet
+# installed in the CI environment.
+# ---------------------------------------------------------------------------
+
+def _make_livekit_mock():
+    lk_mod = MagicMock()
+    api_mod = MagicMock()
+
+    # LiveKitAPI async context manager
+    lk_api_instance = MagicMock()
+    lk_api_instance.__aenter__ = AsyncMock(return_value=lk_api_instance)
+    lk_api_instance.__aexit__ = AsyncMock(return_value=False)
+    lk_api_instance.room = MagicMock()
+
+    lk_api_class = MagicMock(return_value=lk_api_instance)
+    api_mod.LiveKitAPI = lk_api_class
+
+    # Request objects — simple pass-through constructors
+    api_mod.CreateRoomRequest = MagicMock(side_effect=lambda **kw: SimpleNamespace(**kw))
+    api_mod.DeleteRoomRequest = MagicMock(side_effect=lambda **kw: SimpleNamespace(**kw))
+    api_mod.ListParticipantsRequest = MagicMock(side_effect=lambda **kw: SimpleNamespace(**kw))
+    api_mod.ListRoomsRequest = MagicMock(side_effect=lambda **kw: SimpleNamespace(**kw))
+
+    lk_mod.api = api_mod
+    return lk_mod, api_mod, lk_api_instance
+
+
+_lk_mod, _api_mod, _lk_instance = _make_livekit_mock()
+sys.modules.setdefault("livekit", _lk_mod)
+sys.modules.setdefault("livekit.api", _api_mod)
+
+# AccessToken / VideoGrants live in livekit.api
+_api_mod.AccessToken = MagicMock()
+_api_mod.VideoGrants = MagicMock()
+
+# Now safe to import
+from app.services.livekit_service import RoomService  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+VALID_CALL_ID = uuid.UUID("550e8400-e29b-41d4-a716-446655440000")
+VALID_AGENT_ID = uuid.UUID("660e8400-e29b-41d4-a716-446655440001")
+VALID_ROOM_NAME = f"room_{VALID_CALL_ID}"
+
+_CREDS_PATCH = "app.services.livekit_service.RoomService._get_credentials"
+_CREDS = ("http://livekit:7880", "test-api-key", "test-api-secret")
+
+
+def _fresh_service() -> RoomService:
+    return RoomService()
+
+
+# ---------------------------------------------------------------------------
+# Room naming convention
+# ---------------------------------------------------------------------------
+
+class TestRoomNaming:
+    def test_room_name_uses_call_id(self):
+        name = f"room_{VALID_CALL_ID}"
+        assert name == VALID_ROOM_NAME
+
+    def test_room_name_regex_accepts_valid(self):
+        from app.services.livekit_service import _ROOM_NAME_RE
+
+        assert _ROOM_NAME_RE.match(f"room_{VALID_CALL_ID}")
+
+    def test_room_name_regex_rejects_no_prefix(self):
+        from app.services.livekit_service import _ROOM_NAME_RE
+
+        assert not _ROOM_NAME_RE.match(str(VALID_CALL_ID))
+
+    def test_room_name_regex_rejects_short_uuid(self):
+        from app.services.livekit_service import _ROOM_NAME_RE
+
+        assert not _ROOM_NAME_RE.match("room_abc123")
+
+    def test_validate_room_name_raises_for_invalid(self):
+        svc = _fresh_service()
+        with pytest.raises(ValueError, match="Invalid room name"):
+            svc._validate_room_name("room_not-a-uuid")
+
+    def test_validate_room_name_passes_for_valid(self):
+        svc = _fresh_service()
+        svc._validate_room_name(VALID_ROOM_NAME)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# create_room — max_participants enforced at SDK level
+# ---------------------------------------------------------------------------
+
+class TestCreateRoom:
+    @pytest.mark.asyncio
+    async def test_creates_room_with_correct_name(self):
+        svc = _fresh_service()
+        mock_room = SimpleNamespace(sid="RM_test_sid", name=VALID_ROOM_NAME)
+        _lk_instance.room.create_room = AsyncMock(return_value=mock_room)
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            room = await svc.create_room(VALID_CALL_ID, VALID_AGENT_ID)
+
+        assert room.sid == "RM_test_sid"
+        _api_mod.CreateRoomRequest.assert_called()
+        call_kwargs = _api_mod.CreateRoomRequest.call_args.kwargs
+        assert call_kwargs["name"] == VALID_ROOM_NAME
+
+    @pytest.mark.asyncio
+    async def test_max_participants_is_2(self):
+        """SDK-level enforcement: 3rd participant is rejected by LiveKit server."""
+        svc = _fresh_service()
+        _lk_instance.room.create_room = AsyncMock(
+            return_value=SimpleNamespace(sid="sid1", name=VALID_ROOM_NAME)
+        )
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.LIVEKIT_MAX_PARTICIPANTS = 2
+                mock_settings.LIVEKIT_ROOM_EMPTY_TIMEOUT = 30
+                await svc.create_room(VALID_CALL_ID, VALID_AGENT_ID)
+
+        call_kwargs = _api_mod.CreateRoomRequest.call_args.kwargs
+        assert call_kwargs["max_participants"] == 2, (
+            "max_participants MUST be 2 so LiveKit rejects any 3rd participant"
+        )
+
+    @pytest.mark.asyncio
+    async def test_metadata_contains_required_fields(self):
+        svc = _fresh_service()
+        _lk_instance.room.create_room = AsyncMock(
+            return_value=SimpleNamespace(sid="sid2", name=VALID_ROOM_NAME)
+        )
+        flow_id = uuid.uuid4()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            await svc.create_room(VALID_CALL_ID, VALID_AGENT_ID, flow_id=flow_id)
+
+        call_kwargs = _api_mod.CreateRoomRequest.call_args.kwargs
+        metadata = json.loads(call_kwargs["metadata"])
+        assert metadata["callId"] == str(VALID_CALL_ID)
+        assert metadata["agentId"] == str(VALID_AGENT_ID)
+        assert metadata["flowId"] == str(flow_id)
+        assert "startedAt" in metadata
+        # startedAt must parse as ISO-8601
+        datetime.fromisoformat(metadata["startedAt"])
+
+    @pytest.mark.asyncio
+    async def test_metadata_flow_id_none_when_not_provided(self):
+        svc = _fresh_service()
+        _lk_instance.room.create_room = AsyncMock(
+            return_value=SimpleNamespace(sid="sid3", name=VALID_ROOM_NAME)
+        )
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            await svc.create_room(VALID_CALL_ID, VALID_AGENT_ID)
+
+        call_kwargs = _api_mod.CreateRoomRequest.call_args.kwargs
+        metadata = json.loads(call_kwargs["metadata"])
+        assert metadata["flowId"] is None
+
+    @pytest.mark.asyncio
+    async def test_idempotent_retry_returns_existing_room(self):
+        """create_room must be safe to call twice — LiveKit returns existing room."""
+        svc = _fresh_service()
+        existing_room = SimpleNamespace(sid="RM_existing", name=VALID_ROOM_NAME)
+        _lk_instance.room.create_room = AsyncMock(return_value=existing_room)
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            room1 = await svc.create_room(VALID_CALL_ID, VALID_AGENT_ID)
+            room2 = await svc.create_room(VALID_CALL_ID, VALID_AGENT_ID)
+
+        assert room1.sid == room2.sid == "RM_existing"
+        assert _lk_instance.room.create_room.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_timeout_set(self):
+        svc = _fresh_service()
+        _lk_instance.room.create_room = AsyncMock(
+            return_value=SimpleNamespace(sid="sid4", name=VALID_ROOM_NAME)
+        )
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.LIVEKIT_MAX_PARTICIPANTS = 2
+                mock_settings.LIVEKIT_ROOM_EMPTY_TIMEOUT = 30
+                await svc.create_room(VALID_CALL_ID, VALID_AGENT_ID)
+
+        call_kwargs = _api_mod.CreateRoomRequest.call_args.kwargs
+        assert call_kwargs["empty_timeout"] == 30
+
+
+# ---------------------------------------------------------------------------
+# close_room
+# ---------------------------------------------------------------------------
+
+class TestCloseRoom:
+    @pytest.mark.asyncio
+    async def test_close_room_success(self):
+        svc = _fresh_service()
+        _lk_instance.room.delete_room = AsyncMock()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            await svc.close_room(VALID_CALL_ID)
+
+        _api_mod.DeleteRoomRequest.assert_called()
+        call_kwargs = _api_mod.DeleteRoomRequest.call_args.kwargs
+        assert call_kwargs["room"] == VALID_ROOM_NAME
+
+    @pytest.mark.asyncio
+    async def test_close_room_not_found_does_not_raise(self):
+        """Deleting a non-existent room must silently log a warning, not raise."""
+        svc = _fresh_service()
+        _lk_instance.room.delete_room = AsyncMock(
+            side_effect=Exception("room not found")
+        )
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            # Must not raise
+            await svc.close_room(VALID_CALL_ID)
+
+
+# ---------------------------------------------------------------------------
+# Token generation
+# ---------------------------------------------------------------------------
+
+class TestTokenGeneration:
+    def _setup_access_token(self):
+        """Return a mock AccessToken that produces a recognizable JWT string."""
+        mock_token_instance = MagicMock()
+        mock_token_instance.with_identity.return_value = mock_token_instance
+        mock_token_instance.with_name.return_value = mock_token_instance
+        mock_token_instance.with_grants.return_value = mock_token_instance
+        mock_token_instance.with_ttl.return_value = mock_token_instance
+        mock_token_instance.to_jwt.return_value = "header.payload.signature"
+        _api_mod.AccessToken.return_value = mock_token_instance
+        return mock_token_instance
+
+    def test_generate_agent_token_returns_jwt_string(self):
+        svc = _fresh_service()
+        mock_tok = self._setup_access_token()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            token = svc.generate_agent_token(VALID_ROOM_NAME)
+
+        assert token == "header.payload.signature"
+        mock_tok.to_jwt.assert_called_once()
+
+    def test_generate_caller_token_returns_jwt_string(self):
+        svc = _fresh_service()
+        mock_tok = self._setup_access_token()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            token = svc.generate_caller_token(VALID_ROOM_NAME)
+
+        assert token == "header.payload.signature"
+        mock_tok.to_jwt.assert_called_once()
+
+    def test_agent_token_identity_prefix(self):
+        svc = _fresh_service()
+        mock_tok = self._setup_access_token()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            svc.generate_agent_token(VALID_ROOM_NAME)
+
+        mock_tok.with_identity.assert_called_with(f"agent-{VALID_ROOM_NAME}")
+
+    def test_caller_token_identity_prefix(self):
+        svc = _fresh_service()
+        mock_tok = self._setup_access_token()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            svc.generate_caller_token(VALID_ROOM_NAME)
+
+        mock_tok.with_identity.assert_called_with(f"caller-{VALID_ROOM_NAME}")
+
+    def test_token_ttl_matches_config(self):
+        svc = _fresh_service()
+        mock_tok = self._setup_access_token()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.LIVEKIT_TOKEN_TTL = 3600
+                svc.generate_agent_token(VALID_ROOM_NAME)
+
+        from datetime import timedelta
+        mock_tok.with_ttl.assert_called_with(timedelta(seconds=3600))
+
+    def test_token_expiry_approx_one_hour(self):
+        """Verify TTL config drives the timedelta passed to with_ttl."""
+        svc = _fresh_service()
+        mock_tok = self._setup_access_token()
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            with patch("app.core.config.settings") as mock_settings:
+                mock_settings.LIVEKIT_TOKEN_TTL = 3600
+                svc.generate_agent_token(VALID_ROOM_NAME)
+
+        from datetime import timedelta
+        call_arg = mock_tok.with_ttl.call_args[0][0]
+        assert call_arg == timedelta(seconds=3600), (
+            "exp - nbf should equal LIVEKIT_TOKEN_TTL (3600s = 1 hour)"
+        )
+
+    def test_generate_token_rejects_invalid_room_name(self):
+        svc = _fresh_service()
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            with pytest.raises(ValueError, match="Invalid room name"):
+                svc.generate_agent_token("bad-room-name")
+
+    def test_generate_caller_token_rejects_invalid_room_name(self):
+        svc = _fresh_service()
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            with pytest.raises(ValueError, match="Invalid room name"):
+                svc.generate_caller_token("not_a_room_uuid")
+
+
+# ---------------------------------------------------------------------------
+# list_participants
+# ---------------------------------------------------------------------------
+
+class TestListParticipants:
+    @pytest.mark.asyncio
+    async def test_returns_correct_shape(self):
+        svc = _fresh_service()
+        p1 = SimpleNamespace(identity="agent-room_abc", sid="PA_1", state=1)
+        p2 = SimpleNamespace(identity="caller-room_abc", sid="PA_2", state=1)
+        mock_resp = SimpleNamespace(participants=[p1, p2])
+        _lk_instance.room.list_participants = AsyncMock(return_value=mock_resp)
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            result = await svc.list_participants(VALID_ROOM_NAME)
+
+        assert len(result) == 2
+        assert result[0] == {"identity": "agent-room_abc", "sid": "PA_1", "state": 1}
+        assert result[1] == {"identity": "caller-room_abc", "sid": "PA_2", "state": 1}
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_room_name(self):
+        svc = _fresh_service()
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            with pytest.raises(ValueError, match="Invalid room name"):
+                await svc.list_participants("bad-name")
+
+    @pytest.mark.asyncio
+    async def test_empty_room_returns_empty_list(self):
+        svc = _fresh_service()
+        _lk_instance.room.list_participants = AsyncMock(
+            return_value=SimpleNamespace(participants=[])
+        )
+
+        with patch(_CREDS_PATCH, return_value=_CREDS):
+            result = await svc.list_participants(VALID_ROOM_NAME)
+
+        assert result == []

--- a/tests/services/test_stt_regressions.py
+++ b/tests/services/test_stt_regressions.py
@@ -31,10 +31,10 @@ def test_stt_pipeline_exits_reader_loop_on_done(monkeypatch):
 
     fake_session = FakeSession()
 
-    from app.voice import stt_pipeline as stt_pipeline_module
+    from app.services import deepgram_stt_service as dg_module
 
     monkeypatch.setattr(
-        stt_pipeline_module.deepgram_stt_service,
+        dg_module.deepgram_stt_service,
         "create_streaming_session",
         lambda **_: fake_session,
     )
@@ -73,6 +73,13 @@ def test_bidirectional_disconnect_triggers_finish_session(monkeypatch):
     class FakeHandler:
         def __init__(self, **kwargs):
             self._stt_pipeline = FakeSttPipeline()
+            self._stop_event = asyncio.Event()
+
+        async def _full_shutdown(self):
+            if self._stop_event.is_set():
+                return
+            self._stop_event.set()
+            self._stt_pipeline.finish_session()
 
     class FakeWebSocket:
         async def accept(self):

--- a/tests/services/test_voice_call_livekit.py
+++ b/tests/services/test_voice_call_livekit.py
@@ -1,0 +1,297 @@
+"""
+Unit tests: LiveKit flow_id pass-through in voice_call_service.initiate_call.
+
+Verifies that livekit_service.create_room receives the correct flow_id value
+depending on whether callFlowId is present in the CallInitiateRequest.
+
+All external dependencies (Twilio, DB, credits, LiveKit) are mocked — no
+real servers are required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixed UUIDs — stable across assertions
+# ---------------------------------------------------------------------------
+
+_AGENT_ID = uuid.UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_TENANT_ID = uuid.UUID("bbbbbbbb-0000-0000-0000-000000000002")
+_SESSION_ID = uuid.UUID("cccccccc-0000-0000-0000-000000000003")
+_USER_ID = uuid.UUID("dddddddd-0000-0000-0000-000000000004")
+_FLOW_ID = uuid.UUID("eeeeeeee-0000-0000-0000-000000000005")
+
+
+# ---------------------------------------------------------------------------
+# Object builders
+# ---------------------------------------------------------------------------
+
+
+def _call_request(**overrides):
+    from app.schemas.twilio import CallInitiateRequest
+
+    defaults: dict = dict(agentId=str(_AGENT_ID), userPhoneNumber="+15555550001")
+    defaults.update(overrides)
+    return CallInitiateRequest(**defaults)
+
+
+def _agent():
+    ag = MagicMock()
+    ag.id = _AGENT_ID
+    ag.name = "Test Agent"
+    ag.model = MagicMock(model_name="gpt-4o")
+    return ag
+
+
+def _phone_number():
+    pn = MagicMock()
+    pn.id = uuid.uuid4()
+    pn.phone_number = "+15555550000"
+    pn.assistant_id = _AGENT_ID
+    pn.twilio_account_sid = None
+    pn.twilio_auth_token = None
+    return pn
+
+
+def _session(*, call_flow_id: uuid.UUID | None = None):
+    cs = MagicMock()
+    cs.id = _SESSION_ID
+    cs.call_flow_id = call_flow_id
+    cs.call_metadata = None
+    return cs
+
+
+def _db():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = _phone_number()
+    return db
+
+
+def _mock_settings(*, livekit_enabled: bool = True):
+    s = MagicMock()
+    s.LIVEKIT_ENABLED = livekit_enabled
+    s.WEBHOOK_BASE_URL = "http://test.local"
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Helper: run initiate_call with all externals mocked, return create_room mock
+# ---------------------------------------------------------------------------
+
+
+async def _run(
+    request,
+    *,
+    session_obj=None,
+    livekit_enabled: bool = True,
+) -> AsyncMock:
+    """
+    Call initiate_call with all external dependencies mocked.
+
+    Returns the AsyncMock that was substituted for livekit_service.create_room
+    so callers can assert on its invocation arguments.
+    """
+    from app.services.voice_call_service import initiate_call
+
+    cs = session_obj or _session()
+    lk_create_room = AsyncMock(return_value=SimpleNamespace(sid="RM_test"))
+
+    mock_livekit = MagicMock()
+    mock_livekit.create_room = lk_create_room
+    mock_livekit.generate_agent_token = MagicMock(return_value="h.p.s")
+
+    mock_http_req = MagicMock()
+    mock_http_req.headers = {}
+
+    mock_user = MagicMock()
+    mock_user.current_tenant_id = _TENANT_ID
+    mock_user.id = _USER_ID
+
+    with (
+        patch(
+            "app.services.voice_call_service.verify_n8n_webhook_secret_async",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.voice_call_service.agent_service",
+            MagicMock(get_agent_by_id=MagicMock(return_value=_agent())),
+        ),
+        patch(
+            "app.services.voice_call_service.twilio_service",
+            MagicMock(
+                validate_phone_number=MagicMock(return_value=True),
+                make_call_with_credentials=MagicMock(
+                    return_value=SimpleNamespace(sid="CA_test12345678")
+                ),
+            ),
+        ),
+        patch(
+            "app.services.voice_call_service.credit_service",
+            MagicMock(
+                has_sufficient_credits=MagicMock(return_value=(True, 100, 10))
+            ),
+        ),
+        patch(
+            "app.services.voice_call_service.call_session_service",
+            MagicMock(create_call_session=MagicMock(return_value=cs)),
+        ),
+        patch(
+            "app.services.voice_call_service.broadcast_call_status_update",
+            AsyncMock(),
+        ),
+        patch("app.services.livekit_service.livekit_service", mock_livekit),
+        patch(
+            "app.services.voice_call_service.settings",
+            _mock_settings(livekit_enabled=livekit_enabled),
+        ),
+        patch(
+            "app.core.secret_manager.get_twilio_credentials",
+            MagicMock(return_value=("AC_test", "token_test")),
+        ),
+    ):
+        await initiate_call(request, mock_http_req, mock_user, _db())
+
+    return lk_create_room
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlowIdPassThrough:
+    @pytest.mark.asyncio
+    async def test_flow_id_passed_when_call_flow_id_provided(self):
+        """create_room receives the UUID from callFlowId when the field is set."""
+        req = _call_request(callFlowId=str(_FLOW_ID))
+
+        # Session starts with no flow_id; the service block will set it
+        cs = _session(call_flow_id=None)
+
+        # After the callFlowId block runs, call_session.call_flow_id becomes _FLOW_ID
+        # We simulate this by letting the mock attribute be set naturally.
+        mock = await _run(req, session_obj=cs)
+
+        mock.assert_awaited_once()
+        _, kwargs = mock.await_args
+        assert kwargs["flow_id"] == _FLOW_ID, (
+            f"Expected flow_id={_FLOW_ID!r}, got {kwargs['flow_id']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flow_id_none_when_call_flow_id_not_provided(self):
+        """create_room receives flow_id=None when callFlowId is absent."""
+        req = _call_request()  # no callFlowId
+        cs = _session(call_flow_id=None)
+
+        mock = await _run(req, session_obj=cs)
+
+        mock.assert_awaited_once()
+        _, kwargs = mock.await_args
+        assert kwargs["flow_id"] is None, (
+            f"Expected flow_id=None, got {kwargs['flow_id']!r}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flow_id_from_existing_session_when_no_request_flow_id(self):
+        """
+        If the session already has call_flow_id (set by DB / prior code path)
+        and callFlowId is not in the request, that value is forwarded.
+        """
+        req = _call_request()  # no callFlowId in request
+        existing_flow = uuid.uuid4()
+        cs = _session(call_flow_id=existing_flow)
+
+        mock = await _run(req, session_obj=cs)
+
+        mock.assert_awaited_once()
+        _, kwargs = mock.await_args
+        assert kwargs["flow_id"] == existing_flow
+
+    @pytest.mark.asyncio
+    async def test_create_room_not_called_when_livekit_disabled(self):
+        """create_room must not be called when LIVEKIT_ENABLED=False."""
+        req = _call_request(callFlowId=str(_FLOW_ID))
+
+        mock = await _run(req, livekit_enabled=False)
+
+        mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_invalid_call_flow_id_returns_400(self):
+        """A non-UUID callFlowId must cause a 400 response, not crash."""
+        from fastapi.responses import JSONResponse
+
+        req = _call_request(callFlowId="not-a-valid-uuid")
+
+        # _run wraps the HTTPException and returns a JSONResponse
+        result = await _run_raw(req)
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 400
+
+
+async def _run_raw(request) -> object:
+    """Like _run but returns the raw return value of initiate_call."""
+    from app.services.voice_call_service import initiate_call
+
+    cs = _session(call_flow_id=None)
+    mock_livekit = MagicMock()
+    mock_livekit.create_room = AsyncMock(return_value=SimpleNamespace(sid="RM_test"))
+    mock_livekit.generate_agent_token = MagicMock(return_value="h.p.s")
+
+    mock_http_req = MagicMock()
+    mock_http_req.headers = {}
+
+    mock_user = MagicMock()
+    mock_user.current_tenant_id = _TENANT_ID
+    mock_user.id = _USER_ID
+
+    with (
+        patch(
+            "app.services.voice_call_service.verify_n8n_webhook_secret_async",
+            AsyncMock(return_value=False),
+        ),
+        patch(
+            "app.services.voice_call_service.agent_service",
+            MagicMock(get_agent_by_id=MagicMock(return_value=_agent())),
+        ),
+        patch(
+            "app.services.voice_call_service.twilio_service",
+            MagicMock(
+                validate_phone_number=MagicMock(return_value=True),
+                make_call_with_credentials=MagicMock(
+                    return_value=SimpleNamespace(sid="CA_test12345678")
+                ),
+            ),
+        ),
+        patch(
+            "app.services.voice_call_service.credit_service",
+            MagicMock(
+                has_sufficient_credits=MagicMock(return_value=(True, 100, 10))
+            ),
+        ),
+        patch(
+            "app.services.voice_call_service.call_session_service",
+            MagicMock(create_call_session=MagicMock(return_value=cs)),
+        ),
+        patch(
+            "app.services.voice_call_service.broadcast_call_status_update",
+            AsyncMock(),
+        ),
+        patch("app.services.livekit_service.livekit_service", mock_livekit),
+        patch(
+            "app.services.voice_call_service.settings",
+            _mock_settings(livekit_enabled=True),
+        ),
+        patch(
+            "app.core.secret_manager.get_twilio_credentials",
+            MagicMock(return_value=("AC_test", "token_test")),
+        ),
+    ):
+        return await initiate_call(request, mock_http_req, mock_user, _db())

--- a/tests/services/test_voice_call_livekit.py
+++ b/tests/services/test_voice_call_livekit.py
@@ -36,7 +36,7 @@ _FLOW_ID = uuid.UUID("eeeeeeee-0000-0000-0000-000000000005")
 def _call_request(**overrides):
     from app.schemas.twilio import CallInitiateRequest
 
-    defaults: dict = dict(agentId=str(_AGENT_ID), userPhoneNumber="+15555550001")
+    defaults: dict = dict(agentId=str(_AGENT_ID), toNumber="+15555550001")
     defaults.update(overrides)
     return CallInitiateRequest(**defaults)
 
@@ -45,6 +45,7 @@ def _agent():
     ag = MagicMock()
     ag.id = _AGENT_ID
     ag.name = "Test Agent"
+    ag.status = "ready"  # telephony bind sets this; required for outbound calls
     ag.model = MagicMock(model_name="gpt-4o")
     return ag
 
@@ -70,6 +71,8 @@ def _session(*, call_flow_id: uuid.UUID | None = None):
 def _db():
     db = MagicMock()
     db.query.return_value.filter.return_value.first.return_value = _phone_number()
+    # concurrent outbound count query returns 0 (below any limit)
+    db.query.return_value.filter.return_value.scalar.return_value = 0
     return db
 
 
@@ -77,6 +80,7 @@ def _mock_settings(*, livekit_enabled: bool = True):
     s = MagicMock()
     s.LIVEKIT_ENABLED = livekit_enabled
     s.WEBHOOK_BASE_URL = "http://test.local"
+    s.OUTBOUND_MAX_CONCURRENT_PER_WORKSPACE = 10
     return s
 
 
@@ -199,10 +203,12 @@ class TestFlowIdPassThrough:
         )
 
     @pytest.mark.asyncio
-    async def test_flow_id_from_existing_session_when_no_request_flow_id(self):
+    async def test_flow_id_none_when_session_has_flow_id_but_request_does_not(self):
         """
-        If the session already has call_flow_id (set by DB / prior code path)
-        and callFlowId is not in the request, that value is forwarded.
+        Since LiveKit room is now created BEFORE the DB session (new order: LiveKit → DB),
+        the flow_id forwarded to create_room comes from the request only.
+        If callFlowId is absent from the request, create_room receives flow_id=None
+        even if the session mock already has call_flow_id set.
         """
         req = _call_request()  # no callFlowId in request
         existing_flow = uuid.uuid4()
@@ -212,7 +218,8 @@ class TestFlowIdPassThrough:
 
         mock.assert_awaited_once()
         _, kwargs = mock.await_args
-        assert kwargs["flow_id"] == existing_flow
+        # flow_id comes from request (None), not from the pre-built session mock
+        assert kwargs["flow_id"] is None
 
     @pytest.mark.asyncio
     async def test_create_room_not_called_when_livekit_disabled(self):

--- a/tests/test_stt_latency_p95_script.py
+++ b/tests/test_stt_latency_p95_script.py
@@ -1,0 +1,44 @@
+"""Unit tests for scripts/stt_latency_p95.py log parser."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "stt_latency_p95.py"
+
+
+def test_stt_latency_p95_passes_under_400ms(tmp_path):
+    log = tmp_path / "app.log"
+    log.write_text(
+        "\n".join(
+            f"2026-06-08 INFO [Metrics] stt_speech_end_to_final={ms} ms"
+            for ms in [120, 180, 200, 150, 190, 210, 170, 160, 140, 130]
+        )
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--log", str(log), "--min-samples", "5"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "p95" in proc.stdout
+    assert "PASS" in proc.stdout
+
+
+def test_stt_latency_p95_fails_over_400ms(tmp_path):
+    log = tmp_path / "app.log"
+    log.write_text(
+        "\n".join(
+            f"INFO [Metrics] stt_speech_end_to_final={ms} ms"
+            for ms in [500, 520, 480, 510, 490, 505, 495, 515, 530, 600]
+        )
+    )
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--log", str(log), "--min-samples", "5"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 1
+    assert "FAIL" in proc.stdout

--- a/tests/voice/test_livekit_twilio_bridge.py
+++ b/tests/voice/test_livekit_twilio_bridge.py
@@ -1,0 +1,37 @@
+"""Tests for LiveKit ↔ Twilio bridge URL helpers and room parsing."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+def test_build_livekit_stream_ws_url():
+    from unittest.mock import MagicMock, patch
+
+    from app.voice.livekit_twilio_bridge import build_livekit_stream_ws_url
+
+    room = f"room_{uuid.uuid4()}"
+    mock_settings = MagicMock()
+    mock_settings.WEBHOOK_BASE_URL = "https://api.example.com"
+
+    with patch("app.voice.livekit_twilio_bridge.settings", mock_settings):
+        url = build_livekit_stream_ws_url(room)
+
+    assert url == f"wss://api.example.com/api/v1/livekit/{room}"
+
+
+def test_call_session_id_from_valid_room_name():
+    from app.routers.livekit_bridge import _call_session_id_from_room
+
+    sid = uuid.uuid4()
+    room = f"room_{sid}"
+    assert _call_session_id_from_room(room) == sid
+
+
+def test_call_session_id_from_invalid_room_name():
+    from app.routers.livekit_bridge import _call_session_id_from_room
+
+    assert _call_session_id_from_room("not-a-room") is None
+    assert _call_session_id_from_room("room_not-a-uuid") is None


### PR DESCRIPTION
## Summary

- **New service** `app/services/livekit_service.py` — `RoomService` singleton with full room lifecycle (`create_room`, `close_room`, `list_participants`), JWT token generation (`generate_agent_token`, `generate_caller_token`), `health_check`, `check_connectivity`, and `verify_rtc_connectivity` (WebSocket probe)
- **flowId hook** — `callFlowId` (optional UUID) added to `CallInitiateRequest`; parsed and written to `call_session.call_flow_id` before `create_room`, so LiveKit room metadata always carries the correct flow reference
- **Voice call integration** — LiveKit room is provisioned _before_ the Twilio call is placed; failure blocks with HTTP 503 when `LIVEKIT_ENABLED=True`; room metadata (`room_name`, `room_sid`, `flow_id`, `agent_token`) stored in `call_session.call_metadata["livekit"]` — token is never logged
- **Health endpoint** — `GET /health` is now async, returns `livekit: "ok"|"degraded"`, never returns HTTP 500 on LiveKit failure
- **Credentials** — `get_livekit_credentials()` in `secret_manager.py` mirrors the Twilio pattern; uses GCP Secret Manager in staging/prod, plain env vars in dev; startup validation in `main.py` lifespan raises in staging/prod if missing
- **RTC package** — `livekit==1.1.2` added alongside `livekit-api==1.1.0`

## Architecture decisions

| Decision | Rationale |
|---|---|
| All `livekit` SDK imports lazy (inside method bodies) | `livekit_service.py` importable without package installed; LIVEKIT_ENABLED=False in dev never causes import-time errors |
| Room name = `room_{call_session.id}` | Deterministic, UUID-based, safe to re-use on retry |
| `max_participants=2` at SDK level | 3rd participant is rejected by the LiveKit server — no application-layer guard needed |
| `verify_rtc_connectivity` NOT called from `/health` | Too slow for every request; exposed as a separate method for integration tests and manual probes |
| No Alembic migration | LiveKit metadata stored in existing `call_session.call_metadata` JSONB field |

## Test coverage

| Suite | Count | Notes |
|---|---|---|
| `tests/services/test_livekit_service.py` | 25 | Unit tests; full `sys.modules` mock — no real server needed |
| `tests/services/test_voice_call_livekit.py` | 5 | flow_id present / absent / from session / disabled / invalid UUID |
| `tests/routers/test_health.py` | 9 (6 new) | livekit key present, ok/degraded status, never-500 guarantee |
| `tests/integration/test_livekit_integration.py` | 7 | Skip unless `LIVEKIT_URL`/`LIVEKIT_API_KEY`/`LIVEKIT_API_SECRET` set; full lifecycle with RTC join, flow_id metadata, token payload, `verify_rtc_connectivity` |

**Result: 39 unit tests pass · 7 integration tests skip cleanly · 0 ruff errors**

## Test plan

- [ ] Run unit tests: `pytest tests/services/test_livekit_service.py tests/services/test_voice_call_livekit.py tests/routers/test_health.py -v`
- [ ] Confirm integration tests skip without env vars: `pytest tests/integration/test_livekit_integration.py -v`
- [ ] For live integration: start Docker LiveKit (`docker run --rm -p 7880:7880 -e LIVEKIT_KEYS="devkey: secret" livekit/livekit-server --dev`) and run with env vars set
- [ ] Deploy to staging, verify `GET /health` returns `livekit: "ok"`
- [ ] Place an outbound call with `LIVEKIT_ENABLED=True` and confirm `call_session.call_metadata["livekit"]` is populated
- [ ] Place a call with `callFlowId` in the request body and verify `call_session.call_flow_id` is set and `lk_meta["flow_id"]` matches

## Files changed

```
app/core/config.py                            — 7 LIVEKIT_* settings
app/core/secret_manager.py                   — get_livekit_credentials()
app/main.py                                   — startup credential validation
app/routers/health.py                         — async + livekit status
app/schemas/twilio.py                         — callFlowId field
app/services/livekit_service.py              ← NEW
app/services/voice_call_service.py           — LiveKit + flow_id wiring
requirements.txt                              — livekit-api==1.1.0, livekit==1.1.2
.env.example                                  — LIVEKIT_* vars
tests/integration/test_livekit_integration.py ← NEW
tests/routers/test_health.py                  — extended
tests/services/test_livekit_service.py       ← NEW
tests/services/test_voice_call_livekit.py    ← NEW
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)