### PR TITLE
feat(callback): Smart Callback Scheduler — timezone-aware outbound retry with APScheduler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,129 +1,191 @@
-# Backend Expert Agent — TGS Voice Agent Platform
+# CLAUDE.md
 
-## Agent Persona
-
-You are a **senior backend engineer with 7 years of experience** specializing in:
-
-- **Python & FastAPI** — async endpoints, dependency injection, middleware, background tasks, WebSocket streaming
-- **PostgreSQL & SQLAlchemy** — schema design, Alembic migrations, multi-tenancy, query optimization, indexing
-- **Twilio** — voice calls, webhooks, TwiML, call routing, bidirectional media streams, Studio flows
-- **AI Agentic Systems** — building LLM-driven agents with tool use, RAG pipelines, embedding search, multi-turn conversation state, orchestration loops
-- **CRM Integrations** — syncing data with HubSpot, ClickUp, Monday, Jira, Trello; webhook ingestion; field mapping; tenant-level config
-
-You write production-quality code: typed, tested, minimal, and idiomatic. You never over-engineer. You understand the full call lifecycle — from Twilio inbound webhook, through voice agent orchestration, to CRM sync and post-call processing.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ---
 
 ## Project Overview
 
-**Multi-tenant SaaS Voice Agent Backend** built on FastAPI + PostgreSQL.
+Multi-tenant SaaS Voice Agent Backend. Tenants configure AI voice agents that handle inbound/outbound phone calls via Twilio + LiveKit, transcribe speech (Deepgram / Google STT), generate responses via LLM (OpenAI / Gemini / Groq), and synthesise voice (ElevenLabs / Rime / Google TTS). Post-call data syncs to tenant-configured CRMs.
 
-### Key Tech
-- **Runtime**: Python 3.9+, FastAPI, Uvicorn
-- **Database**: PostgreSQL via SQLAlchemy ORM + Alembic migrations
-- **Voice**: Twilio (calls, webhooks, media streams) + ElevenLabs / Google TTS / Deepgram STT
-- **AI**: OpenAI, Gemini, Groq — used for conversation, screening, resume parsing, RAG
-- **CRM**: ClickUp, Monday, Jira, Trello, HubSpot (tenant-configurable)
-- **Infra**: Docker, Stripe billing, SendGrid email, Pinecone vector store
-
-### Directory Layout
-```
-app/
-  api/          # Versioned route registration
-  core/         # Config, security, auth
-  db/           # Session factory, base model
-  models/       # SQLAlchemy ORM models
-  schemas/      # Pydantic request/response schemas
-  services/     # All business logic (one service per domain)
-  routers/      # Health + misc routers
-  middleware/   # Tenant resolution, rate limiting, etc.
-  voice/        # Voice-specific orchestration & streaming
-alembic/        # DB migrations
-tests/          # Pytest test suite
-scripts/        # One-off utility scripts
-```
-
----
-
-## Development Standards
-
-### Code Style
-- Python type hints everywhere — function signatures, return types, class fields
-- Pydantic v2 for all schemas; use `model_validator` / `field_validator` not deprecated v1 patterns
-- SQLAlchemy 2.x style (`select()`, `session.execute()`) — not legacy `session.query()`
-- `async def` for all FastAPI route handlers and service methods that touch the DB or external APIs
-- No bare `except:` — always catch specific exceptions and re-raise or return structured errors
-
-### Services
-- One service class per domain, instantiated and injected via FastAPI `Depends()`
-- Services receive a DB session via constructor injection — never import `SessionLocal` inside a service
-- All DB writes wrapped in explicit transactions; use `async with session.begin()` for multi-step writes
-- External API calls (Twilio, OpenAI, CRMs) always have timeout + retry logic
-
-### Database / Migrations
-- Every schema change gets an Alembic migration — never alter tables directly
-- Multi-tenant isolation is schema-based; always filter queries by `tenant_id`
-- Add indexes on foreign keys and any column used in `WHERE` filters on large tables
-- Migration files must be descriptive: `alembic revision -m "add_index_call_log_tenant_id"`
-
-### Twilio / Voice
-- Webhook handlers must respond within 5 s — offload heavy work to background tasks
-- TwiML responses built with the `twilio` SDK helpers, not raw XML strings
-- Media stream handlers live in `app/voice/`; keep state in `call_session` DB record + in-memory cache keyed by `call_sid`
-- Always validate Twilio request signatures in production webhook routes
-
-### AI / Agentic Patterns
-- LLM calls are wrapped in service methods with explicit `system`, `messages`, and `tools` parameters
-- Tool/function definitions are declared as typed Python dataclasses or Pydantic models
-- Conversation state persisted in `transcript_message` table, not held in memory across requests
-- RAG: embed at write time, retrieve at query time; chunk size and overlap are config, not hardcoded
-- Agents that loop (screening, scheduling) use a state machine pattern stored in `call_session.state`
-
-### CRM Integrations
-- Each CRM has its own service class inheriting `BaseCrmService`
-- Tenant CRM config loaded once per call and cached — never query `tenant_crm_config` per message
-- Field mappings are tenant-configurable via DB, not hardcoded
-- All outbound CRM writes are idempotent — safe to retry on timeout
-
-### Testing
-- Unit tests in `tests/` using `pytest` + `httpx.AsyncClient`
-- Use `pytest-asyncio` for async tests; fixture scope `function` by default
-- Mock external APIs (Twilio, OpenAI) at the HTTP boundary with `respx` or `unittest.mock.patch`
-- Every new endpoint needs at least a happy-path and a validation-error test
-
-### Error Handling
-- Use FastAPI `HTTPException` with meaningful status codes and detail messages
-- Unhandled exceptions bubble to a global exception handler that logs + returns 500
-- Twilio and CRM failures return 200 to the webhook caller but log the failure and enqueue a retry
-
----
-
-## How to Approach Development Tasks
-
-1. **Understand the domain first** — read the relevant service and model files before writing code
-2. **Trace the call flow** — for voice features, follow: Twilio webhook → router → service → voice/ → CRM sync
-3. **Check existing patterns** — look at a similar service before writing a new one; match the style
-4. **Write the migration first** — if the task needs a new column or table, do the Alembic migration before the service code
-5. **Keep it minimal** — solve exactly the stated problem; leave refactoring for a separate PR
-6. **Test locally** — describe how to test the change (curl command, ngrok tunnel for webhooks, etc.)
+**Runtime**: Python 3.14, FastAPI, Uvicorn  
+**DB**: PostgreSQL via SQLAlchemy 2.x (sync) + asyncpg (async) + Alembic  
+**Background jobs**: ARQ (Redis-backed) for batch calls; APScheduler (PostgreSQL job store) for smart callbacks  
+**Vector store**: Pinecone + pgvector for RAG  
+**Infra**: GCS for recordings/KB files, Stripe for billing, SendGrid for email, Redis for rate-limiting
 
 ---
 
 ## Common Commands
 
 ```bash
-# Start dev server
+# Dev server
 uvicorn app.main:app --reload
 
-# Run migrations
+# Migrations
 alembic upgrade head
-
-# Create a new migration
 alembic revision --autogenerate -m "description"
 
-# Run tests
+# Run all tests
 pytest tests/ -v
+
+# Run a single test file
+pytest tests/api/test_callback_scheduler.py -v
+
+# Run a single test by name
+pytest tests/api/test_callback_scheduler.py::test_no_answer_triggers_callback_creation -v
+
+# ARQ batch worker (needs REDIS_URL)
+arq app.workers.batch_call_worker.WorkerSettings
 
 # Lint + format
 ruff check . && black .
 ```
+
+---
+
+## Architecture
+
+### API versioning
+
+| Version | Mount | Auth | Purpose |
+|---|---|---|---|
+| v1 | `/api/v1` | JWT **or** API key (`require_tenant`) | Dashboard + programmatic |
+| v2 | `/api/v2` | API key + `x-workspace-id` (`get_workspace`) | Machine-to-machine |
+
+- v1 routers live in `app/routers/` and are registered in `app/api/api_v1/api.py`.
+- v2 routers live in `app/api/v2/routers/` and carry their own `prefix=` on the `APIRouter`.
+- **Note**: the v1 agents router is registered at `/agent` (singular), not `/agents`.
+
+### Dependency injection
+
+`app/api/deps.py` is the single source for all FastAPI dependencies:
+
+- `get_db()` → sync `SessionLocal` (used throughout v1 and most services)
+- `get_async_db()` → async `AsyncSession` (voice streaming, LiveKit bridge)
+- `require_tenant()` → `Union[User, ApiKeyPrincipal]` — the standard v1 auth dependency
+- `get_workspace()` → `Workspace` — v2 M2M auth (API key + header)
+
+Auth is resolved by `ApiKeyMiddleware` before the handler runs; deps read `request.state` rather than re-verifying.
+
+### Database sessions — two pools
+
+The project runs **two session factories** side by side:
+
+- `app/db/session.py` — `SessionLocal` (sync, used in all services and the APScheduler job thread)
+- `app/db/async_session.py` — `_AsyncSessionLocal` (async, initialised in lifespan via `init_async_db()`)
+
+APScheduler jobs and ARQ workers that need to call async code open their own `asyncio.new_event_loop()` — the APScheduler thread has no running loop, making this safe.
+
+### Table naming convention
+
+`app/db/base_class.py` auto-derives `__tablename__` as `cls.__name__.lower()`. Examples:
+- `CallSession` → `callsession`
+- `CallbackSchedule` → `callbackschedule`
+- `BatchCallRecord` → `batchcallrecord`
+
+Never set an explicit `__tablename__` unless you need to override this.
+
+### Multi-tenancy
+
+Every model that stores tenant data has a `tenant_id` FK. **Always filter by `tenant_id`** in service queries — missing this is the most common security bug. The `AgentService`, `CallSessionService`, etc. all take `tenant_id` as an explicit parameter.
+
+### Service layer pattern
+
+One singleton service per domain, constructed at module level and imported directly:
+
+```python
+# app/services/agent_service.py
+class AgentService:
+    def _repo(self, db: Session) -> AgentRepository: ...
+
+agent_service = AgentService()   # singleton
+
+# usage in router
+from app.services.agent_service import agent_service
+result = agent_service.get_agent_by_id(db, agent_id, tenant_id)
+```
+
+Services never import `SessionLocal` — they always receive `db: Session` as a parameter.
+
+### Outbound call dispatch
+
+Internal code (batch worker, smart callback scheduler) places outbound calls by calling `voice_call_service.initiate_call()` with a fake Starlette `Request` carrying the `x-n8n-webhook-secret` header. This bypasses JWT and resolves to the webhook auth path. See `app/services/batch_call_worker_service.py::_build_fake_request()` for the pattern.
+
+### Voice pipeline
+
+A live call session is managed by `VoiceOrchestrator` (`app/voice/voice_orchestrator.py`):
+
+```
+LiveKit audio → LivKitAudioSubscriber
+                      ↓
+               SttPipeline (Deepgram / Google)
+                      ↓  (final transcript)
+         ConversationOrchestrator → LLM → TtsStreamMixin
+                      ↓
+               TtsPipeline → LiveKit / Twilio media stream
+```
+
+Mixins (`BookingMixin`, `CallControlMixin`, `TtsStreamMixin`) are composed into orchestrator classes. State shared across turns is persisted in `callsession` + `transcript_message` tables — never held in memory across requests.
+
+### Smart Callback Scheduler
+
+APScheduler (`app/core/scheduler.py`) polls `callbackschedule` every 30 s with `IntervalTrigger`. The trigger hook lives in `CallSessionService.update_call_session_status()` — when a call transitions to `no_answer` or `busy` it calls `callback_scheduler_service.maybe_schedule_callback()`. Business hours are read from the `businesshours` table (tenant-scoped, 0=Monday … 6=Sunday).
+
+### Background workers
+
+**ARQ** (`app/workers/batch_call_worker.py`) handles batch outbound campaigns. Start with:
+```bash
+arq app.workers.batch_call_worker.WorkerSettings
+```
+Requires `REDIS_URL` in env. Uses `SKIP LOCKED` to safely distribute work across replicas.
+
+---
+
+## Code Style
+
+- **Pydantic v2**: use `@field_validator` / `@model_validator(mode="after")` — not deprecated v1 patterns.
+- **SQLAlchemy 2.x**: use `select()` + `session.execute()` — not legacy `session.query()`.
+- `async def` for route handlers and any method calling the DB or an external API.
+- No bare `except:` — catch specific exceptions.
+
+### Migrations
+
+Always write the migration before the service code:
+
+```bash
+alembic revision --autogenerate -m "add_callback_timezone_to_agent"
+# review generated file, then:
+alembic upgrade head
+```
+
+After adding a model, import it in `app/db/base.py` so Alembic's autogenerate picks it up.
+
+---
+
+## Testing
+
+`tests/conftest.py` stubs out Google SDK submodules at import time (avoids `ImportError` in unit tests). Set `RUN_GOOGLE_STT_INTEGRATION=1` to run live Google STT tests.
+
+Integration tests that need a real DB read `TEST_DATABASE_URL` from the environment and are skipped when it is unset.
+
+Mock external HTTP APIs at the boundary with `unittest.mock.patch` or `respx`.
+
+---
+
+## Key Environment Variables
+
+| Variable | Required | Notes |
+|---|---|---|
+| `DATABASE_URL` | Yes | PostgreSQL DSN |
+| `SECRET_KEY` | Yes | JWT signing key |
+| `N8N_WEBHOOK_SECRET` | Yes | Auth header for internal outbound call dispatch (batch + callback) |
+| `REDIS_URL` | Batch worker | ARQ queue |
+| `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` | Voice | Auto-switches to test creds in `staging` env |
+| `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` | Voice | Required in staging/production; gated by `LIVEKIT_ENABLED` |
+| `OPENAI_API_KEY` | LLM | |
+| `DEEPGRAM_API_KEY` | STT | |
+| `ELEVENLABS_ENCRYPTION_KEY` | TTS | pgp_sym_encrypt for BYO keys |
+| `PINECONE_API_KEY` / `PINECONE_INDEX_HOST` | RAG | |
+| `API_DOCS_USERNAME` / `API_DOCS_PASSWORD` | Docs | HTTP Basic for `/api/docs` |
+| `ENVIRONMENT` | | `development` / `staging` / `production` |

--- a/alembic/versions/20260615_add_smart_callback_scheduler.py
+++ b/alembic/versions/20260615_add_smart_callback_scheduler.py
@@ -1,0 +1,173 @@
+"""add smart callback scheduler tables and columns
+
+Revision ID: 20260615_callback
+Revises: 7d1c547d8a1f
+Create Date: 2026-06-15 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "20260615_callback"
+down_revision: Union[str, None] = "7d1c547d8a1f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── 1. New smart-callback config columns on the agent table ──────────────
+    op.add_column(
+        "agent",
+        sa.Column(
+            "smart_callback_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "agent",
+        sa.Column(
+            "max_callback_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("5"),
+        ),
+    )
+    op.add_column(
+        "agent",
+        sa.Column(
+            "callback_gap_schedule",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "agent",
+        sa.Column("callback_timezone", sa.Text(), nullable=True),
+    )
+
+    # ── 2. Self-referential parent_call_id on callsession ────────────────────
+    op.add_column(
+        "callsession",
+        sa.Column(
+            "parent_call_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_callsession_parent_call_id",
+        "callsession",
+        "callsession",
+        ["parent_call_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_callsession_parent_call_id",
+        "callsession",
+        ["parent_call_id"],
+    )
+
+    # ── 3. callbackschedule table ─────────────────────────────────────────────
+    op.create_table(
+        "callbackschedule",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "original_call_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "agent_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("phone_number", sa.Text(), nullable=False),
+        sa.Column(
+            "attempt_number",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column(
+            "scheduled_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column("timezone", sa.Text(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column(
+            "executed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["original_call_id"],
+            ["callsession.id"],
+            ondelete="CASCADE",
+            name="fk_callbackschedule_original_call_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["agent_id"],
+            ["agent.id"],
+            ondelete="CASCADE",
+            name="fk_callbackschedule_agent_id",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending','executed','cancelled','exhausted')",
+            name="ck_callbackschedule_status",
+        ),
+    )
+    op.create_index(
+        "ix_callbackschedule_original_call_id",
+        "callbackschedule",
+        ["original_call_id"],
+    )
+    op.create_index(
+        "ix_callbackschedule_agent_id",
+        "callbackschedule",
+        ["agent_id"],
+    )
+    # Composite index used by the polling query: pending rows due now
+    op.create_index(
+        "ix_callbackschedule_status_scheduled_at",
+        "callbackschedule",
+        ["status", "scheduled_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_callbackschedule_status_scheduled_at", table_name="callbackschedule")
+    op.drop_index("ix_callbackschedule_agent_id", table_name="callbackschedule")
+    op.drop_index("ix_callbackschedule_original_call_id", table_name="callbackschedule")
+    op.drop_table("callbackschedule")
+
+    op.drop_index("ix_callsession_parent_call_id", table_name="callsession")
+    op.drop_constraint("fk_callsession_parent_call_id", "callsession", type_="foreignkey")
+    op.drop_column("callsession", "parent_call_id")
+
+    op.drop_column("agent", "callback_timezone")
+    op.drop_column("agent", "callback_gap_schedule")
+    op.drop_column("agent", "max_callback_attempts")
+    op.drop_column("agent", "smart_callback_enabled")

--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -3,8 +3,12 @@ from fastapi import APIRouter
 from app.api.v2.routers.batch_calls import router as batch_calls_router
 from app.api.v2.routers.health import router as health_router
 from app.api.v2.routers.webhooks import router as webhooks_router
+from app.api.v2.routers.callback_scheduler import agents_router as cb_agents_router
+from app.api.v2.routers.callback_scheduler import calls_router as cb_calls_router
 
 v2_router = APIRouter()
 v2_router.include_router(health_router)
 v2_router.include_router(batch_calls_router)
 v2_router.include_router(webhooks_router)
+v2_router.include_router(cb_agents_router)
+v2_router.include_router(cb_calls_router)

--- a/app/api/v2/routers/callback_scheduler.py
+++ b/app/api/v2/routers/callback_scheduler.py
@@ -1,0 +1,107 @@
+"""
+v2 Smart Callback Scheduler endpoints.
+
+Auth: any authenticated tenant principal (API key or JWT).
+
+PUT  /api/v2/agents/{agent_id}/callback-config
+GET  /api/v2/agents/{agent_id}/callback-status
+GET  /api/v2/calls/{call_id}/callback-history
+"""
+from __future__ import annotations
+
+import uuid
+from typing import List, Union
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant
+from app.core.request_auth import ApiKeyPrincipal
+from app.models.user import User
+from app.schemas.callback_scheduler import (
+    CallbackConfigResponse,
+    CallbackConfigUpdate,
+    CallbackHistoryItem,
+    CallbackStatusResponse,
+)
+from app.services.callback_scheduler_service import callback_scheduler_service
+
+
+def _tenant_id(principal: Union[User, ApiKeyPrincipal]) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+# ── /api/v2/agents/… ──────────────────────────────────────────────────────────
+
+agents_router = APIRouter(prefix="/agents", tags=["Smart Callback Scheduler"])
+
+
+@agents_router.put(
+    "/{agent_id}/callback-config",
+    response_model=CallbackConfigResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update agent smart-callback configuration",
+)
+def update_callback_config(
+    agent_id: uuid.UUID,
+    payload: CallbackConfigUpdate,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> CallbackConfigResponse:
+    """
+    Set the smart-callback configuration for an agent.
+
+    - **smart_callback_enabled**: activates the retry loop.
+    - **max_attempts**: total retry budget (1–20).
+    - **gap_schedule**: ordered list of `{days, hours}` gaps between attempts.
+    - **timezone**: IANA timezone string — returns 422 if invalid.
+    """
+    return callback_scheduler_service.update_callback_config(
+        db, agent_id, _tenant_id(principal), payload
+    )
+
+
+@agents_router.get(
+    "/{agent_id}/callback-status",
+    response_model=CallbackStatusResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get agent callback config and live retry counters",
+)
+def get_callback_status(
+    agent_id: uuid.UUID,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> CallbackStatusResponse:
+    """
+    Returns the agent's callback config plus:
+    - `pending_retries`: number of pending callback records.
+    - `next_scheduled_at`: UTC time of the earliest pending callback.
+    """
+    return callback_scheduler_service.get_callback_status(
+        db, agent_id, _tenant_id(principal)
+    )
+
+
+# ── /api/v2/calls/… ───────────────────────────────────────────────────────────
+
+calls_router = APIRouter(prefix="/calls", tags=["Smart Callback Scheduler"])
+
+
+@calls_router.get(
+    "/{call_id}/callback-history",
+    response_model=List[CallbackHistoryItem],
+    status_code=status.HTTP_200_OK,
+    summary="Get callback retry history for a call",
+)
+def get_callback_history(
+    call_id: uuid.UUID,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> List[CallbackHistoryItem]:
+    """
+    Returns ordered callback attempts for `call_id`.
+    Returns 404 if the call does not belong to the caller's tenant.
+    """
+    return callback_scheduler_service.get_callback_history(
+        db, call_id, _tenant_id(principal)
+    )

--- a/app/core/scheduler.py
+++ b/app/core/scheduler.py
@@ -1,0 +1,93 @@
+"""
+APScheduler setup for the Smart Callback Scheduler.
+
+Uses BackgroundScheduler with a SQLAlchemy (PostgreSQL) job store so that
+scheduled jobs survive pod restarts.  APScheduler manages its own
+`apscheduler_jobs` table in the same database.
+
+Lifecycle:
+    start_scheduler()  — called once at application startup (lifespan)
+    stop_scheduler()   — called at application shutdown (lifespan)
+"""
+from __future__ import annotations
+
+from datetime import timezone
+
+from apscheduler.executors.pool import ThreadPoolExecutor
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from app.core.config import settings
+from app.core.logger import logger
+
+
+def _poll_pending_callbacks() -> None:
+    """
+    APScheduler job function.  Runs every 30 seconds.
+
+    Opens its own synchronous DB session (required because APScheduler runs
+    jobs in a thread-pool, outside of any FastAPI request context).
+    """
+    from app.db.session import SessionLocal
+    from app.services.callback_scheduler_service import callback_scheduler_service
+
+    db = SessionLocal()
+    try:
+        callback_scheduler_service.process_pending_callbacks(db)
+    except Exception as exc:  # noqa: BLE001
+        logger.error("callback_poll_job error: %s", exc, exc_info=True)
+    finally:
+        db.close()
+
+
+_JOB_ID = "smart_callback_poll"
+
+
+def _build_scheduler() -> BackgroundScheduler:
+    jobstores = {
+        "default": SQLAlchemyJobStore(url=settings.DATABASE_URL),
+    }
+    executors = {
+        "default": ThreadPoolExecutor(max_workers=4),
+    }
+    job_defaults = {
+        "coalesce": True,   # merge missed runs into one
+        "max_instances": 1, # never run more than one poll concurrently
+    }
+    return BackgroundScheduler(
+        jobstores=jobstores,
+        executors=executors,
+        job_defaults=job_defaults,
+        timezone=timezone.utc,
+    )
+
+
+# Module-level singleton — created once, reused across start/stop calls.
+_scheduler: BackgroundScheduler = _build_scheduler()
+
+
+def start_scheduler() -> None:
+    """Register the polling job and start the scheduler."""
+    if _scheduler.running:
+        logger.warning("APScheduler is already running; start_scheduler() called twice")
+        return
+
+    # Replace any stale job stored in the DB so config changes take effect.
+    _scheduler.add_job(
+        _poll_pending_callbacks,
+        trigger=IntervalTrigger(seconds=30),
+        id=_JOB_ID,
+        name="Smart Callback Poller",
+        replace_existing=True,
+    )
+
+    _scheduler.start()
+    logger.info("APScheduler started — polling for pending callbacks every 30 s")
+
+
+def stop_scheduler() -> None:
+    """Gracefully shut down the scheduler on application exit."""
+    if _scheduler.running:
+        _scheduler.shutdown(wait=False)
+        logger.info("APScheduler stopped")

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -66,3 +66,6 @@ from app.models.webhook import WebhookEndpoint, WebhookDelivery
 from app.models.branding_configs import BrandingConfig  # noqa: F401
 from app.models.pricing_configs import PricingConfig  # noqa: F401
 from app.models.rbac_roles import RbacRole  # noqa: F401
+
+# Smart Callback Scheduler
+from app.models.callback_schedule import CallbackSchedule  # noqa: F401

--- a/app/main.py
+++ b/app/main.py
@@ -99,9 +99,22 @@ def create_app() -> FastAPI:
                     "/api/docs will return 503 until set; restart server after updating .env"
                 )
 
+        # ---- APScheduler — Smart Callback Scheduler ----
+        try:
+            from app.core.scheduler import start_scheduler
+            start_scheduler()
+            logger.info("APScheduler started for smart callback polling")
+        except Exception as exc:
+            logger.warning(
+                "APScheduler startup failed: %s — smart callbacks will not fire automatically",
+                exc,
+            )
+
         yield
 
         # ---- shutdown (SIGTERM / reload) ----
+        from app.core.scheduler import stop_scheduler
+        stop_scheduler()
         await dispose_async_db()
         await graceful_shutdown()
 

--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -41,6 +41,18 @@ class Agent(Base):
     # Smart callback flag — agent proactively calls back when a slot opens.
     smart_callback = Column(Boolean, default=False, nullable=False, server_default="false")
 
+    # ── Smart Callback Scheduler (Sprint 8) ───────────────────────────────────
+    # Enables the APScheduler-driven retry loop for no_answer / busy calls.
+    smart_callback_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    # Maximum number of retry attempts before the chain is exhausted.
+    max_callback_attempts = Column(Integer, default=5, nullable=False, server_default="5")
+    # Ordered list of {days, hours} gaps between attempts, e.g. [{days:0,hours:1},{days:1,hours:0}].
+    callback_gap_schedule = Column(
+        JSON, nullable=False, default=list, server_default="[]"
+    )
+    # IANA timezone used for business-hours enforcement, e.g. "America/New_York".
+    callback_timezone = Column(Text, nullable=True)
+
     # ── STT model triad (mirrors TTS triad: provider_slug / external_id / language) ──
     stt_provider_slug = Column(String(40), nullable=True)
     stt_model_external_id = Column(String(255), nullable=True)
@@ -95,6 +107,7 @@ class Agent(Base):
     stt_provider = relationship("STTProvider", back_populates="agents", foreign_keys=[stt_provider_id])
     stt_model = relationship("STTModel", back_populates="agents", foreign_keys=[stt_model_id])
     transfer_route = relationship("TransferRoute", back_populates="agents")
+    callback_schedules = relationship("CallbackSchedule", back_populates="agent")
 
     __table_args__ = (
         Index("ix_agent_tenant_id", "tenant_id"),

--- a/app/models/call_session.py
+++ b/app/models/call_session.py
@@ -51,6 +51,14 @@ class CallSession(Base):
     # Optional link to the call flow that triggered this session
     call_flow_id = Column(UUID(as_uuid=True), ForeignKey("callflow.id"), nullable=True, index=True)
 
+    # Smart Callback: points to the original missed call in a retry chain
+    parent_call_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("callsession.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
@@ -63,6 +71,9 @@ class CallSession(Base):
     transcript_messages = relationship("TranscriptMessage", back_populates="call_session", cascade="all, delete-orphan")
     slot_reservations = relationship("SlotReservation", back_populates="call_session", cascade="all, delete-orphan")
     call_flow = relationship("CallFlow", back_populates="call_sessions")
+    # Self-referential: retry calls point back to the original missed call
+    parent_call = relationship("CallSession", remote_side="CallSession.id", foreign_keys=[parent_call_id])
+    callback_schedules = relationship("CallbackSchedule", back_populates="original_call", foreign_keys="CallbackSchedule.original_call_id")
     
     def __repr__(self):
         return f"<CallSession(id={self.id}, status={self.status})>"

--- a/app/models/callback_schedule.py
+++ b/app/models/callback_schedule.py
@@ -1,0 +1,62 @@
+from sqlalchemy import Column, String, Text, DateTime, Integer, ForeignKey, CheckConstraint, Index
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import uuid
+
+from app.db.base_class import Base
+
+
+class CallbackSchedule(Base):
+    """
+    Tracks each retry attempt for a missed/busy outbound call.
+    Table name is auto-derived from base class: 'callbackschedule'.
+    """
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+
+    # The original missed call that triggered the callback chain
+    original_call_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("callsession.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # The agent responsible for placing the callback
+    agent_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("agent.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Destination number to dial
+    phone_number = Column(Text, nullable=False)
+    # 1-based attempt counter (1 = first retry, 2 = second, …)
+    attempt_number = Column(Integer, nullable=False, default=1, server_default="1")
+    # When the system should dispatch this callback (UTC stored, tz-aware)
+    scheduled_at = Column(DateTime(timezone=True), nullable=False)
+    # IANA timezone used to evaluate business-hours window
+    timezone = Column(Text, nullable=False)
+    # Lifecycle state: pending → executed | cancelled | exhausted
+    status = Column(String(20), nullable=False, default="pending", server_default="pending")
+    # Populated when the callback call is actually dispatched
+    executed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # ── Relationships ──────────────────────────────────────────────────────────
+    original_call = relationship(
+        "CallSession",
+        foreign_keys=[original_call_id],
+        back_populates="callback_schedules",
+    )
+    agent = relationship("Agent", back_populates="callback_schedules")
+
+    # ── Constraints & indexes ──────────────────────────────────────────────────
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('pending','executed','cancelled','exhausted')",
+            name="ck_callbackschedule_status",
+        ),
+        # Polling query: WHERE status = 'pending' AND scheduled_at <= now()
+        Index("ix_callbackschedule_status_scheduled_at", "status", "scheduled_at"),
+    )

--- a/app/schemas/callback_scheduler.py
+++ b/app/schemas/callback_scheduler.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+from zoneinfo import available_timezones
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class GapInterval(BaseModel):
+    """A single time gap between callback attempts."""
+
+    days: int = Field(default=0, ge=0, description="Number of days to wait")
+    hours: int = Field(default=0, ge=0, description="Number of hours to wait")
+
+    @model_validator(mode="after")
+    def at_least_one_unit(self) -> "GapInterval":
+        if self.days == 0 and self.hours == 0:
+            raise ValueError("Each gap interval must have days > 0 or hours > 0")
+        return self
+
+
+class CallbackConfigUpdate(BaseModel):
+    """
+    PUT /api/v1/agents/{id}/callback-config request body.
+    Validates the timezone against the IANA zoneinfo database.
+    """
+
+    smart_callback_enabled: bool
+    max_attempts: int = Field(
+        default=5,
+        ge=1,
+        le=20,
+        description="Maximum retry attempts before the chain is exhausted",
+    )
+    gap_schedule: List[GapInterval] = Field(
+        default_factory=list,
+        description="Ordered list of gaps between attempts; index 0 = gap after first miss",
+    )
+    timezone: str = Field(description="IANA timezone, e.g. 'America/New_York'")
+
+    @field_validator("timezone")
+    @classmethod
+    def validate_timezone(cls, v: str) -> str:
+        if v not in available_timezones():
+            raise ValueError(
+                f"'{v}' is not a valid IANA timezone. "
+                "Use a value from zoneinfo.available_timezones()."
+            )
+        return v
+
+    @model_validator(mode="after")
+    def gap_schedule_length(self) -> "CallbackConfigUpdate":
+        """
+        When enabled, gap_schedule must have at least one entry and at most
+        max_attempts entries (one gap per inter-attempt interval).
+        """
+        if self.smart_callback_enabled and not self.gap_schedule:
+            raise ValueError(
+                "gap_schedule must contain at least one interval when smart_callback_enabled is True"
+            )
+        if len(self.gap_schedule) > self.max_attempts:
+            raise ValueError(
+                f"gap_schedule length ({len(self.gap_schedule)}) cannot exceed "
+                f"max_attempts ({self.max_attempts})"
+            )
+        return self
+
+
+class CallbackConfigResponse(BaseModel):
+    """Response body for PUT /api/v1/agents/{id}/callback-config."""
+
+    smart_callback_enabled: bool
+    max_attempts: int
+    gap_schedule: List[GapInterval]
+    timezone: Optional[str]
+
+
+class CallbackStatusResponse(BaseModel):
+    """
+    GET /api/v1/agents/{id}/callback-status response.
+    Returns live counters alongside the static config.
+    """
+
+    enabled: bool
+    max_attempts: int
+    gap_schedule: List[GapInterval]
+    timezone: Optional[str]
+    pending_retries: int = Field(description="Number of pending callbacks for this agent")
+    next_scheduled_at: Optional[datetime] = Field(
+        default=None,
+        description="UTC timestamp of the earliest pending callback",
+    )
+
+
+class CallbackHistoryItem(BaseModel):
+    """One row from GET /api/v1/calls/{call_id}/callback-history."""
+
+    attempt_number: int
+    scheduled_at: datetime
+    executed_at: Optional[datetime]
+    status: str

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -206,7 +206,7 @@ class CallSessionService:
                 
                 db.commit()
                 db.refresh(call_session)
-                
+
                 self._update_call_log_for_session(
                     db, call_session, ended_reason, success_evaluation, cost, transferred
                 )
@@ -220,7 +220,19 @@ class CallSessionService:
                         schedule_inbound_crm_sync(call_session.id)
                     except Exception as sync_exc:  # pragma: no cover
                         logger.warning("Inbound CRM schedule failed (non-critical): %s", sync_exc)
-            
+
+                # Smart Callback: trigger a retry chain for missed outbound calls
+                if status in ("no_answer", "busy"):
+                    try:
+                        from app.services.callback_scheduler_service import callback_scheduler_service
+                        callback_scheduler_service.maybe_schedule_callback(db, call_session)
+                    except Exception as cb_exc:
+                        logger.warning(
+                            "Smart callback schedule failed (non-critical) session=%s: %s",
+                            session_id,
+                            cb_exc,
+                        )
+
             return call_session
 
         except Exception as e:

--- a/app/services/callback_scheduler_service.py
+++ b/app/services/callback_scheduler_service.py
@@ -222,17 +222,30 @@ class CallbackSchedulerService:
         """
         Poll for due callbacks and dispatch each one.
         Designed to be called by the APScheduler IntervalTrigger job.
+
+        Each iteration selects a single row with FOR UPDATE SKIP LOCKED so the
+        lock is scoped to exactly one transaction. Committing (or rolling back)
+        inside _dispatch_and_advance releases only that row's lock, which means
+        other workers/pods can safely claim any remaining rows without risk of
+        double-dispatch.
         """
         now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
 
-        due_rows = db.execute(
-            select(CallbackSchedule).where(
-                CallbackSchedule.status == "pending",
-                CallbackSchedule.scheduled_at <= now,
-            ).with_for_update(skip_locked=True)
-        ).scalars().all()
+        while True:
+            schedule = db.execute(
+                select(CallbackSchedule)
+                .where(
+                    CallbackSchedule.status == "pending",
+                    CallbackSchedule.scheduled_at <= now,
+                )
+                .order_by(CallbackSchedule.scheduled_at)
+                .with_for_update(skip_locked=True)
+                .limit(1)
+            ).scalar_one_or_none()
 
-        for schedule in due_rows:
+            if schedule is None:
+                break
+
             try:
                 self._dispatch_and_advance(db, schedule)
             except Exception as exc:  # noqa: BLE001
@@ -348,12 +361,23 @@ class CallbackSchedulerService:
         """
         Dispatch the outbound callback call via the existing initiate_call path.
 
-        Runs in an APScheduler thread-pool thread (no event loop), so we create
-        a fresh event loop for the async call and a dedicated DB session so the
-        async path can commit without interfering with the caller's session.
+        Session boundaries
+        ------------------
+        dispatch_db is intentionally separate from the poller session (db).
+        initiate_call commits its own work (new CallSession, Twilio request)
+        inside dispatch_db. A db.rollback() in the poller NEVER rolls back
+        dispatch_db — the call delivery is guaranteed to persist regardless of
+        any subsequent bookkeeping failure in the poller session.
 
-        After dispatch the new CallSession.parent_call_id is set to
-        schedule.original_call_id for full call-chain traceability.
+        Failure semantics
+        -----------------
+        - initiate_call failure   → real failure; raise so the poller can
+                                    rollback and leave the row in 'pending'.
+        - parent_call_id update failure → non-critical bookkeeping; logged
+                                          but does NOT fail the dispatch.
+
+        Runs in an APScheduler thread-pool thread (no event loop), so we spin
+        up a fresh event loop for the async call.
         """
         import asyncio
         import json as _json
@@ -413,7 +437,9 @@ class CallbackSchedulerService:
 
         fake_request = _Request(scope, receive=_receive)
 
-        # ── Run async initiate_call in a fresh event loop ─────────────────────
+        # ── Phase 1: call initiation (dispatch_db, independent of poller db) ────
+        # dispatch_db owns its own transaction. Commits inside initiate_call are
+        # durable regardless of what happens to the poller session afterwards.
         # APScheduler thread has no running loop, so new_event_loop() is safe.
         dispatch_db = SessionLocal()
         result = None
@@ -433,9 +459,10 @@ class CallbackSchedulerService:
                 loop.close()
                 asyncio.set_event_loop(None)
         finally:
+            # Always close dispatch_db; its commits are already flushed to PG.
             dispatch_db.close()
 
-        # ── Extract the new session id and set parent_call_id ─────────────────
+        # ── Extract new session id — failure here = real initiation failure ────
         if isinstance(result, _JSONResponse):
             body = _json.loads(result.body)
             new_call_id_str = (body.get("data") or {}).get("callId")
@@ -447,8 +474,24 @@ class CallbackSchedulerService:
         else:
             new_call_id_str = getattr(getattr(result, "data", None), "callId", None)
 
-        if new_call_id_str:
-            new_session_id = uuid.UUID(new_call_id_str)
+        if not new_call_id_str:
+            raise RuntimeError(
+                f"initiate_call returned no callId for callback attempt {schedule.attempt_number}"
+            )
+
+        logger.info(
+            "callback_dispatched new_session=%s parent=%s attempt=%d",
+            new_call_id_str,
+            schedule.original_call_id,
+            schedule.attempt_number,
+        )
+
+        # ── Phase 2: bookkeeping — set parent_call_id on the new session ──────
+        # Non-critical: the outbound call is already placed. A failure here
+        # must NOT propagate as a dispatch failure. Log and continue so the
+        # poller can advance the schedule normally.
+        new_session_id = uuid.UUID(new_call_id_str)
+        try:
             db.execute(
                 CallSession.__table__.update()
                 .where(CallSession.__table__.c.id == new_session_id)
@@ -456,15 +499,20 @@ class CallbackSchedulerService:
             )
             db.commit()
             logger.info(
-                "callback_dispatched new_session=%s parent=%s attempt=%d",
+                "callback_parent_linked new_session=%s parent=%s",
                 new_session_id,
                 schedule.original_call_id,
-                schedule.attempt_number,
             )
-        else:
-            raise RuntimeError(
-                f"initiate_call returned no callId for callback attempt {schedule.attempt_number}"
+        except Exception as link_exc:  # noqa: BLE001
+            logger.error(
+                "callback_parent_link_failed new_session=%s parent=%s: %s "
+                "(call was placed successfully; this is a bookkeeping-only failure)",
+                new_session_id,
+                schedule.original_call_id,
+                link_exc,
+                exc_info=True,
             )
+            db.rollback()
 
     # ── Business hours helpers ─────────────────────────────────────────────────
 

--- a/app/services/callback_scheduler_service.py
+++ b/app/services/callback_scheduler_service.py
@@ -1,0 +1,557 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, time
+from typing import List, Optional
+from zoneinfo import ZoneInfo
+
+from fastapi import HTTPException, status
+from sqlalchemy import select, func
+from sqlalchemy.orm import Session
+
+from app.core.logger import logger
+from app.models.agent import Agent
+from app.models.business_hours import BusinessHours
+from app.models.callback_schedule import CallbackSchedule
+from app.models.call_session import CallSession
+from app.schemas.callback_scheduler import (
+    CallbackConfigUpdate,
+    CallbackConfigResponse,
+    CallbackStatusResponse,
+    CallbackHistoryItem,
+    GapInterval,
+)
+
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+CALLBACK_TRIGGER_STATUSES = frozenset({"no_answer", "busy"})
+_MAX_BUSINESS_HOURS_LOOKAHEAD_DAYS = 14  # give up after 2 weeks with no open window
+
+
+# ── Service ────────────────────────────────────────────────────────────────────
+
+
+class CallbackSchedulerService:
+    """
+    Encapsulates all Smart Callback Scheduler business logic.
+
+    Responsibilities:
+    - Store / retrieve per-agent callback config (smart_callback_enabled,
+      max_callback_attempts, callback_gap_schedule, callback_timezone).
+    - Create a CallbackSchedule record when a call ends in no_answer / busy.
+    - Process pending callbacks: enforce business hours, dispatch the call,
+      and chain the next attempt or mark the sequence exhausted.
+    """
+
+    # ── Config endpoints ───────────────────────────────────────────────────────
+
+    def update_callback_config(
+        self,
+        db: Session,
+        agent_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        payload: CallbackConfigUpdate,
+    ) -> CallbackConfigResponse:
+        agent = self._get_agent(db, agent_id, tenant_id)
+
+        agent.smart_callback_enabled = payload.smart_callback_enabled
+        agent.max_callback_attempts = payload.max_attempts
+        agent.callback_gap_schedule = [
+            {"days": g.days, "hours": g.hours} for g in payload.gap_schedule
+        ]
+        agent.callback_timezone = payload.timezone
+
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+
+        logger.info(
+            "callback_config_updated agent_id=%s enabled=%s max_attempts=%s",
+            agent_id,
+            payload.smart_callback_enabled,
+            payload.max_attempts,
+        )
+        return CallbackConfigResponse(
+            smart_callback_enabled=agent.smart_callback_enabled,
+            max_attempts=agent.max_callback_attempts,
+            gap_schedule=[GapInterval(**g) for g in (agent.callback_gap_schedule or [])],
+            timezone=agent.callback_timezone,
+        )
+
+    def get_callback_status(
+        self,
+        db: Session,
+        agent_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> CallbackStatusResponse:
+        agent = self._get_agent(db, agent_id, tenant_id)
+
+        pending_count: int = db.execute(
+            select(func.count(CallbackSchedule.id)).where(
+                CallbackSchedule.agent_id == agent_id,
+                CallbackSchedule.status == "pending",
+            )
+        ).scalar_one()
+
+        next_scheduled_at: Optional[datetime] = db.execute(
+            select(func.min(CallbackSchedule.scheduled_at)).where(
+                CallbackSchedule.agent_id == agent_id,
+                CallbackSchedule.status == "pending",
+            )
+        ).scalar_one()
+
+        return CallbackStatusResponse(
+            enabled=agent.smart_callback_enabled,
+            max_attempts=agent.max_callback_attempts,
+            gap_schedule=[GapInterval(**g) for g in (agent.callback_gap_schedule or [])],
+            timezone=agent.callback_timezone,
+            pending_retries=pending_count,
+            next_scheduled_at=next_scheduled_at,
+        )
+
+    def get_callback_history(
+        self,
+        db: Session,
+        call_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> List[CallbackHistoryItem]:
+        # Verify the call belongs to this tenant before exposing history
+        call = db.execute(
+            select(CallSession).where(
+                CallSession.id == call_id,
+                CallSession.tenant_id == tenant_id,
+            )
+        ).scalar_one_or_none()
+
+        if call is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Call session not found",
+            )
+
+        rows = db.execute(
+            select(CallbackSchedule)
+            .where(CallbackSchedule.original_call_id == call_id)
+            .order_by(CallbackSchedule.attempt_number)
+        ).scalars().all()
+
+        return [
+            CallbackHistoryItem(
+                attempt_number=r.attempt_number,
+                scheduled_at=r.scheduled_at,
+                executed_at=r.executed_at,
+                status=r.status,
+            )
+            for r in rows
+        ]
+
+    # ── Trigger logic (called from call-status webhook / call-end handler) ─────
+
+    def maybe_schedule_callback(
+        self,
+        db: Session,
+        call_session: CallSession,
+    ) -> Optional[CallbackSchedule]:
+        """
+        Called when a CallSession's status is updated.
+        Creates the first CallbackSchedule record if the agent has smart
+        callbacks enabled and the call ended as no_answer or busy.
+
+        Returns the created CallbackSchedule or None.
+        """
+        if call_session.status not in CALLBACK_TRIGGER_STATUSES:
+            return None
+
+        agent: Optional[Agent] = db.get(Agent, call_session.agent_id)
+        if agent is None or not agent.smart_callback_enabled:
+            return None
+
+        gap_schedule: List[dict] = agent.callback_gap_schedule or []
+        if not gap_schedule:
+            logger.warning(
+                "smart_callback_enabled but gap_schedule is empty for agent %s",
+                agent.id,
+            )
+            return None
+
+        # The first callback uses gap_schedule[0]
+        first_gap = gap_schedule[0]
+        base_time = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        target_at = base_time + timedelta(
+            days=first_gap.get("days", 0),
+            hours=first_gap.get("hours", 0),
+        )
+
+        # Enforce business hours for the first attempt
+        tz_name = agent.callback_timezone or "UTC"
+        scheduled_at = self._next_valid_window(db, agent, target_at, tz_name)
+
+        phone = call_session.customer_phone_number or call_session.to_number
+        if not phone:
+            logger.warning(
+                "Cannot schedule callback for call %s: no destination phone number",
+                call_session.id,
+            )
+            return None
+
+        schedule = CallbackSchedule(
+            original_call_id=call_session.id,
+            agent_id=agent.id,
+            phone_number=phone,
+            attempt_number=1,
+            scheduled_at=scheduled_at,
+            timezone=tz_name,
+            status="pending",
+        )
+        db.add(schedule)
+        db.commit()
+        db.refresh(schedule)
+
+        logger.info(
+            "callback_scheduled call_id=%s attempt=1 at=%s tz=%s",
+            call_session.id,
+            scheduled_at.isoformat(),
+            tz_name,
+        )
+        return schedule
+
+    # ── APScheduler job (runs every 30 s) ─────────────────────────────────────
+
+    def process_pending_callbacks(self, db: Session) -> None:
+        """
+        Poll for due callbacks and dispatch each one.
+        Designed to be called by the APScheduler IntervalTrigger job.
+        """
+        now = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+
+        due_rows = db.execute(
+            select(CallbackSchedule).where(
+                CallbackSchedule.status == "pending",
+                CallbackSchedule.scheduled_at <= now,
+            ).with_for_update(skip_locked=True)
+        ).scalars().all()
+
+        for schedule in due_rows:
+            try:
+                self._dispatch_and_advance(db, schedule)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "callback_dispatch_error schedule_id=%s: %s",
+                    schedule.id,
+                    exc,
+                    exc_info=True,
+                )
+                db.rollback()
+
+    # ── Internal helpers ───────────────────────────────────────────────────────
+
+    def _dispatch_and_advance(self, db: Session, schedule: CallbackSchedule) -> None:
+        """
+        1. Verify business hours (reschedule if outside window).
+        2. Dispatch the outbound call.
+        3. Mark this record executed.
+        4. If more attempts remain, insert the next CallbackSchedule.
+           Otherwise mark the chain exhausted.
+        """
+        agent: Optional[Agent] = db.get(Agent, schedule.agent_id)
+        if agent is None:
+            schedule.status = "cancelled"
+            db.commit()
+            return
+
+        tz_name = schedule.timezone
+        now_tz = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC")).astimezone(ZoneInfo(tz_name))
+
+        # Re-check business hours at dispatch time
+        if not self._is_within_business_hours(db, agent, now_tz):
+            # Push to next open window starting from now
+            next_window = self._next_valid_window(
+                db, agent, datetime.utcnow().replace(tzinfo=ZoneInfo("UTC")), tz_name
+            )
+            schedule.scheduled_at = next_window
+            db.commit()
+            logger.info(
+                "callback_rescheduled schedule_id=%s next=%s reason=outside_business_hours",
+                schedule.id,
+                next_window.isoformat(),
+            )
+            return
+
+        # Dispatch the call
+        self._dispatch_call(db, schedule, agent)
+
+        # Mark this attempt executed
+        schedule.status = "executed"
+        schedule.executed_at = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+        db.add(schedule)
+
+        # Chain next attempt if budget remains
+        gap_schedule: List[dict] = agent.callback_gap_schedule or []
+        next_attempt_number = schedule.attempt_number + 1
+
+        if next_attempt_number <= agent.max_callback_attempts and gap_schedule:
+            # Use the gap at index (next_attempt_number - 1), clamped to last entry
+            gap_index = min(next_attempt_number - 1, len(gap_schedule) - 1)
+            gap = gap_schedule[gap_index]
+
+            base_time = datetime.utcnow().replace(tzinfo=ZoneInfo("UTC"))
+            target_at = base_time + timedelta(
+                days=gap.get("days", 0),
+                hours=gap.get("hours", 0),
+            )
+            next_scheduled_at = self._next_valid_window(db, agent, target_at, tz_name)
+
+            next_schedule = CallbackSchedule(
+                original_call_id=schedule.original_call_id,
+                agent_id=schedule.agent_id,
+                phone_number=schedule.phone_number,
+                attempt_number=next_attempt_number,
+                scheduled_at=next_scheduled_at,
+                timezone=tz_name,
+                status="pending",
+            )
+            db.add(next_schedule)
+            logger.info(
+                "callback_chained original_call_id=%s attempt=%d at=%s",
+                schedule.original_call_id,
+                next_attempt_number,
+                next_scheduled_at.isoformat(),
+            )
+        else:
+            # Budget exhausted — mark this final attempt as exhausted and
+            # cancel any stale pending rows that may exist for the same chain.
+            schedule.status = "exhausted"
+            db.execute(
+                CallbackSchedule.__table__.update()
+                .where(
+                    CallbackSchedule.__table__.c.original_call_id == schedule.original_call_id,
+                    CallbackSchedule.__table__.c.status == "pending",
+                    CallbackSchedule.__table__.c.id != schedule.id,
+                )
+                .values(status="cancelled")
+            )
+            logger.info(
+                "callback_exhausted original_call_id=%s max_attempts=%d reached",
+                schedule.original_call_id,
+                agent.max_callback_attempts,
+            )
+
+        db.commit()
+
+    def _dispatch_call(
+        self,
+        db: Session,
+        schedule: CallbackSchedule,
+        agent: Agent,
+    ) -> None:
+        """
+        Dispatch the outbound callback call via the existing initiate_call path.
+
+        Runs in an APScheduler thread-pool thread (no event loop), so we create
+        a fresh event loop for the async call and a dedicated DB session so the
+        async path can commit without interfering with the caller's session.
+
+        After dispatch the new CallSession.parent_call_id is set to
+        schedule.original_call_id for full call-chain traceability.
+        """
+        import asyncio
+        import json as _json
+
+        from fastapi.responses import JSONResponse as _JSONResponse
+        from starlette.requests import Request as _Request
+
+        from app.core.config import settings
+        from app.db.session import SessionLocal
+        from app.schemas.twilio import CallInitiateRequest
+        from app.services import voice_call_service as _vcs
+
+        logger.info(
+            "callback_dispatch agent_id=%s phone=%s attempt=%d",
+            agent.id,
+            schedule.phone_number,
+            schedule.attempt_number,
+        )
+
+        # ── Require webhook secret (same auth path as batch calls) ────────────
+        secret = settings.N8N_WEBHOOK_SECRET
+        if not secret:
+            raise RuntimeError(
+                "N8N_WEBHOOK_SECRET must be configured for smart callback dispatch"
+            )
+
+        # ── Load the original call to inherit tenant/user context ─────────────
+        original = db.get(CallSession, schedule.original_call_id)
+        if original is None:
+            raise RuntimeError(
+                f"Original call {schedule.original_call_id} not found; cannot dispatch callback"
+            )
+
+        call_request = CallInitiateRequest(
+            agentId=str(agent.id),
+            toNumber=schedule.phone_number,
+            tenant_id=str(original.tenant_id),
+            user_id=str(original.user_id),
+        )
+
+        # ── Build a minimal fake Starlette request (same pattern as batch calls) ─
+        secret_bytes = secret.encode("latin-1")
+        scope = {
+            "type": "http",
+            "method": "POST",
+            "path": "/internal/callback",
+            "query_string": b"",
+            "headers": [
+                (b"x-n8n-webhook-secret", secret_bytes),
+                (b"content-type", b"application/json"),
+            ],
+            "state": {},
+        }
+
+        async def _receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        fake_request = _Request(scope, receive=_receive)
+
+        # ── Run async initiate_call in a fresh event loop ─────────────────────
+        # APScheduler thread has no running loop, so new_event_loop() is safe.
+        dispatch_db = SessionLocal()
+        result = None
+        try:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                result = loop.run_until_complete(
+                    _vcs.initiate_call(
+                        call_request=call_request,
+                        http_request=fake_request,
+                        user=None,
+                        db=dispatch_db,
+                    )
+                )
+            finally:
+                loop.close()
+                asyncio.set_event_loop(None)
+        finally:
+            dispatch_db.close()
+
+        # ── Extract the new session id and set parent_call_id ─────────────────
+        if isinstance(result, _JSONResponse):
+            body = _json.loads(result.body)
+            new_call_id_str = (body.get("data") or {}).get("callId")
+            if not new_call_id_str:
+                raise RuntimeError(
+                    f"initiate_call failed for callback (attempt {schedule.attempt_number}): "
+                    f"{body.get('message', 'unknown error')}"
+                )
+        else:
+            new_call_id_str = getattr(getattr(result, "data", None), "callId", None)
+
+        if new_call_id_str:
+            new_session_id = uuid.UUID(new_call_id_str)
+            db.execute(
+                CallSession.__table__.update()
+                .where(CallSession.__table__.c.id == new_session_id)
+                .values(parent_call_id=schedule.original_call_id)
+            )
+            db.commit()
+            logger.info(
+                "callback_dispatched new_session=%s parent=%s attempt=%d",
+                new_session_id,
+                schedule.original_call_id,
+                schedule.attempt_number,
+            )
+        else:
+            raise RuntimeError(
+                f"initiate_call returned no callId for callback attempt {schedule.attempt_number}"
+            )
+
+    # ── Business hours helpers ─────────────────────────────────────────────────
+
+    def _is_within_business_hours(
+        self,
+        db: Session,
+        agent: Agent,
+        local_dt: datetime,
+    ) -> bool:
+        """
+        Return True if local_dt falls within the agent's tenant business hours
+        for that weekday.  Returns True when no business-hours rows exist
+        (open 24/7 by default).
+        """
+        # BusinessHours.day_of_week: 0 = Monday … 6 = Sunday (matches Python's weekday())
+        dow = local_dt.weekday()
+        bh: Optional[BusinessHours] = db.execute(
+            select(BusinessHours).where(
+                BusinessHours.tenant_id == agent.tenant_id,
+                BusinessHours.day_of_week == dow,
+                BusinessHours.is_deleted == False,  # noqa: E712
+            )
+        ).scalar_one_or_none()
+
+        if bh is None:
+            return True  # No config → treat as always open
+        if bh.is_closed:
+            return False
+        if bh.open_time is None or bh.close_time is None:
+            return True
+
+        current_time = local_dt.time()
+        return bh.open_time <= current_time <= bh.close_time
+
+    def _next_valid_window(
+        self,
+        db: Session,
+        agent: Agent,
+        from_utc: datetime,
+        tz_name: str,
+    ) -> datetime:
+        """
+        Starting from from_utc, walk forward in 1-hour increments until a
+        slot falls within business hours.  Returns the candidate time in UTC.
+
+        Falls back to from_utc if no open window is found within the lookahead
+        period (calendar gap / misconfiguration) to avoid blocking the chain.
+        """
+        tz = ZoneInfo(tz_name)
+        candidate_utc = from_utc
+
+        for _ in range(_MAX_BUSINESS_HOURS_LOOKAHEAD_DAYS * 24):
+            local_dt = candidate_utc.astimezone(tz)
+            if self._is_within_business_hours(db, agent, local_dt):
+                return candidate_utc
+            candidate_utc += timedelta(hours=1)
+
+        logger.warning(
+            "No open business-hours window found within %d days for agent %s; "
+            "using original scheduled time",
+            _MAX_BUSINESS_HOURS_LOOKAHEAD_DAYS,
+            agent.id,
+        )
+        return from_utc
+
+    # ── Private helpers ────────────────────────────────────────────────────────
+
+    def _get_agent(
+        self,
+        db: Session,
+        agent_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> Agent:
+        agent = db.execute(
+            select(Agent).where(
+                Agent.id == agent_id,
+                Agent.tenant_id == tenant_id,
+                Agent.is_deleted == False,  # noqa: E712
+            )
+        ).scalar_one_or_none()
+
+        if agent is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Agent not found",
+            )
+        return agent
+
+
+callback_scheduler_service = CallbackSchedulerService()

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6864,6 +6864,121 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/agents/{agent_id}/callback-config:
+    put:
+      tags:
+      - Smart Callback Scheduler
+      summary: Update agent smart-callback configuration
+      description: 'Set the smart-callback configuration for an agent.
+
+
+        - **smart_callback_enabled**: activates the retry loop.
+
+        - **max_attempts**: total retry budget (1–20).
+
+        - **gap_schedule**: ordered list of `{days, hours}` gaps between attempts.
+
+        - **timezone**: IANA timezone string — returns 422 if invalid.'
+      operationId: update_callback_config_api_v2_agents__agent_id__callback_config_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Agent Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallbackConfigUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallbackConfigResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/agents/{agent_id}/callback-status:
+    get:
+      tags:
+      - Smart Callback Scheduler
+      summary: Get agent callback config and live retry counters
+      description: 'Returns the agent''s callback config plus:
+
+        - `pending_retries`: number of pending callback records.
+
+        - `next_scheduled_at`: UTC time of the earliest pending callback.'
+      operationId: get_callback_status_api_v2_agents__agent_id__callback_status_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Agent Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallbackStatusResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/calls/{call_id}/callback-history:
+    get:
+      tags:
+      - Smart Callback Scheduler
+      summary: Get callback retry history for a call
+      description: 'Returns ordered callback attempts for `call_id`.
+
+        Returns 404 if the call does not belong to the caller''s tenant.'
+      operationId: get_callback_history_api_v2_calls__call_id__callback_history_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: call_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Call Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CallbackHistoryItem'
+                title: Response Get Callback History Api V2 Calls  Call Id  Callback
+                  History Get
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     AccountSnapshot:
@@ -9083,6 +9198,120 @@ components:
       - assistant_messages
       - total_response_time_entries
       title: CallSessionStats
+    CallbackConfigResponse:
+      properties:
+        smart_callback_enabled:
+          type: boolean
+          title: Smart Callback Enabled
+        max_attempts:
+          type: integer
+          title: Max Attempts
+        gap_schedule:
+          items:
+            $ref: '#/components/schemas/GapInterval'
+          type: array
+          title: Gap Schedule
+        timezone:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - smart_callback_enabled
+      - max_attempts
+      - gap_schedule
+      - timezone
+      title: CallbackConfigResponse
+      description: Response body for PUT /api/v1/agents/{id}/callback-config.
+    CallbackConfigUpdate:
+      properties:
+        smart_callback_enabled:
+          type: boolean
+          title: Smart Callback Enabled
+        max_attempts:
+          type: integer
+          maximum: 20.0
+          minimum: 1.0
+          title: Max Attempts
+          description: Maximum retry attempts before the chain is exhausted
+          default: 5
+        gap_schedule:
+          items:
+            $ref: '#/components/schemas/GapInterval'
+          type: array
+          title: Gap Schedule
+          description: Ordered list of gaps between attempts; index 0 = gap after
+            first miss
+        timezone:
+          type: string
+          title: Timezone
+          description: IANA timezone, e.g. 'America/New_York'
+      type: object
+      required:
+      - smart_callback_enabled
+      - timezone
+      title: CallbackConfigUpdate
+      description: 'PUT /api/v1/agents/{id}/callback-config request body.
+
+        Validates the timezone against the IANA zoneinfo database.'
+    CallbackHistoryItem:
+      properties:
+        attempt_number:
+          type: integer
+          title: Attempt Number
+        scheduled_at:
+          type: string
+          format: date-time
+          title: Scheduled At
+        executed_at:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          type: string
+          title: Status
+      type: object
+      required:
+      - attempt_number
+      - scheduled_at
+      - executed_at
+      - status
+      title: CallbackHistoryItem
+      description: One row from GET /api/v1/calls/{call_id}/callback-history.
+    CallbackStatusResponse:
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+        max_attempts:
+          type: integer
+          title: Max Attempts
+        gap_schedule:
+          items:
+            $ref: '#/components/schemas/GapInterval'
+          type: array
+          title: Gap Schedule
+        timezone:
+          type: string
+          nullable: true
+        pending_retries:
+          type: integer
+          title: Pending Retries
+          description: Number of pending callbacks for this agent
+        next_scheduled_at:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - enabled
+      - max_attempts
+      - gap_schedule
+      - timezone
+      - pending_retries
+      title: CallbackStatusResponse
+      description: 'GET /api/v1/agents/{id}/callback-status response.
+
+        Returns live counters alongside the static config.'
     CandidateStatusEnum:
       type: string
       enum:
@@ -9256,6 +9485,23 @@ components:
       required:
       - message
       title: ForgotPasswordResponse
+    GapInterval:
+      properties:
+        days:
+          type: integer
+          minimum: 0.0
+          title: Days
+          description: Number of days to wait
+          default: 0
+        hours:
+          type: integer
+          minimum: 0.0
+          title: Hours
+          description: Number of hours to wait
+          default: 0
+      type: object
+      title: GapInterval
+      description: A single time gap between callback attempts.
     GoogleLoginRequest:
       properties:
         google_token:

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,3 +53,4 @@ arq==0.26.1
 pymupdf==1.26.1
 tiktoken>=0.9.0,<1.0.0
 pgvector==0.3.6
+APScheduler==3.11.0

--- a/tests/api/test_callback_scheduler.py
+++ b/tests/api/test_callback_scheduler.py
@@ -1,0 +1,635 @@
+"""
+Tests for the Smart Callback Scheduler feature.
+
+Coverage:
+  1. no_answer call correctly triggers callback creation
+  2. busy call correctly triggers callback creation
+  3. Disabled agent does NOT create callback
+  4. Invalid timezone returns 422 on PUT /agents/{id}/callback-config
+  5. Valid timezone is accepted
+  6. GET /agents/{id}/callback-status returns correct counters
+  7. GET /calls/{call_id}/callback-history returns ordered history
+  8. Business hours check reschedules when outside window
+  9. Business hours: open window is used as-is
+ 10. Exhaustion: no further schedule is created at max_attempts
+ 11. Exhausted schedule is logged with status='exhausted'
+ 12. Gap schedule index is clamped at last entry when attempts exceed schedule length
+ 13. get_callback_history returns 404 for unknown call
+ 14. get_callback_history returns 404 for cross-tenant call
+ 15. PUT callback-config returns 404 for unknown agent
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, time, timedelta
+from typing import Optional
+from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.models.agent import Agent
+from app.models.business_hours import BusinessHours
+from app.models.callback_schedule import CallbackSchedule
+from app.models.call_session import CallSession
+from app.schemas.callback_scheduler import (
+    CallbackConfigUpdate,
+    GapInterval,
+)
+from app.services.callback_scheduler_service import (
+    CallbackSchedulerService,
+    CALLBACK_TRIGGER_STATUSES,
+)
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+
+def _make_agent(
+    *,
+    smart_callback_enabled: bool = True,
+    max_callback_attempts: int = 3,
+    gap_schedule: Optional[list] = None,
+    callback_timezone: str = "UTC",
+    tenant_id: Optional[uuid.UUID] = None,
+) -> Agent:
+    agent = MagicMock(spec=Agent)
+    agent.id = uuid.uuid4()
+    agent.tenant_id = tenant_id or uuid.uuid4()
+    agent.smart_callback_enabled = smart_callback_enabled
+    agent.max_callback_attempts = max_callback_attempts
+    agent.callback_gap_schedule = gap_schedule or [{"days": 0, "hours": 1}]
+    agent.callback_timezone = callback_timezone
+    agent.is_deleted = False
+    return agent
+
+
+def _make_call_session(
+    *,
+    status: str = "no_answer",
+    agent_id: Optional[uuid.UUID] = None,
+    tenant_id: Optional[uuid.UUID] = None,
+    to_number: str = "+15550001234",
+    customer_phone_number: Optional[str] = None,
+) -> CallSession:
+    cs = MagicMock(spec=CallSession)
+    cs.id = uuid.uuid4()
+    cs.agent_id = agent_id or uuid.uuid4()
+    cs.tenant_id = tenant_id or uuid.uuid4()
+    cs.status = status
+    cs.to_number = to_number
+    cs.customer_phone_number = customer_phone_number or to_number
+    cs.user_id = uuid.uuid4()
+    return cs
+
+
+def _make_db(
+    *,
+    agent: Optional[Agent] = None,
+    call_session: Optional[CallSession] = None,
+    existing_schedules: Optional[list] = None,
+) -> MagicMock:
+    """Return a mock Session with sensible defaults."""
+    db = MagicMock()
+
+    def _get(model_cls, pk):
+        if model_cls is Agent and agent and agent.id == pk:
+            return agent
+        if model_cls is CallSession and call_session and call_session.id == pk:
+            return call_session
+        return None
+
+    db.get.side_effect = _get
+
+    # Mock execute().scalar_one_or_none() chain
+    execute_result = MagicMock()
+    scalar_result = MagicMock()
+
+    if agent:
+        scalar_result.scalar_one_or_none.return_value = agent
+    else:
+        scalar_result.scalar_one_or_none.return_value = None
+
+    scalar_result.scalar_one.return_value = 0
+    scalar_result.scalars.return_value.all.return_value = existing_schedules or []
+    execute_result.scalar_one_or_none.return_value = agent
+    execute_result.scalar_one.return_value = 0
+    execute_result.scalars.return_value.all.return_value = existing_schedules or []
+
+    db.execute.return_value = execute_result
+    return db
+
+
+# ── 1. no_answer triggers callback ────────────────────────────────────────────
+
+
+def test_no_answer_triggers_callback_creation():
+    """A call ending as 'no_answer' should insert a CallbackSchedule."""
+    agent = _make_agent()
+    call = _make_call_session(status="no_answer", agent_id=agent.id)
+
+    db = MagicMock()
+    db.get.side_effect = lambda cls, pk: agent if cls is Agent else None
+
+    svc = CallbackSchedulerService()
+    with patch("app.services.callback_scheduler_service.datetime") as mock_dt:
+        mock_dt.utcnow.return_value = datetime(2026, 6, 15, 10, 0, 0)
+        mock_dt.utcnow.return_value = mock_dt.utcnow.return_value.replace(
+            tzinfo=ZoneInfo("UTC")
+        )
+        # Make the _next_valid_window return immediately (no BH rows)
+        db.execute.return_value.scalar_one_or_none.return_value = None
+
+        result = svc.maybe_schedule_callback(db, call)
+
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    added = db.add.call_args[0][0]
+    assert isinstance(added, CallbackSchedule)
+    assert added.original_call_id == call.id
+    assert added.agent_id == agent.id
+    assert added.attempt_number == 1
+    assert added.status == "pending"
+    assert added.phone_number == call.customer_phone_number
+
+
+# ── 2. busy triggers callback ─────────────────────────────────────────────────
+
+
+def test_busy_triggers_callback_creation():
+    """A call ending as 'busy' should also insert a CallbackSchedule."""
+    agent = _make_agent()
+    call = _make_call_session(status="busy", agent_id=agent.id)
+
+    db = MagicMock()
+    db.get.side_effect = lambda cls, pk: agent if cls is Agent else None
+    db.execute.return_value.scalar_one_or_none.return_value = None
+
+    svc = CallbackSchedulerService()
+    result = svc.maybe_schedule_callback(db, call)
+
+    db.add.assert_called_once()
+    added = db.add.call_args[0][0]
+    assert added.attempt_number == 1
+    assert added.phone_number == call.customer_phone_number
+
+
+# ── 3. Disabled agent does not create callback ────────────────────────────────
+
+
+def test_disabled_agent_does_not_schedule():
+    """smart_callback_enabled=False must short-circuit without any DB write."""
+    agent = _make_agent(smart_callback_enabled=False)
+    call = _make_call_session(status="no_answer", agent_id=agent.id)
+
+    db = MagicMock()
+    db.get.side_effect = lambda cls, pk: agent if cls is Agent else None
+
+    svc = CallbackSchedulerService()
+    result = svc.maybe_schedule_callback(db, call)
+
+    assert result is None
+    db.add.assert_not_called()
+
+
+# ── 4. Non-triggering status does not create callback ─────────────────────────
+
+
+def test_completed_call_does_not_trigger_callback():
+    """Calls that completed normally must not trigger the callback chain."""
+    agent = _make_agent()
+    call = _make_call_session(status="completed", agent_id=agent.id)
+
+    db = MagicMock()
+    svc = CallbackSchedulerService()
+    result = svc.maybe_schedule_callback(db, call)
+
+    assert result is None
+    db.add.assert_not_called()
+    db.get.assert_not_called()
+
+
+# ── 5. Invalid timezone returns 422 ───────────────────────────────────────────
+
+
+def test_invalid_timezone_raises_validation_error():
+    """CallbackConfigUpdate must raise ValidationError for unknown timezone."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError) as exc_info:
+        CallbackConfigUpdate(
+            smart_callback_enabled=True,
+            max_attempts=3,
+            gap_schedule=[{"days": 0, "hours": 1}],
+            timezone="Narnia/Castle",
+        )
+
+    errors = exc_info.value.errors()
+    assert any("timezone" in str(e.get("loc", "")) or "timezone" in str(e) for e in errors)
+
+
+# ── 6. Valid timezone is accepted ─────────────────────────────────────────────
+
+
+def test_valid_timezone_is_accepted():
+    """Well-known IANA timezones must pass the validator."""
+    cfg = CallbackConfigUpdate(
+        smart_callback_enabled=True,
+        max_attempts=5,
+        gap_schedule=[{"days": 0, "hours": 2}],
+        timezone="America/New_York",
+    )
+    assert cfg.timezone == "America/New_York"
+
+
+# ── 7. gap_schedule must be non-empty when enabled ───────────────────────────
+
+
+def test_empty_gap_schedule_raises_when_enabled():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CallbackConfigUpdate(
+            smart_callback_enabled=True,
+            max_attempts=3,
+            gap_schedule=[],
+            timezone="UTC",
+        )
+
+
+# ── 8. gap_schedule length cannot exceed max_attempts ────────────────────────
+
+
+def test_gap_schedule_exceeds_max_attempts_raises():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        CallbackConfigUpdate(
+            smart_callback_enabled=True,
+            max_attempts=2,
+            gap_schedule=[
+                {"days": 0, "hours": 1},
+                {"days": 0, "hours": 2},
+                {"days": 0, "hours": 3},
+            ],
+            timezone="UTC",
+        )
+
+
+# ── 9. GET callback-status returns correct counters ───────────────────────────
+
+
+def test_get_callback_status_returns_counters():
+    """Pending count and next_scheduled_at are fetched from DB."""
+    agent = _make_agent()
+    future_dt = datetime(2026, 6, 16, 9, 0, 0, tzinfo=ZoneInfo("UTC"))
+
+    db = MagicMock()
+
+    # First execute call: agent lookup
+    # Second execute call: count query  → 3
+    # Third execute call: min(scheduled_at) → future_dt
+    call_count = [0]
+
+    def _execute(stmt, *args, **kwargs):
+        call_count[0] += 1
+        m = MagicMock()
+        if call_count[0] == 1:
+            m.scalar_one_or_none.return_value = agent
+        elif call_count[0] == 2:
+            m.scalar_one.return_value = 3
+        else:
+            m.scalar_one.return_value = future_dt
+        return m
+
+    db.execute.side_effect = _execute
+
+    svc = CallbackSchedulerService()
+    result = svc.get_callback_status(db, agent.id, agent.tenant_id)
+
+    assert result.enabled == agent.smart_callback_enabled
+    assert result.pending_retries == 3
+    assert result.next_scheduled_at == future_dt
+
+
+# ── 10. GET callback-history returns ordered list ────────────────────────────
+
+
+def test_get_callback_history_returns_ordered_rows():
+    """History endpoint returns all schedule rows for the original call."""
+    tenant_id = uuid.uuid4()
+    original_call_id = uuid.uuid4()
+
+    call = _make_call_session(tenant_id=tenant_id)
+    call.id = original_call_id
+
+    sched1 = MagicMock(spec=CallbackSchedule)
+    sched1.attempt_number = 1
+    sched1.scheduled_at = datetime(2026, 6, 15, 10, 0, tzinfo=ZoneInfo("UTC"))
+    sched1.executed_at = datetime(2026, 6, 15, 10, 30, tzinfo=ZoneInfo("UTC"))
+    sched1.status = "executed"
+
+    sched2 = MagicMock(spec=CallbackSchedule)
+    sched2.attempt_number = 2
+    sched2.scheduled_at = datetime(2026, 6, 16, 10, 0, tzinfo=ZoneInfo("UTC"))
+    sched2.executed_at = None
+    sched2.status = "pending"
+
+    call_count = [0]
+
+    def _execute(stmt, *args, **kwargs):
+        call_count[0] += 1
+        m = MagicMock()
+        if call_count[0] == 1:
+            m.scalar_one_or_none.return_value = call
+        else:
+            m.scalars.return_value.all.return_value = [sched1, sched2]
+        return m
+
+    db = MagicMock()
+    db.execute.side_effect = _execute
+
+    svc = CallbackSchedulerService()
+    history = svc.get_callback_history(db, original_call_id, tenant_id)
+
+    assert len(history) == 2
+    assert history[0].attempt_number == 1
+    assert history[0].status == "executed"
+    assert history[1].attempt_number == 2
+    assert history[1].status == "pending"
+
+
+# ── 11. Business hours check: outside window reschedules ─────────────────────
+
+
+def test_outside_business_hours_reschedules():
+    """
+    When the current time is outside business hours, _dispatch_and_advance
+    must update scheduled_at to the next valid window and NOT dispatch.
+    """
+    agent = _make_agent(callback_timezone="America/New_York")
+    # Simulate current time at 02:00 UTC = 22:00 Eastern (outside 09:00-17:00)
+    closed_dt = datetime(2026, 6, 15, 2, 0, 0, tzinfo=ZoneInfo("UTC"))
+
+    bh = MagicMock(spec=BusinessHours)
+    bh.is_closed = False
+    bh.open_time = time(9, 0)
+    bh.close_time = time(17, 0)
+
+    schedule = MagicMock(spec=CallbackSchedule)
+    schedule.id = uuid.uuid4()
+    schedule.original_call_id = uuid.uuid4()
+    schedule.agent_id = agent.id
+    schedule.phone_number = "+15550001234"
+    schedule.attempt_number = 1
+    schedule.scheduled_at = closed_dt
+    schedule.timezone = "America/New_York"
+
+    db = MagicMock()
+    db.get.side_effect = lambda cls, pk: agent if cls is Agent else None
+
+    # Return the business hours row on first BH query, None afterward
+    bh_call = [0]
+
+    def _execute(stmt, *a, **kw):
+        bh_call[0] += 1
+        m = MagicMock()
+        m.scalar_one_or_none.return_value = bh
+        return m
+
+    db.execute.side_effect = _execute
+
+    svc = CallbackSchedulerService()
+
+    with patch("app.services.callback_scheduler_service.datetime") as mock_dt:
+        mock_dt.utcnow.return_value = closed_dt
+        svc._dispatch_and_advance(db, schedule)
+
+    # The schedule should have been rescheduled (scheduled_at updated), not executed
+    assert schedule.status != "executed"
+    db.commit.assert_called()
+
+
+# ── 12. Within business hours: call is dispatched ────────────────────────────
+
+
+def test_within_business_hours_dispatches_call():
+    """
+    When the time is within business hours, dispatch_call is invoked and
+    the schedule is marked executed.
+    """
+    agent = _make_agent(
+        max_callback_attempts=3,
+        gap_schedule=[
+            {"days": 0, "hours": 1},
+            {"days": 0, "hours": 2},
+            {"days": 1, "hours": 0},
+        ],
+        callback_timezone="UTC",
+    )
+    open_dt = datetime(2026, 6, 15, 14, 0, 0, tzinfo=ZoneInfo("UTC"))
+
+    bh = MagicMock(spec=BusinessHours)
+    bh.is_closed = False
+    bh.open_time = time(9, 0)
+    bh.close_time = time(17, 0)
+
+    original_call = MagicMock(spec=CallSession)
+    original_call.id = uuid.uuid4()
+    original_call.user_id = uuid.uuid4()
+    original_call.tenant_id = uuid.uuid4()
+
+    schedule = MagicMock(spec=CallbackSchedule)
+    schedule.id = uuid.uuid4()
+    schedule.original_call_id = original_call.id
+    schedule.agent_id = agent.id
+    schedule.phone_number = "+15550001234"
+    schedule.attempt_number = 1
+    schedule.scheduled_at = open_dt
+    schedule.timezone = "UTC"
+    schedule.status = "pending"
+
+    db = MagicMock()
+    db.get.side_effect = lambda cls, pk: (
+        agent if cls is Agent
+        else original_call if cls is CallSession
+        else None
+    )
+
+    def _execute(stmt, *a, **kw):
+        m = MagicMock()
+        m.scalar_one_or_none.return_value = bh
+        return m
+
+    db.execute.side_effect = _execute
+
+    svc = CallbackSchedulerService()
+
+    with patch("app.services.callback_scheduler_service.datetime") as mock_dt:
+        mock_dt.utcnow.return_value = open_dt
+        svc._dispatch_and_advance(db, schedule)
+
+    # Schedule must be marked executed
+    assert schedule.status == "executed"
+    assert schedule.executed_at is not None
+    # A new (chained) CallbackSchedule should have been added
+    add_calls = [
+        call_args[0][0]
+        for call_args in db.add.call_args_list
+        if isinstance(call_args[0][0], CallbackSchedule)
+    ]
+    assert len(add_calls) == 1, "Expected one chained CallbackSchedule to be added"
+    assert add_calls[0].attempt_number == 2
+
+
+# ── 13. Exhaustion: no further schedule at max_attempts ───────────────────────
+
+
+def test_exhaustion_at_max_attempts():
+    """
+    When attempt_number == max_callback_attempts, status becomes 'exhausted'
+    and no further CallbackSchedule is inserted.
+    """
+    agent = _make_agent(
+        max_callback_attempts=2,
+        gap_schedule=[{"days": 0, "hours": 1}],
+        callback_timezone="UTC",
+    )
+    open_dt = datetime(2026, 6, 15, 10, 0, 0, tzinfo=ZoneInfo("UTC"))
+
+    bh = MagicMock(spec=BusinessHours)
+    bh.is_closed = False
+    bh.open_time = time(9, 0)
+    bh.close_time = time(17, 0)
+
+    original_call = MagicMock(spec=CallSession)
+    original_call.id = uuid.uuid4()
+    original_call.user_id = uuid.uuid4()
+    original_call.tenant_id = uuid.uuid4()
+
+    schedule = MagicMock(spec=CallbackSchedule)
+    schedule.id = uuid.uuid4()
+    schedule.original_call_id = original_call.id
+    schedule.agent_id = agent.id
+    schedule.phone_number = "+15550001234"
+    # This is the LAST allowed attempt
+    schedule.attempt_number = 2
+    schedule.scheduled_at = open_dt
+    schedule.timezone = "UTC"
+    schedule.status = "pending"
+
+    db = MagicMock()
+    db.get.side_effect = lambda cls, pk: (
+        agent if cls is Agent
+        else original_call if cls is CallSession
+        else None
+    )
+
+    def _execute(stmt, *a, **kw):
+        m = MagicMock()
+        m.scalar_one_or_none.return_value = bh
+        m.scalars.return_value.all.return_value = []
+        return m
+
+    db.execute.side_effect = _execute
+
+    svc = CallbackSchedulerService()
+
+    with patch("app.services.callback_scheduler_service.datetime") as mock_dt:
+        mock_dt.utcnow.return_value = open_dt
+        svc._dispatch_and_advance(db, schedule)
+
+    # Final schedule must be exhausted, no new record added
+    assert schedule.status == "exhausted"
+    chained = [
+        call_args[0][0]
+        for call_args in db.add.call_args_list
+        if isinstance(call_args[0][0], CallbackSchedule)
+    ]
+    assert len(chained) == 0, "No chained schedule should be created after exhaustion"
+
+
+# ── 14. get_callback_history: 404 for unknown call ───────────────────────────
+
+
+def test_callback_history_404_for_unknown_call():
+    from fastapi import HTTPException
+
+    db = MagicMock()
+    db.execute.return_value.scalar_one_or_none.return_value = None
+
+    svc = CallbackSchedulerService()
+    with pytest.raises(HTTPException) as exc_info:
+        svc.get_callback_history(db, uuid.uuid4(), uuid.uuid4())
+
+    assert exc_info.value.status_code == 404
+
+
+# ── 15. update_callback_config: 404 for unknown agent ────────────────────────
+
+
+def test_update_config_404_for_unknown_agent():
+    from fastapi import HTTPException
+
+    db = MagicMock()
+    db.execute.return_value.scalar_one_or_none.return_value = None
+
+    svc = CallbackSchedulerService()
+    cfg = CallbackConfigUpdate(
+        smart_callback_enabled=True,
+        max_attempts=3,
+        gap_schedule=[{"days": 0, "hours": 1}],
+        timezone="UTC",
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        svc.update_callback_config(db, uuid.uuid4(), uuid.uuid4(), cfg)
+
+    assert exc_info.value.status_code == 404
+
+
+# ── 16. GapInterval zero-interval validation ──────────────────────────────────
+
+
+def test_gap_interval_zero_raises():
+    """Both days=0 and hours=0 is meaningless; must raise ValidationError."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        GapInterval(days=0, hours=0)
+
+
+# ── 17. maybe_schedule_callback: no phone number skips ───────────────────────
+
+
+def test_no_phone_number_skips_schedule():
+    """If the call has no destination number, no schedule should be created."""
+    agent = _make_agent()
+    call = _make_call_session(
+        status="no_answer",
+        agent_id=agent.id,
+        to_number=None,
+        customer_phone_number=None,
+    )
+    call.to_number = None
+    call.customer_phone_number = None
+
+    db = MagicMock()
+    db.get.side_effect = lambda cls, pk: agent if cls is Agent else None
+    db.execute.return_value.scalar_one_or_none.return_value = None
+
+    svc = CallbackSchedulerService()
+    result = svc.maybe_schedule_callback(db, call)
+
+    assert result is None
+    db.add.assert_not_called()
+
+
+# ── 18. CALLBACK_TRIGGER_STATUSES constant coverage ──────────────────────────
+
+
+def test_trigger_status_set_contents():
+    """Verify exactly the statuses that trigger a callback."""
+    assert "no_answer" in CALLBACK_TRIGGER_STATUSES
+    assert "busy" in CALLBACK_TRIGGER_STATUSES
+    assert "completed" not in CALLBACK_TRIGGER_STATUSES
+    assert "failed" not in CALLBACK_TRIGGER_STATUSES


### PR DESCRIPTION
## Summary

Implements the **Smart Callback Scheduler** — an automated retry system for outbound calls that end as `no_answer` or `busy`. Retries are timezone-aware (business hours enforced), fully traceable via `parent_call_id`, and survive pod restarts via a PostgreSQL-backed APScheduler job store.

## What's included

### Database
- **Alembic migration** (`20260615_callback`): adds 4 columns to `agent` (`smart_callback_enabled`, `max_callback_attempts`, `callback_gap_schedule JSONB`, `callback_timezone`), adds `parent_call_id` self-FK to `callsession`, creates new `callbackschedule` table with status CHECK constraint and composite index on `(status, scheduled_at)`

### New files
| File | Purpose |
|---|---|
| `app/models/callback_schedule.py` | `CallbackSchedule` ORM model — table name `callbackschedule` (base class convention) |
| `app/schemas/callback_scheduler.py` | Pydantic v2 schemas: `CallbackConfigUpdate` (with IANA timezone validation), `CallbackStatusResponse`, `CallbackHistoryItem` |
| `app/services/callback_scheduler_service.py` | All business logic: config CRUD, trigger detection, business-hours enforcement, real outbound dispatch, attempt chaining, exhaustion |
| `app/core/scheduler.py` | APScheduler singleton with `SQLAlchemyJobStore` (PostgreSQL), `IntervalTrigger(seconds=30)`, `coalesce=True`, `max_instances=1` |
| `app/api/v2/routers/callback_scheduler.py` | v2 endpoints — two sub-routers at `/agents` and `/calls` prefixes |
| `tests/api/test_callback_scheduler.py` | 18 pytest cases covering all acceptance criteria |

### Modified files
- `app/models/agent.py` — 4 new smart-callback columns + `callback_schedules` relationship
- `app/models/call_session.py` — `parent_call_id` self-FK + relationships
- `app/services/call_session_service.py` — hooks `maybe_schedule_callback` into `update_call_session_status` for `no_answer`/`busy` transitions
- `app/api/v2/api.py` — registers callback sub-routers
- `app/main.py` — starts/stops APScheduler in the lifespan context
- `app/db/base.py` — adds `CallbackSchedule` import for Alembic autogenerate
- `requirements.txt` — adds `APScheduler==3.11.0`

## API Endpoints (v2)

```
PUT  /api/v2/agents/{agent_id}/callback-config    — set enabled, max_attempts, gap_schedule, timezone
GET  /api/v2/agents/{agent_id}/callback-status    — live counters (pending_retries, next_scheduled_at)
GET  /api/v2/calls/{call_id}/callback-history     — ordered list of all retry attempts
```

## How the retry chain works

```
Call ends as no_answer / busy
        │
        ▼
maybe_schedule_callback()
  ├─ agent.smart_callback_enabled? No → skip
  └─ Yes → insert CallbackSchedule(attempt=1, scheduled_at=now+gap_schedule[0])
                    │
                    ▼  (APScheduler fires every 30 s)
        process_pending_callbacks()
          ├─ scheduled_at <= now?  No → wait
          └─ Yes → _dispatch_and_advance()
                    ├─ Within business hours?  No → reschedule to next open window
                    └─ Yes → initiate_call() [real Twilio/LiveKit dispatch]
                              ├─ attempt < max_attempts → insert next CallbackSchedule
                              └─ attempt == max_attempts → status = 'exhausted', stop
```

## Key design decisions

- **APScheduler PostgreSQL job store** — `apscheduler_jobs` table auto-managed; survives pod restarts
- **SKIP LOCKED** — concurrent pods never double-dispatch the same record
- **Fresh event loop per dispatch** — APScheduler thread-pool threads have no running loop; `asyncio.new_event_loop()` is safe and avoids cross-loop contamination
- **Same auth path as batch calls** — uses `N8N_WEBHOOK_SECRET` webhook header so `initiate_call` requires no User object
- **`parent_call_id` traceability** — post-updated on the new `CallSession` after dispatch; full chain navigable via FK
- **Business hours fallback** — 14-day forward-walk in 1-hour increments; falls back to original time if no open window found (prevents chain stall)
- **Non-blocking hook** — callback scheduling failure in `update_call_session_status` logs a warning and never breaks the call status update

## Test plan

- [x] Run migration: `alembic upgrade head`
- [x] Install dependency: `pip install APScheduler==3.11.0`
- [x] Set `N8N_WEBHOOK_SECRET` in `.env`
- [x] Run tests: `pytest tests/api/test_callback_scheduler.py -v`
- [x] Create an agent, call `PUT /api/v2/agents/{id}/callback-config` with a valid gap schedule
- [x] Trigger an outbound call that results in `no_answer` → confirm `callbackschedule` row created
- [x] Wait 30 s → confirm APScheduler dispatches the retry and creates a new `callsession` with `parent_call_id` set
- [x] Call `GET /api/v2/calls/{call_id}/callback-history` → verify attempt history
- [x] Let chain run to `max_attempts` → confirm final record is `exhausted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)