### PR TITLE
feat(analytics): Call history & batch metrics API

### DIFF
--- a/alembic/versions/20260616_add_callsession_analytics_index.py
+++ b/alembic/versions/20260616_add_callsession_analytics_index.py
@@ -1,0 +1,29 @@
+"""add composite analytics index on callsession
+
+Revision ID: 20260616_analytics_index
+Revises: 20260615_callback
+Create Date: 2026-06-16 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260616_analytics_index"
+down_revision: Union[str, None] = "20260615_workspace_settings"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Composite index for date-range analytics queries filtered by tenant.
+    # Covers GET /calls/history, /calls/history/metrics, /calls/history/time-series.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_callsession_tenant_start_time "
+        "ON callsession (tenant_id, start_time DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_callsession_tenant_start_time")

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -46,6 +46,8 @@ from app.routers.internal_stt import router as internal_stt_router
 from app.routers.business_knowledge import router as business_knowledge_router
 from app.routers.recordings import router as recordings_router
 from app.routers.integrations import router as integrations_router
+from app.routers.call_history import router as call_history_router
+from app.routers.call_history import batch_router as batch_call_metrics_router
 
 api_router = APIRouter()
 api_router.include_router(user.router, prefix="/users", tags=["users"])
@@ -150,3 +152,5 @@ api_router.include_router(
 )
 api_router.include_router(recordings_router, prefix="/recordings", tags=["Call Recordings"])
 api_router.include_router(integrations_router, prefix="/integrations", tags=["Integrations"])
+api_router.include_router(call_history_router, prefix="/calls", tags=["Call History Analytics"])
+api_router.include_router(batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"])

--- a/app/routers/call_history.py
+++ b/app/routers/call_history.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, date
+from typing import List, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant
+from app.models.user import User
+from app.schemas.base import SuccessResponse
+from app.schemas.call_history import (
+    BatchCallMetrics,
+    CallHistoryItem,
+    CallHistoryList,
+    CallHistoryMetrics,
+    CallHistoryTimeSeriesPoint,
+)
+from app.services.call_history_service import call_history_service
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+
+# ── shared filter params (re-used across several endpoints) ───────────────────
+
+def _common_filters(
+    agent_id: Optional[uuid.UUID] = Query(None, description="Filter by agent ID"),
+    flow_id: Optional[uuid.UUID] = Query(None, description="Filter by call flow ID"),
+    direction: Optional[Literal["inbound", "outbound"]] = Query(
+        None, description="Filter by call direction"
+    ),
+    date_from: Optional[datetime] = Query(
+        None, description="ISO 8601 UTC lower bound for call start time"
+    ),
+    date_to: Optional[datetime] = Query(
+        None, description="ISO 8601 UTC upper bound for call start time"
+    ),
+    status: Optional[str] = Query(
+        None, description="Filter by call status (completed, failed, no_answer, …)"
+    ),
+):
+    return {
+        "agent_id": agent_id,
+        "flow_id": flow_id,
+        "direction": direction,
+        "date_from": date_from,
+        "date_to": date_to,
+        "status": status,
+    }
+
+
+# ── GET /calls/history ────────────────────────────────────────────────────────
+
+@router.get(
+    "/history",
+    response_model=SuccessResponse[CallHistoryList],
+    summary="Paginated call history list",
+)
+async def get_call_history(
+    page: int = Query(1, ge=1),
+    per_page: int = Query(25, ge=1, le=200),
+    sort_by: Literal["started_at", "duration", "status"] = Query("started_at"),
+    sort_dir: Literal["asc", "desc"] = Query("desc"),
+    filters: dict = Depends(_common_filters),
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """
+    Paginated call history. Date filters expect ISO 8601 UTC timestamps.
+    """
+    try:
+        result = call_history_service.get_list(
+            db,
+            user.current_tenant_id,
+            page=page,
+            per_page=per_page,
+            sort_by=sort_by,
+            sort_dir=sort_dir,
+            **filters,
+        )
+        return create_success_response(result, "Call history retrieved successfully")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+# ── GET /calls/history/metrics ────────────────────────────────────────────────
+
+@router.get(
+    "/history/metrics",
+    response_model=SuccessResponse[CallHistoryMetrics],
+    summary="Aggregated call metrics",
+)
+async def get_call_metrics(
+    filters: dict = Depends(_common_filters),
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """
+    Returns aggregated totals and success rate. All computation is pushed to Postgres.
+    Date filters expect ISO 8601 UTC timestamps.
+    """
+    try:
+        metrics = call_history_service.get_metrics(
+            db, user.current_tenant_id, **filters
+        )
+        return create_success_response(metrics, "Metrics retrieved successfully")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+# ── GET /calls/history/time-series ────────────────────────────────────────────
+
+@router.get(
+    "/history/time-series",
+    response_model=SuccessResponse[List[CallHistoryTimeSeriesPoint]],
+    summary="Daily call counts for charts",
+)
+async def get_call_time_series(
+    date_from: Optional[datetime] = Query(
+        None, description="ISO 8601 UTC lower bound"
+    ),
+    date_to: Optional[datetime] = Query(
+        None, description="ISO 8601 UTC upper bound"
+    ),
+    agent_id: Optional[uuid.UUID] = Query(None),
+    flow_id: Optional[uuid.UUID] = Query(None),
+    direction: Optional[Literal["inbound", "outbound"]] = Query(None),
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """
+    Returns one row per calendar day (UTC). Format matches Recharts LineChart:
+    [{date:'2026-05-01', total:12, completed:10, failed:2}]
+    """
+    try:
+        series = call_history_service.get_time_series(
+            db,
+            user.current_tenant_id,
+            date_from=date_from,
+            date_to=date_to,
+            agent_id=agent_id,
+            flow_id=flow_id,
+            direction=direction,
+        )
+        return create_success_response(series, "Time-series retrieved successfully")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+# ── POST /calls/history/export ────────────────────────────────────────────────
+
+@router.post(
+    "/history/export",
+    summary="Stream CSV export of call history",
+    response_class=StreamingResponse,
+)
+async def export_call_history_csv(
+    filters: dict = Depends(_common_filters),
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """
+    Streams a CSV file directly from the database cursor — no in-memory buffering.
+    Columns: call_id, direction, from_number, to_number, agent_name, flow_name,
+             status, duration_seconds, started_at, ended_at.
+    Date filters expect ISO 8601 UTC timestamps.
+    """
+    filename = f"calls-{date.today().isoformat()}.csv"
+
+    def _generate():
+        yield from call_history_service.iter_export_csv(
+            db, user.current_tenant_id, **filters
+        )
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+# ── GET /batch-calls/metrics ──────────────────────────────────────────────────
+# Registered on a separate prefix in api.py; kept in this file for locality.
+
+batch_router = APIRouter()
+
+
+@batch_router.get(
+    "/metrics",
+    response_model=SuccessResponse[BatchCallMetrics],
+    summary="Batch call campaign metrics",
+)
+async def get_batch_call_metrics(
+    date_from: Optional[datetime] = Query(None, description="ISO 8601 UTC lower bound"),
+    date_to: Optional[datetime] = Query(None, description="ISO 8601 UTC upper bound"),
+    user: User = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """
+    Returns aggregated statistics across all batch call campaigns for this tenant.
+    """
+    try:
+        metrics = call_history_service.get_batch_metrics(
+            db,
+            user.current_tenant_id,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        return create_success_response(metrics, "Batch metrics retrieved successfully")
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/app/schemas/call_history.py
+++ b/app/schemas/call_history.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CallHistoryMetrics(BaseModel):
+    total_calls: int
+    completed: int
+    failed: int
+    no_answer: int
+    avg_duration_seconds: Optional[float]
+    total_duration_seconds: Optional[int]
+    success_rate_percent: Optional[float]
+
+
+class CallHistoryTimeSeriesPoint(BaseModel):
+    date: str  # YYYY-MM-DD
+    total: int
+    completed: int
+    failed: int
+
+
+class CallHistoryItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    call_id: uuid.UUID
+    direction: str
+    from_number: Optional[str]
+    to_number: Optional[str]
+    agent_name: Optional[str]
+    flow_name: Optional[str]
+    status: str
+    duration_seconds: Optional[int]
+    started_at: Optional[datetime]
+    ended_at: Optional[datetime]
+
+
+class CallHistoryList(BaseModel):
+    items: List[CallHistoryItem]
+    total: int
+    page: int
+    per_page: int
+    pages: int
+
+
+class BatchCallMetrics(BaseModel):
+    total_batches: int
+    avg_completion_rate_percent: Optional[float]
+    total_calls_dispatched: int
+    total_failed: int

--- a/app/services/call_history_service.py
+++ b/app/services/call_history_service.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import csv
+import io
+import math
+import uuid
+from datetime import datetime
+from typing import AsyncIterator, List, Optional
+
+from sqlalchemy import case, cast, func, select, text
+from sqlalchemy.orm import Session
+
+from app.models.agent import Agent
+from app.models.batch_job import BatchJob
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.schemas.call_history import (
+    BatchCallMetrics,
+    CallHistoryItem,
+    CallHistoryList,
+    CallHistoryMetrics,
+    CallHistoryTimeSeriesPoint,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _base_filter(
+    stmt,
+    tenant_id: uuid.UUID,
+    *,
+    agent_id: Optional[uuid.UUID] = None,
+    flow_id: Optional[uuid.UUID] = None,
+    direction: Optional[str] = None,
+    date_from: Optional[datetime] = None,
+    date_to: Optional[datetime] = None,
+    status: Optional[str] = None,
+):
+    """Apply the common WHERE predicates to any statement that touches callsession."""
+    stmt = stmt.where(CallSession.tenant_id == tenant_id)
+    if agent_id:
+        stmt = stmt.where(CallSession.agent_id == agent_id)
+    if flow_id:
+        stmt = stmt.where(CallSession.call_flow_id == flow_id)
+    if direction:
+        stmt = stmt.where(CallSession.call_type == direction)
+    if date_from:
+        stmt = stmt.where(CallSession.start_time >= date_from)
+    if date_to:
+        stmt = stmt.where(CallSession.start_time <= date_to)
+    if status:
+        stmt = stmt.where(CallSession.status == status)
+    return stmt
+
+
+# ── service ───────────────────────────────────────────────────────────────────
+
+class CallHistoryService:
+
+    # ── metrics ───────────────────────────────────────────────────────────────
+
+    def get_metrics(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        *,
+        agent_id: Optional[uuid.UUID] = None,
+        flow_id: Optional[uuid.UUID] = None,
+        direction: Optional[str] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+        status: Optional[str] = None,
+    ) -> CallHistoryMetrics:
+        completed_expr = case((CallSession.status == "completed", 1), else_=None)
+        failed_expr = case((CallSession.status == "failed", 1), else_=None)
+        no_answer_expr = case((CallSession.status == "no_answer", 1), else_=None)
+
+        stmt = select(
+            func.count().label("total_calls"),
+            func.count(completed_expr).label("completed"),
+            func.count(failed_expr).label("failed"),
+            func.count(no_answer_expr).label("no_answer"),
+            func.avg(CallSession.duration).label("avg_duration_seconds"),
+            func.sum(CallSession.duration).label("total_duration_seconds"),
+            # success_rate computed entirely in Postgres
+            func.round(
+                100.0
+                * func.count(completed_expr)
+                / func.nullif(func.count(), 0),
+                2,
+            ).label("success_rate_percent"),
+        ).select_from(CallSession)
+
+        stmt = _base_filter(
+            stmt,
+            tenant_id,
+            agent_id=agent_id,
+            flow_id=flow_id,
+            direction=direction,
+            date_from=date_from,
+            date_to=date_to,
+            status=status,
+        )
+
+        row = db.execute(stmt).one()
+
+        return CallHistoryMetrics(
+            total_calls=row.total_calls or 0,
+            completed=row.completed or 0,
+            failed=row.failed or 0,
+            no_answer=row.no_answer or 0,
+            avg_duration_seconds=(
+                float(round(row.avg_duration_seconds, 2))
+                if row.avg_duration_seconds is not None
+                else None
+            ),
+            total_duration_seconds=(
+                int(row.total_duration_seconds)
+                if row.total_duration_seconds is not None
+                else None
+            ),
+            success_rate_percent=(
+                float(row.success_rate_percent)
+                if row.success_rate_percent is not None
+                else None
+            ),
+        )
+
+    # ── time-series ───────────────────────────────────────────────────────────
+
+    def get_time_series(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        *,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+        agent_id: Optional[uuid.UUID] = None,
+        flow_id: Optional[uuid.UUID] = None,
+        direction: Optional[str] = None,
+    ) -> List[CallHistoryTimeSeriesPoint]:
+        date_col = func.date(CallSession.start_time).label("date")
+        completed_expr = case((CallSession.status == "completed", 1), else_=None)
+        failed_expr = case((CallSession.status == "failed", 1), else_=None)
+
+        stmt = (
+            select(
+                date_col,
+                func.count().label("total"),
+                func.count(completed_expr).label("completed"),
+                func.count(failed_expr).label("failed"),
+            )
+            .select_from(CallSession)
+            .group_by(date_col)
+            .order_by(date_col)
+        )
+
+        stmt = _base_filter(
+            stmt,
+            tenant_id,
+            agent_id=agent_id,
+            flow_id=flow_id,
+            direction=direction,
+            date_from=date_from,
+            date_to=date_to,
+        )
+
+        rows = db.execute(stmt).all()
+
+        return [
+            CallHistoryTimeSeriesPoint(
+                date=str(row.date),
+                total=row.total,
+                completed=row.completed,
+                failed=row.failed,
+            )
+            for row in rows
+        ]
+
+    # ── paginated list ────────────────────────────────────────────────────────
+
+    _SORT_COLUMNS = {
+        "started_at": CallSession.start_time,
+        "duration": CallSession.duration,
+        "status": CallSession.status,
+    }
+
+    def get_list(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        *,
+        page: int = 1,
+        per_page: int = 25,
+        sort_by: str = "started_at",
+        sort_dir: str = "desc",
+        agent_id: Optional[uuid.UUID] = None,
+        flow_id: Optional[uuid.UUID] = None,
+        direction: Optional[str] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+        status: Optional[str] = None,
+    ) -> CallHistoryList:
+        sort_col = self._SORT_COLUMNS.get(sort_by, CallSession.start_time)
+        order_expr = sort_col.desc() if sort_dir == "desc" else sort_col.asc()
+
+        # count
+        count_stmt = select(func.count()).select_from(CallSession)
+        count_stmt = _base_filter(
+            count_stmt,
+            tenant_id,
+            agent_id=agent_id,
+            flow_id=flow_id,
+            direction=direction,
+            date_from=date_from,
+            date_to=date_to,
+            status=status,
+        )
+        total: int = db.execute(count_stmt).scalar_one()
+
+        # data — LEFT JOIN agent and call_flow for names
+        stmt = (
+            select(
+                CallSession.id.label("call_id"),
+                CallSession.call_type.label("direction"),
+                CallSession.from_number,
+                CallSession.to_number,
+                Agent.name.label("agent_name"),
+                CallFlow.name.label("flow_name"),
+                CallSession.status,
+                CallSession.duration.label("duration_seconds"),
+                CallSession.start_time.label("started_at"),
+                CallSession.end_time.label("ended_at"),
+            )
+            .select_from(CallSession)
+            .outerjoin(Agent, Agent.id == CallSession.agent_id)
+            .outerjoin(CallFlow, CallFlow.id == CallSession.call_flow_id)
+            .order_by(order_expr)
+            .offset((page - 1) * per_page)
+            .limit(per_page)
+        )
+
+        stmt = _base_filter(
+            stmt,
+            tenant_id,
+            agent_id=agent_id,
+            flow_id=flow_id,
+            direction=direction,
+            date_from=date_from,
+            date_to=date_to,
+            status=status,
+        )
+
+        rows = db.execute(stmt).all()
+
+        items = [
+            CallHistoryItem(
+                call_id=row.call_id,
+                direction=row.direction,
+                from_number=row.from_number,
+                to_number=row.to_number,
+                agent_name=row.agent_name,
+                flow_name=row.flow_name,
+                status=row.status,
+                duration_seconds=row.duration_seconds,
+                started_at=row.started_at,
+                ended_at=row.ended_at,
+            )
+            for row in rows
+        ]
+
+        return CallHistoryList(
+            items=items,
+            total=total,
+            page=page,
+            per_page=per_page,
+            pages=math.ceil(total / per_page) if total else 0,
+        )
+
+    # ── CSV streaming ─────────────────────────────────────────────────────────
+
+    CSV_COLUMNS = [
+        "call_id",
+        "direction",
+        "from_number",
+        "to_number",
+        "agent_name",
+        "flow_name",
+        "status",
+        "duration_seconds",
+        "started_at",
+        "ended_at",
+    ]
+
+    def iter_export_csv(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        *,
+        agent_id: Optional[uuid.UUID] = None,
+        flow_id: Optional[uuid.UUID] = None,
+        direction: Optional[str] = None,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+        status: Optional[str] = None,
+    ):
+        """Yield CSV lines (str) one at a time — header first, then one row per call."""
+        stmt = (
+            select(
+                CallSession.id.label("call_id"),
+                CallSession.call_type.label("direction"),
+                CallSession.from_number,
+                CallSession.to_number,
+                Agent.name.label("agent_name"),
+                CallFlow.name.label("flow_name"),
+                CallSession.status,
+                CallSession.duration.label("duration_seconds"),
+                CallSession.start_time.label("started_at"),
+                CallSession.end_time.label("ended_at"),
+            )
+            .select_from(CallSession)
+            .outerjoin(Agent, Agent.id == CallSession.agent_id)
+            .outerjoin(CallFlow, CallFlow.id == CallSession.call_flow_id)
+            .order_by(CallSession.start_time.desc())
+            .execution_options(yield_per=500)
+        )
+
+        stmt = _base_filter(
+            stmt,
+            tenant_id,
+            agent_id=agent_id,
+            flow_id=flow_id,
+            direction=direction,
+            date_from=date_from,
+            date_to=date_to,
+            status=status,
+        )
+
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+
+        # header
+        writer.writerow(self.CSV_COLUMNS)
+        yield buf.getvalue()
+
+        for row in db.execute(stmt):
+            buf.seek(0)
+            buf.truncate()
+            writer.writerow([
+                str(row.call_id),
+                row.direction or "",
+                row.from_number or "",
+                row.to_number or "",
+                row.agent_name or "",
+                row.flow_name or "",
+                row.status or "",
+                row.duration_seconds if row.duration_seconds is not None else "",
+                row.started_at.isoformat() if row.started_at else "",
+                row.ended_at.isoformat() if row.ended_at else "",
+            ])
+            yield buf.getvalue()
+
+    # ── batch metrics ─────────────────────────────────────────────────────────
+
+    def get_batch_metrics(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        *,
+        date_from: Optional[datetime] = None,
+        date_to: Optional[datetime] = None,
+    ) -> BatchCallMetrics:
+        stmt = select(
+            func.count().label("total_batches"),
+            func.round(
+                func.avg(
+                    BatchJob.completed_count
+                    * 100.0
+                    / func.nullif(BatchJob.total_count, 0)
+                ),
+                2,
+            ).label("avg_completion_rate_percent"),
+            func.coalesce(func.sum(BatchJob.total_count), 0).label("total_calls_dispatched"),
+            func.coalesce(func.sum(BatchJob.failed_count), 0).label("total_failed"),
+        ).select_from(BatchJob).where(BatchJob.workspace_id == tenant_id)
+
+        if date_from:
+            stmt = stmt.where(BatchJob.created_at >= date_from)
+        if date_to:
+            stmt = stmt.where(BatchJob.created_at <= date_to)
+
+        row = db.execute(stmt).one()
+
+        return BatchCallMetrics(
+            total_batches=row.total_batches or 0,
+            avg_completion_rate_percent=(
+                float(row.avg_completion_rate_percent)
+                if row.avg_completion_rate_percent is not None
+                else None
+            ),
+            total_calls_dispatched=int(row.total_calls_dispatched),
+            total_failed=int(row.total_failed),
+        )
+
+
+call_history_service = CallHistoryService()

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6616,6 +6616,367 @@ paths:
                 $ref: '#/components/schemas/IntegrationListResponse'
       security:
       - HTTPBearer: []
+  /api/v1/calls/history:
+    get:
+      tags:
+      - Call History Analytics
+      summary: Paginated call history list
+      description: Paginated call history. Date filters expect ISO 8601 UTC timestamps.
+      operationId: get_call_history_api_v1_calls_history_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+          title: Page
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 200
+          minimum: 1
+          default: 25
+          title: Per Page
+      - name: sort_by
+        in: query
+        required: false
+        schema:
+          enum:
+          - started_at
+          - duration
+          - status
+          type: string
+          default: started_at
+          title: Sort By
+      - name: sort_dir
+        in: query
+        required: false
+        schema:
+          enum:
+          - asc
+          - desc
+          type: string
+          default: desc
+          title: Sort Dir
+      - name: agent_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+        description: Filter by agent ID
+      - name: flow_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+        description: Filter by call flow ID
+      - name: direction
+        in: query
+        required: false
+        schema:
+          enum:
+          - inbound
+          - outbound
+          type: string
+          nullable: true
+        description: Filter by call direction
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC lower bound for call start time
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC upper bound for call start time
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+          nullable: true
+        description: Filter by call status (completed, failed, no_answer, …)
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_CallHistoryList_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/calls/history/metrics:
+    get:
+      tags:
+      - Call History Analytics
+      summary: Aggregated call metrics
+      description: 'Returns aggregated totals and success rate. All computation is
+        pushed to Postgres.
+
+        Date filters expect ISO 8601 UTC timestamps.'
+      operationId: get_call_metrics_api_v1_calls_history_metrics_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: agent_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+        description: Filter by agent ID
+      - name: flow_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+        description: Filter by call flow ID
+      - name: direction
+        in: query
+        required: false
+        schema:
+          enum:
+          - inbound
+          - outbound
+          type: string
+          nullable: true
+        description: Filter by call direction
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC lower bound for call start time
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC upper bound for call start time
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+          nullable: true
+        description: Filter by call status (completed, failed, no_answer, …)
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_CallHistoryMetrics_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/calls/history/time-series:
+    get:
+      tags:
+      - Call History Analytics
+      summary: Daily call counts for charts
+      description: 'Returns one row per calendar day (UTC). Format matches Recharts
+        LineChart:
+
+        [{date:''2026-05-01'', total:12, completed:10, failed:2}]'
+      operationId: get_call_time_series_api_v1_calls_history_time_series_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC lower bound
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC upper bound
+      - name: agent_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+      - name: flow_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+      - name: direction
+        in: query
+        required: false
+        schema:
+          enum:
+          - inbound
+          - outbound
+          type: string
+          nullable: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_List_CallHistoryTimeSeriesPoint__'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/calls/history/export:
+    post:
+      tags:
+      - Call History Analytics
+      summary: Stream CSV export of call history
+      description: "Streams a CSV file directly from the database cursor — no in-memory\
+        \ buffering.\nColumns: call_id, direction, from_number, to_number, agent_name,\
+        \ flow_name,\n         status, duration_seconds, started_at, ended_at.\nDate\
+        \ filters expect ISO 8601 UTC timestamps."
+      operationId: export_call_history_csv_api_v1_calls_history_export_post
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: agent_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+        description: Filter by agent ID
+      - name: flow_id
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+          nullable: true
+        description: Filter by call flow ID
+      - name: direction
+        in: query
+        required: false
+        schema:
+          enum:
+          - inbound
+          - outbound
+          type: string
+          nullable: true
+        description: Filter by call direction
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC lower bound for call start time
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC upper bound for call start time
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+          nullable: true
+        description: Filter by call status (completed, failed, no_answer, …)
+      responses:
+        '200':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/batch-calls/metrics:
+    get:
+      tags:
+      - Batch Call Analytics
+      summary: Batch call campaign metrics
+      description: Returns aggregated statistics across all batch call campaigns for
+        this tenant.
+      operationId: get_batch_call_metrics_api_v1_batch_calls_metrics_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: date_from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC lower bound
+      - name: date_to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+          nullable: true
+        description: ISO 8601 UTC upper bound
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_BatchCallMetrics_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /health:
     get:
       summary: Health Check
@@ -7882,6 +8243,27 @@ components:
       - slots
       - total
       title: AvailableSlotsResponse
+    BatchCallMetrics:
+      properties:
+        total_batches:
+          type: integer
+          title: Total Batches
+        avg_completion_rate_percent:
+          type: number
+          nullable: true
+        total_calls_dispatched:
+          type: integer
+          title: Total Calls Dispatched
+        total_failed:
+          type: integer
+          title: Total Failed
+      type: object
+      required:
+      - total_batches
+      - avg_completion_rate_percent
+      - total_calls_dispatched
+      - total_failed
+      title: BatchCallMetrics
     BatchCallRecordOut:
       properties:
         id:
@@ -8811,6 +9193,135 @@ components:
       additionalProperties: false
       type: object
       title: CallFlowUpdate
+    CallHistoryItem:
+      properties:
+        call_id:
+          type: string
+          format: uuid
+          title: Call Id
+        direction:
+          type: string
+          title: Direction
+        from_number:
+          type: string
+          nullable: true
+        to_number:
+          type: string
+          nullable: true
+        agent_name:
+          type: string
+          nullable: true
+        flow_name:
+          type: string
+          nullable: true
+        status:
+          type: string
+          title: Status
+        duration_seconds:
+          type: integer
+          nullable: true
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        ended_at:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - call_id
+      - direction
+      - from_number
+      - to_number
+      - agent_name
+      - flow_name
+      - status
+      - duration_seconds
+      - started_at
+      - ended_at
+      title: CallHistoryItem
+    CallHistoryList:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/CallHistoryItem'
+          type: array
+          title: Items
+        total:
+          type: integer
+          title: Total
+        page:
+          type: integer
+          title: Page
+        per_page:
+          type: integer
+          title: Per Page
+        pages:
+          type: integer
+          title: Pages
+      type: object
+      required:
+      - items
+      - total
+      - page
+      - per_page
+      - pages
+      title: CallHistoryList
+    CallHistoryMetrics:
+      properties:
+        total_calls:
+          type: integer
+          title: Total Calls
+        completed:
+          type: integer
+          title: Completed
+        failed:
+          type: integer
+          title: Failed
+        no_answer:
+          type: integer
+          title: No Answer
+        avg_duration_seconds:
+          type: number
+          nullable: true
+        total_duration_seconds:
+          type: integer
+          nullable: true
+        success_rate_percent:
+          type: number
+          nullable: true
+      type: object
+      required:
+      - total_calls
+      - completed
+      - failed
+      - no_answer
+      - avg_duration_seconds
+      - total_duration_seconds
+      - success_rate_percent
+      title: CallHistoryMetrics
+    CallHistoryTimeSeriesPoint:
+      properties:
+        date:
+          type: string
+          title: Date
+        total:
+          type: integer
+          title: Total
+        completed:
+          type: integer
+          title: Completed
+        failed:
+          type: integer
+          title: Failed
+      type: object
+      required:
+      - date
+      - total
+      - completed
+      - failed
+      title: CallHistoryTimeSeriesPoint
     CallInitiateRequest:
       properties:
         agentId:
@@ -12629,6 +13140,22 @@ components:
       required:
       - data
       title: SuccessResponse[AvailableSlotsResponse]
+    SuccessResponse_BatchCallMetrics_:
+      properties:
+        data:
+          $ref: '#/components/schemas/BatchCallMetrics'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[BatchCallMetrics]
     SuccessResponse_BindingStatusResponse_:
       properties:
         data:
@@ -12773,6 +13300,38 @@ components:
       required:
       - data
       title: SuccessResponse[CSVUploadResponse]
+    SuccessResponse_CallHistoryList_:
+      properties:
+        data:
+          $ref: '#/components/schemas/CallHistoryList'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[CallHistoryList]
+    SuccessResponse_CallHistoryMetrics_:
+      properties:
+        data:
+          $ref: '#/components/schemas/CallHistoryMetrics'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[CallHistoryMetrics]
     SuccessResponse_CallInitiateResponse_:
       properties:
         data:
@@ -13163,6 +13722,25 @@ components:
       required:
       - data
       title: SuccessResponse[List[BusinessHoursOut]]
+    SuccessResponse_List_CallHistoryTimeSeriesPoint__:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/CallHistoryTimeSeriesPoint'
+          type: array
+          title: Data
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[List[CallHistoryTimeSeriesPoint]]
     SuccessResponse_List_PlanOut__:
       properties:
         data:

--- a/tests/api/test_call_history.py
+++ b/tests/api/test_call_history.py
@@ -1,0 +1,412 @@
+"""
+Tests for the Call History Analytics API.
+
+Coverage:
+  1.  get_metrics returns correct aggregated totals
+  2.  get_metrics date_from filter narrows results
+  3.  get_metrics date_to filter narrows results
+  4.  get_metrics agent_id filter is forwarded to the query
+  5.  get_metrics flow_id filter is forwarded to the query
+  6.  get_metrics direction filter maps to call_type
+  7.  get_metrics status filter is forwarded to the query
+  8.  get_metrics success_rate_percent is None when total_calls == 0
+  9.  get_time_series returns one entry per day in date order
+  10. get_list returns correct pagination metadata
+  11. get_list sort_by / sort_dir defaults accepted
+  12. CSV header row contains all required columns in correct order
+  13. CSV data rows are emitted one per call, not buffered
+  14. get_batch_metrics returns correct totals from BatchJob rows
+  15. get_batch_metrics avg_completion_rate_percent is None with no batches
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import List
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.schemas.call_history import (
+    BatchCallMetrics,
+    CallHistoryItem,
+    CallHistoryList,
+    CallHistoryMetrics,
+    CallHistoryTimeSeriesPoint,
+)
+from app.services.call_history_service import CallHistoryService
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _svc() -> CallHistoryService:
+    return CallHistoryService()
+
+
+def _tenant() -> uuid.UUID:
+    return uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _mock_db_one(row) -> MagicMock:
+    """Return a db mock whose execute(...).one() returns *row*."""
+    db = MagicMock()
+    db.execute.return_value.one.return_value = row
+    return db
+
+
+def _mock_db_scalar_and_all(scalar_value, rows: list) -> MagicMock:
+    """
+    Return a db mock where:
+      - first execute(...).scalar_one() → scalar_value  (count query)
+      - second execute(...).all() → rows                 (data query)
+    """
+    db = MagicMock()
+    results = [
+        MagicMock(**{"scalar_one.return_value": scalar_value}),
+        MagicMock(**{"all.return_value": rows}),
+    ]
+    db.execute.side_effect = results
+    return db
+
+
+def _metrics_row(
+    total_calls=10,
+    completed=7,
+    failed=2,
+    no_answer=1,
+    avg_duration_seconds=45.5,
+    total_duration_seconds=455,
+    success_rate_percent=70.0,
+):
+    return SimpleNamespace(
+        total_calls=total_calls,
+        completed=completed,
+        failed=failed,
+        no_answer=no_answer,
+        avg_duration_seconds=avg_duration_seconds,
+        total_duration_seconds=total_duration_seconds,
+        success_rate_percent=success_rate_percent,
+    )
+
+
+def _call_row(
+    call_id=None,
+    direction="inbound",
+    from_number="+1111",
+    to_number="+2222",
+    agent_name="Bot",
+    flow_name="Main Flow",
+    status="completed",
+    duration_seconds=60,
+    started_at=None,
+    ended_at=None,
+):
+    return SimpleNamespace(
+        call_id=call_id or uuid.uuid4(),
+        direction=direction,
+        from_number=from_number,
+        to_number=to_number,
+        agent_name=agent_name,
+        flow_name=flow_name,
+        status=status,
+        duration_seconds=duration_seconds,
+        started_at=started_at or datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc),
+        ended_at=ended_at or datetime(2026, 6, 1, 10, 1, tzinfo=timezone.utc),
+    )
+
+
+# ── 1. get_metrics returns correct aggregated totals ──────────────────────────
+
+def test_metrics_correct_totals():
+    row = _metrics_row()
+    db = _mock_db_one(row)
+    svc = _svc()
+
+    result = svc.get_metrics(db, _tenant())
+
+    assert isinstance(result, CallHistoryMetrics)
+    assert result.total_calls == 10
+    assert result.completed == 7
+    assert result.failed == 2
+    assert result.no_answer == 1
+    assert result.avg_duration_seconds == 45.5
+    assert result.total_duration_seconds == 455
+    assert result.success_rate_percent == 70.0
+
+
+# ── 2. get_metrics date_from filter forwarded ─────────────────────────────────
+
+def test_metrics_date_from_forwarded():
+    db = _mock_db_one(_metrics_row())
+    svc = _svc()
+    date_from = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    svc.get_metrics(db, _tenant(), date_from=date_from)
+
+    # The WHERE clause is built inside SQLAlchemy; we verify execute was called.
+    db.execute.assert_called_once()
+    # Retrieve the compiled statement string to confirm the filter appears.
+    stmt = db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "start_time" in compiled
+
+
+# ── 3. get_metrics date_to filter forwarded ───────────────────────────────────
+
+def test_metrics_date_to_forwarded():
+    db = _mock_db_one(_metrics_row())
+    svc = _svc()
+    date_to = datetime(2026, 6, 30, tzinfo=timezone.utc)
+
+    svc.get_metrics(db, _tenant(), date_to=date_to)
+
+    stmt = db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "start_time" in compiled
+
+
+# ── 4. get_metrics agent_id filter forwarded ─────────────────────────────────
+
+def test_metrics_agent_id_forwarded():
+    db = _mock_db_one(_metrics_row())
+    svc = _svc()
+    agent_id = uuid.uuid4()
+
+    svc.get_metrics(db, _tenant(), agent_id=agent_id)
+
+    stmt = db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    # SQLAlchemy renders UUIDs without dashes in the Postgres dialect literal
+    assert str(agent_id).replace("-", "") in compiled
+
+
+# ── 5. get_metrics flow_id filter forwarded ───────────────────────────────────
+
+def test_metrics_flow_id_forwarded():
+    db = _mock_db_one(_metrics_row())
+    svc = _svc()
+    flow_id = uuid.uuid4()
+
+    svc.get_metrics(db, _tenant(), flow_id=flow_id)
+
+    stmt = db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert str(flow_id).replace("-", "") in compiled
+
+
+# ── 6. get_metrics direction maps to call_type ───────────────────────────────
+
+def test_metrics_direction_maps_to_call_type():
+    db = _mock_db_one(_metrics_row())
+    svc = _svc()
+
+    svc.get_metrics(db, _tenant(), direction="inbound")
+
+    stmt = db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "call_type" in compiled
+    assert "inbound" in compiled
+
+
+# ── 7. get_metrics status filter forwarded ───────────────────────────────────
+
+def test_metrics_status_forwarded():
+    db = _mock_db_one(_metrics_row())
+    svc = _svc()
+
+    svc.get_metrics(db, _tenant(), status="completed")
+
+    stmt = db.execute.call_args[0][0]
+    compiled = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+    assert "completed" in compiled
+
+
+# ── 8. success_rate_percent is None when no calls ────────────────────────────
+
+def test_metrics_success_rate_none_when_zero_calls():
+    row = _metrics_row(
+        total_calls=0,
+        completed=0,
+        failed=0,
+        no_answer=0,
+        avg_duration_seconds=None,
+        total_duration_seconds=None,
+        success_rate_percent=None,
+    )
+    db = _mock_db_one(row)
+    svc = _svc()
+
+    result = svc.get_metrics(db, _tenant())
+
+    assert result.total_calls == 0
+    assert result.success_rate_percent is None
+    assert result.avg_duration_seconds is None
+    assert result.total_duration_seconds is None
+
+
+# ── 9. get_time_series returns entries in date order ─────────────────────────
+
+def test_time_series_returns_daily_rows():
+    rows = [
+        SimpleNamespace(date="2026-06-01", total=5, completed=4, failed=1),
+        SimpleNamespace(date="2026-06-02", total=3, completed=3, failed=0),
+    ]
+    db = MagicMock()
+    db.execute.return_value.all.return_value = rows
+    svc = _svc()
+
+    result = svc.get_time_series(db, _tenant())
+
+    assert len(result) == 2
+    assert isinstance(result[0], CallHistoryTimeSeriesPoint)
+    assert result[0].date == "2026-06-01"
+    assert result[0].total == 5
+    assert result[0].completed == 4
+    assert result[0].failed == 1
+    assert result[1].date == "2026-06-02"
+
+
+# ── 10. get_list returns correct pagination metadata ─────────────────────────
+
+def test_list_pagination_metadata():
+    rows = [_call_row() for _ in range(5)]
+    db = _mock_db_scalar_and_all(scalar_value=47, rows=rows)
+    svc = _svc()
+
+    result = svc.get_list(db, _tenant(), page=2, per_page=25)
+
+    assert isinstance(result, CallHistoryList)
+    assert result.total == 47
+    assert result.page == 2
+    assert result.per_page == 25
+    assert result.pages == 2  # ceil(47/25)
+    assert len(result.items) == 5
+
+
+# ── 11. get_list accepts default sort params ──────────────────────────────────
+
+def test_list_default_sort():
+    db = _mock_db_scalar_and_all(scalar_value=0, rows=[])
+    svc = _svc()
+
+    # Should not raise
+    result = svc.get_list(db, _tenant())
+
+    assert result.total == 0
+    assert result.items == []
+    assert result.pages == 0
+
+
+# ── 12. CSV header contains all required columns ──────────────────────────────
+
+def test_csv_header_columns():
+    db = MagicMock()
+    db.execute.return_value.__iter__.return_value = iter([])
+    svc = _svc()
+
+    chunks = list(svc.iter_export_csv(db, _tenant()))
+
+    assert len(chunks) >= 1
+    header = chunks[0]
+    expected_columns = [
+        "call_id",
+        "direction",
+        "from_number",
+        "to_number",
+        "agent_name",
+        "flow_name",
+        "status",
+        "duration_seconds",
+        "started_at",
+        "ended_at",
+    ]
+    for col in expected_columns:
+        assert col in header, f"Column '{col}' missing from CSV header"
+
+
+# ── 13. CSV data rows emitted one per call ────────────────────────────────────
+
+def test_csv_data_rows_streamed():
+    cid1 = uuid.uuid4()
+    cid2 = uuid.uuid4()
+    data_rows = [
+        SimpleNamespace(
+            call_id=cid1,
+            direction="inbound",
+            from_number="+1111",
+            to_number="+2222",
+            agent_name="Alpha",
+            flow_name="Flow A",
+            status="completed",
+            duration_seconds=90,
+            started_at=datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc),
+            ended_at=datetime(2026, 6, 1, 10, 1, 30, tzinfo=timezone.utc),
+        ),
+        SimpleNamespace(
+            call_id=cid2,
+            direction="outbound",
+            from_number="+3333",
+            to_number="+4444",
+            agent_name="Beta",
+            flow_name=None,
+            status="failed",
+            duration_seconds=None,
+            started_at=datetime(2026, 6, 2, 9, 0, tzinfo=timezone.utc),
+            ended_at=None,
+        ),
+    ]
+    db = MagicMock()
+    db.execute.return_value.__iter__.return_value = iter(data_rows)
+    svc = _svc()
+
+    chunks = list(svc.iter_export_csv(db, _tenant()))
+
+    # header + 2 data rows
+    assert len(chunks) == 3
+    assert str(cid1) in chunks[1]
+    assert "inbound" in chunks[1]
+    assert str(cid2) in chunks[2]
+    assert "outbound" in chunks[2]
+    # None values rendered as empty string
+    assert ",,failed" in chunks[2] or ",failed," in chunks[2]
+
+
+# ── 14. get_batch_metrics returns correct totals ──────────────────────────────
+
+def test_batch_metrics_correct_totals():
+    row = SimpleNamespace(
+        total_batches=5,
+        avg_completion_rate_percent=82.5,
+        total_calls_dispatched=1000,
+        total_failed=50,
+    )
+    db = _mock_db_one(row)
+    svc = _svc()
+
+    result = svc.get_batch_metrics(db, _tenant())
+
+    assert isinstance(result, BatchCallMetrics)
+    assert result.total_batches == 5
+    assert result.avg_completion_rate_percent == 82.5
+    assert result.total_calls_dispatched == 1000
+    assert result.total_failed == 50
+
+
+# ── 15. get_batch_metrics avg is None with no batches ────────────────────────
+
+def test_batch_metrics_avg_none_when_no_batches():
+    row = SimpleNamespace(
+        total_batches=0,
+        avg_completion_rate_percent=None,
+        total_calls_dispatched=0,
+        total_failed=0,
+    )
+    db = _mock_db_one(row)
+    svc = _svc()
+
+    result = svc.get_batch_metrics(db, _tenant())
+
+    assert result.total_batches == 0
+    assert result.avg_completion_rate_percent is None
+    assert result.total_calls_dispatched == 0


### PR DESCRIPTION
## Summary

- **`GET /api/v1/calls/history`** — Paginated call list (25/page), sortable by `started_at` (default desc), `duration`, or `status`. Supports filters: `agent_id`, `flow_id`, `direction`, `date_from`, `date_to`, `status`.
- **`GET /api/v1/calls/history/metrics`** — Returns `{total_calls, completed, failed, no_answer, avg_duration_seconds, total_duration_seconds, success_rate_percent}`. All aggregation done in Postgres via `ROUND(100.0 * COUNT(CASE WHEN …) / NULLIF(COUNT(*), 0), 2)` — zero Python-side computation.
- **`GET /api/v1/calls/history/time-series`** — Daily `{date, total, completed, failed}` rows grouped by `DATE(start_time)`. Format matches Recharts `LineChart` directly.
- **`POST /api/v1/calls/history/export`** — Streams CSV via `StreamingResponse` with `yield_per=500` DB cursor. No full-dataset buffering. `Content-Disposition: attachment; filename=calls-{date}.csv`. Columns: `call_id, direction, from_number, to_number, agent_name, flow_name, status, duration_seconds, started_at, ended_at`.
- **`GET /api/v1/batch-calls/metrics`** — Returns `{total_batches, avg_completion_rate_percent, total_calls_dispatched, total_failed}` aggregated from `BatchJob` table.
- **Migration** — Composite index `ix_callsession_tenant_start_time ON callsession (tenant_id, start_time DESC)` for date-range query performance. Applied as single head revision `20260616_analytics_index`.

## Implementation notes

- `direction` query param maps to `CallSession.call_type` column; `flow_id` maps to `call_flow_id` — no schema changes needed.
- `started_at` / `ended_at` in responses/CSV are aliases for `start_time` / `end_time` from the model.
- Agent name and flow name resolved via `LEFT OUTER JOIN` in a single query — no N+1.
- All date filters documented as ISO 8601 UTC in route docstrings.

## Files changed

| File | Purpose |
|---|---|
| `alembic/versions/20260616_add_callsession_analytics_index.py` | Composite index migration |
| `app/schemas/call_history.py` | Pydantic v2 response schemas |
| `app/services/call_history_service.py` | SQL-based service singleton |
| `app/routers/call_history.py` | 5 route handlers + batch_router |
| `app/api/api_v1/api.py` | Router registration |
| `tests/api/test_call_history.py` | 15 unit tests (all passing) |

## Test plan

- [x] `pytest tests/api/test_call_history.py -v` → 15 passed
- [x] `alembic upgrade head` applied cleanly, single migration head confirmed
- [ ] Manual smoke-test against staging DB with real call data
- [ ] Verify time-series chart renders correctly in Recharts with Zaid

🤖 Generated with [Claude Code](https://claude.com/claude-code)