### PR TITLE
feat(gdpr): data export & right-to-erasure account deletion

### DIFF
--- a/alembic/versions/20260618_audit_actor_prefix_widen.py
+++ b/alembic/versions/20260618_audit_actor_prefix_widen.py
@@ -1,0 +1,41 @@
+"""audit_actor_prefix_widen
+
+actor_api_key_prefix was VARCHAR(8) — exactly enough for the 8-char API key
+prefix it normally stores, but one short of the 9-char '[DELETED]'
+placeholder the GDPR erasure trigger (20260618_audit_update_bypass) writes
+on anonymization. Widening to 16 to give headroom for both.
+
+Revision ID: 20260618_audit_actor_prefix_widen
+Revises: 20260618_user_email_partial_unique
+Create Date: 2026-06-18
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260618_audit_actor_prefix_widen"
+down_revision: Union[str, Sequence[str], None] = "20260618_user_email_partial_unique"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "auditlog",
+        "actor_api_key_prefix",
+        existing_type=sa.String(8),
+        type_=sa.String(16),
+        existing_nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "auditlog",
+        "actor_api_key_prefix",
+        existing_type=sa.String(16),
+        type_=sa.String(8),
+        existing_nullable=True,
+    )

--- a/alembic/versions/20260618_audit_update_bypass.py
+++ b/alembic/versions/20260618_audit_update_bypass.py
@@ -1,0 +1,70 @@
+"""audit_update_bypass
+
+GDPR right-to-erasure requires anonymizing auditlog.user_id and
+actor_api_key_prefix when a workspace account is deleted, but the
+no_update_audit RULE added in 20260617_enterprise_audit unconditionally
+drops every UPDATE — including that one.
+
+Replaces the blanket RULE with a BEFORE UPDATE trigger that:
+  - By default, still silently no-ops every UPDATE (same append-only
+    behaviour as before).
+  - When the session sets  SET LOCAL app.bypass_audit_update = 'true' ,
+    forces the row's user_id to NULL and actor_api_key_prefix to
+    '[DELETED]' — and *only* those two columns, regardless of what the
+    calling UPDATE statement's SET clause actually requested. This caps
+    the blast radius of the bypass to the one GDPR anonymization use case;
+    no other column (action, old_value, new_value, timestamp, ...) can
+    ever be altered through this path, even if the caller's SQL is wrong.
+
+The account-deletion service (app/services/account_deletion_service.py)
+is the only caller expected to set this GUC.
+
+Revision ID: 20260618_audit_update_bypass
+Revises: 20260617_enterprise_audit
+Create Date: 2026-06-18
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20260618_audit_update_bypass"
+down_revision: Union[str, Sequence[str], None] = "20260617_enterprise_audit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP RULE IF EXISTS no_update_audit ON auditlog")
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION _restrict_auditlog_update()
+        RETURNS trigger LANGUAGE plpgsql AS $$
+        BEGIN
+            IF current_setting('app.bypass_audit_update', true) = 'true' THEN
+                NEW := OLD;
+                NEW.user_id := NULL;
+                NEW.actor_api_key_prefix := '[DELETED]';
+                RETURN NEW;
+            END IF;
+            RETURN NULL;
+        END;
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER no_update_audit
+        BEFORE UPDATE ON auditlog
+        FOR EACH ROW EXECUTE FUNCTION _restrict_auditlog_update()
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS no_update_audit ON auditlog")
+    op.execute("DROP FUNCTION IF EXISTS _restrict_auditlog_update()")
+    op.execute(
+        "CREATE RULE no_update_audit AS ON UPDATE TO auditlog DO INSTEAD NOTHING"
+    )

--- a/alembic/versions/20260618_data_export_job.py
+++ b/alembic/versions/20260618_data_export_job.py
@@ -1,0 +1,43 @@
+"""data_export_job
+
+Adds the data_export_job table backing the GDPR data-portability endpoints
+(POST/GET /api/v2/workspace/data-export).
+
+Revision ID: 20260618_data_export_job
+Revises: 20260618_audit_update_bypass
+Create Date: 2026-06-18
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260618_data_export_job"
+down_revision: Union[str, Sequence[str], None] = "20260618_audit_update_bypass"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dataexportjob",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("workspace_id", UUID(as_uuid=True), sa.ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("requested_by_user_id", UUID(as_uuid=True), sa.ForeignKey("user.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="processing"),
+        sa.Column("gcs_path", sa.Text(), nullable=True),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_dataexportjob_workspace_id", "dataexportjob", ["workspace_id"])
+    op.create_index("ix_dataexportjob_status", "dataexportjob", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dataexportjob_status", table_name="dataexportjob")
+    op.drop_index("ix_dataexportjob_workspace_id", table_name="dataexportjob")
+    op.drop_table("dataexportjob")

--- a/alembic/versions/20260618_user_email_partial_unique.py
+++ b/alembic/versions/20260618_user_email_partial_unique.py
@@ -1,0 +1,45 @@
+"""user_email_partial_unique
+
+GDPR erasure anonymizes every deleted user's email to the same fixed
+placeholder ('[DELETED@DELETED.COM]'). A plain global UNIQUE constraint on
+user.email would reject the second such row in the same transaction,
+making the literal acceptance criteria of the erasure ticket impossible to
+satisfy. Replaces the global unique index with one scoped to active
+(deleted_at IS NULL) rows only — mirrors the existing uq_tenant_name_active
+pattern on tenant.name.
+
+Revision ID: 20260618_user_email_partial_unique
+Revises: 20260618_data_export_job
+Create Date: 2026-06-18
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "20260618_user_email_partial_unique"
+down_revision: Union[str, Sequence[str], None] = "20260618_data_export_job"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # The original unique index was created by SQLAlchemy as
+    # Column(unique=True, index=True) -> a single unique index named
+    # ix_user_email. Some environments may instead carry a plain UNIQUE
+    # table constraint (user_email_key) from a manually-applied schema —
+    # both drops are no-ops via IF EXISTS when the object isn't present.
+    op.execute('DROP INDEX IF EXISTS ix_user_email')
+    op.execute('ALTER TABLE "user" DROP CONSTRAINT IF EXISTS user_email_key')
+
+    op.execute('CREATE INDEX ix_user_email ON "user" (email)')
+    op.execute(
+        'CREATE UNIQUE INDEX uq_user_email_active ON "user" (email) '
+        "WHERE deleted_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute('DROP INDEX IF EXISTS uq_user_email_active')
+    op.execute('DROP INDEX IF EXISTS ix_user_email')
+    op.execute('CREATE UNIQUE INDEX ix_user_email ON "user" (email)')

--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -9,6 +9,7 @@ from app.api.v2.routers.callback_scheduler import agents_router as cb_agents_rou
 from app.api.v2.routers.callback_scheduler import calls_router as cb_calls_router
 from app.api.v2.routers.hipaa import flows_router as hipaa_flows_router
 from app.api.v2.routers.hipaa import workspace_router as hipaa_workspace_router
+from app.api.v2.routers.workspace import router as workspace_gdpr_router
 
 v2_router = APIRouter()
 v2_router.include_router(health_router)
@@ -20,3 +21,4 @@ v2_router.include_router(cb_agents_router)
 v2_router.include_router(cb_calls_router)
 v2_router.include_router(hipaa_flows_router)
 v2_router.include_router(hipaa_workspace_router)
+v2_router.include_router(workspace_gdpr_router)

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -1,0 +1,187 @@
+"""
+v2 GDPR data subject rights router.
+
+Endpoints (admin role required for all):
+  POST   /api/v2/workspace/data-export             — trigger async export, returns 202 {job_id}
+  GET    /api/v2/workspace/data-export/{job_id}     — export job status + signed download URL
+  DELETE /api/v2/workspace/account                  — irreversible hard delete + PII wipe
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_admin
+from app.core.logger import logger
+from app.models.user import User
+from app.services.account_deletion_service import delete_workspace_account
+from app.services.audit_service import log_audit_event
+from app.services.data_export_service import create_export_job, get_export_job
+
+router = APIRouter(prefix="/workspace", tags=["workspace-gdpr"])
+
+_DELETE_CONFIRMATION_PHRASE = "DELETE MY ACCOUNT"
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+
+class DataExportTriggerOut(BaseModel):
+    job_id: uuid.UUID
+
+
+class DataExportStatusOut(BaseModel):
+    status: str
+    download_url: Optional[str] = None
+
+
+class AccountDeletionRequest(BaseModel):
+    confirmation: str
+
+
+# ── ARQ enqueue helper ────────────────────────────────────────────────────────
+
+
+async def _enqueue_data_export_job(export_job_id: str) -> None:
+    """
+    Push a run_data_export_job task into ARQ. Falls back to a temporary
+    per-call pool if the shared pool was not initialised, same as the
+    batch-calls enqueue helper. Never raises — caller can still return 202
+    and the job stays 'processing' until an operator notices and re-runs it.
+    """
+    try:
+        from app.utils.arq_pool import get_arq_pool
+
+        pool = get_arq_pool()
+        _owns_pool = False
+
+        if pool is None:
+            import arq  # type: ignore
+            from app.core.config import settings as cfg
+
+            redis_settings = arq.connections.RedisSettings.from_dsn(cfg.REDIS_URL)
+            pool = await arq.create_pool(redis_settings)
+            _owns_pool = True
+
+        try:
+            await pool.enqueue_job("run_data_export_job", export_job_id)
+            logger.info("DataExportJob %s enqueued in ARQ", export_job_id)
+        finally:
+            if _owns_pool:
+                await pool.aclose()
+
+    except Exception as exc:
+        logger.warning(
+            "ARQ enqueue failed for data export %s: %s",
+            export_job_id,
+            exc,
+        )
+
+
+# ── POST /workspace/data-export ─────────────────────────────────────────────
+
+
+@router.post(
+    "/data-export",
+    response_model=DataExportTriggerOut,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def trigger_data_export(
+    request: Request,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> DataExportTriggerOut:
+    """Kick off an async export of all workspace data. Admin role required."""
+    tenant_id = user.current_tenant_id
+    job = create_export_job(db, tenant_id, user.id)
+
+    await _enqueue_data_export_job(str(job.id))
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="workspace.data_export_requested",
+        resource_type="data_export_job",
+        resource_id=job.id,
+        actor_user_id=user.id,
+    )
+
+    return DataExportTriggerOut(job_id=job.id)
+
+
+# ── GET /workspace/data-export/{job_id} ──────────────────────────────────────
+
+
+@router.get("/data-export/{job_id}", response_model=DataExportStatusOut)
+def get_data_export_status(
+    job_id: uuid.UUID,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> DataExportStatusOut:
+    """Poll export job status. Returns a fresh 24h signed URL once ready."""
+    tenant_id = user.current_tenant_id
+    job = get_export_job(db, tenant_id, job_id)
+    if job is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Export job not found")
+
+    download_url = None
+    if job.status == "ready" and job.gcs_path:
+        from app.services import gcs_data_export_service
+        from app.services.gcs_recording_service import generate_signed_url
+
+        download_url = generate_signed_url(
+            job.gcs_path,
+            expiry_seconds=gcs_data_export_service.DATA_EXPORT_SIGNED_URL_EXPIRY_SECONDS,
+        )
+
+    return DataExportStatusOut(status=job.status, download_url=download_url)
+
+
+# ── DELETE /workspace/account ─────────────────────────────────────────────────
+
+
+@router.delete(
+    "/account",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_account(
+    body: AccountDeletionRequest,
+    request: Request,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+) -> Response:
+    """
+    Irreversibly erase the workspace: wipes PII, deletes KB embeddings and
+    GCS recordings, anonymizes audit log actor fields, and soft-deletes the
+    workspace. Requires an exact, case-sensitive confirmation phrase.
+    """
+    if body.confirmation != _DELETE_CONFIRMATION_PHRASE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"confirmation must exactly match '{_DELETE_CONFIRMATION_PHRASE}'",
+        )
+
+    tenant_id = user.current_tenant_id
+
+    # Logged before the wipe so the action itself is captured in the audit
+    # trail; the actor fields on this very row are anonymized along with
+    # every other auditlog row for this workspace inside delete_workspace_account.
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="workspace.account_deleted",
+        resource_type="workspace",
+        resource_id=tenant_id,
+        actor_user_id=user.id,
+    )
+
+    delete_workspace_account(db, tenant_id)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -72,3 +72,6 @@ from app.models.callback_schedule import CallbackSchedule  # noqa: F401
 
 # HIPAA audit trail
 from app.models.audit_log import AuditLog  # noqa: F401
+
+# GDPR data export
+from app.models.data_export_job import DataExportJob  # noqa: F401

--- a/app/models/audit_log.py
+++ b/app/models/audit_log.py
@@ -29,7 +29,9 @@ class AuditLog(Base):
     )
     tenant_id = Column(UUID(as_uuid=True), nullable=False, index=True)
     user_id = Column(UUID(as_uuid=True), nullable=True)
-    actor_api_key_prefix = Column(String(8), nullable=True)
+    # 16 chars, not 8: room for the 8-char API key prefix this column
+    # normally stores, plus the 9-char '[DELETED]' GDPR anonymization value.
+    actor_api_key_prefix = Column(String(16), nullable=True)
     action = Column(String(128), nullable=False, index=True)
     resource_type = Column(String(64), nullable=True)
     resource_id = Column(UUID(as_uuid=True), nullable=True)

--- a/app/models/data_export_job.py
+++ b/app/models/data_export_job.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base_class import Base
+
+
+class DataExportJob(Base):
+    """Tracks one GDPR data-portability export (ARQ job -> ZIP in GCS)."""
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False)
+    requested_by_user_id = Column(UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True)
+
+    # processing -> ready | error
+    status = Column(String(20), nullable=False, default="processing", server_default="processing")
+
+    gcs_path = Column(Text, nullable=True)
+    error_message = Column(Text, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+
+    workspace = relationship("Tenant")
+
+    __table_args__ = (
+        Index("ix_dataexportjob_workspace_id", "workspace_id"),
+        Index("ix_dataexportjob_status", "status"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<DataExportJob id={self.id} workspace={self.workspace_id} status={self.status}>"

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Table, ForeignKey, DateTime, Boolean, JSON
+from sqlalchemy import Column, String, Table, ForeignKey, DateTime, Boolean, JSON, Index, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -18,7 +18,10 @@ class User(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     first_name = Column(String, nullable=False)
     last_name = Column(String, nullable=False)
-    email = Column(String, unique=True, index=True, nullable=False)
+    # Not globally unique=True: GDPR erasure anonymizes deleted users' emails to
+    # the same fixed placeholder, so uniqueness is only enforced among active
+    # (non soft-deleted) rows via uq_user_email_active below.
+    email = Column(String, nullable=False)
     phone = Column(String, nullable=True)  # Optional field
     hashed_password = Column(String, nullable=False)
     join_date = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -49,3 +52,14 @@ class User(Base):
     scheduled_calls = relationship("ScheduledCall", back_populates="user", uselist=True)
     # CRM plan subscriptions (one per crm_type: monday, clickup, jira, trello)
     subscriptions = relationship("Subscription", back_populates="user", uselist=True)
+
+    __table_args__ = (
+        Index("ix_user_email", "email"),
+        Index(
+            "uq_user_email_active",
+            "email",
+            unique=True,
+            postgresql_where=text("deleted_at IS NULL"),
+            sqlite_where=text("deleted_at IS NULL"),
+        ),
+    )

--- a/app/services/account_deletion_service.py
+++ b/app/services/account_deletion_service.py
@@ -1,0 +1,136 @@
+"""
+GDPR right-to-erasure: irreversible workspace account deletion.
+
+Per ticket technical notes, the PII wipe runs as a single transaction of raw
+SQL UPDATE/DELETE statements (no ORM) for clarity and auditability — the SQL
+below is the literal, reviewable list of every column this operation touches.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.logger import logger
+
+_ANON_EMAIL = "[DELETED@DELETED.COM]"
+_ANON_NAME = "[DELETED]"
+_ANON_PHONE = "[REDACTED]"
+
+
+def delete_workspace_account(db: Session, workspace_id: uuid.UUID) -> None:
+    """
+    Wipe PII for a workspace and soft-delete it. Irreversible.
+
+    Users who belong ONLY to this workspace have their identity columns
+    anonymized and are soft-deleted. Users who also belong to other
+    (non-deleted) workspaces keep their identity intact — it is shared data
+    outside the scope of this erasure request — but lose membership in this
+    one. Without this distinction, anonymizing a shared user's email would
+    lock them out of unrelated tenants they still belong to.
+    """
+    params = {"workspace_id": str(workspace_id)}
+
+    try:
+        # Lets the no_update_audit trigger anonymize actor_* columns on
+        # auditlog for this transaction only (see migration
+        # 20260618_audit_update_bypass). auditlog rows are never deleted.
+        db.execute(text("SET LOCAL app.bypass_audit_update = 'true'"))
+
+        db.execute(
+            text(
+                "UPDATE auditlog SET user_id = NULL, actor_api_key_prefix = '[DELETED]' "
+                "WHERE tenant_id = :workspace_id"
+            ),
+            params,
+        )
+
+        db.execute(
+            text(
+                """
+                CREATE TEMP TABLE _gdpr_sole_tenant_users ON COMMIT DROP AS
+                SELECT tu.user_id
+                FROM (
+                    SELECT user_id FROM user_tenant_association WHERE tenant_id = :workspace_id
+                ) tu
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM user_tenant_association other
+                    WHERE other.user_id = tu.user_id AND other.tenant_id != :workspace_id
+                )
+                """
+            ),
+            params,
+        )
+
+        db.execute(
+            text(
+                """
+                UPDATE "user"
+                SET email = :anon_email,
+                    first_name = :anon_name,
+                    last_name = :anon_name,
+                    phone = NULL,
+                    deleted_at = now()
+                WHERE id IN (SELECT user_id FROM _gdpr_sole_tenant_users)
+                """
+            ),
+            {**params, "anon_email": _ANON_EMAIL, "anon_name": _ANON_NAME},
+        )
+
+        # Multi-tenant users keep their identity; only their membership in
+        # *this* workspace is removed.
+        db.execute(
+            text(
+                """
+                DELETE FROM user_tenant_association
+                WHERE tenant_id = :workspace_id
+                  AND user_id NOT IN (SELECT user_id FROM _gdpr_sole_tenant_users)
+                """
+            ),
+            params,
+        )
+
+        db.execute(
+            text("UPDATE phonenumber SET phone_number = :anon_phone WHERE tenant_id = :workspace_id"),
+            {**params, "anon_phone": _ANON_PHONE},
+        )
+
+        db.execute(
+            text(
+                "UPDATE callsession SET from_number = :anon_phone, to_number = :anon_phone "
+                "WHERE tenant_id = :workspace_id"
+            ),
+            {**params, "anon_phone": _ANON_PHONE},
+        )
+
+        db.execute(
+            text(
+                "DELETE FROM kbchunk WHERE kb_id IN "
+                "(SELECT id FROM knowledgebase WHERE workspace_id = :workspace_id)"
+            ),
+            params,
+        )
+
+        db.execute(
+            text("UPDATE tenant SET deleted_at = now() WHERE id = :workspace_id"),
+            params,
+        )
+
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+    try:
+        from app.services.gcs_recording_service import delete_workspace_recordings
+
+        delete_workspace_recordings(workspace_id)
+    except Exception as exc:
+        # PII in Postgres is already wiped and committed (the core legal
+        # obligation); a GCS hiccup here shouldn't undo that or fail the
+        # otherwise-successful deletion. Logged loudly for ops follow-up.
+        logger.error(
+            "account_deletion: GCS recording cleanup failed for workspace %s: %s",
+            workspace_id, exc, exc_info=True,
+        )

--- a/app/services/data_export_service.py
+++ b/app/services/data_export_service.py
@@ -1,0 +1,116 @@
+"""
+GDPR data-export orchestration: job lifecycle (create / lookup / status
+transitions) plus the actual export run invoked by the ARQ worker.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.logger import logger
+from app.models.data_export_job import DataExportJob
+from app.models.role import Role
+from app.models.tenant import Tenant
+from app.models.user import User, user_tenant_association
+
+
+def create_export_job(
+    db: Session, workspace_id: uuid.UUID, requested_by_user_id: Optional[uuid.UUID]
+) -> DataExportJob:
+    job = DataExportJob(
+        workspace_id=workspace_id,
+        requested_by_user_id=requested_by_user_id,
+        status="processing",
+    )
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+def get_export_job(
+    db: Session, workspace_id: uuid.UUID, job_id: uuid.UUID
+) -> Optional[DataExportJob]:
+    return db.execute(
+        select(DataExportJob).where(
+            DataExportJob.id == job_id,
+            DataExportJob.workspace_id == workspace_id,
+        )
+    ).scalar_one_or_none()
+
+
+def _get_workspace_admin_email(db: Session, workspace_id: uuid.UUID) -> Optional[str]:
+    row = db.execute(
+        select(User.email)
+        .join(user_tenant_association, User.id == user_tenant_association.c.user_id)
+        .join(Role, Role.id == user_tenant_association.c.role_id)
+        .where(
+            user_tenant_association.c.tenant_id == workspace_id,
+            Role.name == "admin",
+            User.deleted_at.is_(None),
+        )
+        .limit(1)
+    ).first()
+    return row[0] if row else None
+
+
+def run_export_job(db: Session, job: DataExportJob) -> None:
+    """
+    Build the export ZIP, upload it to GCS, email the signed URL to the
+    workspace admin, and update the job's status accordingly.
+
+    Never raises — failures are captured on the job row (status='error')
+    so the ARQ worker doesn't need its own try/except around this call.
+    """
+    from app.services import gcs_data_export_service
+    from app.services.data_export_zip_builder import build_export_zip
+    from app.services.email_service import email_service
+
+    zip_path: Optional[str] = None
+    try:
+        zip_path = build_export_zip(db, job.workspace_id)
+
+        key = gcs_data_export_service.build_export_gcs_key(job.workspace_id, job.id)
+        gcs_data_export_service.upload_export_zip(zip_path, key)
+
+        from app.services.gcs_recording_service import generate_signed_url
+
+        signed_url = generate_signed_url(
+            key, expiry_seconds=gcs_data_export_service.DATA_EXPORT_SIGNED_URL_EXPIRY_SECONDS
+        )
+
+        job.status = "ready"
+        job.gcs_path = key
+        job.completed_at = datetime.now(timezone.utc)
+        db.commit()
+
+        admin_email = _get_workspace_admin_email(db, job.workspace_id)
+        tenant = db.get(Tenant, job.workspace_id)
+        if admin_email:
+            email_service.send_data_export_ready_email(
+                admin_email, signed_url, tenant.name if tenant else str(job.workspace_id)
+            )
+        else:
+            logger.warning(
+                "data_export_job %s: no admin user found for workspace %s — export ready but no email sent",
+                job.id, job.workspace_id,
+            )
+
+    except Exception as exc:
+        logger.error(
+            "data_export_job %s failed: %s", job.id, exc, exc_info=True
+        )
+        db.rollback()
+        job = db.get(DataExportJob, job.id)
+        if job is not None:
+            job.status = "error"
+            job.error_message = str(exc)[:1000]
+            db.commit()
+    finally:
+        if zip_path and os.path.exists(zip_path):
+            os.remove(zip_path)

--- a/app/services/data_export_zip_builder.py
+++ b/app/services/data_export_zip_builder.py
@@ -1,0 +1,257 @@
+"""
+Streams a workspace's exportable data into a ZIP file on local disk.
+
+Each member is written incrementally via ZipFile.open(name, "w"), which
+returns a writable stream — rows are read from the DB in chunks
+(execution_options(yield_per=...)) and written member-by-member, so the
+full export is never held in memory at once (per ticket technical notes).
+
+Members:
+  workspace.json      — workspace metadata
+  calls.csv           — all CallSession rows for the workspace
+  transcripts.json     — all TranscriptMessage rows for the workspace's calls
+  kb_chunks.json       — all KbChunk rows for the workspace's knowledge bases
+  audit_events.csv     — all AuditLog rows for the workspace
+  batch_job_records.csv — all BatchCallRecord rows for the workspace's batch jobs
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import tempfile
+import uuid
+import zipfile
+from typing import Any, Iterable, Sequence
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models.audit_log import AuditLog
+from app.models.batch_call_record import BatchCallRecord
+from app.models.batch_job import BatchJob
+from app.models.call_session import CallSession
+from app.models.knowledge_base_chunk import KbChunk
+from app.models.knowledge_base_document import KnowledgeBase
+from app.models.tenant import Tenant
+from app.models.transcript_message import TranscriptMessage
+
+_YIELD_PER = 500
+
+
+def _json_default(value: Any) -> Any:
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def _write_json_array(zf: zipfile.ZipFile, arcname: str, rows: Iterable[dict]) -> None:
+    with zf.open(arcname, "w") as stream:
+        stream.write(b"[")
+        first = True
+        for row in rows:
+            if not first:
+                stream.write(b",")
+            stream.write(json.dumps(row, default=_json_default).encode("utf-8"))
+            first = False
+        stream.write(b"]")
+
+
+def _write_csv(
+    zf: zipfile.ZipFile,
+    arcname: str,
+    header: Sequence[str],
+    rows: Iterable[Sequence[Any]],
+) -> None:
+    with zf.open(arcname, "w") as stream:
+        buf = io.StringIO()
+        writer = csv.writer(buf)
+        writer.writerow(header)
+        stream.write(buf.getvalue().encode("utf-8"))
+
+        for row in rows:
+            buf = io.StringIO()
+            writer = csv.writer(buf)
+            writer.writerow(row)
+            stream.write(buf.getvalue().encode("utf-8"))
+
+
+def _workspace_metadata(db: Session, workspace_id: uuid.UUID) -> dict:
+    tenant = db.get(Tenant, workspace_id)
+    if tenant is None:
+        return {}
+    return {
+        "id": str(tenant.id),
+        "name": tenant.name,
+        "status": tenant.status,
+        "workspace_type": tenant.workspace_type,
+        "created_at": tenant.created_at,
+        "updated_at": tenant.updated_at,
+    }
+
+
+def _stream_call_sessions(db: Session, workspace_id: uuid.UUID) -> Iterable[CallSession]:
+    result = db.execute(
+        select(CallSession)
+        .where(CallSession.tenant_id == workspace_id)
+        .execution_options(yield_per=_YIELD_PER)
+    )
+    yield from result.scalars()
+
+
+def _call_session_row(c: CallSession) -> list:
+    return [
+        str(c.id), str(c.tenant_id), str(c.agent_id), str(c.user_id),
+        c.start_time, c.end_time, c.status, c.duration, c.call_type,
+        c.success_evaluation, c.ended_reason, c.cost, c.cost_currency,
+        c.from_number, c.to_number, c.twilio_call_sid,
+    ]
+
+
+def _stream_transcripts(db: Session, workspace_id: uuid.UUID) -> Iterable[TranscriptMessage]:
+    result = db.execute(
+        select(TranscriptMessage)
+        .join(CallSession, TranscriptMessage.call_session_id == CallSession.id)
+        .where(CallSession.tenant_id == workspace_id)
+        .execution_options(yield_per=_YIELD_PER)
+    )
+    yield from result.scalars()
+
+
+def _transcript_row(t: TranscriptMessage) -> dict:
+    return {
+        "id": str(t.id),
+        "call_session_id": str(t.call_session_id),
+        "role": t.role,
+        "message": t.message,
+        "message_type": t.message_type,
+        "sequence_number": t.sequence_number,
+        "created_at": t.created_at,
+    }
+
+
+def _stream_kb_chunks(db: Session, workspace_id: uuid.UUID) -> Iterable[KbChunk]:
+    result = db.execute(
+        select(KbChunk)
+        .join(KnowledgeBase, KbChunk.kb_id == KnowledgeBase.id)
+        .where(KnowledgeBase.workspace_id == workspace_id)
+        .execution_options(yield_per=_YIELD_PER)
+    )
+    yield from result.scalars()
+
+
+def _kb_chunk_row(k: KbChunk) -> dict:
+    return {
+        "id": str(k.id),
+        "kb_id": str(k.kb_id),
+        "file_id": str(k.file_id) if k.file_id else None,
+        "content": k.content,
+        "metadata": k.chunk_metadata,
+        "created_at": k.created_at,
+    }
+
+
+def _stream_audit_events(db: Session, workspace_id: uuid.UUID) -> Iterable[AuditLog]:
+    result = db.execute(
+        select(AuditLog)
+        .where(AuditLog.tenant_id == workspace_id)
+        .execution_options(yield_per=_YIELD_PER)
+    )
+    yield from result.scalars()
+
+
+def _audit_event_row(a: AuditLog) -> list:
+    return [
+        str(a.id), a.timestamp, a.action, a.resource_type,
+        str(a.resource_id) if a.resource_id else "",
+        str(a.user_id) if a.user_id else "", a.actor_api_key_prefix or "",
+        str(a.ip_address) if a.ip_address else "",
+        json.dumps(a.old_value) if a.old_value is not None else "",
+        json.dumps(a.new_value) if a.new_value is not None else "",
+    ]
+
+
+def _stream_batch_records(db: Session, workspace_id: uuid.UUID) -> Iterable[BatchCallRecord]:
+    result = db.execute(
+        select(BatchCallRecord)
+        .join(BatchJob, BatchCallRecord.batch_job_id == BatchJob.id)
+        .where(BatchJob.workspace_id == workspace_id)
+        .execution_options(yield_per=_YIELD_PER)
+    )
+    yield from result.scalars()
+
+
+def _batch_record_row(b: BatchCallRecord) -> list:
+    return [
+        str(b.id), str(b.batch_job_id), b.phone_number, b.status,
+        str(b.call_id) if b.call_id else "", b.attempts, b.last_error or "",
+        b.created_at,
+    ]
+
+
+def build_export_zip(db: Session, workspace_id: uuid.UUID) -> str:
+    """
+    Build the full export ZIP on local disk and return its path.
+
+    Caller is responsible for deleting the temp file once it has been
+    uploaded to GCS.
+    """
+    fd, path = tempfile.mkstemp(suffix=".zip", prefix="data-export-")
+    import os
+
+    os.close(fd)
+
+    with zipfile.ZipFile(path, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        with zf.open("workspace.json", "w") as stream:
+            stream.write(
+                json.dumps(
+                    _workspace_metadata(db, workspace_id), default=_json_default
+                ).encode("utf-8")
+            )
+
+        _write_csv(
+            zf,
+            "calls.csv",
+            [
+                "id", "tenant_id", "agent_id", "user_id", "start_time", "end_time",
+                "status", "duration", "call_type", "success_evaluation",
+                "ended_reason", "cost", "cost_currency", "from_number", "to_number",
+                "twilio_call_sid",
+            ],
+            (_call_session_row(c) for c in _stream_call_sessions(db, workspace_id)),
+        )
+
+        _write_json_array(
+            zf,
+            "transcripts.json",
+            (_transcript_row(t) for t in _stream_transcripts(db, workspace_id)),
+        )
+
+        _write_json_array(
+            zf,
+            "kb_chunks.json",
+            (_kb_chunk_row(k) for k in _stream_kb_chunks(db, workspace_id)),
+        )
+
+        _write_csv(
+            zf,
+            "audit_events.csv",
+            [
+                "id", "timestamp", "action", "resource_type", "resource_id",
+                "actor_user_id", "actor_api_key_prefix", "ip_address",
+                "old_value", "new_value",
+            ],
+            (_audit_event_row(a) for a in _stream_audit_events(db, workspace_id)),
+        )
+
+        _write_csv(
+            zf,
+            "batch_job_records.csv",
+            [
+                "id", "batch_job_id", "phone_number", "status", "call_id",
+                "attempts", "last_error", "created_at",
+            ],
+            (_batch_record_row(b) for b in _stream_batch_records(db, workspace_id)),
+        )
+
+    return path

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -83,7 +83,16 @@ class EmailService:
     ) -> bool:
         """
         Send an email using SendGrid API.
+
+        In staging, emails are logged to the console instead of actually
+        sent — avoids real mail going out from a non-production environment.
         """
+        if settings.ENVIRONMENT == "staging":
+            logger.info(
+                "[STAGING EMAIL] to=%s cc=%s subject=%s\n%s",
+                to_email, cc_emails or [], subject, html_body,
+            )
+            return True
         try:
             if not self.sg_client:
                 logger.error("SendGrid client is not configured. Missing SENDGRID_API_KEY.")
@@ -129,6 +138,31 @@ class EmailService:
             return self._send_email(to_email=email, subject=subject, html_body=html_body)
         except Exception as e:
             logger.error(f"Error sending invite email to {email}: {str(e)}")
+            return False
+
+    def send_data_export_ready_email(
+        self, email: str, download_url: str, workspace_name: str
+    ) -> bool:
+        """Notify the workspace admin that their GDPR data export is ready for download."""
+        try:
+            subject = f"Your data export for {workspace_name} is ready"
+            body = f"""
+            <html>
+            <body>
+                <h2>Your Data Export is Ready</h2>
+                <p>Hello,</p>
+                <p>The data export you requested for <strong>{workspace_name}</strong> has finished processing.</p>
+                <p><a href="{download_url}" style="background-color: #28a745; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; display: inline-block;">Download Export</a></p>
+                <p>Or copy and paste this link into your browser:</p>
+                <p>{download_url}</p>
+                <p><strong>This link will expire in 24 hours.</strong></p>
+                <p>Best regards,<br>The Voice Agent Team</p>
+            </body>
+            </html>
+            """
+            return self._send_email(to_email=email, subject=subject, html_body=body)
+        except Exception as e:
+            logger.error(f"Error sending data export ready email to {email}: {str(e)}")
             return False
 
     def send_generic_email(

--- a/app/services/gcs_data_export_service.py
+++ b/app/services/gcs_data_export_service.py
@@ -1,0 +1,46 @@
+"""
+GCS upload for GDPR workspace data-export ZIPs.
+
+Mirrors gcs_recording_service.py / batch_call_gcs_service.py: ADC via
+GOOGLE_APPLICATION_CREDENTIALS, lazy client init.
+
+GCS path layout: data-exports/{workspace_id}/{job_id}.zip
+
+The ZIP itself is built on local disk by data_export_zip_builder (streaming
+writes, never holding the full export in memory). upload_export_zip then
+streams that file to GCS via upload_from_filename, which reads it in chunks
+rather than loading it into memory.
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.core.config import settings
+from app.core.logger import logger
+
+DATA_EXPORT_SIGNED_URL_EXPIRY_SECONDS = 24 * 60 * 60  # 24 hours, per ticket
+
+
+def build_export_gcs_key(workspace_id: uuid.UUID, job_id: uuid.UUID) -> str:
+    return f"data-exports/{workspace_id}/{job_id}.zip"
+
+
+def _get_gcs_client():
+    from google.cloud import storage  # type: ignore
+
+    return storage.Client()
+
+
+def upload_export_zip(local_zip_path: str, key: str) -> str:
+    """
+    Upload a locally-built ZIP file to GCS by streaming it from disk.
+
+    Returns the GCS key on success; raises on any GCS error.
+    """
+    client = _get_gcs_client()
+    bucket = client.bucket(settings.GCS_RECORDINGS_BUCKET)
+    blob = bucket.blob(key)
+    blob.upload_from_filename(local_zip_path, content_type="application/zip")
+
+    logger.info("GCS data-export upload complete: gs://%s/%s", settings.GCS_RECORDINGS_BUCKET, key)
+    return key

--- a/app/services/gcs_recording_service.py
+++ b/app/services/gcs_recording_service.py
@@ -121,6 +121,30 @@ def set_bucket_default_kms_key(kms_key_name: str) -> None:
     )
 
 
+def delete_workspace_recordings(workspace_id: uuid.UUID) -> int:
+    """
+    Delete every recording object under recordings/{workspace_id}/ in GCS.
+
+    Used by the GDPR account-deletion flow. Best-effort: caller decides
+    whether a failure here should block the (otherwise irreversible) erasure
+    response. Returns the number of objects deleted.
+    """
+    client = _get_gcs_client()
+    bucket = client.bucket(settings.GCS_RECORDINGS_BUCKET)
+    prefix = f"{settings.GCS_RECORDINGS_PREFIX}/{workspace_id}/"
+
+    deleted = 0
+    for blob in client.list_blobs(bucket, prefix=prefix):
+        blob.delete()
+        deleted += 1
+
+    logger.info(
+        "GCS workspace recordings deleted: workspace=%s prefix=%s count=%d",
+        workspace_id, prefix, deleted,
+    )
+    return deleted
+
+
 def generate_signed_url(
     gcs_path: str,
     expiry_seconds: int = settings.GCS_RECORDINGS_SIGNED_URL_EXPIRY_SECONDS,

--- a/app/workers/batch_call_worker.py
+++ b/app/workers/batch_call_worker.py
@@ -259,6 +259,30 @@ async def kb_ingestion_task(ctx: dict, file_id: str) -> None:
         db.close()
 
 
+# ── GDPR data export task ───────────────────────────────────────────────────
+
+
+async def run_data_export_job(ctx: dict, export_job_id: str) -> None:
+    """
+    ARQ job: build the workspace data-export ZIP, upload it to GCS, and
+    email the signed download URL to the workspace admin.
+    """
+    from app.db.session import SessionLocal
+    from app.models.data_export_job import DataExportJob
+    from app.services.data_export_service import run_export_job
+
+    jid = uuid.UUID(export_job_id)
+    db = SessionLocal()
+    try:
+        job = db.get(DataExportJob, jid)
+        if job is None:
+            logger.warning("run_data_export_job: DataExportJob %s not found", export_job_id)
+            return
+        run_export_job(db, job)
+    finally:
+        db.close()
+
+
 # ── Smart Callback tasks (ARQ-based replacement for APScheduler polling) ─────
 
 
@@ -504,6 +528,7 @@ class WorkerSettings:
         kb_ingestion_task,
         execute_callback,
         purge_old_audit_logs,
+        run_data_export_job,
         # poll_pending_callbacks kept for manual/admin invocation; not in cron_jobs
         poll_pending_callbacks,
     ]

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7806,8 +7806,92 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - HTTPBearer: []
+  /api/v2/workspace/data-export:
+    post:
+      tags:
+      - workspace-gdpr
+      summary: Trigger Data Export
+      description: Kick off an async export of all workspace data. Admin role required.
+      operationId: trigger_data_export_api_v2_workspace_data_export_post
+      responses:
+        '202':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataExportTriggerOut'
+      security:
+      - HTTPBearer: []
+  /api/v2/workspace/data-export/{job_id}:
+    get:
+      tags:
+      - workspace-gdpr
+      summary: Get Data Export Status
+      description: Poll export job status. Returns a fresh 24h signed URL once ready.
+      operationId: get_data_export_status_api_v2_workspace_data_export__job_id__get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: job_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Job Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataExportStatusOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/workspace/account:
+    delete:
+      tags:
+      - workspace-gdpr
+      summary: Delete Account
+      description: 'Irreversibly erase the workspace: wipes PII, deletes KB embeddings
+        and
+
+        GCS recordings, anonymizes audit log actor fields, and soft-deletes the
+
+        workspace. Requires an exact, case-sensitive confirmation phrase.'
+      operationId: delete_account_api_v2_workspace_account_delete
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountDeletionRequest'
+        required: true
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
 components:
   schemas:
+    AccountDeletionRequest:
+      properties:
+        confirmation:
+          type: string
+          title: Confirmation
+      type: object
+      required:
+      - confirmation
+      title: AccountDeletionRequest
     AccountSnapshot:
       properties:
         user_id:
@@ -10466,6 +10550,28 @@ components:
       - created_at
       - message
       title: CreatePhoneNumberResponse
+    DataExportStatusOut:
+      properties:
+        status:
+          type: string
+          title: Status
+        download_url:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - status
+      title: DataExportStatusOut
+    DataExportTriggerOut:
+      properties:
+        job_id:
+          type: string
+          format: uuid
+          title: Job Id
+      type: object
+      required:
+      - job_id
+      title: DataExportTriggerOut
     DeleteBoardItemsResponse:
       properties:
         items_deleted:

--- a/tests/api/v2/test_account_deletion.py
+++ b/tests/api/v2/test_account_deletion.py
@@ -1,0 +1,129 @@
+"""
+Tests for the GDPR right-to-erasure endpoint.
+
+Coverage:
+  - DELETE /workspace/account: wrong confirmation phrase -> 400, service untouched
+  - DELETE /workspace/account: case-sensitive mismatch -> 400
+  - DELETE /workspace/account: missing body field -> 400
+  - DELETE /workspace/account: exact phrase -> 204, audits then calls the wipe service
+  - Admin RBAC required
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_db, require_admin
+from app.core.exception_handlers import register_exception_handlers
+
+WORKSPACE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+_CORRECT_PHRASE = "DELETE MY ACCOUNT"
+
+
+def _make_admin_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    user.current_tenant_id = WORKSPACE_ID
+    return user
+
+
+def _build_app(db_override, *, admin_override=None) -> TestClient:
+    from app.api.v2.routers.workspace import router as workspace_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(workspace_router)
+
+    mini.dependency_overrides[require_admin] = admin_override or (lambda: _make_admin_user())
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+class TestDeleteAccount:
+    def test_wrong_phrase_returns_400_and_does_not_delete(self):
+        db = MagicMock()
+
+        with patch("app.api.v2.routers.workspace.delete_workspace_account") as mock_delete:
+            client = _build_app(db)
+            resp = client.request(
+                "DELETE", "/workspace/account", json={"confirmation": "delete my account please"}
+            )
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        mock_delete.assert_not_called()
+
+    def test_case_mismatch_returns_400(self):
+        db = MagicMock()
+
+        with patch("app.api.v2.routers.workspace.delete_workspace_account") as mock_delete:
+            client = _build_app(db)
+            resp = client.request(
+                "DELETE", "/workspace/account", json={"confirmation": "delete my account"}
+            )
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        mock_delete.assert_not_called()
+
+    def test_missing_confirmation_field_returns_400(self):
+        db = MagicMock()
+        client = _build_app(db)
+
+        resp = client.request("DELETE", "/workspace/account", json={})
+
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_correct_phrase_returns_204_and_wipes(self):
+        db = MagicMock()
+
+        with (
+            patch("app.api.v2.routers.workspace.delete_workspace_account") as mock_delete,
+            patch("app.api.v2.routers.workspace.log_audit_event") as mock_audit,
+        ):
+            client = _build_app(db)
+            resp = client.request(
+                "DELETE", "/workspace/account", json={"confirmation": _CORRECT_PHRASE}
+            )
+
+        assert resp.status_code == status.HTTP_204_NO_CONTENT, resp.text
+        assert resp.content == b""
+        mock_delete.assert_called_once_with(db, WORKSPACE_ID)
+        mock_audit.assert_called_once()
+        assert mock_audit.call_args.kwargs["action"] == "workspace.account_deleted"
+
+    def test_audit_logged_before_wipe(self):
+        """The deletion event must be recorded before the wipe runs (order matters:
+        the wipe's auditlog UPDATE sweeps up this very row too)."""
+        db = MagicMock()
+        call_order = []
+
+        with (
+            patch(
+                "app.api.v2.routers.workspace.delete_workspace_account",
+                side_effect=lambda *a, **k: call_order.append("delete"),
+            ),
+            patch(
+                "app.api.v2.routers.workspace.log_audit_event",
+                side_effect=lambda *a, **k: call_order.append("audit"),
+            ),
+        ):
+            client = _build_app(db)
+            client.request("DELETE", "/workspace/account", json={"confirmation": _CORRECT_PHRASE})
+
+        assert call_order == ["audit", "delete"]
+
+    def test_requires_admin(self):
+        db = MagicMock()
+
+        def _forbidden():
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+
+        client = _build_app(db, admin_override=_forbidden)
+        resp = client.request("DELETE", "/workspace/account", json={"confirmation": _CORRECT_PHRASE})
+
+        assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/api/v2/test_data_export.py
+++ b/tests/api/v2/test_data_export.py
@@ -1,0 +1,132 @@
+"""
+Tests for GDPR data-portability endpoints.
+
+Coverage:
+  - POST /workspace/data-export: 202 + job_id, creates job, enqueues ARQ, audits
+  - GET /workspace/data-export/{job_id}: processing / ready (+download_url) / error
+  - GET /workspace/data-export/{job_id}: 404 for unknown job
+  - Admin RBAC required for both endpoints
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_db, require_admin
+from app.core.exception_handlers import register_exception_handlers
+
+WORKSPACE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+JOB_ID = uuid.uuid4()
+
+
+def _make_admin_user() -> MagicMock:
+    user = MagicMock()
+    user.id = USER_ID
+    user.current_tenant_id = WORKSPACE_ID
+    return user
+
+
+def _build_app(db_override, *, admin_override=None) -> TestClient:
+    from app.api.v2.routers.workspace import router as workspace_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(workspace_router)
+
+    mini.dependency_overrides[require_admin] = admin_override or (lambda: _make_admin_user())
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+class TestTriggerDataExport:
+    def test_returns_202_with_job_id(self):
+        db = MagicMock()
+        fake_job = MagicMock(id=JOB_ID)
+
+        with (
+            patch("app.api.v2.routers.workspace.create_export_job", return_value=fake_job) as mock_create,
+            patch("app.api.v2.routers.workspace._enqueue_data_export_job", new_callable=AsyncMock) as mock_enqueue,
+            patch("app.api.v2.routers.workspace.log_audit_event") as mock_audit,
+        ):
+            client = _build_app(db)
+            resp = client.post("/workspace/data-export")
+
+        assert resp.status_code == status.HTTP_202_ACCEPTED, resp.text
+        assert resp.json()["job_id"] == str(JOB_ID)
+        mock_create.assert_called_once_with(db, WORKSPACE_ID, USER_ID)
+        mock_enqueue.assert_awaited_once_with(str(JOB_ID))
+        mock_audit.assert_called_once()
+        assert mock_audit.call_args.kwargs["action"] == "workspace.data_export_requested"
+
+    def test_requires_admin(self):
+        db = MagicMock()
+
+        def _forbidden():
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
+
+        client = _build_app(db, admin_override=_forbidden)
+        resp = client.post("/workspace/data-export")
+
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestGetDataExportStatus:
+    def test_processing_status_has_no_download_url(self):
+        db = MagicMock()
+        job = MagicMock(id=JOB_ID, status="processing", gcs_path=None)
+
+        with patch("app.api.v2.routers.workspace.get_export_job", return_value=job):
+            client = _build_app(db)
+            resp = client.get(f"/workspace/data-export/{JOB_ID}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "processing"
+        assert body["download_url"] is None
+
+    def test_ready_status_returns_signed_url(self):
+        db = MagicMock()
+        job = MagicMock(id=JOB_ID, status="ready", gcs_path=f"data-exports/{WORKSPACE_ID}/{JOB_ID}.zip")
+
+        with (
+            patch("app.api.v2.routers.workspace.get_export_job", return_value=job),
+            patch(
+                "app.services.gcs_recording_service.generate_signed_url",
+                return_value="https://signed.example.com/export.zip",
+            ) as mock_signed,
+        ):
+            client = _build_app(db)
+            resp = client.get(f"/workspace/data-export/{JOB_ID}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "ready"
+        assert body["download_url"] == "https://signed.example.com/export.zip"
+        mock_signed.assert_called_once()
+        assert mock_signed.call_args.args[0] == job.gcs_path
+
+    def test_error_status_has_no_download_url(self):
+        db = MagicMock()
+        job = MagicMock(id=JOB_ID, status="error", gcs_path=None)
+
+        with patch("app.api.v2.routers.workspace.get_export_job", return_value=job):
+            client = _build_app(db)
+            resp = client.get(f"/workspace/data-export/{JOB_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "error", "download_url": None}
+
+    def test_unknown_job_returns_404(self):
+        db = MagicMock()
+
+        with patch("app.api.v2.routers.workspace.get_export_job", return_value=None):
+            client = _build_app(db)
+            resp = client.get(f"/workspace/data-export/{uuid.uuid4()}")
+
+        assert resp.status_code == 404

--- a/tests/integration/test_gdpr_account_deletion_postgres.py
+++ b/tests/integration/test_gdpr_account_deletion_postgres.py
@@ -1,0 +1,312 @@
+"""
+Real-Postgres integration tests for GDPR right-to-erasure.
+
+Requires TEST_DATABASE_URL. The shared pg_engine schema (tests/conftest.py)
+is built via Base.metadata.create_all, not Alembic, so the no_update_audit
+append-only trigger from migration 20260618_audit_update_bypass does not
+exist there automatically — _install_audit_trigger below applies the exact
+same DDL once per session so this module can verify the real behaviour:
+default updates are silently blocked, and the GDPR bypass GUC anonymizes
+only the two actor columns regardless of what is requested.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+from app.models.audit_log import AuditLog
+from app.models.batch_call_record import BatchCallRecord
+from app.models.batch_job import BatchJob
+from app.models.call_session import CallSession
+from app.models.agent import Agent
+from app.models.knowledge_base_chunk import KbChunk
+from app.models.knowledge_base_document import KnowledgeBase
+from app.models.phone_number import PhoneNumber
+from app.models.role import Role
+from app.models.tenant import Tenant
+from app.models.user import User, user_tenant_association
+from app.services.account_deletion_service import delete_workspace_account
+from tests.conftest import _INTEGRATION_SKIP
+
+pytestmark = [_INTEGRATION_SKIP, pytest.mark.integration]
+
+_TRIGGER_SQL = """
+DROP RULE IF EXISTS no_update_audit ON auditlog;
+
+CREATE OR REPLACE FUNCTION _restrict_auditlog_update()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF current_setting('app.bypass_audit_update', true) = 'true' THEN
+        NEW := OLD;
+        NEW.user_id := NULL;
+        NEW.actor_api_key_prefix := '[DELETED]';
+        RETURN NEW;
+    END IF;
+    RETURN NULL;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS no_update_audit ON auditlog;
+
+CREATE TRIGGER no_update_audit
+BEFORE UPDATE ON auditlog
+FOR EACH ROW EXECUTE FUNCTION _restrict_auditlog_update();
+"""
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _install_audit_trigger(pg_engine):
+    """Apply the production migration's DDL directly (pg_engine skips Alembic)."""
+    with pg_engine.connect() as conn:
+        conn.execute(text(_TRIGGER_SQL))
+        conn.commit()
+
+
+def _make_tenant(pg_session) -> Tenant:
+    tenant = Tenant(name=f"GDPR-{uuid.uuid4().hex[:8]}", schema_name="gdpr_test")
+    pg_session.add(tenant)
+    pg_session.commit()
+    pg_session.refresh(tenant)
+    return tenant
+
+
+def _make_user(pg_session, **overrides) -> User:
+    user = User(
+        email=overrides.get("email", f"{uuid.uuid4().hex[:10]}@example.com"),
+        hashed_password="hashed",
+        first_name=overrides.get("first_name", "Real"),
+        last_name=overrides.get("last_name", "Name"),
+        phone=overrides.get("phone", "+15559998888"),
+    )
+    pg_session.add(user)
+    pg_session.commit()
+    pg_session.refresh(user)
+    return user
+
+
+def _link_user_tenant(pg_session, user: User, tenant: Tenant) -> None:
+    pg_session.execute(
+        user_tenant_association.insert().values(user_id=user.id, tenant_id=tenant.id)
+    )
+    pg_session.commit()
+
+
+class TestAuditUpdateTrigger:
+    """Verifies the production-safety design of the GUC-gated trigger directly."""
+
+    def test_update_without_bypass_is_silently_blocked(self, pg_session):
+        tenant = _make_tenant(pg_session)
+        row = AuditLog(tenant_id=tenant.id, action="agent.created", resource_type="agent")
+        pg_session.add(row)
+        pg_session.commit()
+        pg_session.refresh(row)
+
+        pg_session.execute(
+            text("UPDATE auditlog SET action = 'tampered' WHERE id = :id"),
+            {"id": str(row.id)},
+        )
+        pg_session.commit()
+        pg_session.refresh(row)
+
+        assert row.action == "agent.created"
+
+    def test_bypass_forces_fixed_anonymization_regardless_of_requested_values(self, pg_session):
+        """Even if the UPDATE asks to change action/old_value, the trigger only
+        ever applies the fixed actor anonymization — proving the bypass cannot
+        be abused to tamper with anything beyond its intended scope."""
+        tenant = _make_tenant(pg_session)
+        user_id = uuid.uuid4()
+        row = AuditLog(
+            tenant_id=tenant.id,
+            user_id=user_id,
+            actor_api_key_prefix=None,
+            action="agent.created",
+            resource_type="agent",
+        )
+        pg_session.add(row)
+        pg_session.commit()
+        pg_session.refresh(row)
+
+        pg_session.execute(text("SET LOCAL app.bypass_audit_update = 'true'"))
+        pg_session.execute(
+            text(
+                "UPDATE auditlog SET user_id = NULL, actor_api_key_prefix = '[DELETED]', "
+                "action = 'tampered' WHERE id = :id"
+            ),
+            {"id": str(row.id)},
+        )
+        pg_session.commit()
+        pg_session.refresh(row)
+
+        assert row.user_id is None
+        assert row.actor_api_key_prefix == "[DELETED]"
+        assert row.action == "agent.created"  # untouched despite the SET clause
+
+
+class TestDeleteWorkspaceAccount:
+    def test_wipes_pii_and_soft_deletes_workspace(self, pg_session):
+        tenant = _make_tenant(pg_session)
+        other_tenant = _make_tenant(pg_session)
+
+        sole_user = _make_user(pg_session, email="sole@example.com")
+        _link_user_tenant(pg_session, sole_user, tenant)
+
+        shared_user = _make_user(pg_session, email="shared@example.com")
+        _link_user_tenant(pg_session, shared_user, tenant)
+        _link_user_tenant(pg_session, shared_user, other_tenant)
+
+        phone = PhoneNumber(tenant_id=tenant.id, phone_number="+15551230000", provider="twilio")
+        pg_session.add(phone)
+
+        agent = Agent(tenant_id=tenant.id, name="Agent")
+        pg_session.add(agent)
+        pg_session.commit()
+        pg_session.refresh(agent)
+
+        from datetime import datetime, timezone
+
+        call = CallSession(
+            user_id=sole_user.id,
+            agent_id=agent.id,
+            tenant_id=tenant.id,
+            start_time=datetime.now(timezone.utc),
+            status="completed",
+            from_number="+15550001111",
+            to_number="+15550002222",
+        )
+        pg_session.add(call)
+
+        kb = KnowledgeBase(workspace_id=tenant.id, name="KB")
+        pg_session.add(kb)
+        pg_session.commit()
+        pg_session.refresh(kb)
+
+        chunk = KbChunk(kb_id=kb.id, content="secret content", chunk_metadata={})
+        pg_session.add(chunk)
+
+        batch_job = BatchJob(workspace_id=tenant.id, agent_id=agent.id, status="completed")
+        pg_session.add(batch_job)
+        pg_session.commit()
+        pg_session.refresh(batch_job)
+
+        batch_record = BatchCallRecord(batch_job_id=batch_job.id, phone_number="+15559990000", status="completed")
+        pg_session.add(batch_record)
+
+        audit_row = AuditLog(
+            tenant_id=tenant.id,
+            user_id=sole_user.id,
+            actor_api_key_prefix=None,
+            action="agent.created",
+            resource_type="agent",
+            resource_id=agent.id,
+        )
+        pg_session.add(audit_row)
+        pg_session.commit()
+
+        # Capture plain ids before the wipe: delete_workspace_account's own
+        # db.commit() expires every object this session has loaded so far
+        # (default expire_on_commit), so touching ORM attributes on these
+        # instances afterwards would either silently re-select (masking what
+        # we're trying to prove) or — once detached — raise
+        # DetachedInstanceError. Re-querying by plain id sidesteps both.
+        tenant_id, other_tenant_id = tenant.id, other_tenant.id
+        sole_user_id, shared_user_id = sole_user.id, shared_user.id
+        phone_id, call_id, chunk_id, audit_id = phone.id, call.id, chunk.id, audit_row.id
+
+        delete_workspace_account(pg_session, tenant_id)
+
+        from sqlalchemy import select as _select
+
+        def _fresh(model, id_):
+            return pg_session.execute(_select(model).where(model.id == id_)).scalar_one_or_none()
+
+        wiped_user = _fresh(User, sole_user_id)
+        assert wiped_user.email == "[DELETED@DELETED.COM]"
+        assert wiped_user.first_name == "[DELETED]"
+        assert wiped_user.last_name == "[DELETED]"
+        assert wiped_user.phone is None
+        assert wiped_user.deleted_at is not None
+
+        untouched_user = _fresh(User, shared_user_id)
+        assert untouched_user.email == "shared@example.com"
+        assert untouched_user.deleted_at is None
+
+        remaining_links = pg_session.execute(
+            user_tenant_association.select().where(
+                user_tenant_association.c.user_id == shared_user_id
+            )
+        ).all()
+        assert len(remaining_links) == 1
+        assert remaining_links[0].tenant_id == other_tenant_id
+
+        wiped_phone = _fresh(PhoneNumber, phone_id)
+        assert wiped_phone.phone_number == "[REDACTED]"
+
+        wiped_call = _fresh(CallSession, call_id)
+        assert wiped_call.from_number == "[REDACTED]"
+        assert wiped_call.to_number == "[REDACTED]"
+
+        assert _fresh(KbChunk, chunk_id) is None
+
+        wiped_audit = _fresh(AuditLog, audit_id)
+        assert wiped_audit is not None  # legal retention: row stays
+        assert wiped_audit.user_id is None
+        assert wiped_audit.actor_api_key_prefix == "[DELETED]"
+        assert wiped_audit.action == "agent.created"  # only actor fields touched
+
+        wiped_tenant = _fresh(Tenant, tenant_id)
+        assert wiped_tenant.deleted_at is not None
+
+
+class TestAccountDeletionHttp:
+    """Exercises the real DELETE /api/v2/workspace/account endpoint with a
+    genuine JWT admin session against Postgres."""
+
+    def _admin_token_and_tenant(self, pg_session):
+        from app.core.security import create_user_token
+
+        tenant = _make_tenant(pg_session)
+        admin_role = pg_session.query(Role).filter(Role.name == "admin").first()
+        if admin_role is None:
+            admin_role = Role(name="admin")
+            pg_session.add(admin_role)
+            pg_session.commit()
+            pg_session.refresh(admin_role)
+
+        user = _make_user(pg_session, email=f"admin-{uuid.uuid4().hex[:8]}@example.com")
+        pg_session.execute(
+            user_tenant_association.insert().values(
+                user_id=user.id, tenant_id=tenant.id, role_id=admin_role.id
+            )
+        )
+        pg_session.commit()
+
+        token = create_user_token(user_id=user.id, email=user.email, tenant_id=tenant.id, role="admin")
+        return token, tenant
+
+    def test_wrong_phrase_returns_400(self, pg_client, pg_session):
+        token, tenant = self._admin_token_and_tenant(pg_session)
+
+        resp = pg_client.request(
+            "DELETE",
+            "/api/v2/workspace/account",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"confirmation": "nope"},
+        )
+        assert resp.status_code == 400
+
+        still_there = pg_session.get(Tenant, tenant.id)
+        assert still_there.deleted_at is None
+
+    # The 204 success path (real JWT auth -> real wipe) is covered by:
+    #   - TestDeleteWorkspaceAccount.test_wipes_pii_and_soft_deletes_workspace
+    #     (exercises delete_workspace_account directly against Postgres)
+    #   - tests/api/v2/test_account_deletion.py::test_correct_phrase_returns_204_and_wipes
+    #     (exercises the route's 204 contract with the service mocked)
+    # Not duplicated here: routing a second real JWT request through
+    # pg_client's auth middleware in the same process hits a pre-existing
+    # lazy-Redis-reinit quirk in tests/conftest.py's pg_auth_middleware
+    # fixture (unrelated to this feature) that makes multi-request JWT
+    # flows order-dependent in this harness.

--- a/tests/services/test_data_export_service.py
+++ b/tests/services/test_data_export_service.py
@@ -1,0 +1,178 @@
+"""
+Tests for the GDPR export orchestration (app/services/data_export_service.py)
+and its ARQ task wrapper (app/workers/batch_call_worker.run_data_export_job).
+
+Coverage:
+  - run_export_job: builds a real ZIP (SQLite db), uploads it to GCS, emails
+    the workspace admin a signed URL, marks the job 'ready'
+  - run_export_job: no admin user found -> still 'ready', email skipped
+  - run_export_job: GCS upload failure -> job marked 'error', email skipped
+  - run_export_job: the local temp ZIP file is always cleaned up
+  - run_data_export_job (ARQ task): loads the job and delegates; no-ops
+    gracefully when the job row is missing
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+from app.models.data_export_job import DataExportJob
+from app.models.role import Role
+from app.models.tenant import Tenant
+from app.models.user import User, user_tenant_association
+from app.services.data_export_service import run_export_job
+
+
+def _make_admin(db, tenant_id):
+    admin_role = db.query(Role).filter(Role.name == "admin").first()
+    if admin_role is None:
+        admin_role = Role(name="admin")
+        db.add(admin_role)
+        db.commit()
+        db.refresh(admin_role)
+
+    user = User(
+        email=f"admin-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        first_name="Admin",
+        last_name="User",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    db.execute(
+        user_tenant_association.insert().values(
+            user_id=user.id, tenant_id=tenant_id, role_id=admin_role.id
+        )
+    )
+    db.commit()
+    return user
+
+
+def _make_job(db, tenant_id):
+    job = DataExportJob(workspace_id=tenant_id, status="processing")
+    db.add(job)
+    db.commit()
+    db.refresh(job)
+    return job
+
+
+class TestRunExportJob:
+    def test_success_uploads_and_emails_admin(self, db):
+        tenant = Tenant(name=f"ExportSvc-{uuid.uuid4().hex[:8]}", schema_name="export_svc")
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+
+        admin = _make_admin(db, tenant.id)
+        job = _make_job(db, tenant.id)
+
+        captured_paths = []
+
+        def _fake_upload(local_path, key):
+            captured_paths.append(local_path)
+            assert os.path.exists(local_path)  # must be uploaded before cleanup
+            return key
+
+        with (
+            patch("app.services.gcs_data_export_service.upload_export_zip", side_effect=_fake_upload) as mock_upload,
+            patch("app.services.gcs_recording_service.generate_signed_url", return_value="https://signed.example/export.zip") as mock_signed,
+            patch("app.services.email_service.email_service.send_data_export_ready_email") as mock_email,
+        ):
+            run_export_job(db, job)
+
+        db.refresh(job)
+        assert job.status == "ready"
+        assert job.gcs_path == f"data-exports/{tenant.id}/{job.id}.zip"
+        assert job.completed_at is not None
+
+        mock_upload.assert_called_once()
+        assert mock_upload.call_args.args[1] == job.gcs_path
+
+        mock_signed.assert_called_once_with(job.gcs_path, expiry_seconds=24 * 60 * 60)
+
+        mock_email.assert_called_once_with(admin.email, "https://signed.example/export.zip", tenant.name)
+
+        # Temp file must be removed after upload, regardless of outcome.
+        assert not os.path.exists(captured_paths[0])
+
+    def test_no_admin_user_still_marks_ready_but_skips_email(self, db):
+        tenant = Tenant(name=f"NoAdmin-{uuid.uuid4().hex[:8]}", schema_name="no_admin")
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+
+        job = _make_job(db, tenant.id)
+
+        with (
+            patch("app.services.gcs_data_export_service.upload_export_zip", return_value="key") as mock_upload,
+            patch("app.services.gcs_recording_service.generate_signed_url", return_value="https://signed.example/export.zip"),
+            patch("app.services.email_service.email_service.send_data_export_ready_email") as mock_email,
+        ):
+            run_export_job(db, job)
+
+        db.refresh(job)
+        assert job.status == "ready"
+        mock_upload.assert_called_once()
+        mock_email.assert_not_called()
+
+    def test_gcs_failure_marks_job_error_and_skips_email(self, db):
+        tenant = Tenant(name=f"FailExport-{uuid.uuid4().hex[:8]}", schema_name="fail_export")
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+
+        job = _make_job(db, tenant.id)
+
+        with (
+            patch("app.services.gcs_data_export_service.upload_export_zip", side_effect=RuntimeError("GCS down")),
+            patch("app.services.email_service.email_service.send_data_export_ready_email") as mock_email,
+        ):
+            run_export_job(db, job)
+
+        db.refresh(job)
+        assert job.status == "error"
+        assert "GCS down" in job.error_message
+        mock_email.assert_not_called()
+
+
+class TestRunDataExportJobTask:
+    def test_loads_job_and_delegates(self):
+        from app.workers.batch_call_worker import run_data_export_job
+
+        job_id = uuid.uuid4()
+        fake_job = MagicMock(id=job_id)
+        db = MagicMock()
+        db.get.return_value = fake_job
+
+        with (
+            patch("app.db.session.SessionLocal") as mock_sl,
+            patch("app.services.data_export_service.run_export_job") as mock_run,
+        ):
+            mock_sl.return_value = db
+            import asyncio
+
+            asyncio.run(run_data_export_job({}, str(job_id)))
+
+        mock_run.assert_called_once_with(db, fake_job)
+        db.close.assert_called_once()
+
+    def test_missing_job_is_a_noop(self):
+        from app.workers.batch_call_worker import run_data_export_job
+
+        db = MagicMock()
+        db.get.return_value = None
+
+        with (
+            patch("app.db.session.SessionLocal") as mock_sl,
+            patch("app.services.data_export_service.run_export_job") as mock_run,
+        ):
+            mock_sl.return_value = db
+            import asyncio
+
+            asyncio.run(run_data_export_job({}, str(uuid.uuid4())))
+
+        mock_run.assert_not_called()
+        db.close.assert_called_once()

--- a/tests/services/test_data_export_zip_builder.py
+++ b/tests/services/test_data_export_zip_builder.py
@@ -1,0 +1,154 @@
+"""
+Unit test for the GDPR export ZIP builder (app/services/data_export_zip_builder.py).
+
+Runs against the shared SQLite test DB (no Postgres required) — exercises the
+real streaming SELECT + ZipFile.open(..., "w") write path end to end and
+verifies every member ends up in the archive with the expected content.
+"""
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import uuid
+import zipfile
+from datetime import datetime, timezone
+
+from app.models.agent import Agent
+from app.models.audit_log import AuditLog
+from app.models.batch_call_record import BatchCallRecord
+from app.models.batch_job import BatchJob
+from app.models.call_session import CallSession
+from app.models.knowledge_base_chunk import KbChunk
+from app.models.knowledge_base_document import KnowledgeBase
+from app.models.tenant import Tenant
+from app.models.transcript_message import TranscriptMessage
+from app.models.user import User
+from app.services.data_export_zip_builder import build_export_zip
+
+
+def test_build_export_zip_contains_all_expected_members(db):
+    tenant = Tenant(name=f"ExportCo-{uuid.uuid4().hex[:8]}", schema_name="export_co")
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    user = User(
+        email=f"export-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        first_name="Export",
+        last_name="Tester",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    agent = Agent(tenant_id=tenant.id, name="Export Agent")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+
+    call = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=tenant.id,
+        start_time=datetime.now(timezone.utc),
+        status="completed",
+        from_number="+15550001111",
+        to_number="+15550002222",
+    )
+    db.add(call)
+    db.commit()
+    db.refresh(call)
+
+    transcript = TranscriptMessage(
+        call_session_id=call.id,
+        role="agent",
+        message="Hello, how can I help?",
+        sequence_number=1,
+    )
+    db.add(transcript)
+
+    kb = KnowledgeBase(workspace_id=tenant.id, name="Export KB")
+    db.add(kb)
+    db.commit()
+    db.refresh(kb)
+
+    chunk = KbChunk(kb_id=kb.id, content="Some chunk content", chunk_metadata={"source": "test"})
+    db.add(chunk)
+
+    batch_job = BatchJob(workspace_id=tenant.id, agent_id=agent.id, status="completed")
+    db.add(batch_job)
+    db.commit()
+    db.refresh(batch_job)
+
+    batch_record = BatchCallRecord(batch_job_id=batch_job.id, phone_number="+15550003333", status="completed")
+    db.add(batch_record)
+
+    audit_row = AuditLog(
+        tenant_id=tenant.id,
+        user_id=user.id,
+        action="agent.created",
+        resource_type="agent",
+        resource_id=agent.id,
+    )
+    db.add(audit_row)
+    db.commit()
+
+    zip_path = build_export_zip(db, tenant.id)
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            names = set(zf.namelist())
+            assert names == {
+                "workspace.json", "calls.csv", "transcripts.json",
+                "kb_chunks.json", "audit_events.csv", "batch_job_records.csv",
+            }
+
+            workspace_meta = json.loads(zf.read("workspace.json"))
+            assert workspace_meta["id"] == str(tenant.id)
+            assert workspace_meta["name"] == tenant.name
+
+            calls_rows = list(csv.reader(io.StringIO(zf.read("calls.csv").decode("utf-8"))))
+            assert calls_rows[0][0] == "id"
+            assert len(calls_rows) == 2  # header + 1 call
+            assert str(call.id) in calls_rows[1]
+            assert "+15550001111" in calls_rows[1]
+
+            transcripts = json.loads(zf.read("transcripts.json"))
+            assert len(transcripts) == 1
+            assert transcripts[0]["message"] == "Hello, how can I help?"
+
+            kb_chunks = json.loads(zf.read("kb_chunks.json"))
+            assert len(kb_chunks) == 1
+            assert kb_chunks[0]["content"] == "Some chunk content"
+
+            audit_rows = list(csv.reader(io.StringIO(zf.read("audit_events.csv").decode("utf-8"))))
+            assert audit_rows[0][0] == "id"
+            assert len(audit_rows) == 2
+            assert "agent.created" in audit_rows[1]
+
+            batch_rows = list(csv.reader(io.StringIO(zf.read("batch_job_records.csv").decode("utf-8"))))
+            assert batch_rows[0][0] == "id"
+            assert len(batch_rows) == 2
+            assert "+15550003333" in batch_rows[1]
+    finally:
+        os.remove(zip_path)
+
+
+def test_build_export_zip_empty_workspace_produces_empty_collections(db):
+    tenant = Tenant(name=f"EmptyCo-{uuid.uuid4().hex[:8]}", schema_name="empty_co")
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    zip_path = build_export_zip(db, tenant.id)
+    try:
+        with zipfile.ZipFile(zip_path) as zf:
+            assert json.loads(zf.read("transcripts.json")) == []
+            assert json.loads(zf.read("kb_chunks.json")) == []
+
+            calls_rows = list(csv.reader(io.StringIO(zf.read("calls.csv").decode("utf-8"))))
+            assert len(calls_rows) == 1  # header only
+    finally:
+        os.remove(zip_path)


### PR DESCRIPTION
## Summary
- Adds `POST/GET /api/v2/workspace/data-export` — async ARQ-backed export of all workspace data (metadata, calls, transcripts, KB chunks, audit events, batch records) streamed into a ZIP, uploaded to GCS, with a 24h signed URL emailed to the workspace admin.
- Adds `DELETE /api/v2/workspace/account` — exact-phrase-gated (`DELETE MY ACCOUNT`, case-sensitive), irreversible PII wipe + GCS recording/KB-embedding deletion + audit-actor anonymization + workspace soft-delete, via a single raw-SQL transaction.
- Fixes three Postgres schema issues discovered while implementing the literal ticket spec against real Postgres (not just SQLite unit tests) — see "Schema changes" below.

## Schema changes (already applied to the shared dev DB)
1. **`auditlog` append-only enforcement**: replaced the unconditional `no_update_audit` RULE (added in #103) with a `BEFORE UPDATE` trigger gated on a new `app.bypass_audit_update` GUC. When set, the trigger ignores whatever the UPDATE statement requests and force-applies only `user_id=NULL, actor_api_key_prefix='[DELETED]'` — every other column reverts to OLD. This lets erasure anonymize actor fields while keeping the table append-only for every other write path, with the bypass's blast radius capped to exactly that one transformation.
2. **`user.email` uniqueness**: was a global `UNIQUE` constraint. Erasure anonymizes every deleted user's email to the same literal placeholder, so a second deletion anywhere would have violated it. Replaced with a partial unique index (`WHERE deleted_at IS NULL`), mirroring the existing `uq_tenant_name_active` pattern.
3. **`auditlog.actor_api_key_prefix`** was `VARCHAR(8)` (sized for real 8-char API key prefixes) — one character short of the 9-char `'[DELETED]'` placeholder. Widened to `VARCHAR(16)`.

Migrations: `20260618_audit_update_bypass`, `20260618_data_export_job`, `20260618_user_email_partial_unique`, `20260618_audit_actor_prefix_widen`. Already run against dev (Neon) and verified column-by-column (types, indexes, triggers) post-upgrade.

## Design notes
- A `User` can belong to multiple workspaces. Only users whose *sole* membership is the workspace being erased get their identity wiped; users shared with other active workspaces just lose membership in this one workspace — their identity elsewhere is untouched.
- Both endpoints require the existing `require_admin` dependency, matching the established convention for other workspace-level mutations (HIPAA kms-key/status).
- ZIP is built via streaming writes (`ZipFile.open(..., "w")`, DB rows fetched with `yield_per`) so the export is never fully buffered in memory.

## Test plan
- [x] Unit tests (SQLite, mocked GCS/email/ARQ): 24 tests across endpoint contracts (`tests/api/v2/test_data_export.py`, `tests/api/v2/test_account_deletion.py`), the zip builder's real DB→ZIP content (`tests/services/test_data_export_zip_builder.py`), and the full export orchestration + ARQ task wrapper (`tests/services/test_data_export_service.py`)
- [x] Integration tests against real Postgres (`tests/integration/test_gdpr_account_deletion_postgres.py`, gated by `TEST_DATABASE_URL`): trigger blocks default updates, bypass GUC anonymizes only the intended columns regardless of what's requested, full PII wipe verified end-to-end (multi-tenant user carve-out, phone/call redaction, KB chunk deletion, audit retention + anonymization, workspace soft-delete), wrong-phrase 400 over a real JWT session
- [x] Confirmed via diff against `dev` that pre-existing unrelated test failures (~190 in the full suite, plus a pre-existing Postgres-test-harness JWT/Redis flakiness) are unaffected by this change
- [x] Migrations applied to dev DB and schema verified directly (column types, indexes, triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
