### PR TITLE
feat(sdk): Web SDK public call-token endpoint with domain whitelisting

### DIFF
--- a/alembic/versions/20260618_public_call_token.py
+++ b/alembic/versions/20260618_public_call_token.py
@@ -1,0 +1,45 @@
+"""public_access + alloweddomain
+
+Backs the Web SDK public-call-token endpoints:
+  callflow.public_access  BOOL DEFAULT FALSE NOT NULL
+  alloweddomain table     — per-workspace Origin whitelist (table name follows
+                            the base-class convention: lowercased class name,
+                            not the ticket's literal "allowed_domains")
+
+Revision ID: 20260618_public_call_token
+Revises: 20260618_audit_actor_prefix_widen
+Create Date: 2026-06-18
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "20260618_public_call_token"
+down_revision: Union[str, Sequence[str], None] = "20260618_audit_actor_prefix_widen"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "callflow",
+        sa.Column("public_access", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+    op.create_table(
+        "alloweddomain",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("workspace_id", UUID(as_uuid=True), sa.ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("domain", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_alloweddomain_workspace_id", "alloweddomain", ["workspace_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_alloweddomain_workspace_id", table_name="alloweddomain")
+    op.drop_table("alloweddomain")
+    op.drop_column("callflow", "public_access")

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from app.api.api_v1.endpoints import (
     accept_invite,
+    allowed_domains,
     api_keys,
     billing,
     gemini,
@@ -33,6 +34,7 @@ from app.routers.recruitment_dashboard import router as recruitment_dashboard_ro
 from app.routers.resumes import router as resume_router
 from app.routers.resume_interviews import router as resume_interviews_router
 from app.routers.scheduled_calls import router as scheduled_calls_router
+from app.routers.sdk import router as sdk_router
 from app.routers.tts_audio import router as tts_audio_router
 from app.routers.tts import router as tts_router
 from app.routers.voice import router as voice_router
@@ -53,9 +55,10 @@ api_router = APIRouter()
 api_router.include_router(user.router, prefix="/users", tags=["users"])
 api_router.include_router(api_keys.router, prefix="/api-keys", tags=["API Keys"])
 api_router.include_router(tenant.router, prefix="/tenants", tags=["tenants"])
-# Invite sub-routes must be registered BEFORE workspace.router so that
-# /workspace/invite and /workspace/invitations take priority over /workspace/{workspace_id}.
+# Invite/allowed-domains sub-routes must be registered BEFORE workspace.router so
+# that their literal paths take priority over /workspace/{workspace_id}.
 api_router.include_router(workspace_invites.router, prefix="/workspace", tags=["Workspace Invitations"])
+api_router.include_router(allowed_domains.router, prefix="/workspace", tags=["Workspace — Allowed Domains"])
 api_router.include_router(workspace.router, prefix="/workspace", tags=["Workspace"])
 api_router.include_router(role.router, prefix="/roles", tags=["roles"])
 api_router.include_router(agent_router, prefix="/agent", tags=["Voice Agent"])
@@ -108,6 +111,7 @@ api_router.include_router(
     include_in_schema=False,
 )
 api_router.include_router(scheduled_calls_router, prefix="/schedule", tags=["Scheduled Calls"])
+api_router.include_router(sdk_router, prefix="/sdk", tags=["Web SDK — Public"])
 api_router.include_router(crm_config_router, prefix="/crm-config", tags=["CRM Configuration"])
 api_router.include_router(
     clickup_oauth_router,

--- a/app/api/api_v1/endpoints/allowed_domains.py
+++ b/app/api/api_v1/endpoints/allowed_domains.py
@@ -1,0 +1,72 @@
+"""Web SDK domain whitelist management — /api/v1/workspace/allowed-domains.
+
+Registered under the ``/workspace`` prefix in app/api/api_v1/api.py, and
+must be included BEFORE ``workspace.router`` so this literal path takes
+priority over that router's ``/{workspace_id}`` catch-all — same reasoning
+as workspace_invites.router.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Union
+
+from fastapi import APIRouter, Depends, Response, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant
+from app.core.request_auth import ApiKeyPrincipal
+from app.models.user import User
+from app.schemas.allowed_domain import AllowedDomainCreate, AllowedDomainOut
+from app.schemas.base import SuccessResponse
+from app.services.allowed_domain_service import allowed_domain_service
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+
+def _workspace_id(principal: Union[User, ApiKeyPrincipal]) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+@router.post(
+    "/allowed-domains",
+    response_model=AllowedDomainOut,
+    response_model_by_alias=True,
+    status_code=status.HTTP_201_CREATED,
+    summary="Whitelist a domain for the Web SDK",
+)
+def create_allowed_domain(
+    body: AllowedDomainCreate,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    return allowed_domain_service.create_domain(db, _workspace_id(principal), body)
+
+
+@router.get(
+    "/allowed-domains",
+    response_model=SuccessResponse[list[AllowedDomainOut]],
+    response_model_by_alias=True,
+    summary="List domains whitelisted for the Web SDK",
+)
+def list_allowed_domains(
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    domains = allowed_domain_service.list_domains(db, _workspace_id(principal))
+    return create_success_response(domains, "Allowed domains retrieved successfully")
+
+
+@router.delete(
+    "/allowed-domains/{domain_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    summary="Remove a whitelisted domain",
+)
+def delete_allowed_domain(
+    domain_id: uuid.UUID,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    allowed_domain_service.delete_domain(db, _workspace_id(principal), domain_id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -4,7 +4,13 @@ v2 GDPR data subject rights router.
 Endpoints (admin role required for all):
   POST   /api/v2/workspace/data-export             — trigger async export, returns 202 {job_id}
   GET    /api/v2/workspace/data-export/{job_id}     — export job status + signed download URL
-  DELETE /api/v2/workspace/account                  — irreversible hard delete + PII wipe
+  POST   /api/v2/workspace/account/delete           — irreversible hard delete + PII wipe
+
+Account deletion is a POST action endpoint rather than DELETE-with-body:
+proxies/load balancers (nginx, AWS ALB) are not guaranteed to forward a
+request body on DELETE, which would silently turn the confirmation-phrase
+check into a 400 (body missing) or, with a looser body-parsing path, a
+bypass. POST has no such ambiguity.
 """
 from __future__ import annotations
 
@@ -142,11 +148,11 @@ def get_data_export_status(
     return DataExportStatusOut(status=job.status, download_url=download_url)
 
 
-# ── DELETE /workspace/account ─────────────────────────────────────────────────
+# ── POST /workspace/account/delete ────────────────────────────────────────────
 
 
-@router.delete(
-    "/account",
+@router.post(
+    "/account/delete",
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
 )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -248,6 +248,10 @@ class Settings(BaseSettings):
     API_RATE_LIMIT: int = 60   # requests per window per identity
     API_RATE_WINDOW: int = 60  # seconds
 
+    # Public Web SDK token endpoint — per-IP, no auth required (BE1 ticket)
+    PUBLIC_TOKEN_RATE_LIMIT: int = 20
+    PUBLIC_TOKEN_RATE_WINDOW: int = 60  # seconds
+
     # Google OAuth
     GOOGLE_CLIENT_ID: str = ""
     GOOGLE_CLIENT_SECRET: str = ""

--- a/app/core/origin.py
+++ b/app/core/origin.py
@@ -1,0 +1,24 @@
+"""Origin / domain normalization shared by allowed-domains CRUD and the
+public SDK token endpoint — both must agree on the same canonical form so
+a stored domain matches a browser's ``Origin`` header.
+
+Rules: lowercase, drop any path (Origin headers never have one anyway),
+drop the port when it's the default HTTPS port 443.
+"""
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+
+def normalize_origin(value: str) -> str:
+    parsed = urlsplit(value.strip())
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    port = parsed.port
+    netloc = host if not port or port == 443 else f"{host}:{port}"
+    return f"{scheme}://{netloc}"
+
+
+def is_localhost_origin(value: str) -> bool:
+    parsed = urlsplit(value.strip())
+    return (parsed.hostname or "").lower() == "localhost"

--- a/app/core/origin.py
+++ b/app/core/origin.py
@@ -19,6 +19,9 @@ def normalize_origin(value: str) -> str:
     return f"{scheme}://{netloc}"
 
 
+_LOCALHOST_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
 def is_localhost_origin(value: str) -> bool:
     parsed = urlsplit(value.strip())
-    return (parsed.hostname or "").lower() == "localhost"
+    return (parsed.hostname or "").lower() in _LOCALHOST_HOSTS

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -75,3 +75,6 @@ from app.models.audit_log import AuditLog  # noqa: F401
 
 # GDPR data export
 from app.models.data_export_job import DataExportJob  # noqa: F401
+
+# Web SDK — public call-token domain whitelist
+from app.models.allowed_domain import AllowedDomain  # noqa: F401

--- a/app/main.py
+++ b/app/main.py
@@ -35,6 +35,7 @@ def create_app() -> FastAPI:
     from app.middleware.api_key_middleware import ApiKeyMiddleware
     from app.middleware.body_limit_middleware import BodyLimitMiddleware
     from app.middleware.pii_logging_middleware import PiiLoggingMiddleware
+    from app.middleware.public_sdk_cors_middleware import PublicSdkCorsMiddleware
     from app.middleware.rate_limit_middleware import RateLimitMiddleware
     from app.middleware.request_id_middleware import RequestIdMiddleware
 
@@ -188,7 +189,11 @@ def create_app() -> FastAPI:
     # Middleware stack (add_middleware is LIFO — LAST added = OUTERMOST on request)
     #
     # Incoming (outer → inner):
-    #   CORS → RequestId → BodyLimit → PiiLogging → ApiKey → RateLimit → handler
+    #   PublicSdkCors → CORS → RequestId → BodyLimit → PiiLogging → ApiKey → RateLimit → handler
+    #
+    # PublicSdkCors only acts on /api/v1/sdk/public-call-token (reflects Origin
+    # dynamically for the allowed_domains whitelist); every other path passes
+    # through it untouched and is governed by the static CORS config below.
     # -------------------------------------------------------------------------
     _allowed_origins = [o.strip() for o in settings.ALLOWED_ORIGINS.split(",") if o.strip()]
 
@@ -204,6 +209,7 @@ def create_app() -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+    _app.add_middleware(PublicSdkCorsMiddleware)
 
     # -------------------------------------------------------------------------
     # Routes

--- a/app/middleware/api_key_middleware.py
+++ b/app/middleware/api_key_middleware.py
@@ -61,6 +61,9 @@ _SKIP_PREFIXES = (
     "/api/v1/billing/webhook",
     "/api/v1/voice/",
     "/api/v1/stream/",
+    # Public Web SDK endpoints — security enforced via flow.public_access +
+    # allowed_domains Origin check inside the handler, not API credentials.
+    "/api/v1/sdk/",
     "/health",
     # v2 public endpoints — no auth required
     "/api/v2/health",

--- a/app/middleware/public_sdk_cors_middleware.py
+++ b/app/middleware/public_sdk_cors_middleware.py
@@ -1,0 +1,60 @@
+"""Dynamic CORS for the public Web SDK endpoint.
+
+The global ``CORSMiddleware`` only allows origins listed in the static
+``ALLOWED_ORIGINS`` env var. But /api/v1/sdk/public-call-token must be
+embeddable from whatever domain a tenant adds to their ``allowed_domains``
+table — a value that only exists at the application/DB layer, not at
+CORS-middleware startup time. Without this, Starlette's CORSMiddleware
+rejects the browser's preflight OPTIONS for any origin outside the static
+list before the request ever reaches our handler, so a whitelisted tenant
+domain could never actually call the endpoint from a browser.
+
+This middleware reflects the request's Origin for that one path only — it
+grants no security by itself. The real authorization boundary is the
+allowed_domains check inside app/routers/sdk.py (403 domain_not_allowed).
+Must be registered OUTERMOST (added after CORSMiddleware in main.py) so it
+intercepts preflight before the static-origin CORSMiddleware can 400 it.
+"""
+from __future__ import annotations
+
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+_PUBLIC_SDK_PATHS = frozenset({"/api/v1/sdk/public-call-token"})
+
+
+class PublicSdkCorsMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("path") not in _PUBLIC_SDK_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        origin = headers.get(b"origin")
+
+        if scope.get("method") == "OPTIONS":
+            response_headers = [(b"access-control-allow-methods", b"POST, OPTIONS")]
+            if origin:
+                response_headers.append((b"access-control-allow-origin", origin))
+            requested_headers = headers.get(b"access-control-request-headers")
+            if requested_headers:
+                response_headers.append((b"access-control-allow-headers", requested_headers))
+            await send({"type": "http.response.start", "status": 200, "headers": response_headers})
+            await send({"type": "http.response.body", "body": b""})
+            return
+
+        async def _send(message):
+            if message["type"] == "http.response.start" and origin:
+                headers_list = [
+                    (k, v)
+                    for k, v in message.get("headers", [])
+                    if k.lower() != b"access-control-allow-origin"
+                ]
+                headers_list.append((b"access-control-allow-origin", origin))
+                headers_list.append((b"vary", b"Origin"))
+                message = {**message, "headers": headers_list}
+            await send(message)
+
+        await self.app(scope, receive, _send)

--- a/app/middleware/rate_limit_middleware.py
+++ b/app/middleware/rate_limit_middleware.py
@@ -63,6 +63,12 @@ _LOGIN_POST_PATHS: frozenset[str] = frozenset({
     "/api/v1/users/login/google",
 })
 
+# Public, unauthenticated Web SDK token endpoint — strict per-IP cap (20/min)
+# since there's no API key/JWT identity to bucket on otherwise.
+_PUBLIC_TOKEN_POST_PATHS: frozenset[str] = frozenset({
+    "/api/v1/sdk/public-call-token",
+})
+
 
 def _should_skip(path: str) -> bool:
     if path in _SKIP_EXACT:
@@ -80,6 +86,13 @@ def _is_auth_sensitive_post(scope: Scope) -> bool:
         return False
     path = scope.get("path", "")
     return path in _AUTH_SENSITIVE_POST_PATHS
+
+
+def _is_public_token_post(scope: Scope) -> bool:
+    if scope.get("method") != "POST":
+        return False
+    path = scope.get("path", "")
+    return path in _PUBLIC_TOKEN_POST_PATHS
 
 
 def _sha256(raw: str) -> str:
@@ -211,6 +224,16 @@ class RateLimitMiddleware:
             auth_key = f"auth:{path}:{_client_host(scope)}"
             allowed, retry_after = await _check_rate_limit(
                 auth_key, settings.LOGIN_RATE_LIMIT, settings.LOGIN_RATE_WINDOW
+            )
+            if not allowed:
+                await self._send_rate_limited(scope, receive, send, retry_after)
+                return
+
+        # Public Web SDK token endpoint — no auth, so this is the only per-IP cap.
+        if _is_public_token_post(scope):
+            token_key = f"public_token:{path}:{_client_host(scope)}"
+            allowed, retry_after = await _check_rate_limit(
+                token_key, settings.PUBLIC_TOKEN_RATE_LIMIT, settings.PUBLIC_TOKEN_RATE_WINDOW
             )
             if not allowed:
                 await self._send_rate_limited(scope, receive, send, retry_after)

--- a/app/models/allowed_domain.py
+++ b/app/models/allowed_domain.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base_class import Base
+
+
+class AllowedDomain(Base):
+    """A domain whitelisted to embed the Web SDK for a workspace.
+
+    Stored in normalized origin form (lowercase, no trailing slash, no :443)
+    so it can be compared directly against a normalized Origin header —
+    see app/core/origin.py.
+    """
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False)
+    domain = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    workspace = relationship("Tenant")
+
+    __table_args__ = (
+        Index("ix_alloweddomain_workspace_id", "workspace_id"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<AllowedDomain id={self.id} workspace={self.workspace_id} domain={self.domain}>"

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -25,6 +25,7 @@ class CallFlow(Base):
     settings = Column(JSONB, nullable=True)
     knowledge_base_ids = Column(JSONB, nullable=True, default=list)
     hipaa_compliance = Column(Boolean, default=False, nullable=False, server_default="false")
+    public_access = Column(Boolean, default=False, nullable=False, server_default="false")
     is_deleted = Column(Boolean, default=False, nullable=False, server_default="false")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=True)

--- a/app/routers/call_flows.py
+++ b/app/routers/call_flows.py
@@ -13,7 +13,7 @@ from app.core.request_auth import ApiKeyPrincipal
 from app.models.call_flow import CallFlow
 from app.models.knowledge_base_document import KnowledgeBase
 from app.models.user import User
-from app.schemas.call_flow import CallFlowCreate, CallFlowUpdate
+from app.schemas.call_flow import CallFlowCreate, CallFlowSettingsUpdate, CallFlowUpdate
 from app.schemas.knowledge_base import FlowKbUpdate
 from app.services.audit_service import log_audit_event
 from app.services.call_flow_service import call_flow_service
@@ -118,6 +118,32 @@ def update_call_flow(
         resource_id=flow_id,
         old_value=old_flow if isinstance(old_flow, dict) else None,
         new_value=body.model_dump(exclude_none=True),
+        actor_user_id=principal.id if isinstance(principal, User) else None,
+    )
+    return result
+
+
+@router.put("/{flow_id}/settings")
+def update_call_flow_settings(
+    flow_id: uuid.UUID,
+    body: CallFlowSettingsUpdate,
+    request: Request,
+    principal: User = Depends(require_admin_or_owner),
+    db: Session = Depends(get_db),
+):
+    """Toggle Web SDK public access for a flow. Requires admin or owner role."""
+    tid = _workspace_id(principal)
+    old_flow = call_flow_service.get_flow(db, flow_id, tid)
+    result = call_flow_service.update_settings(db, flow_id, tid, body)
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tid,
+        action="call_flow.settings_updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        old_value={"public_access": old_flow.get("publicAccess")} if isinstance(old_flow, dict) else None,
+        new_value={"public_access": body.public_access},
         actor_user_id=principal.id if isinstance(principal, User) else None,
     )
     return result

--- a/app/routers/sdk.py
+++ b/app/routers/sdk.py
@@ -1,0 +1,143 @@
+"""Public (unauthenticated) Web SDK endpoints.
+
+POST /api/v1/sdk/public-call-token is the only route in the app that takes
+no API key and no JWT — see _SKIP_PREFIXES in app/middleware/api_key_middleware.py.
+Security is enforced inside the handler instead of via credentials:
+  1. The target call flow must have public_access=True.
+  2. The request's Origin header must match an allowed_domains entry for
+     the workspace that owns the flow (or be localhost in development).
+IP-based rate limiting (20/min) is enforced by RateLimitMiddleware before
+the request reaches this handler — see _PUBLIC_TOKEN_POST_PATHS there.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db
+from app.core.config import settings
+from app.core.error_responses import build_api_error_payload
+from app.core.logger import logger
+from app.core.origin import is_localhost_origin, normalize_origin
+from app.models.allowed_domain import AllowedDomain
+from app.models.call_flow import CallFlow
+
+router = APIRouter()
+
+
+class PublicCallTokenRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    flow_id: uuid.UUID
+    agent_id: uuid.UUID
+
+
+def _request_id(request: Request) -> str:
+    return getattr(request.state, "request_id", "")
+
+
+def _client_ip(request: Request) -> str:
+    """Client IP, preferring X-Forwarded-For (load-balanced deployments)."""
+    forwarded_for = request.headers.get("x-forwarded-for", "").strip()
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    client = request.client
+    return client.host if client else "unknown"
+
+
+def _error(request: Request, code: int, message: str, error_code: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=code,
+        content=build_api_error_payload(
+            code, message, error_code=error_code, request_id=_request_id(request)
+        ),
+    )
+
+
+def _origin_allowed(db: Session, origin: Optional[str], workspace_id: uuid.UUID) -> bool:
+    if not origin:
+        return False
+    if settings.ENVIRONMENT.lower() == "development" and is_localhost_origin(origin):
+        return True
+    normalized = normalize_origin(origin)
+    existing = db.execute(
+        select(AllowedDomain.id).where(
+            AllowedDomain.workspace_id == workspace_id,
+            AllowedDomain.domain == normalized,
+        )
+    ).first()
+    return existing is not None
+
+
+@router.post("/public-call-token")
+def public_call_token(
+    body: PublicCallTokenRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    origin = request.headers.get("origin")
+    ip = _client_ip(request)
+
+    flow = db.execute(
+        select(CallFlow).where(
+            CallFlow.id == body.flow_id,
+            CallFlow.agent_id == body.agent_id,
+            CallFlow.is_deleted == False,  # noqa: E712
+        )
+    ).scalar_one_or_none()
+
+    if flow is None:
+        logger.info(
+            "Public token request: flow not found flow_id=%s agent_id=%s ip=%s origin=%s",
+            body.flow_id, body.agent_id, ip, origin,
+        )
+        return _error(request, 404, "Call flow not found", "flow_not_found")
+
+    if not flow.public_access:
+        logger.info(
+            "Public token request denied (public_access disabled) flow_id=%s ip=%s origin=%s",
+            flow.id, ip, origin,
+        )
+        return _error(
+            request,
+            403,
+            "Enable public access on this flow first.",
+            "public_access_disabled",
+        )
+
+    if not _origin_allowed(db, origin, flow.tenant_id):
+        logger.info(
+            "Public token request denied (origin not allowed) flow_id=%s ip=%s origin=%s",
+            flow.id, ip, origin,
+        )
+        return _error(
+            request,
+            403,
+            "This domain is not whitelisted for the workspace.",
+            "domain_not_allowed",
+        )
+
+    from app.services.livekit_service import livekit_service
+
+    room_name = f"room_{uuid.uuid4()}"
+    token = livekit_service.generate_caller_token(room_name)
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=settings.LIVEKIT_TOKEN_TTL)
+
+    logger.info(
+        "Public token issued flow_id=%s ip=%s origin=%s room=%s",
+        flow.id, ip, origin, room_name,
+    )
+
+    return {
+        "livekit_token": token,
+        "room_name": room_name,
+        "flow_id": str(flow.id),
+        "expires_at": expires_at.isoformat(),
+    }

--- a/app/schemas/allowed_domain.py
+++ b/app/schemas/allowed_domain.py
@@ -1,0 +1,34 @@
+"""Allowed-domain (Web SDK whitelist) request/response schemas — Pydantic v2."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class AllowedDomainCreate(BaseModel):
+    """Request body for ``POST /api/v1/workspace/allowed-domains``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    domain: str = Field(..., min_length=1, max_length=255, examples=["https://app.example.com"])
+
+    @field_validator("domain")
+    @classmethod
+    def _validate_https_url(cls, v: str) -> str:
+        parsed = urlsplit(v.strip())
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise ValueError(
+                "domain must be a valid HTTPS URL, e.g. https://app.example.com"
+            )
+        return v
+
+
+class AllowedDomainOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    domain: str
+    created_at: datetime = Field(serialization_alias="createdAt")

--- a/app/schemas/allowed_domain.py
+++ b/app/schemas/allowed_domain.py
@@ -23,7 +23,10 @@ class AllowedDomainCreate(BaseModel):
             raise ValueError(
                 "domain must be a valid HTTPS URL, e.g. https://app.example.com"
             )
-        return v
+
+        from app.core.origin import normalize_origin
+
+        return normalize_origin(v)
 
 
 class AllowedDomainOut(BaseModel):

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -78,6 +78,14 @@ class CallFlowUpdate(BaseModel):
         return self
 
 
+class CallFlowSettingsUpdate(BaseModel):
+    """Request body for ``PUT /api/v1/call-flows/{id}/settings``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    public_access: bool = Field(..., alias="public_access")
+
+
 class CallFlowOut(BaseModel):
     """Full flow response including all prompt versions."""
 
@@ -95,6 +103,7 @@ class CallFlowOut(BaseModel):
     prompt_versions: List[PromptVersionOut] = Field(default_factory=list, serialization_alias="promptVersions")
     flow_data: Optional[Dict[str, Any]] = Field(None, serialization_alias="flowData")
     settings: Optional[Dict[str, Any]] = None
+    public_access: bool = Field(False, serialization_alias="publicAccess")
     created_at: datetime = Field(..., serialization_alias="createdAt")
     updated_at: Optional[datetime] = Field(None, serialization_alias="updatedAt")
 
@@ -114,6 +123,7 @@ class CallFlowListItem(BaseModel):
     current_prompt_id: Optional[uuid.UUID] = Field(None, serialization_alias="currentPromptId")
     flow_data: Optional[Dict[str, Any]] = Field(None, serialization_alias="flowData")
     settings: Optional[Dict[str, Any]] = None
+    public_access: bool = Field(False, serialization_alias="publicAccess")
     created_at: datetime = Field(..., serialization_alias="createdAt")
     updated_at: Optional[datetime] = Field(None, serialization_alias="updatedAt")
 

--- a/app/services/account_deletion_service.py
+++ b/app/services/account_deletion_service.py
@@ -4,6 +4,13 @@ GDPR right-to-erasure: irreversible workspace account deletion.
 Per ticket technical notes, the PII wipe runs as a single transaction of raw
 SQL UPDATE/DELETE statements (no ORM) for clarity and auditability — the SQL
 below is the literal, reviewable list of every column this operation touches.
+
+Vector embeddings: RAG embeddings live exclusively in Postgres via pgvector
+(KbChunk.embedding, see app/models/knowledge_base_chunk.py) — there is no
+Pinecone or other external vector store in this codebase (rag_service.py
+replaced the old Pinecone backend). The `DELETE FROM kbchunk` below removes
+the embedding column along with the rest of the row, so no separate
+vector-store erasure step is needed for GDPR compliance.
 """
 from __future__ import annotations
 

--- a/app/services/allowed_domain_service.py
+++ b/app/services/allowed_domain_service.py
@@ -1,0 +1,69 @@
+"""Allowed-domain (Web SDK whitelist) service."""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.core.origin import normalize_origin
+from app.models.allowed_domain import AllowedDomain
+from app.schemas.allowed_domain import AllowedDomainCreate, AllowedDomainOut
+
+MAX_DOMAINS_PER_WORKSPACE = 20
+
+
+class AllowedDomainService:
+    def list_domains(self, db: Session, workspace_id: uuid.UUID) -> list[AllowedDomainOut]:
+        rows = (
+            db.execute(
+                select(AllowedDomain)
+                .where(AllowedDomain.workspace_id == workspace_id)
+                .order_by(AllowedDomain.created_at.desc())
+            )
+            .scalars()
+            .all()
+        )
+        return [AllowedDomainOut.model_validate(r) for r in rows]
+
+    def create_domain(
+        self, db: Session, workspace_id: uuid.UUID, body: AllowedDomainCreate
+    ) -> AllowedDomainOut:
+        count = db.execute(
+            select(func.count())
+            .select_from(AllowedDomain)
+            .where(AllowedDomain.workspace_id == workspace_id)
+        ).scalar_one()
+        if count >= MAX_DOMAINS_PER_WORKSPACE:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Workspace already has the maximum of {MAX_DOMAINS_PER_WORKSPACE} allowed domains",
+            )
+
+        domain = AllowedDomain(
+            workspace_id=workspace_id,
+            domain=normalize_origin(body.domain),
+        )
+        db.add(domain)
+        db.commit()
+        db.refresh(domain)
+        return AllowedDomainOut.model_validate(domain)
+
+    def delete_domain(self, db: Session, workspace_id: uuid.UUID, domain_id: uuid.UUID) -> None:
+        domain = db.execute(
+            select(AllowedDomain).where(
+                AllowedDomain.id == domain_id,
+                AllowedDomain.workspace_id == workspace_id,
+            )
+        ).scalar_one_or_none()
+        if domain is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Allowed domain not found",
+            )
+        db.delete(domain)
+        db.commit()
+
+
+allowed_domain_service = AllowedDomainService()

--- a/app/services/allowed_domain_service.py
+++ b/app/services/allowed_domain_service.py
@@ -7,7 +7,6 @@ from fastapi import HTTPException, status
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from app.core.origin import normalize_origin
 from app.models.allowed_domain import AllowedDomain
 from app.schemas.allowed_domain import AllowedDomainCreate, AllowedDomainOut
 
@@ -43,7 +42,7 @@ class AllowedDomainService:
 
         domain = AllowedDomain(
             workspace_id=workspace_id,
-            domain=normalize_origin(body.domain),
+            domain=body.domain,
         )
         db.add(domain)
         db.commit()

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -16,7 +16,15 @@ from app.models.prompt_version import PromptVersion
 from app.repositories.call_flow_repository import CallFlowRepository
 from app.repositories.prompt_version_repository import PromptVersionRepository
 from app.schemas.agent import agent_to_out
-from app.schemas.call_flow import CallFlowCreate, CallFlowListResponse, CallFlowListItem, CallFlowOut, AgentRef, CallFlowUpdate
+from app.schemas.call_flow import (
+    CallFlowCreate,
+    CallFlowListResponse,
+    CallFlowListItem,
+    CallFlowOut,
+    AgentRef,
+    CallFlowSettingsUpdate,
+    CallFlowUpdate,
+)
 from app.schemas.prompt_version import PromptVersionOut
 from app.utils.gemini_prompt_sanitizer import sanitize_prompt_for_gemini
 
@@ -146,6 +154,7 @@ class CallFlowService:
             prompt_versions=[self._version_to_out(v) for v in versions],
             flow_data=flow.flow_data,
             settings=flow.settings,
+            public_access=flow.public_access,
             created_at=flow.created_at,
             updated_at=flow.updated_at,
         )
@@ -167,6 +176,7 @@ class CallFlowService:
             current_prompt_id=flow.current_prompt_id,
             flow_data=flow.flow_data,
             settings=flow.settings,
+            public_access=flow.public_access,
             created_at=flow.created_at,
             updated_at=flow.updated_at,
         )
@@ -297,6 +307,24 @@ class CallFlowService:
         if scalar_updates:
             flow = repo.update(flow, scalar_updates)
 
+        db.commit()
+        db.refresh(flow)
+        if flow.agent is None:
+            flow.agent = db.execute(
+                select(Agent).where(Agent.id == flow.agent_id)
+            ).scalar_one_or_none()
+        return self._flow_to_out(db, flow)
+
+    def update_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: CallFlowSettingsUpdate,
+    ) -> dict:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        repo = CallFlowRepository(db)
+        flow = repo.update(flow, {"public_access": body.public_access})
         db.commit()
         db.refresh(flow)
         if flow.agent is None:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7975,8 +7975,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-  /api/v2/workspace/account:
-    delete:
+  /api/v2/workspace/account/delete:
+    post:
       tags:
       - workspace-gdpr
       summary: Delete Account
@@ -7986,7 +7986,7 @@ paths:
         GCS recordings, anonymizes audit log actor fields, and soft-deletes the
 
         workspace. Requires an exact, case-sensitive confirmation phrase.'
-      operationId: delete_account_api_v2_workspace_account_delete
+      operationId: delete_account_api_v2_workspace_account_delete_post
       requestBody:
         content:
           application/json:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -613,6 +613,69 @@ paths:
               schema:
                 $ref: '#/components/schemas/SuccessResponse_list_InviteOut__'
       security: *id001
+  /api/v1/workspace/allowed-domains:
+    get:
+      tags:
+      - Workspace — Allowed Domains
+      summary: List domains whitelisted for the Web SDK
+      operationId: list_allowed_domains_api_v1_workspace_allowed_domains_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_list_AllowedDomainOut__'
+      security: *id001
+    post:
+      tags:
+      - Workspace — Allowed Domains
+      summary: Whitelist a domain for the Web SDK
+      operationId: create_allowed_domain_api_v1_workspace_allowed_domains_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AllowedDomainCreate'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllowedDomainOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security: *id001
+  /api/v1/workspace/allowed-domains/{domain_id}:
+    delete:
+      tags:
+      - Workspace — Allowed Domains
+      summary: Remove a whitelisted domain
+      operationId: delete_allowed_domain_api_v1_workspace_allowed_domains__domain_id__delete
+      security: *id001
+      parameters:
+      - name: domain_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Domain Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/workspace:
     post:
       tags:
@@ -1345,6 +1408,42 @@ paths:
       responses:
         '204':
           description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/call-flows/{flow_id}/settings:
+    put:
+      tags:
+      - Call Flows
+      summary: Update Call Flow Settings
+      description: Toggle Web SDK public access for a flow. Requires admin or owner
+        role.
+      operationId: update_call_flow_settings_api_v1_call_flows__flow_id__settings_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallFlowSettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -4365,6 +4464,30 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse_dict_'
       security:
       - HTTPBearer: []
+  /api/v1/sdk/public-call-token:
+    post:
+      tags:
+      - Web SDK — Public
+      summary: Public Call Token
+      operationId: public_call_token_api_v1_sdk_public_call_token_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PublicCallTokenRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/crm-config:
     get:
       tags:
@@ -8242,6 +8365,40 @@ components:
       additionalProperties: false
       type: object
       title: AgentUpdate
+    AllowedDomainCreate:
+      properties:
+        domain:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Domain
+          examples:
+          - https://app.example.com
+      additionalProperties: false
+      type: object
+      required:
+      - domain
+      title: AllowedDomainCreate
+      description: Request body for ``POST /api/v1/workspace/allowed-domains``.
+    AllowedDomainOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        domain:
+          type: string
+          title: Domain
+        createdAt:
+          type: string
+          format: date-time
+          title: Createdat
+      type: object
+      required:
+      - id
+      - domain
+      - createdAt
+      title: AllowedDomainOut
     ApiKeyCreate:
       properties:
         name:
@@ -9653,6 +9810,17 @@ components:
       - direction
       - agentId
       title: CallFlowCreate
+    CallFlowSettingsUpdate:
+      properties:
+        public_access:
+          type: boolean
+          title: Public Access
+      additionalProperties: false
+      type: object
+      required:
+      - public_access
+      title: CallFlowSettingsUpdate
+      description: Request body for ``PUT /api/v1/call-flows/{id}/settings``.
     CallFlowUpdate:
       properties:
         name:
@@ -12592,6 +12760,22 @@ components:
       type: object
       title: ProviderUpdate
       description: Schema for updating a provider
+    PublicCallTokenRequest:
+      properties:
+        flow_id:
+          type: string
+          format: uuid
+          title: Flow Id
+        agent_id:
+          type: string
+          format: uuid
+          title: Agent Id
+      additionalProperties: false
+      type: object
+      required:
+      - flow_id
+      - agent_id
+      title: PublicCallTokenRequest
     PurchasePhoneNumberRequest:
       properties:
         phone_number:
@@ -15041,6 +15225,25 @@ components:
       required:
       - data
       title: SuccessResponse[list]
+    SuccessResponse_list_AllowedDomainOut__:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/AllowedDomainOut'
+          type: array
+          title: Data
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[list[AllowedDomainOut]]
     SuccessResponse_list_ApiKeyOut__:
       properties:
         data:

--- a/tests/api/test_allowed_domains.py
+++ b/tests/api/test_allowed_domains.py
@@ -77,6 +77,15 @@ class TestCreateAllowedDomain:
         assert body["domain"] == "https://app.example.com"
         assert "id" in body and "createdAt" in body
 
+    def test_create_normalizes_path_before_storing(self, authed_client, auth_tenant):
+        resp = authed_client.post(
+            "/api/v1/workspace/allowed-domains",
+            json={"domain": "https://example.com/some-path"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["domain"] == "https://example.com"
+
     def test_rejects_non_https(self, authed_client, auth_tenant):
         resp = authed_client.post(
             "/api/v1/workspace/allowed-domains",

--- a/tests/api/test_allowed_domains.py
+++ b/tests/api/test_allowed_domains.py
@@ -1,0 +1,172 @@
+"""Integration tests for /api/v1/workspace/allowed-domains.
+
+Mirrors the auth-mocking pattern from tests/api/test_call_flows.py.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.allowed_domain import AllowedDomain
+from app.models.tenant import Tenant
+
+_API_KEY = "test-allowed-domains-key"
+
+
+def _payload_for(tenant: Tenant) -> dict:
+    return {
+        "api_key_id": str(uuid.uuid4()),
+        "tenant_id": str(tenant.id),
+        "key_is_active": True,
+        "workspace": {
+            "id": str(tenant.id),
+            "name": tenant.name,
+            "schema_name": tenant.schema_name,
+            "status": "active",
+            "credits": 0.0,
+            "stripe_customer_id": None,
+            "stripe_subscription_id": None,
+        },
+    }
+
+
+def _headers(tenant: Tenant) -> dict:
+    return {"x-api-key": _API_KEY, "x-workspace-id": str(tenant.id)}
+
+
+@pytest.fixture
+def auth_tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"DomainWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"domain_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def authed_client(client: TestClient, auth_tenant: Tenant):
+    payload = _payload_for(auth_tenant)
+
+    async def _resolve(_key_hash, _workspace_id):
+        return payload
+
+    with patch(
+        "app.middleware.api_key_middleware._resolve_api_key",
+        side_effect=_resolve,
+    ):
+        yield client
+
+
+@pytest.mark.usefixtures("db")
+class TestCreateAllowedDomain:
+    def test_create_returns_201_normalized(self, authed_client, auth_tenant):
+        resp = authed_client.post(
+            "/api/v1/workspace/allowed-domains",
+            json={"domain": "https://App.Example.com:443/"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["domain"] == "https://app.example.com"
+        assert "id" in body and "createdAt" in body
+
+    def test_rejects_non_https(self, authed_client, auth_tenant):
+        resp = authed_client.post(
+            "/api/v1/workspace/allowed-domains",
+            json={"domain": "http://example.com"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_max_20_domains_returns_422(self, authed_client, auth_tenant, db):
+        for i in range(20):
+            db.add(
+                AllowedDomain(
+                    workspace_id=auth_tenant.id,
+                    domain=f"https://site{i}.example.com",
+                )
+            )
+        db.commit()
+
+        resp = authed_client.post(
+            "/api/v1/workspace/allowed-domains",
+            json={"domain": "https://one-too-many.example.com"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.usefixtures("db")
+class TestListAllowedDomains:
+    def test_list_returns_workspace_domains_only(self, authed_client, auth_tenant, db):
+        other_tenant = Tenant(
+            name=f"OtherWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"other_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        db.add(AllowedDomain(workspace_id=auth_tenant.id, domain="https://mine.example.com"))
+        db.add(AllowedDomain(workspace_id=other_tenant.id, domain="https://theirs.example.com"))
+        db.commit()
+
+        resp = authed_client.get(
+            "/api/v1/workspace/allowed-domains",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        domains = [d["domain"] for d in resp.json()["data"]]
+        assert domains == ["https://mine.example.com"]
+
+
+@pytest.mark.usefixtures("db")
+class TestDeleteAllowedDomain:
+    def test_delete_returns_204(self, authed_client, auth_tenant, db):
+        domain = AllowedDomain(workspace_id=auth_tenant.id, domain="https://gone.example.com")
+        db.add(domain)
+        db.commit()
+        db.refresh(domain)
+
+        resp = authed_client.delete(
+            f"/api/v1/workspace/allowed-domains/{domain.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 204, resp.text
+        assert db.query(AllowedDomain).filter(AllowedDomain.id == domain.id).first() is None
+
+    def test_delete_unknown_returns_404(self, authed_client, auth_tenant):
+        resp = authed_client.delete(
+            f"/api/v1/workspace/allowed-domains/{uuid.uuid4()}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_delete_other_workspace_domain_returns_404(self, authed_client, auth_tenant, db):
+        other_tenant = Tenant(
+            name=f"OtherWS2-{uuid.uuid4().hex[:8]}",
+            schema_name=f"other_ws2_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        domain = AllowedDomain(workspace_id=other_tenant.id, domain="https://notyours.example.com")
+        db.add(domain)
+        db.commit()
+        db.refresh(domain)
+
+        resp = authed_client.delete(
+            f"/api/v1/workspace/allowed-domains/{domain.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404, resp.text

--- a/tests/api/test_call_flows.py
+++ b/tests/api/test_call_flows.py
@@ -5,6 +5,7 @@ Mirrors the auth-mocking pattern from tests/api/test_agents.py.
 from __future__ import annotations
 
 import uuid
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -17,7 +18,9 @@ from app.models.agent import Agent
 from app.models.call_flow import CallFlow
 from app.models.call_session import CallSession
 from app.models.prompt_version import PromptVersion
+from app.models.role import Role
 from app.models.tenant import Tenant
+from app.models.user import User, user_tenant_association
 
 _API_KEY = "test-callflows-key"
 
@@ -91,6 +94,51 @@ def authed_client(client: TestClient, auth_tenant: Tenant):
         side_effect=_resolve,
     ):
         yield client
+
+
+def _make_jwt_user(db, tenant_id: uuid.UUID, role_name: str) -> User:
+    role = db.query(Role).filter(Role.name == role_name).first()
+    if role is None:
+        role = Role(name=role_name, description=role_name)
+        db.add(role)
+        db.commit()
+        db.refresh(role)
+
+    user = User(
+        email=f"{role_name}-{uuid.uuid4().hex[:8]}@example.com",
+        first_name=role_name.title(),
+        last_name="User",
+        hashed_password="",
+        current_tenant_id=tenant_id,
+    )
+    db.add(user)
+    db.flush()
+    db.execute(
+        user_tenant_association.insert().values(
+            user_id=user.id, tenant_id=tenant_id, role_id=role.id, is_creator=False
+        )
+    )
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@contextmanager
+def _jwt_auth_ctx(workspace: Workspace, user_id: uuid.UUID):
+    """Patch the JWT auth branch to attach the given workspace/user — bypasses
+    real token verification while still exercising the real DB-backed role
+    check inside require_admin_or_owner."""
+
+    async def _jwt_auth(request):
+        _attach_workspace_context(
+            request, workspace=workspace, auth_method=AUTH_METHOD_JWT, user_id=user_id,
+        )
+        return True
+
+    with patch(
+        "app.middleware.api_key_middleware._try_jwt_auth", side_effect=_jwt_auth
+    ):
+        yield
 
 
 def _create_body(agent_id: uuid.UUID, **overrides) -> dict:
@@ -444,6 +492,69 @@ class TestDeleteCallFlow:
         )
         assert resp.status_code == 409, resp.text
         assert resp.json()["error"]["code"] == "flow_has_active_calls"
+
+
+@pytest.mark.usefixtures("db")
+class TestUpdateCallFlowSettings:
+    def test_admin_can_enable_public_access(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        created = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id),
+            headers=_headers(auth_tenant),
+        ).json()
+        assert created["publicAccess"] is False
+
+        admin = _make_jwt_user(db, auth_tenant.id, "admin")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, admin.id):
+            resp = authed_client.put(
+                f"/api/v1/call-flows/{created['id']}/settings",
+                json={"public_access": True},
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["publicAccess"] is True
+
+        row = db.query(CallFlow).filter(CallFlow.id == uuid.UUID(created["id"])).first()
+        assert row.public_access is True
+
+    def test_member_role_forbidden(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        created = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id),
+            headers=_headers(auth_tenant),
+        ).json()
+
+        member = _make_jwt_user(db, auth_tenant.id, "member")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, member.id):
+            resp = authed_client.put(
+                f"/api/v1/call-flows/{created['id']}/settings",
+                json={"public_access": True},
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    def test_api_key_forbidden(self, authed_client, auth_tenant, test_agent):
+        """ApiKeyPrincipal has no role — require_admin_or_owner rejects it outright."""
+        created = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id),
+            headers=_headers(auth_tenant),
+        ).json()
+
+        resp = authed_client.put(
+            f"/api/v1/call-flows/{created['id']}/settings",
+            json={"public_access": True},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 403, resp.text
 
 
 @pytest.mark.usefixtures("db")

--- a/tests/api/test_public_call_token.py
+++ b/tests/api/test_public_call_token.py
@@ -1,0 +1,193 @@
+"""Integration tests for the unauthenticated POST /api/v1/sdk/public-call-token.
+
+No x-api-key / x-workspace-id / Authorization headers are ever sent here —
+that's the point of this endpoint. Security is exercised via flow.public_access
+and the allowed_domains Origin check instead.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.agent import Agent
+from app.models.allowed_domain import AllowedDomain
+from app.models.call_flow import CallFlow
+from app.models.tenant import Tenant
+
+
+@pytest.fixture
+def tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"SdkWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"sdk_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def agent(db, tenant: Tenant) -> Agent:
+    a = Agent(
+        tenant_id=tenant.id,
+        name="SDK Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def public_flow(db, tenant: Tenant, agent: Agent) -> CallFlow:
+    flow = CallFlow(
+        tenant_id=tenant.id,
+        agent_id=agent.id,
+        name="Public Flow",
+        direction="inbound",
+        public_access=True,
+    )
+    db.add(flow)
+    db.commit()
+    db.refresh(flow)
+    return flow
+
+
+@pytest.fixture
+def private_flow(db, tenant: Tenant, agent: Agent) -> CallFlow:
+    flow = CallFlow(
+        tenant_id=tenant.id,
+        agent_id=agent.id,
+        name="Private Flow",
+        direction="inbound",
+        public_access=False,
+    )
+    db.add(flow)
+    db.commit()
+    db.refresh(flow)
+    return flow
+
+
+@pytest.fixture
+def mock_livekit():
+    mock = MagicMock()
+    mock.generate_caller_token = MagicMock(return_value="signed.jwt.token")
+    with patch("app.services.livekit_service.livekit_service", mock):
+        yield mock
+
+
+def _body(flow: CallFlow) -> dict:
+    return {"flow_id": str(flow.id), "agent_id": str(flow.agent_id)}
+
+
+@pytest.mark.usefixtures("db")
+class TestPublicCallToken:
+    def test_allowed_origin_returns_token(
+        self, client: TestClient, db, tenant, public_flow, mock_livekit
+    ):
+        db.add(AllowedDomain(workspace_id=tenant.id, domain="https://embed.example.com"))
+        db.commit()
+
+        resp = client.post(
+            "/api/v1/sdk/public-call-token",
+            json=_body(public_flow),
+            headers={"Origin": "https://embed.example.com"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["livekit_token"] == "signed.jwt.token"
+        assert body["flow_id"] == str(public_flow.id)
+        assert body["room_name"].startswith("room_")
+        assert "expires_at" in body
+        mock_livekit.generate_caller_token.assert_called_once()
+
+    def test_disallowed_origin_returns_403(self, client: TestClient, db, tenant, public_flow, mock_livekit):
+        db.add(AllowedDomain(workspace_id=tenant.id, domain="https://embed.example.com"))
+        db.commit()
+
+        resp = client.post(
+            "/api/v1/sdk/public-call-token",
+            json=_body(public_flow),
+            headers={"Origin": "https://evil.example.com"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "domain_not_allowed"
+
+    def test_flow_without_public_access_returns_403(
+        self, client: TestClient, db, tenant, private_flow, mock_livekit
+    ):
+        db.add(AllowedDomain(workspace_id=tenant.id, domain="https://embed.example.com"))
+        db.commit()
+
+        resp = client.post(
+            "/api/v1/sdk/public-call-token",
+            json=_body(private_flow),
+            headers={"Origin": "https://embed.example.com"},
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "public_access_disabled"
+
+    def test_missing_origin_header_returns_403(self, client: TestClient, db, tenant, public_flow, mock_livekit):
+        db.add(AllowedDomain(workspace_id=tenant.id, domain="https://embed.example.com"))
+        db.commit()
+
+        resp = client.post("/api/v1/sdk/public-call-token", json=_body(public_flow))
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "domain_not_allowed"
+
+    def test_unknown_flow_returns_404(self, client: TestClient, mock_livekit):
+        resp = client.post(
+            "/api/v1/sdk/public-call-token",
+            json={"flow_id": str(uuid.uuid4()), "agent_id": str(uuid.uuid4())},
+            headers={"Origin": "https://embed.example.com"},
+        )
+        assert resp.status_code == 404, resp.text
+
+    def test_localhost_allowed_in_development_without_whitelist(
+        self, client: TestClient, public_flow, mock_livekit
+    ):
+        """No allowed_domains row needed — localhost:* always passes in development."""
+        resp = client.post(
+            "/api/v1/sdk/public-call-token",
+            json=_body(public_flow),
+            headers={"Origin": "http://localhost:5173"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_normalized_origin_matches_stored_domain(
+        self, client: TestClient, db, tenant, public_flow, mock_livekit
+    ):
+        """Stored as https://app.example.com; browser sends with trailing slash
+        stripped and default port — both normalize to the same value."""
+        db.add(AllowedDomain(workspace_id=tenant.id, domain="https://app.example.com"))
+        db.commit()
+
+        resp = client.post(
+            "/api/v1/sdk/public-call-token",
+            json=_body(public_flow),
+            headers={"Origin": "https://App.Example.com:443"},
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_does_not_log_token(self, client: TestClient, db, tenant, public_flow, mock_livekit, caplog):
+        db.add(AllowedDomain(workspace_id=tenant.id, domain="https://embed.example.com"))
+        db.commit()
+
+        with caplog.at_level("INFO"):
+            resp = client.post(
+                "/api/v1/sdk/public-call-token",
+                json=_body(public_flow),
+                headers={"Origin": "https://embed.example.com"},
+            )
+        assert resp.status_code == 200
+        assert "signed.jwt.token" not in caplog.text

--- a/tests/api/v2/test_account_deletion.py
+++ b/tests/api/v2/test_account_deletion.py
@@ -2,11 +2,14 @@
 Tests for the GDPR right-to-erasure endpoint.
 
 Coverage:
-  - DELETE /workspace/account: wrong confirmation phrase -> 400, service untouched
-  - DELETE /workspace/account: case-sensitive mismatch -> 400
-  - DELETE /workspace/account: missing body field -> 400
-  - DELETE /workspace/account: exact phrase -> 204, audits then calls the wipe service
+  - POST /workspace/account/delete: wrong confirmation phrase -> 400, service untouched
+  - POST /workspace/account/delete: case-sensitive mismatch -> 400
+  - POST /workspace/account/delete: missing body field -> 400
+  - POST /workspace/account/delete: exact phrase -> 204, audits then calls the wipe service
   - Admin RBAC required
+
+POST (not DELETE-with-body) because proxies/load balancers aren't guaranteed
+to forward a body on DELETE — see app/api/v2/routers/workspace.py docstring.
 """
 from __future__ import annotations
 
@@ -51,8 +54,8 @@ class TestDeleteAccount:
 
         with patch("app.api.v2.routers.workspace.delete_workspace_account") as mock_delete:
             client = _build_app(db)
-            resp = client.request(
-                "DELETE", "/workspace/account", json={"confirmation": "delete my account please"}
+            resp = client.post(
+                "/workspace/account/delete", json={"confirmation": "delete my account please"}
             )
 
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -63,8 +66,8 @@ class TestDeleteAccount:
 
         with patch("app.api.v2.routers.workspace.delete_workspace_account") as mock_delete:
             client = _build_app(db)
-            resp = client.request(
-                "DELETE", "/workspace/account", json={"confirmation": "delete my account"}
+            resp = client.post(
+                "/workspace/account/delete", json={"confirmation": "delete my account"}
             )
 
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
@@ -74,7 +77,7 @@ class TestDeleteAccount:
         db = MagicMock()
         client = _build_app(db)
 
-        resp = client.request("DELETE", "/workspace/account", json={})
+        resp = client.post("/workspace/account/delete", json={})
 
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -86,8 +89,8 @@ class TestDeleteAccount:
             patch("app.api.v2.routers.workspace.log_audit_event") as mock_audit,
         ):
             client = _build_app(db)
-            resp = client.request(
-                "DELETE", "/workspace/account", json={"confirmation": _CORRECT_PHRASE}
+            resp = client.post(
+                "/workspace/account/delete", json={"confirmation": _CORRECT_PHRASE}
             )
 
         assert resp.status_code == status.HTTP_204_NO_CONTENT, resp.text
@@ -113,7 +116,7 @@ class TestDeleteAccount:
             ),
         ):
             client = _build_app(db)
-            client.request("DELETE", "/workspace/account", json={"confirmation": _CORRECT_PHRASE})
+            client.post("/workspace/account/delete", json={"confirmation": _CORRECT_PHRASE})
 
         assert call_order == ["audit", "delete"]
 
@@ -124,6 +127,6 @@ class TestDeleteAccount:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required")
 
         client = _build_app(db, admin_override=_forbidden)
-        resp = client.request("DELETE", "/workspace/account", json={"confirmation": _CORRECT_PHRASE})
+        resp = client.post("/workspace/account/delete", json={"confirmation": _CORRECT_PHRASE})
 
         assert resp.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/core/test_origin.py
+++ b/tests/core/test_origin.py
@@ -24,5 +24,13 @@ class TestIsLocalhostOrigin:
         assert is_localhost_origin("http://localhost:5173") is True
         assert is_localhost_origin("http://localhost") is True
 
+    def test_ipv4_loopback(self):
+        assert is_localhost_origin("http://127.0.0.1:3000") is True
+        assert is_localhost_origin("http://127.0.0.1") is True
+
+    def test_ipv6_loopback(self):
+        assert is_localhost_origin("http://[::1]:3000") is True
+        assert is_localhost_origin("http://[::1]") is True
+
     def test_non_localhost(self):
         assert is_localhost_origin("https://app.example.com") is False

--- a/tests/core/test_origin.py
+++ b/tests/core/test_origin.py
@@ -1,0 +1,28 @@
+from app.core.origin import is_localhost_origin, normalize_origin
+
+
+class TestNormalizeOrigin:
+    def test_lowercases_host(self):
+        assert normalize_origin("https://App.Example.COM") == "https://app.example.com"
+
+    def test_strips_trailing_slash_and_path(self):
+        assert normalize_origin("https://app.example.com/") == "https://app.example.com"
+        assert normalize_origin("https://app.example.com/some/path") == "https://app.example.com"
+
+    def test_drops_default_https_port(self):
+        assert normalize_origin("https://app.example.com:443") == "https://app.example.com"
+
+    def test_keeps_non_default_port(self):
+        assert normalize_origin("https://app.example.com:8443") == "https://app.example.com:8443"
+
+    def test_combination(self):
+        assert normalize_origin("HTTPS://App.Example.com:443/") == "https://app.example.com"
+
+
+class TestIsLocalhostOrigin:
+    def test_localhost_any_port(self):
+        assert is_localhost_origin("http://localhost:5173") is True
+        assert is_localhost_origin("http://localhost") is True
+
+    def test_non_localhost(self):
+        assert is_localhost_origin("https://app.example.com") is False

--- a/tests/integration/test_gdpr_account_deletion_postgres.py
+++ b/tests/integration/test_gdpr_account_deletion_postgres.py
@@ -183,7 +183,15 @@ class TestDeleteWorkspaceAccount:
         pg_session.commit()
         pg_session.refresh(kb)
 
-        chunk = KbChunk(kb_id=kb.id, content="secret content", chunk_metadata={})
+        # Non-null embedding: proves the wipe erases the pgvector column too,
+        # not just the text — there is no separate Pinecone/external vector
+        # store to clean up (see account_deletion_service module docstring).
+        chunk = KbChunk(
+            kb_id=kb.id,
+            content="secret content",
+            chunk_metadata={},
+            embedding=[0.1] * 1536,
+        )
         pg_session.add(chunk)
 
         batch_job = BatchJob(workspace_id=tenant.id, agent_id=agent.id, status="completed")
@@ -261,8 +269,8 @@ class TestDeleteWorkspaceAccount:
 
 
 class TestAccountDeletionHttp:
-    """Exercises the real DELETE /api/v2/workspace/account endpoint with a
-    genuine JWT admin session against Postgres."""
+    """Exercises the real POST /api/v2/workspace/account/delete endpoint with
+    a genuine JWT admin session against Postgres."""
 
     def _admin_token_and_tenant(self, pg_session):
         from app.core.security import create_user_token
@@ -289,9 +297,8 @@ class TestAccountDeletionHttp:
     def test_wrong_phrase_returns_400(self, pg_client, pg_session):
         token, tenant = self._admin_token_and_tenant(pg_session)
 
-        resp = pg_client.request(
-            "DELETE",
-            "/api/v2/workspace/account",
+        resp = pg_client.post(
+            "/api/v2/workspace/account/delete",
             headers={"Authorization": f"Bearer {token}"},
             json={"confirmation": "nope"},
         )

--- a/tests/middleware/auth/test_api_key_middleware_unit.py
+++ b/tests/middleware/auth/test_api_key_middleware_unit.py
@@ -86,6 +86,10 @@ def _app() -> FastAPI:
     def public_api_keys():
         return {"ok": True}
 
+    @mini.post("/api/v1/sdk/public-call-token")
+    def public_sdk_token():
+        return {"ok": True}
+
     @mini.get("/health")
     def health():
         return {"ok": True}
@@ -175,6 +179,10 @@ class TestSkipPaths:
 
     def test_health_no_auth(self, client):
         resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_sdk_public_call_token_no_auth(self, client):
+        resp = client.post("/api/v1/sdk/public-call-token")
         assert resp.status_code == 200
 
     def test_v2_health_no_auth(self, client):

--- a/tests/middleware/test_public_sdk_cors_middleware.py
+++ b/tests/middleware/test_public_sdk_cors_middleware.py
@@ -1,0 +1,63 @@
+"""Unit tests for PublicSdkCorsMiddleware — dynamic CORS for the one public
+Web SDK route. The static global CORSMiddleware can't allow per-workspace
+allowed_domains, so this middleware reflects Origin only on that one path;
+real authorization still happens in app/routers/sdk.py.
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.middleware.public_sdk_cors_middleware import PublicSdkCorsMiddleware
+
+
+def _app() -> FastAPI:
+    mini = FastAPI()
+    mini.add_middleware(PublicSdkCorsMiddleware)
+
+    @mini.post("/api/v1/sdk/public-call-token")
+    def public_sdk_token():
+        return {"ok": True}
+
+    @mini.get("/api/v1/other")
+    def other():
+        return {"ok": True}
+
+    return mini
+
+
+def test_preflight_reflects_arbitrary_origin():
+    client = TestClient(_app())
+    resp = client.options(
+        "/api/v1/sdk/public-call-token",
+        headers={
+            "Origin": "https://totally-unlisted.example.com",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "https://totally-unlisted.example.com"
+
+
+def test_actual_response_reflects_origin():
+    client = TestClient(_app())
+    resp = client.post(
+        "/api/v1/sdk/public-call-token",
+        headers={"Origin": "https://embed.example.com"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["access-control-allow-origin"] == "https://embed.example.com"
+
+
+def test_other_paths_untouched():
+    client = TestClient(_app())
+    resp = client.get("/api/v1/other", headers={"Origin": "https://embed.example.com"})
+    assert resp.status_code == 200
+    assert "access-control-allow-origin" not in resp.headers
+
+
+def test_no_origin_header_no_cors_header_added():
+    client = TestClient(_app())
+    resp = client.post("/api/v1/sdk/public-call-token")
+    assert resp.status_code == 200
+    assert "access-control-allow-origin" not in resp.headers

--- a/tests/middleware/test_rate_limit_middleware.py
+++ b/tests/middleware/test_rate_limit_middleware.py
@@ -43,6 +43,10 @@ def _make_app(limit: int = 5, window: int = 60) -> FastAPI:
     def register():
         return {"ok": True}
 
+    @mini.post("/api/v1/sdk/public-call-token")
+    def public_call_token():
+        return {"ok": True}
+
     return mini
 
 
@@ -133,6 +137,37 @@ class TestAuthSensitive:
 
         assert resp.status_code == 429
         assert resp.json()["error"]["code"] == "rate_limit_exceeded"
+
+
+class TestPublicTokenEndpoint:
+    def test_exceeding_20_per_minute_returns_429(self):
+        app = _make_app()
+        pipe_cls = _fake_redis_pipeline([21])  # count > 20 default limit
+
+        mock_r = MagicMock()
+        mock_r.pipeline.return_value = pipe_cls()
+        mock_r.zremrangebyscore = AsyncMock()
+
+        with patch("app.middleware.rate_limit_middleware._get_redis", return_value=mock_r):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/api/v1/sdk/public-call-token")
+
+        assert resp.status_code == 429
+        assert resp.json()["error"]["code"] == "rate_limit_exceeded"
+
+    def test_within_20_per_minute_passes(self):
+        app = _make_app()
+        pipe_cls = _fake_redis_pipeline([5])
+
+        mock_r = MagicMock()
+        mock_r.pipeline.return_value = pipe_cls()
+        mock_r.zremrangebyscore = AsyncMock()
+
+        with patch("app.middleware.rate_limit_middleware._get_redis", return_value=mock_r):
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.post("/api/v1/sdk/public-call-token")
+
+        assert resp.status_code == 200
 
 
 class TestAllowed:


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/sdk/public-call-token` — the first fully unauthenticated endpoint in the app — so the Web SDK can fetch a LiveKit token without an API key. Validated via `call_flows.public_access` + a per-workspace `allowed_domains` Origin whitelist (with a `localhost:*` bypass in development), origin normalization (lowercase, no trailing slash, no `:443`), and a dedicated 20-req/min-per-IP rate limit. Returns `{livekit_token, room_name, flow_id, expires_at}` using the same Sprint-2 LiveKit token path (1h TTL). Logs origin/flow_id/IP on every request, never the token.
- `PUT /api/v1/call-flows/{id}/settings` — toggles `public_access`, gated to admin/owner.
- `POST/GET/DELETE /api/v1/workspace/allowed-domains` — HTTPS-validated, capped at 20 domains/workspace (422 past the cap).
- Migration adds `callflow.public_access` and a new `alloweddomain` table (table name follows the codebase's lowercased-classname convention rather than the ticket's literal `allowed_domains`, consistent with prior tickets on this repo).
- Added a small outermost CORS-reflection middleware scoped to only the public token route, since the static env-configured CORS policy would otherwise block a browser from any tenant-whitelisted domain that isn't also in the global `ALLOWED_ORIGINS` list. The real authorization boundary stays the `allowed_domains` DB check inside the handler — this middleware grants no security by itself.

## Test plan
- [x] Allowed origin → 200 with token
- [x] Disallowed origin → 403 `domain_not_allowed`
- [x] Flow without `public_access` → 403 `public_access_disabled`
- [x] Exceeding 20 allowed domains → 422
- [x] `localhost:*` bypass works in development without a whitelist entry
- [x] Origin normalization (case, trailing slash, default port) matches stored domains
- [x] Token value never appears in logs
- [x] IP rate-limit bucket (20/min) enforced at the middleware layer
- [x] Admin/owner-only gate on the settings endpoint (real DB-backed role check, not just a mock)
- [x] Migration applied and verified against the dev DB (`alloweddomain` table + `callflow.public_access` column present)
- [x] Full existing test suite diffed against the unmodified base branch — zero regressions (pre-existing cross-module flakiness in the full-suite run is identical with or without this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)