### PR TITLE
feat: integrate HubSpot CRM via OAuth 2.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,7 +76,9 @@ HUBSPOT_CLIENT_SECRET=
 # Must exactly match the redirect URI configured on the HubSpot app. Defaults to
 # {WEBHOOK_BASE_URL}/api/v1/integrations/hubspot/callback when unset.
 HUBSPOT_REDIRECT_URI=
-# Symmetric encryption key for workspaceintegration.access_token/refresh_token (pgp_sym_encrypt).
+# Symmetric encryption key for workspaceintegration.access_token/refresh_token (AES-256-GCM).
+# MUST be a randomly generated 32-byte secret (represented as a 64-character hex string).
+# Preserve compatibility with existing encrypted tokens by keeping the key unchanged.
 HUBSPOT_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
 
 # --- BYO telephony -----------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,18 @@ RIME_API_KEY=
 # Symmetric encryption key for agent.encrypted_elevenlabs_api_key (pgp_sym_encrypt).
 ELEVENLABS_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
 
+# --- HubSpot CRM integration ---------------------------------------------------
+# OAuth app credentials from https://developers.hubspot.com/. In staging/production
+# these are read from Secret Manager (see app/core/secret_manager.py); these env
+# vars are local-dev fallbacks only.
+HUBSPOT_CLIENT_ID=
+HUBSPOT_CLIENT_SECRET=
+# Must exactly match the redirect URI configured on the HubSpot app. Defaults to
+# {WEBHOOK_BASE_URL}/api/v1/integrations/hubspot/callback when unset.
+HUBSPOT_REDIRECT_URI=
+# Symmetric encryption key for workspaceintegration.access_token/refresh_token (pgp_sym_encrypt).
+HUBSPOT_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
+
 # --- BYO telephony -----------------------------------------------------------
 # TELEPHONY_PROVIDER: 'twilio' | 'sip'
 TELEPHONY_PROVIDER=twilio

--- a/alembic/versions/f75178a95482_add_workspaceintegration_table.py
+++ b/alembic/versions/f75178a95482_add_workspaceintegration_table.py
@@ -1,0 +1,46 @@
+"""add_workspaceintegration_table
+
+Revision ID: f75178a95482
+Revises: fdff731d11a7
+Create Date: 2026-06-24 20:31:39.546692
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'f75178a95482'
+down_revision: Union[str, Sequence[str], None] = 'fdff731d11a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'workspaceintegration',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('workspace_id', sa.UUID(), nullable=False),
+        sa.Column('provider', sa.String(length=50), nullable=False),
+        sa.Column('access_token', sa.Text(), nullable=True),
+        sa.Column('refresh_token', sa.Text(), nullable=True),
+        sa.Column('token_expires_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['workspace_id'], ['tenant.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('workspace_id', 'provider', name='uq_workspace_integration_provider'),
+    )
+    op.create_index(op.f('ix_workspaceintegration_id'), 'workspaceintegration', ['id'], unique=False)
+    op.create_index(op.f('ix_workspaceintegration_workspace_id'), 'workspaceintegration', ['workspace_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_workspaceintegration_workspace_id'), table_name='workspaceintegration')
+    op.drop_index(op.f('ix_workspaceintegration_id'), table_name='workspaceintegration')
+    op.drop_table('workspaceintegration')

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -48,6 +48,7 @@ from app.routers.internal_stt import router as internal_stt_router
 from app.routers.business_knowledge import router as business_knowledge_router
 from app.routers.recordings import router as recordings_router
 from app.routers.integrations import router as integrations_router
+from app.routers.hubspot_integration import router as hubspot_integration_router
 from app.routers.call_history import router as call_history_router
 from app.routers.call_history import batch_router as batch_call_metrics_router
 
@@ -156,5 +157,10 @@ api_router.include_router(
 )
 api_router.include_router(recordings_router, prefix="/recordings", tags=["Call Recordings"])
 api_router.include_router(integrations_router, prefix="/integrations", tags=["Integrations"])
+api_router.include_router(
+    hubspot_integration_router,
+    prefix="/integrations/hubspot",
+    tags=["HubSpot Integration"],
+)
 api_router.include_router(call_history_router, prefix="/calls", tags=["Call History Analytics"])
 api_router.include_router(batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"])

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -82,7 +82,18 @@ class Settings(BaseSettings):
     # When True, voice LLM prompts may suggest bracketed audio tags for ElevenLabs TTS only
     # ([breathes], [pause], [excited], [sad], …). Set False if your TTS model reads brackets out loud.
     ENABLE_ELEVENLABS_AUDIO_TAGS: bool = True
-    
+
+    # HubSpot CRM OAuth (app/services/hubspot_service.py).
+    # client_id/client_secret kept here as local-dev fallbacks only — in
+    # staging/production they are read from Secret Manager (see
+    # app/core/secret_manager.py::get_hubspot_oauth_credentials).
+    HUBSPOT_CLIENT_ID: str = ""
+    HUBSPOT_CLIENT_SECRET: str = ""
+    HUBSPOT_REDIRECT_URI: str = ""  # defaults to {WEBHOOK_BASE_URL}/api/v1/integrations/hubspot/callback
+    # Symmetric encryption key for workspaceintegration.access_token / refresh_token
+    # (pgp_sym_encrypt) — same scheme as ELEVENLABS_ENCRYPTION_KEY above.
+    HUBSPOT_TOKEN_ENCRYPTION_KEY: str = ""
+
     # Google Cloud Speech-to-Text Configuration
     GOOGLE_APPLICATION_CREDENTIALS: str = ""  # Path to service account JSON file for Vertex AI + STT
     GOOGLE_CLOUD_PROJECT_ID: str = ""
@@ -289,7 +300,7 @@ class Settings(BaseSettings):
     RAG_EMBEDDING_MODEL: str = "text-embedding-3-small"
     # Fallback embedding model/provider used when the primary embedding call fails.
     RAG_FALLBACK_EMBEDDING_PROVIDER: str = "gemini"
-    RAG_FALLBACK_EMBEDDING_MODEL: str = "gemini-embedding-001"
+    RAG_FALLBACK_EMBEDDING_MODEL: str = "gemini-embedding-002"
     RAG_TOP_K: int = 5
     RAG_SCORE_THRESHOLD: float = 0.4
     # Hard cap for the size of the rendered context block injected into prompts.

--- a/app/core/db_encryption.py
+++ b/app/core/db_encryption.py
@@ -230,7 +230,18 @@ _HUBSPOT_AESGCM_PREFIX = "gcm1:"
 
 
 def _hubspot_aes_key() -> bytes:
-    """Derive a 32-byte AES-256 key from HUBSPOT_TOKEN_ENCRYPTION_KEY (any length/format)."""
+    """Derive a 32-byte AES-256 key from HUBSPOT_TOKEN_ENCRYPTION_KEY.
+
+    SECURITY NOTE:
+      For secure AES-256-GCM encryption, HUBSPOT_TOKEN_ENCRYPTION_KEY must be configured
+      as a randomly generated 32-byte secret (typically represented as a 64-character
+      hex string, e.g. generated via `secrets.token_hex(32)`).
+
+    BACKWARD COMPATIBILITY:
+      We derive the key using hashlib.sha256 to ensure that any key length/format can
+      be safely resolved, and to preserve 100% backward compatibility for already
+      connected HubSpot workspaces encrypted under older/existing settings keys.
+    """
     key = settings.HUBSPOT_TOKEN_ENCRYPTION_KEY
     if not key:
         raise ValueError(

--- a/app/core/db_encryption.py
+++ b/app/core/db_encryption.py
@@ -13,14 +13,22 @@ used by the Twilio credentials.
 
 If the key is missing or empty the encrypt call raises ``ValueError`` so that
 the application fails loudly rather than silently storing plaintext.
+
+HubSpot tokens (below) are the one exception: pgcrypto's ``pgp_sym_encrypt``
+is OpenPGP symmetric encryption and has no GCM mode, so it cannot satisfy a
+literal AES-256-GCM requirement. Those two helpers perform AES-256-GCM in
+Python via ``cryptography`` instead of pgcrypto SQL.
 """
 
 from __future__ import annotations
 
 import base64
+import hashlib
 import logging
+import os
 from contextlib import contextmanager
 
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
@@ -216,31 +224,62 @@ def decrypt_stored_webhook_secret(
         raise
 
 
-def encrypt_hubspot_token(plaintext: str, db: Session) -> str:
-    """Encrypt *plaintext* HubSpot OAuth token using pgp_sym_encrypt; return base64 ciphertext.
+# Tags new-format ciphertext unambiguously so decrypt never has to guess between
+# AES-256-GCM and the legacy pgp_sym_encrypt format below — no byte-sniffing heuristic.
+_HUBSPOT_AESGCM_PREFIX = "gcm1:"
 
-    Raises ``ValueError`` if ``HUBSPOT_TOKEN_ENCRYPTION_KEY`` is not configured.
-    """
+
+def _hubspot_aes_key() -> bytes:
+    """Derive a 32-byte AES-256 key from HUBSPOT_TOKEN_ENCRYPTION_KEY (any length/format)."""
     key = settings.HUBSPOT_TOKEN_ENCRYPTION_KEY
     if not key:
         raise ValueError(
             "HUBSPOT_TOKEN_ENCRYPTION_KEY is not configured — "
-            "cannot encrypt HubSpot OAuth token."
+            "cannot encrypt/decrypt HubSpot OAuth token."
         )
-    result = _pgcrypto_scalar(
-        db,
-        "SELECT encode(pgp_sym_encrypt(:pt, :key), 'base64')",
-        {"pt": plaintext, "key": key},
-    )
-    return result  # type: ignore[return-value]
+    return hashlib.sha256(key.encode("utf-8")).digest()
+
+
+def encrypt_hubspot_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+    """Encrypt *plaintext* HubSpot OAuth token with AES-256-GCM.
+
+    Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
+    encryption has no GCM mode). ``db`` is accepted only for parity with the other
+    encrypt_* helpers in this module; it is unused here.
+
+    Raises ``ValueError`` if ``HUBSPOT_TOKEN_ENCRYPTION_KEY`` is not configured.
+    """
+    key = _hubspot_aes_key()
+    nonce = os.urandom(12)  # 96-bit nonce, the standard size for AES-GCM
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext.encode("utf-8"), None)
+    return _HUBSPOT_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode("ascii")
 
 
 def decrypt_hubspot_token(ciphertext: str, db: Session) -> str:
-    """Decrypt base64 ciphertext produced by :func:`encrypt_hubspot_token`.
+    """Decrypt a HubSpot OAuth token written by :func:`encrypt_hubspot_token`.
+
+    Handles two formats so workspaces connected before the AES-256-GCM migration
+    don't need to reconnect:
+      - ``gcm1:``-prefixed: AES-256-GCM (current format).
+      - Unprefixed: legacy pgp_sym_encrypt base64 (pgcrypto), written before this
+        migration — decrypted via the same SQL path as the ElevenLabs/webhook keys.
 
     Raises ``ValueError`` if ``HUBSPOT_TOKEN_ENCRYPTION_KEY`` is not configured or
     if the ciphertext is corrupt / encrypted with a different key.
     """
+    if not ciphertext:
+        raise ValueError("ciphertext is empty")
+
+    if ciphertext.startswith(_HUBSPOT_AESGCM_PREFIX):
+        key = _hubspot_aes_key()
+        try:
+            raw = base64.b64decode(ciphertext[len(_HUBSPOT_AESGCM_PREFIX):])
+            nonce, body = raw[:12], raw[12:]
+            return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
+        except Exception as exc:
+            raise ValueError(f"HubSpot token decryption failed: {exc}") from exc
+
+    # Legacy pgp_sym_encrypt ciphertext (pre-AES-256-GCM migration).
     key = settings.HUBSPOT_TOKEN_ENCRYPTION_KEY
     if not key:
         raise ValueError(

--- a/app/core/db_encryption.py
+++ b/app/core/db_encryption.py
@@ -216,6 +216,48 @@ def decrypt_stored_webhook_secret(
         raise
 
 
+def encrypt_hubspot_token(plaintext: str, db: Session) -> str:
+    """Encrypt *plaintext* HubSpot OAuth token using pgp_sym_encrypt; return base64 ciphertext.
+
+    Raises ``ValueError`` if ``HUBSPOT_TOKEN_ENCRYPTION_KEY`` is not configured.
+    """
+    key = settings.HUBSPOT_TOKEN_ENCRYPTION_KEY
+    if not key:
+        raise ValueError(
+            "HUBSPOT_TOKEN_ENCRYPTION_KEY is not configured — "
+            "cannot encrypt HubSpot OAuth token."
+        )
+    result = _pgcrypto_scalar(
+        db,
+        "SELECT encode(pgp_sym_encrypt(:pt, :key), 'base64')",
+        {"pt": plaintext, "key": key},
+    )
+    return result  # type: ignore[return-value]
+
+
+def decrypt_hubspot_token(ciphertext: str, db: Session) -> str:
+    """Decrypt base64 ciphertext produced by :func:`encrypt_hubspot_token`.
+
+    Raises ``ValueError`` if ``HUBSPOT_TOKEN_ENCRYPTION_KEY`` is not configured or
+    if the ciphertext is corrupt / encrypted with a different key.
+    """
+    key = settings.HUBSPOT_TOKEN_ENCRYPTION_KEY
+    if not key:
+        raise ValueError(
+            "HUBSPOT_TOKEN_ENCRYPTION_KEY is not configured — "
+            "cannot decrypt HubSpot OAuth token."
+        )
+    try:
+        result = _pgcrypto_scalar(
+            db,
+            "SELECT pgp_sym_decrypt(decode(:ct, 'base64'), :key)",
+            {"ct": ciphertext, "key": key},
+        )
+        return result or ""  # type: ignore[return-value]
+    except Exception as exc:
+        raise ValueError(f"HubSpot token decryption failed: {exc}") from exc
+
+
 def decrypt_stored_elevenlabs_key(
     ciphertext: str,
     *,

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -179,3 +179,41 @@ def get_rime_api_key() -> str:
             "RIME_API_KEY is not set. Add it to your .env file for local development."
         )
     return env_key.strip()
+
+
+@lru_cache(maxsize=1)
+def _load_hubspot_production_credentials() -> Tuple[str, str]:
+    """Fetch HubSpot OAuth app credentials from Secret Manager (cached after first call)."""
+    client_id = _fetch_from_secret_manager("HUBSPOT_CLIENT_ID") or settings.HUBSPOT_CLIENT_ID
+    client_secret = _fetch_from_secret_manager("HUBSPOT_CLIENT_SECRET") or settings.HUBSPOT_CLIENT_SECRET
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "HubSpot OAuth credentials unavailable. Set GCP_PROJECT_ID and Secret Manager "
+            "secrets (HUBSPOT_CLIENT_ID, HUBSPOT_CLIENT_SECRET) or the equivalent env vars."
+        )
+    return client_id, client_secret
+
+
+def get_hubspot_oauth_credentials() -> Tuple[str, str]:
+    """
+    Return (client_id, client_secret) appropriate for the current environment.
+
+    - production/staging → GCP Secret Manager with env-var fallback
+    - development         → env-var / .env values
+
+    Raises RuntimeError in staging/production when credentials are absent,
+    ValueError in development.
+    """
+    env = settings.ENVIRONMENT.lower()
+
+    if env in ("production", "staging"):
+        return _load_hubspot_production_credentials()
+
+    client_id = settings.HUBSPOT_CLIENT_ID
+    client_secret = settings.HUBSPOT_CLIENT_SECRET
+    if not client_id or not client_secret:
+        raise ValueError(
+            "HubSpot OAuth credentials not configured. Set HUBSPOT_CLIENT_ID and "
+            "HUBSPOT_CLIENT_SECRET in your .env file for local development."
+        )
+    return client_id, client_secret

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -78,3 +78,6 @@ from app.models.data_export_job import DataExportJob  # noqa: F401
 
 # Web SDK — public call-token domain whitelist
 from app.models.allowed_domain import AllowedDomain  # noqa: F401
+
+# Third-party CRM integrations (HubSpot OAuth, etc.)
+from app.models.workspace_integration import WorkspaceIntegration  # noqa: F401

--- a/app/middleware/api_key_middleware.py
+++ b/app/middleware/api_key_middleware.py
@@ -64,6 +64,7 @@ _SKIP_PREFIXES = (
     # Public Web SDK endpoints — security enforced via flow.public_access +
     # allowed_domains Origin check inside the handler, not API credentials.
     "/api/v1/sdk/",
+    "/api/v1/integrations/hubspot/callback",
     "/health",
     # v2 public endpoints — no auth required
     "/api/v2/health",

--- a/app/models/workspace_integration.py
+++ b/app/models/workspace_integration.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Column, String, DateTime, ForeignKey, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import uuid
+
+from app.db.base_class import Base
+
+
+class WorkspaceIntegration(Base):
+    """Third-party CRM/integration connection for a workspace (tenant). One row per provider."""
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+    workspace_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id"), nullable=False, index=True)
+
+    provider = Column(String(50), nullable=False)  # "hubspot"
+
+    # pgp_sym_encrypt ciphertext (base64) — see app/core/db_encryption.py.
+    access_token = Column(Text, nullable=True)
+    refresh_token = Column(Text, nullable=True)
+    token_expires_at = Column(DateTime(timezone=True), nullable=True)
+
+    # SQLAlchemy's declarative Base reserves the `metadata` attribute name for the
+    # schema MetaData registry, so the Python attribute is `extra_metadata` while
+    # the underlying DB column stays literally named `metadata`.
+    extra_metadata = Column("metadata", JSONB, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    workspace = relationship("Tenant", foreign_keys=[workspace_id])
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "provider", name="uq_workspace_integration_provider"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<WorkspaceIntegration(workspace_id={self.workspace_id}, provider={self.provider})>"

--- a/app/routers/hubspot_integration.py
+++ b/app/routers/hubspot_integration.py
@@ -1,0 +1,120 @@
+"""
+HubSpot CRM OAuth integration endpoints.
+
+GET    /connect    — redirect to HubSpot's OAuth consent page (tenant-authenticated)
+GET    /callback   — public; HubSpot redirects the browser here with no auth headers,
+                      so the connecting tenant is recovered from the signed `state` param
+DELETE ""          — revoke at HubSpot and delete the local connection
+GET    /contact     — CRM Search API lookup by phone, used by the dashboard and tests
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant
+from app.core.config import settings
+from app.core.logger import logger
+from app.schemas.base import SuccessResponse
+from app.schemas.hubspot_integration import (
+    HubSpotContactOut,
+    HubSpotDisconnectResponse,
+)
+from app.services import hubspot_service
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+
+def _tenant_id(principal) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+@router.get("/connect")
+async def hubspot_connect(
+    principal=Depends(require_tenant),
+):
+    """Redirect to HubSpot's OAuth consent page. Scopes: contacts read/write."""
+    tenant_id = _tenant_id(principal)
+    state = hubspot_service.build_oauth_state(tenant_id)
+    auth_url = hubspot_service.build_authorization_url(state)
+    return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/callback")
+async def hubspot_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+):
+    """
+    HubSpot OAuth callback. No auth dependency — this is a top-level browser
+    redirect from HubSpot, which cannot carry our JWT/API-key headers. The
+    connecting tenant is recovered from the signed `state` param instead.
+    """
+    try:
+        tenant_id = hubspot_service.verify_oauth_state(state)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    try:
+        token_response = await hubspot_service.exchange_code_for_tokens(code)
+    except Exception as exc:
+        logger.warning("HubSpot OAuth code exchange failed for tenant=%s: %s", tenant_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to exchange authorization code with HubSpot",
+        )
+
+    hubspot_service.upsert_tokens(db, tenant_id, token_response)
+
+    base = (settings.FRONTEND_URL or "").rstrip("/")
+    redirect_to = f"{base}/settings/integrations?hubspot=connected" if base else "/settings/integrations"
+    return RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
+
+
+@router.delete("", response_model=SuccessResponse[HubSpotDisconnectResponse])
+async def hubspot_disconnect(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Revoke the token at HubSpot and delete the workspaceintegration row."""
+    tenant_id = _tenant_id(principal)
+    disconnected = await hubspot_service.disconnect(db, tenant_id)
+    if not disconnected:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="HubSpot is not connected for this workspace",
+        )
+    return create_success_response(
+        HubSpotDisconnectResponse(disconnected=True),
+        "HubSpot disconnected successfully",
+    )
+
+
+@router.get("/contact", response_model=SuccessResponse[HubSpotContactOut])
+async def hubspot_get_contact(
+    phone: str = Query(..., description="Phone number to search for (E.164 or local format)"),
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """CRM Search API lookup by phone. Redis-cached for 5 minutes per phone number."""
+    tenant_id = _tenant_id(principal)
+
+    if not hubspot_service.tenant_has_hubspot_connected(db, tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="HubSpot is not connected for this workspace",
+        )
+
+    contact = await hubspot_service.get_contact_for_phone(db, tenant_id, phone)
+    if not contact:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No HubSpot contact found for this phone number",
+        )
+
+    return create_success_response(HubSpotContactOut(**contact))

--- a/app/routers/hubspot_integration.py
+++ b/app/routers/hubspot_integration.py
@@ -15,7 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, require_tenant
+from app.api.deps import get_db, require_tenant, require_admin
 from app.core.config import settings
 from app.core.logger import logger
 from app.schemas.base import SuccessResponse
@@ -33,9 +33,9 @@ def _tenant_id(principal) -> uuid.UUID:
     return principal.current_tenant_id
 
 
-@router.get("/connect")
+@router.get("/connect",include_in_schema=False)
 async def hubspot_connect(
-    principal=Depends(require_tenant),
+    principal=Depends(require_admin),
 ):
     """Redirect to HubSpot's OAuth consent page. Scopes: contacts read/write."""
     tenant_id = _tenant_id(principal)
@@ -44,7 +44,7 @@ async def hubspot_connect(
     return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
 
 
-@router.get("/callback")
+@router.get("/callback",include_in_schema=False)
 async def hubspot_callback(
     code: str = Query(...),
     state: str = Query(...),

--- a/app/routers/hubspot_integration.py
+++ b/app/routers/hubspot_integration.py
@@ -35,15 +35,12 @@ def _tenant_id(principal) -> uuid.UUID:
 
 @router.get("/connect")
 async def hubspot_connect(
-    json: bool = Query(False, description="Return the authorization URL as JSON instead of redirecting"),
     principal=Depends(require_tenant),
 ):
     """Redirect to HubSpot's OAuth consent page. Scopes: contacts read/write."""
     tenant_id = _tenant_id(principal)
     state = hubspot_service.build_oauth_state(tenant_id)
     auth_url = hubspot_service.build_authorization_url(state)
-    if json:
-        return {"url": auth_url}
     return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
 
 

--- a/app/routers/hubspot_integration.py
+++ b/app/routers/hubspot_integration.py
@@ -35,12 +35,15 @@ def _tenant_id(principal) -> uuid.UUID:
 
 @router.get("/connect")
 async def hubspot_connect(
+    json: bool = Query(False, description="Return the authorization URL as JSON instead of redirecting"),
     principal=Depends(require_tenant),
 ):
     """Redirect to HubSpot's OAuth consent page. Scopes: contacts read/write."""
     tenant_id = _tenant_id(principal)
     state = hubspot_service.build_oauth_state(tenant_id)
     auth_url = hubspot_service.build_authorization_url(state)
+    if json:
+        return {"url": auth_url}
     return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
 
 

--- a/app/routers/integrations.py
+++ b/app/routers/integrations.py
@@ -298,6 +298,10 @@ async def list_integrations(
     make_secret = get_make_secret(tenant)
     n8n_secret = get_n8n_secret(tenant)
 
+    from app.services import hubspot_service
+
+    hubspot_connected, hubspot_connected_at = hubspot_service.get_connection_status(db, tenant.id)
+
     integrations = [
         IntegrationItem(
             name="make",
@@ -310,6 +314,11 @@ async def list_integrations(
             connected=bool(n8n_secret),
             webhook_url=f"{base_url}/api/v1/integrations/n8n/trigger",
             last_triggered_at=get_last_triggered_at(tenant, "n8n"),
+        ),
+        IntegrationItem(
+            name="hubspot",
+            connected=hubspot_connected,
+            connected_at=hubspot_connected_at,
         ),
     ]
 

--- a/app/schemas/hubspot_integration.py
+++ b/app/schemas/hubspot_integration.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class HubSpotAuthorizeResponse(BaseModel):
+    authorization_url: str
+
+
+class HubSpotContactOut(BaseModel):
+    id: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+    company: Optional[str] = None
+    last_interaction_date: Optional[str] = None
+
+
+class HubSpotDisconnectResponse(BaseModel):
+    disconnected: bool
+    provider: str = "hubspot"

--- a/app/schemas/integration.py
+++ b/app/schemas/integration.py
@@ -25,8 +25,9 @@ class N8nTriggerResponse(BaseModel):
 class IntegrationItem(BaseModel):
     name: str
     connected: bool
-    webhook_url: str
+    webhook_url: Optional[str] = None
     last_triggered_at: Optional[datetime] = None
+    connected_at: Optional[datetime] = None
 
 
 class IntegrationListResponse(BaseModel):

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -277,6 +277,23 @@ class CallSessionService:
                     except Exception as sync_exc:  # pragma: no cover
                         logger.warning("Inbound CRM schedule failed (non-critical): %s", sync_exc)
 
+                # HubSpot post-call write-back: create a Call engagement with the
+                # transcript summary once the call has actually completed. Fire-and-forget
+                # (fail open) — see app/services/hubspot_service.py::schedule_hubspot_writeback.
+                if status == "completed":
+                    try:
+                        from app.services.hubspot_service import (
+                            schedule_hubspot_writeback,
+                            tenant_has_hubspot_connected,
+                        )
+
+                        if tenant_has_hubspot_connected(db, call_session.tenant_id):
+                            schedule_hubspot_writeback(call_session.id)
+                    except Exception as hubspot_exc:  # pragma: no cover
+                        logger.warning(
+                            "HubSpot write-back schedule failed (non-critical): %s", hubspot_exc
+                        )
+
                 # Smart Callback: schedule a retry for missed outbound calls.
                 # maybe_schedule_callback writes the CallbackSchedule row (sync).
                 # _fire_callback_enqueue then submits the ARQ job on the current

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -44,7 +44,7 @@ def _embed_openai_ada002(text: str) -> list[float]:
 
     client = get_openai_client()
     resp = client.embeddings.create(
-        model="text-embedding-ada-002",
+        model=settings.RAG_EMBEDDING_MODEL,
         input=text,
     )
     return resp.data[0].embedding

--- a/app/services/hubspot_service.py
+++ b/app/services/hubspot_service.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import hashlib
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple
@@ -291,8 +292,68 @@ async def disconnect(db: Session, tenant_id: uuid.UUID) -> bool:
 # ─── Contact lookup (CRM Search API, Redis-cached) ────────────────────────────
 
 
+def normalize_to_e164(phone: str) -> str:
+    """Normalize phone number to E.164 format if possible.
+    E.164 format: +[country_code][subscriber_number] up to 15 digits total.
+    """
+    if not phone:
+        return ""
+    # Strip any leading/trailing whitespace
+    phone = phone.strip()
+    
+    # Check if it has a leading '+'
+    has_plus = phone.startswith("+")
+    
+    # Extract only digits
+    digits = "".join(c for c in phone if c.isdigit())
+    
+    if not digits:
+        return phone
+        
+    if has_plus:
+        return f"+{digits}"
+        
+    # If no leading '+', handle common cases:
+    # 10 digits: assume US number, prepend +1
+    if len(digits) == 10:
+        return f"+1{digits}"
+    # 11 digits starting with 1: prepend +
+    elif len(digits) == 11 and digits.startswith("1"):
+        return f"+{digits}"
+    # Otherwise, just prepend '+'
+    else:
+        return f"+{digits}"
+
+
+def _get_phone_search_values(phone: str) -> list[str]:
+    """Generate a list of unique exact-match phone number variations for lookup."""
+    values = set()
+    digits = "".join(c for c in phone if c.isdigit())
+    
+    normalized = normalize_to_e164(phone)
+    if normalized:
+        values.add(normalized)
+        
+    stripped = phone.strip()
+    if stripped:
+        values.add(stripped)
+        
+    if digits:
+        values.add(digits)
+        # If it's a US number with country code, add the 10-digit national number
+        if len(digits) == 11 and digits.startswith("1"):
+            values.add(digits[1:])
+        # If it's a 10-digit number, also add with country code '1' (without '+')
+        elif len(digits) == 10:
+            values.add(f"1{digits}")
+            
+    return sorted(list(values))
+
+
 def _contact_cache_key(tenant_id: uuid.UUID, phone: str) -> str:
-    return f"hubspot:contact:{tenant_id}:{phone}"
+    # Hash the phone number to avoid storing PII in plaintext in Redis keys.
+    phone_hash = hashlib.sha256(phone.encode("utf-8")).hexdigest()
+    return f"hubspot:contact:{tenant_id}:{phone_hash}"
 
 
 def _contact_dict_from_hubspot(raw: dict) -> dict:
@@ -311,28 +372,46 @@ def _contact_dict_from_hubspot(raw: dict) -> dict:
 
 
 async def search_contact_by_phone(access_token: str, phone: str) -> Optional[dict]:
+    search_vals = _get_phone_search_values(phone)
+    if not search_vals:
+        return None
+
+    # Construct filter groups to search both `phone` and `mobilephone` fields
+    # against all exact-match variations (joined with OR logic).
+    filter_groups = []
+    for val in search_vals:
+        filter_groups.append({
+            "filters": [
+                {
+                    "propertyName": "phone",
+                    "operator": "EQ",
+                    "value": val,
+                }
+            ]
+        })
+        filter_groups.append({
+            "filters": [
+                {
+                    "propertyName": "mobilephone",
+                    "operator": "EQ",
+                    "value": val,
+                }
+            ]
+        })
+
     response = await _request_with_backoff(
         "POST",
         SEARCH_CONTACTS_URL,
         headers={"Authorization": f"Bearer {access_token}"},
         json={
-            "filterGroups": [
-                {
-                    "filters": [
-                        {
-                            "propertyName": "phone",
-                            "operator": "CONTAINS_TOKEN",
-                            "value": phone,
-                        }
-                    ]
-                }
-            ],
+            "filterGroups": filter_groups,
             "properties": [
                 "firstname",
                 "lastname",
                 "email",
                 "company",
                 "phone",
+                "mobilephone",
                 "notes_last_contacted",
                 "lastmodifieddate",
             ],
@@ -348,8 +427,10 @@ async def get_contact_for_phone(
     db: Session, tenant_id: uuid.UUID, phone: str
 ) -> Optional[dict]:
     """Look up a contact by phone, Redis-cached for 5 minutes. Fails open on any error."""
+    # Normalize phone numbers to E.164 format if possible before lookup/caching.
+    normalized_phone = normalize_to_e164(phone)
     redis_client = get_redis()
-    cache_key = _contact_cache_key(tenant_id, phone)
+    cache_key = _contact_cache_key(tenant_id, normalized_phone)
 
     if redis_client is not None:
         try:
@@ -363,7 +444,7 @@ async def get_contact_for_phone(
         access_token = await get_valid_access_token(db, tenant_id)
         if not access_token:
             return None
-        raw_contact = await search_contact_by_phone(access_token, phone)
+        raw_contact = await search_contact_by_phone(access_token, normalized_phone)
     except Exception:
         logger.warning(
             "HubSpot contact search failed for tenant=%s (failing open)",
@@ -425,14 +506,17 @@ async def get_crm_context_block_for_call(db: Session, call_session: CallSession)
         context_block = ""
 
     try:
-        updated_metadata = dict(call_session.call_metadata or {})
-        updated_metadata["hubspot_crm_context"] = context_block
-        call_session.call_metadata = updated_metadata
-        flag_modified(call_session, "call_metadata")
-        db.add(call_session)
-        db.commit()
+        # Use a nested transaction savepoint to isolate database flushing.
+        # This keeps the helper fail-open and avoids committing the main transaction
+        # during prompt generation.
+        with db.begin_nested():
+            updated_metadata = dict(call_session.call_metadata or {})
+            updated_metadata["hubspot_crm_context"] = context_block
+            call_session.call_metadata = updated_metadata
+            flag_modified(call_session, "call_metadata")
+            db.add(call_session)
+            db.flush()
     except Exception:
-        db.rollback()
         logger.warning(
             "Failed to cache HubSpot CRM context on call_session (non-critical)",
             exc_info=True,

--- a/app/services/hubspot_service.py
+++ b/app/services/hubspot_service.py
@@ -1,0 +1,599 @@
+"""
+HubSpot CRM integration — OAuth 2.0, contact lookup, and post-call write-back.
+
+External HTTP calls: HubSpot OAuth (api.hubapi.com/oauth/v1/token), CRM Search API
+(crm/v3/objects/contacts/search), and Engagements/Calls API (crm/v3/objects/calls).
+
+Rate limit: HubSpot allows 110 requests/10s per account — _request_with_backoff
+retries on 429 with exponential backoff (honoring Retry-After when present).
+
+Every public entrypoint used at call time (contact lookup, CRM context injection,
+post-call write-back) fails open: HubSpot being down or rate-limited logs a
+warning and returns None/"" rather than raising, so a call is never blocked.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+from urllib.parse import urlencode
+
+import httpx
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.core.config import settings
+from app.core.db_encryption import decrypt_hubspot_token, encrypt_hubspot_token
+from app.core.logger import logger
+from app.core.secret_manager import get_hubspot_oauth_credentials
+from app.db.session import SessionLocal
+from app.models.call_session import CallSession
+from app.models.workspace_integration import WorkspaceIntegration
+from app.utils.redis_client import get_redis
+
+AUTHORIZE_URL = "https://app.hubspot.com/oauth/authorize"
+TOKEN_URL = "https://api.hubapi.com/oauth/v1/token"
+REVOKE_URL_TEMPLATE = "https://api.hubapi.com/oauth/v1/refresh-tokens/{token}"
+SEARCH_CONTACTS_URL = "https://api.hubapi.com/crm/v3/objects/contacts/search"
+CREATE_CALL_URL = "https://api.hubapi.com/crm/v3/objects/calls"
+
+SCOPES = "crm.objects.contacts.read crm.objects.contacts.write"
+
+# HubSpot-documented default association type ID for "call to contact"
+# (HUBSPOT_DEFINED associations table). Stable across portals.
+HUBSPOT_CALL_TO_CONTACT_ASSOCIATION_TYPE_ID = 194
+
+PROVIDER = "hubspot"
+
+_MAX_RETRIES = 5
+_BASE_BACKOFF_SECONDS = 1.0
+
+_STATE_PURPOSE = "hubspot_oauth_state"
+_STATE_TTL_MINUTES = 10
+
+_CONTACT_CACHE_TTL_SECONDS = 300  # 5 minutes, per acceptance criteria
+_CONTACT_NOT_FOUND_SENTINEL = "__not_found__"
+
+_HS_CALL_STATUS_MAP = {
+    "completed": "COMPLETED",
+    "failed": "FAILED",
+    "busy": "BUSY",
+    "no_answer": "NO_ANSWER",
+}
+
+
+# ─── HTTP with backoff ────────────────────────────────────────────────────────
+
+
+async def _request_with_backoff(method: str, url: str, **kwargs) -> httpx.Response:
+    """Call HubSpot with exponential backoff on 429 (1s, 2s, 4s, 8s, 16s)."""
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        attempt = 0
+        while True:
+            response = await client.request(method, url, **kwargs)
+            if response.status_code != 429 or attempt >= _MAX_RETRIES:
+                return response
+
+            retry_after_header = response.headers.get("Retry-After")
+            wait_seconds = (
+                float(retry_after_header)
+                if retry_after_header
+                else _BASE_BACKOFF_SECONDS * (2 ** attempt)
+            )
+            logger.warning(
+                "HubSpot 429 on %s %s; retrying in %.1fs (attempt %d/%d)",
+                method,
+                url,
+                wait_seconds,
+                attempt + 1,
+                _MAX_RETRIES,
+            )
+            await asyncio.sleep(wait_seconds)
+            attempt += 1
+
+
+# ─── OAuth state (signed, carries tenant_id through the redirect round-trip) ──
+
+
+def build_oauth_state(tenant_id: uuid.UUID) -> str:
+    payload = {
+        "tenant_id": str(tenant_id),
+        "purpose": _STATE_PURPOSE,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=_STATE_TTL_MINUTES),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def verify_oauth_state(state: str) -> uuid.UUID:
+    """Raises ValueError if state is missing, expired, tampered, or malformed."""
+    try:
+        payload = jwt.decode(state, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+    except JWTError as exc:
+        raise ValueError("Invalid or expired OAuth state") from exc
+
+    if payload.get("purpose") != _STATE_PURPOSE:
+        raise ValueError("Invalid OAuth state purpose")
+
+    tenant_id_str = payload.get("tenant_id")
+    if not tenant_id_str:
+        raise ValueError("OAuth state missing tenant_id")
+
+    try:
+        return uuid.UUID(tenant_id_str)
+    except ValueError as exc:
+        raise ValueError("OAuth state has malformed tenant_id") from exc
+
+
+def get_redirect_uri() -> str:
+    return settings.HUBSPOT_REDIRECT_URI or (
+        f"{settings.WEBHOOK_BASE_URL.rstrip('/')}/api/v1/integrations/hubspot/callback"
+    )
+
+
+def build_authorization_url(state: str) -> str:
+    client_id, _ = get_hubspot_oauth_credentials()
+    params = {
+        "client_id": client_id,
+        "redirect_uri": get_redirect_uri(),
+        "scope": SCOPES,
+        "state": state,
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+
+# ─── Token exchange / refresh ─────────────────────────────────────────────────
+
+
+async def exchange_code_for_tokens(code: str) -> dict:
+    client_id, client_secret = get_hubspot_oauth_credentials()
+    response = await _request_with_backoff(
+        "POST",
+        TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": get_redirect_uri(),
+            "code": code,
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def refresh_access_token(refresh_token: str) -> dict:
+    client_id, client_secret = get_hubspot_oauth_credentials()
+    response = await _request_with_backoff(
+        "POST",
+        TOKEN_URL,
+        data={
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# ─── WorkspaceIntegration CRUD ────────────────────────────────────────────────
+
+
+def get_integration(db: Session, tenant_id: uuid.UUID) -> Optional[WorkspaceIntegration]:
+    return (
+        db.query(WorkspaceIntegration)
+        .filter(
+            WorkspaceIntegration.workspace_id == tenant_id,
+            WorkspaceIntegration.provider == PROVIDER,
+        )
+        .first()
+    )
+
+
+def tenant_has_hubspot_connected(db: Session, tenant_id: uuid.UUID) -> bool:
+    return get_integration(db, tenant_id) is not None
+
+
+def get_connection_status(
+    db: Session, tenant_id: uuid.UUID
+) -> Tuple[bool, Optional[datetime]]:
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return False, None
+    return True, row.created_at
+
+
+def upsert_tokens(
+    db: Session, tenant_id: uuid.UUID, token_response: dict
+) -> WorkspaceIntegration:
+    access_token = token_response["access_token"]
+    refresh_token = token_response.get("refresh_token")
+    expires_in = int(token_response.get("expires_in", 1800))
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+
+    row = get_integration(db, tenant_id)
+    if row is None:
+        row = WorkspaceIntegration(workspace_id=tenant_id, provider=PROVIDER)
+
+    row.access_token = encrypt_hubspot_token(access_token, db)
+    if refresh_token:
+        row.refresh_token = encrypt_hubspot_token(refresh_token, db)
+    row.token_expires_at = expires_at
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+async def get_valid_access_token(db: Session, tenant_id: uuid.UUID) -> Optional[str]:
+    """Return a usable access token, refreshing it first if it's expired (or near-expiry)."""
+    row = get_integration(db, tenant_id)
+    if row is None or not row.access_token:
+        return None
+
+    expires_at = row.token_expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    now = datetime.now(timezone.utc)
+    if expires_at is not None and expires_at > now + timedelta(seconds=60):
+        return decrypt_hubspot_token(row.access_token, db)
+
+    if not row.refresh_token:
+        logger.warning(
+            "HubSpot access token expired for tenant=%s but no refresh_token stored",
+            tenant_id,
+        )
+        return None
+
+    try:
+        refresh_token_plain = decrypt_hubspot_token(row.refresh_token, db)
+        token_response = await refresh_access_token(refresh_token_plain)
+    except Exception:
+        logger.warning(
+            "HubSpot token refresh failed for tenant=%s", tenant_id, exc_info=True
+        )
+        return None
+
+    row = upsert_tokens(db, tenant_id, token_response)
+    return decrypt_hubspot_token(row.access_token, db)
+
+
+async def disconnect(db: Session, tenant_id: uuid.UUID) -> bool:
+    """Revoke the refresh token at HubSpot (best-effort) and delete the local row."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return False
+
+    if row.refresh_token:
+        try:
+            refresh_token_plain = decrypt_hubspot_token(row.refresh_token, db)
+            await _request_with_backoff(
+                "DELETE", REVOKE_URL_TEMPLATE.format(token=refresh_token_plain)
+            )
+        except Exception:
+            logger.warning(
+                "HubSpot token revoke failed (continuing with local disconnect) tenant=%s",
+                tenant_id,
+                exc_info=True,
+            )
+
+    db.delete(row)
+    db.commit()
+    return True
+
+
+# ─── Contact lookup (CRM Search API, Redis-cached) ────────────────────────────
+
+
+def _contact_cache_key(tenant_id: uuid.UUID, phone: str) -> str:
+    return f"hubspot:contact:{tenant_id}:{phone}"
+
+
+def _contact_dict_from_hubspot(raw: dict) -> dict:
+    props = raw.get("properties", {}) or {}
+    first = (props.get("firstname") or "").strip()
+    last = (props.get("lastname") or "").strip()
+    name = f"{first} {last}".strip() or None
+    last_interaction = props.get("notes_last_contacted") or props.get("lastmodifieddate")
+    return {
+        "id": raw.get("id"),
+        "name": name,
+        "email": props.get("email"),
+        "company": props.get("company"),
+        "last_interaction_date": last_interaction,
+    }
+
+
+async def search_contact_by_phone(access_token: str, phone: str) -> Optional[dict]:
+    response = await _request_with_backoff(
+        "POST",
+        SEARCH_CONTACTS_URL,
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={
+            "filterGroups": [
+                {
+                    "filters": [
+                        {
+                            "propertyName": "phone",
+                            "operator": "CONTAINS_TOKEN",
+                            "value": phone,
+                        }
+                    ]
+                }
+            ],
+            "properties": [
+                "firstname",
+                "lastname",
+                "email",
+                "company",
+                "phone",
+                "notes_last_contacted",
+                "lastmodifieddate",
+            ],
+            "limit": 1,
+        },
+    )
+    response.raise_for_status()
+    results = response.json().get("results") or []
+    return results[0] if results else None
+
+
+async def get_contact_for_phone(
+    db: Session, tenant_id: uuid.UUID, phone: str
+) -> Optional[dict]:
+    """Look up a contact by phone, Redis-cached for 5 minutes. Fails open on any error."""
+    redis_client = get_redis()
+    cache_key = _contact_cache_key(tenant_id, phone)
+
+    if redis_client is not None:
+        try:
+            cached = await redis_client.get(cache_key)
+            if cached is not None:
+                return None if cached == _CONTACT_NOT_FOUND_SENTINEL else json.loads(cached)
+        except Exception:
+            logger.warning("HubSpot contact cache read failed (continuing)", exc_info=True)
+
+    try:
+        access_token = await get_valid_access_token(db, tenant_id)
+        if not access_token:
+            return None
+        raw_contact = await search_contact_by_phone(access_token, phone)
+    except Exception:
+        logger.warning(
+            "HubSpot contact search failed for tenant=%s (failing open)",
+            tenant_id,
+            exc_info=True,
+        )
+        return None
+
+    contact = _contact_dict_from_hubspot(raw_contact) if raw_contact else None
+
+    if redis_client is not None:
+        try:
+            payload = (
+                _CONTACT_NOT_FOUND_SENTINEL if contact is None else json.dumps(contact)
+            )
+            await redis_client.set(cache_key, payload, ex=_CONTACT_CACHE_TTL_SECONDS)
+        except Exception:
+            logger.warning("HubSpot contact cache write failed (non-critical)", exc_info=True)
+
+    return contact
+
+
+# ─── CRM context injection (conversation_orchestrator) ────────────────────────
+
+
+async def get_crm_context_block_for_call(db: Session, call_session: CallSession) -> str:
+    """
+    Fetch the CRM context block for a call's system prompt, once per call.
+
+    Cached in call_session.call_metadata["hubspot_crm_context"] so subsequent
+    turns (the prompt is rebuilt every turn) reuse the cached string instead of
+    re-querying HubSpot/Redis. Fails open — returns "" on any error so a CRM
+    outage never blocks the call.
+    """
+    metadata = call_session.call_metadata or {}
+    if "hubspot_crm_context" in metadata:
+        return metadata.get("hubspot_crm_context") or ""
+
+    context_block = ""
+    try:
+        if call_session.customer_phone_number and tenant_has_hubspot_connected(
+            db, call_session.tenant_id
+        ):
+            contact = await get_contact_for_phone(
+                db, call_session.tenant_id, call_session.customer_phone_number
+            )
+            if contact:
+                context_block = (
+                    "# CRM CONTEXT\n"
+                    f"CRM CONTEXT: Caller name: {contact.get('name') or 'Unknown'}, "
+                    f"Company: {contact.get('company') or 'Unknown'}, "
+                    f"Last interaction: {contact.get('last_interaction_date') or 'Unknown'}."
+                )
+    except Exception:
+        logger.warning(
+            "HubSpot CRM context lookup failed (continuing without CRM context)",
+            exc_info=True,
+        )
+        context_block = ""
+
+    try:
+        updated_metadata = dict(call_session.call_metadata or {})
+        updated_metadata["hubspot_crm_context"] = context_block
+        call_session.call_metadata = updated_metadata
+        flag_modified(call_session, "call_metadata")
+        db.add(call_session)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.warning(
+            "Failed to cache HubSpot CRM context on call_session (non-critical)",
+            exc_info=True,
+        )
+
+    return context_block
+
+
+# ─── Post-call write-back (Engagements/Calls API + Gemini summary) ────────────
+
+
+def _hs_call_status(status: Optional[str]) -> str:
+    return _HS_CALL_STATUS_MAP.get((status or "").lower(), "COMPLETED")
+
+
+def _hs_call_direction(call_type: Optional[str]) -> str:
+    return "INBOUND" if (call_type or "").lower() == "inbound" else "OUTBOUND"
+
+
+def _transcript_text(db: Session, call_session: CallSession) -> str:
+    from app.services.transcript_service import transcript_service
+
+    messages = transcript_service.get_messages_by_session(db, call_session.id)
+    lines = [f"{m.role}: {m.message}" for m in messages if m.message]
+    return "\n".join(lines)
+
+
+def generate_transcript_summary(db: Session, call_session: CallSession) -> str:
+    """2-sentence Gemini summary of the call transcript. Fails open — returns ''."""
+    transcript_text = _transcript_text(db, call_session)
+    if not transcript_text.strip():
+        return ""
+
+    from app.services.gemini_service import gemini_service
+
+    try:
+        result = gemini_service.generate_text(
+            prompt=(
+                "Summarize this phone call transcript in exactly 2 sentences, "
+                "focused on the caller's request and the outcome:\n\n" + transcript_text
+            ),
+            model_name="gemini-2.0-flash",
+            temperature=0.2,
+            max_tokens=120,
+        )
+        return (result.get("content") or "").strip()
+    except Exception:
+        logger.warning(
+            "HubSpot post-call summary generation failed (continuing without summary)",
+            exc_info=True,
+        )
+        return ""
+
+
+async def create_call_engagement(
+    access_token: str,
+    contact_id: str,
+    *,
+    occurred_at: datetime,
+    duration_seconds: int,
+    direction: str,
+    hs_status: str,
+    title: str,
+    body_text: str,
+) -> dict:
+    payload = {
+        "properties": {
+            "hs_timestamp": str(int(occurred_at.timestamp() * 1000)),
+            "hs_call_title": title,
+            "hs_call_body": body_text,
+            "hs_call_duration": str(int(duration_seconds * 1000)),
+            "hs_call_direction": direction,
+            "hs_call_status": hs_status,
+        },
+        "associations": [
+            {
+                "to": {"id": contact_id},
+                "types": [
+                    {
+                        "associationCategory": "HUBSPOT_DEFINED",
+                        "associationTypeId": HUBSPOT_CALL_TO_CONTACT_ASSOCIATION_TYPE_ID,
+                    }
+                ],
+            }
+        ],
+    }
+    response = await _request_with_backoff(
+        "POST",
+        CREATE_CALL_URL,
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=payload,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def _run_post_call_writeback_async(db: Session, call_session: CallSession) -> None:
+    access_token = await get_valid_access_token(db, call_session.tenant_id)
+    if not access_token:
+        return
+
+    contact = await get_contact_for_phone(
+        db, call_session.tenant_id, call_session.customer_phone_number
+    )
+    if not contact or not contact.get("id"):
+        logger.info(
+            "HubSpot write-back skipped — no matching contact for session=%s",
+            call_session.id,
+        )
+        return
+
+    summary = generate_transcript_summary(db, call_session)
+    body_text = summary or "Call completed — no transcript summary available."
+
+    await create_call_engagement(
+        access_token,
+        contact["id"],
+        occurred_at=call_session.start_time or datetime.now(timezone.utc),
+        duration_seconds=call_session.duration or 0,
+        direction=_hs_call_direction(call_session.call_type),
+        hs_status=_hs_call_status(call_session.status),
+        title=f"Voice agent call — {call_session.status}",
+        body_text=body_text,
+    )
+    logger.info(
+        "HubSpot call engagement created for session=%s contact=%s",
+        call_session.id,
+        contact["id"],
+    )
+
+
+def run_post_call_writeback(call_session_id: uuid.UUID) -> None:
+    """Sync entrypoint — opens its own session, mirrors sync_inbound_call_to_crm."""
+    db: Session = SessionLocal()
+    try:
+        call_session = db.query(CallSession).filter(CallSession.id == call_session_id).first()
+        if not call_session or not call_session.customer_phone_number:
+            return
+        if not tenant_has_hubspot_connected(db, call_session.tenant_id):
+            return
+
+        asyncio.run(_run_post_call_writeback_async(db, call_session))
+    except Exception:
+        logger.warning(
+            "HubSpot post-call write-back failed (non-critical) session=%s",
+            call_session_id,
+            exc_info=True,
+        )
+    finally:
+        db.close()
+
+
+async def _run_post_call_writeback_in_thread(call_session_id: uuid.UUID) -> None:
+    await asyncio.to_thread(run_post_call_writeback, call_session_id)
+
+
+def schedule_hubspot_writeback(call_session_id: uuid.UUID) -> None:
+    """Fire-and-forget post-call write-back. Never blocks the caller."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        run_post_call_writeback(call_session_id)
+        return
+    asyncio.create_task(_run_post_call_writeback_in_thread(call_session_id))

--- a/app/services/kb_ingestion_service.py
+++ b/app/services/kb_ingestion_service.py
@@ -18,7 +18,7 @@ from typing import IO, List
 from app.core.config import settings
 from app.core.logger import logger
 
-EMBEDDING_MODEL = "text-embedding-ada-002"
+EMBEDDING_MODEL = settings.RAG_EMBEDDING_MODEL
 EMBEDDING_DIM = 1536
 CHUNK_MAX_TOKENS = 800
 CHUNK_OVERLAP_TOKENS = 100
@@ -67,6 +67,9 @@ def chunk_text(
 ) -> List[str]:
     import tiktoken
 
+    if not text or not text.strip():
+        return []
+
     enc = tiktoken.get_encoding("cl100k_base")
     tokens = enc.encode(text)
     if not tokens:
@@ -79,7 +82,7 @@ def chunk_text(
     while start < total:
         end = min(start + max_tokens, total)
         chunk_tokens = tokens[start:end]
-        if len(chunk_tokens) >= min_tokens:
+        if len(chunk_tokens) >= min_tokens or not chunks:
             chunks.append(enc.decode(chunk_tokens))
         elif chunks:
             # Append under-minimum tail to the previous chunk (avoids orphan slivers)

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -501,6 +501,37 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 else:
                     system_prompt = system_prompt + "\n\n" + kb_context_block
 
+            # HubSpot CRM context injection: fetched once at call start (Redis-cached
+            # contact lookup) and cached on call_session.call_metadata, so every later
+            # turn (the prompt is rebuilt each turn) is a cheap in-memory dict read.
+            # Fails open on timeout/error — never blocks the call.
+            crm_context_block = ""
+            if self._h.call_session and self._h.db:
+                try:
+                    from app.services.hubspot_service import get_crm_context_block_for_call
+
+                    crm_context_block = await asyncio.wait_for(
+                        get_crm_context_block_for_call(self._h.db, self._h.call_session),
+                        timeout=0.6,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "HubSpot CRM context lookup timed out; proceeding without CRM context"
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "HubSpot CRM context lookup failed; proceeding without context: %s", exc
+                    )
+
+            if crm_context_block:
+                anchor = "# CONVERSATION STATE"
+                if anchor in system_prompt:
+                    system_prompt = system_prompt.replace(
+                        anchor, crm_context_block + "\n\n" + anchor, 1
+                    )
+                else:
+                    system_prompt = system_prompt + "\n\n" + crm_context_block
+
             from app.core.agent_runtime import llm_service_for_provider, resolve_llm_runtime
 
             llm_runtime = resolve_llm_runtime(self._h.agent)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6796,14 +6796,30 @@ paths:
       summary: Hubspot Connect
       description: 'Redirect to HubSpot''s OAuth consent page. Scopes: contacts read/write.'
       operationId: hubspot_connect_api_v1_integrations_hubspot_connect_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: json
+        in: query
+        required: false
+        schema:
+          type: boolean
+          description: Return the authorization URL as JSON instead of redirecting
+          default: false
+          title: Json
+        description: Return the authorization URL as JSON instead of redirecting
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema: {}
-      security:
-      - HTTPBearer: []
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/integrations/hubspot/callback:
     get:
       tags:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6789,58 +6789,6 @@ paths:
                 $ref: '#/components/schemas/IntegrationListResponse'
       security:
       - HTTPBearer: []
-  /api/v1/integrations/hubspot/connect:
-    get:
-      tags:
-      - HubSpot Integration
-      summary: Hubspot Connect
-      description: 'Redirect to HubSpot''s OAuth consent page. Scopes: contacts read/write.'
-      operationId: hubspot_connect_api_v1_integrations_hubspot_connect_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-      security:
-      - HTTPBearer: []
-  /api/v1/integrations/hubspot/callback:
-    get:
-      tags:
-      - HubSpot Integration
-      summary: Hubspot Callback
-      description: 'HubSpot OAuth callback. No auth dependency — this is a top-level
-        browser
-
-        redirect from HubSpot, which cannot carry our JWT/API-key headers. The
-
-        connecting tenant is recovered from the signed `state` param instead.'
-      operationId: hubspot_callback_api_v1_integrations_hubspot_callback_get
-      parameters:
-      - name: code
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Code
-      - name: state
-        in: query
-        required: true
-        schema:
-          type: string
-          title: State
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/integrations/hubspot:
     delete:
       tags:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6796,30 +6796,14 @@ paths:
       summary: Hubspot Connect
       description: 'Redirect to HubSpot''s OAuth consent page. Scopes: contacts read/write.'
       operationId: hubspot_connect_api_v1_integrations_hubspot_connect_get
-      security:
-      - HTTPBearer: []
-      parameters:
-      - name: json
-        in: query
-        required: false
-        schema:
-          type: boolean
-          description: Return the authorization URL as JSON instead of redirecting
-          default: false
-          title: Json
-        description: Return the authorization URL as JSON instead of redirecting
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
               schema: {}
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /api/v1/integrations/hubspot/callback:
     get:
       tags:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6789,6 +6789,107 @@ paths:
                 $ref: '#/components/schemas/IntegrationListResponse'
       security:
       - HTTPBearer: []
+  /api/v1/integrations/hubspot/connect:
+    get:
+      tags:
+      - HubSpot Integration
+      summary: Hubspot Connect
+      description: 'Redirect to HubSpot''s OAuth consent page. Scopes: contacts read/write.'
+      operationId: hubspot_connect_api_v1_integrations_hubspot_connect_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/hubspot/callback:
+    get:
+      tags:
+      - HubSpot Integration
+      summary: Hubspot Callback
+      description: 'HubSpot OAuth callback. No auth dependency — this is a top-level
+        browser
+
+        redirect from HubSpot, which cannot carry our JWT/API-key headers. The
+
+        connecting tenant is recovered from the signed `state` param instead.'
+      operationId: hubspot_callback_api_v1_integrations_hubspot_callback_get
+      parameters:
+      - name: code
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Code
+      - name: state
+        in: query
+        required: true
+        schema:
+          type: string
+          title: State
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/integrations/hubspot:
+    delete:
+      tags:
+      - HubSpot Integration
+      summary: Hubspot Disconnect
+      description: Revoke the token at HubSpot and delete the workspaceintegration
+        row.
+      operationId: hubspot_disconnect_api_v1_integrations_hubspot_delete
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_HubSpotDisconnectResponse_'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/hubspot/contact:
+    get:
+      tags:
+      - HubSpot Integration
+      summary: Hubspot Get Contact
+      description: CRM Search API lookup by phone. Redis-cached for 5 minutes per
+        phone number.
+      operationId: hubspot_get_contact_api_v1_integrations_hubspot_contact_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: phone
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Phone number to search for (E.164 or local format)
+          title: Phone
+        description: Phone number to search for (E.164 or local format)
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_HubSpotContactOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/calls/history:
     get:
       tags:
@@ -11096,6 +11197,40 @@ components:
       required:
       - hipaa_compliance
       title: HipaaSettingsUpdate
+    HubSpotContactOut:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        company:
+          type: string
+          nullable: true
+        last_interaction_date:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - id
+      title: HubSpotContactOut
+    HubSpotDisconnectResponse:
+      properties:
+        disconnected:
+          type: boolean
+          title: Disconnected
+        provider:
+          type: string
+          title: Provider
+          default: hubspot
+      type: object
+      required:
+      - disconnected
+      title: HubSpotDisconnectResponse
     ImportTwilioPhoneNumberRequest:
       properties:
         phone_number:
@@ -11176,8 +11311,12 @@ components:
           title: Connected
         webhook_url:
           type: string
-          title: Webhook Url
+          nullable: true
         last_triggered_at:
+          type: string
+          format: date-time
+          nullable: true
+        connected_at:
           type: string
           format: date-time
           nullable: true
@@ -11185,7 +11324,6 @@ components:
       required:
       - name
       - connected
-      - webhook_url
       title: IntegrationItem
     IntegrationListResponse:
       properties:
@@ -14515,6 +14653,38 @@ components:
       required:
       - data
       title: SuccessResponse[ForgotPasswordResponse]
+    SuccessResponse_HubSpotContactOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/HubSpotContactOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[HubSpotContactOut]
+    SuccessResponse_HubSpotDisconnectResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/HubSpotDisconnectResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[HubSpotDisconnectResponse]
     SuccessResponse_ImportTwilioPhoneNumberResponse_:
       properties:
         data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ psycopg2-binary==2.9.12
 asyncpg==0.31.0
 alembic==1.18.4
 python-jose[cryptography]==3.5.0
+cryptography==49.0.0
 passlib[bcrypt]==1.7.4
 pydantic==2.13.4
 pydantic-settings==2.14.1

--- a/tests/api/test_hubspot_integration.py
+++ b/tests/api/test_hubspot_integration.py
@@ -1,0 +1,244 @@
+"""
+Tests for HubSpot OAuth integration router endpoints.
+
+Router functions are called directly (mirroring tests/api/test_integrations.py),
+with `db` mocked and external HubSpot calls patched at the service boundary.
+
+Coverage:
+  1.  GET /connect — redirects to HubSpot's OAuth consent page
+  2.  GET /callback — exchanges mock code for tokens, stores them, redirects
+  3.  GET /callback — invalid state -> 400; token exchange failure -> 502
+  4.  GET /contact — correct response shape; not connected -> 400; not found -> 404
+  5.  DELETE "" — disconnects; 404 when not connected
+  6.  GET /api/v1/integrations — includes a hubspot entry with connected/connected_at
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_TENANT_ID = uuid.UUID("aa100000-0000-0000-0000-000000000001")
+
+
+def _principal():
+    p = MagicMock()
+    p.current_tenant_id = _TENANT_ID
+    return p
+
+
+class TestConnect:
+    @pytest.mark.anyio
+    async def test_redirects_to_hubspot(self):
+        from app.routers.hubspot_integration import hubspot_connect
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.build_oauth_state",
+                return_value="signed-state",
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.build_authorization_url",
+                return_value="https://app.hubspot.com/oauth/authorize?client_id=abc&state=signed-state",
+            ),
+        ):
+            response = await hubspot_connect(principal=_principal())
+
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://app.hubspot.com/oauth/authorize?client_id=abc&state=signed-state"
+        )
+
+
+class TestCallback:
+    @pytest.mark.anyio
+    async def test_exchanges_code_and_stores_tokens(self):
+        from app.routers.hubspot_integration import hubspot_callback
+
+        db = MagicMock()
+        token_response = {"access_token": "a", "refresh_token": "r", "expires_in": 1800}
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.exchange_code_for_tokens",
+                new=AsyncMock(return_value=token_response),
+            ) as mock_exchange,
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.upsert_tokens"
+            ) as mock_upsert,
+        ):
+            response = await hubspot_callback(code="mock-auth-code", state="signed-state", db=db)
+
+        mock_exchange.assert_awaited_once_with("mock-auth-code")
+        mock_upsert.assert_called_once_with(db, _TENANT_ID, token_response)
+        assert response.status_code == 302
+        assert "hubspot=connected" in response.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_invalid_state_returns_400(self):
+        from app.routers.hubspot_integration import hubspot_callback
+
+        with patch(
+            "app.routers.hubspot_integration.hubspot_service.verify_oauth_state",
+            side_effect=ValueError("Invalid or expired OAuth state"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await hubspot_callback(code="mock-auth-code", state="bad-state", db=MagicMock())
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_token_exchange_failure_returns_502(self):
+        from app.routers.hubspot_integration import hubspot_callback
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.exchange_code_for_tokens",
+                new=AsyncMock(side_effect=Exception("HubSpot 400")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await hubspot_callback(code="mock-auth-code", state="signed-state", db=MagicMock())
+
+        assert exc_info.value.status_code == 502
+
+
+class TestContactEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_correct_shape(self):
+        from app.routers.hubspot_integration import hubspot_get_contact
+
+        contact = {
+            "id": "100451",
+            "name": "Ada Lovelace",
+            "email": "ada@example.com",
+            "company": "Acme Corp",
+            "last_interaction_date": "2026-06-01T10:00:00Z",
+        }
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.tenant_has_hubspot_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+        ):
+            result = await hubspot_get_contact(
+                phone="+15550001111", principal=_principal(), db=MagicMock()
+            )
+
+        assert result.data.id == "100451"
+        assert result.data.name == "Ada Lovelace"
+        assert result.data.email == "ada@example.com"
+        assert result.data.company == "Acme Corp"
+        assert result.data.last_interaction_date == "2026-06-01T10:00:00Z"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_400(self):
+        from app.routers.hubspot_integration import hubspot_get_contact
+
+        with patch(
+            "app.routers.hubspot_integration.hubspot_service.tenant_has_hubspot_connected",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await hubspot_get_contact(
+                    phone="+15550001111", principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_no_match_returns_404(self):
+        from app.routers.hubspot_integration import hubspot_get_contact
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.tenant_has_hubspot_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.get_contact_for_phone",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await hubspot_get_contact(
+                    phone="+15550001111", principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 404
+
+
+class TestDisconnectEndpoint:
+    @pytest.mark.anyio
+    async def test_disconnects_successfully(self):
+        from app.routers.hubspot_integration import hubspot_disconnect
+
+        with patch(
+            "app.routers.hubspot_integration.hubspot_service.disconnect",
+            new=AsyncMock(return_value=True),
+        ):
+            result = await hubspot_disconnect(principal=_principal(), db=MagicMock())
+
+        assert result.data.disconnected is True
+        assert result.data.provider == "hubspot"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_404(self):
+        from app.routers.hubspot_integration import hubspot_disconnect
+
+        with patch(
+            "app.routers.hubspot_integration.hubspot_service.disconnect",
+            new=AsyncMock(return_value=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await hubspot_disconnect(principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 404
+
+
+class TestIntegrationListIncludesHubSpot:
+    @pytest.mark.anyio
+    async def test_list_integrations_includes_hubspot_status(self):
+        from app.routers.integrations import list_integrations
+
+        request = MagicMock()
+        tenant = MagicMock()
+        tenant.id = _TENANT_ID
+        tenant.workspace_settings = {}
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = tenant
+
+        connected_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        with (
+            patch(
+                "app.core.request_auth.get_workspace_from_request",
+                return_value=MagicMock(id=_TENANT_ID),
+            ),
+            patch(
+                "app.services.hubspot_service.get_connection_status",
+                return_value=(True, connected_at),
+            ),
+        ):
+            result = await list_integrations(request=request, user=_principal(), db=db)
+
+        hubspot_item = next(i for i in result.integrations if i.name == "hubspot")
+        assert hubspot_item.connected is True
+        assert hubspot_item.connected_at == connected_at

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,10 @@ os.environ.setdefault(
     "WEBHOOK_SECRET_ENCRYPTION_KEY",
     "test-webhook-encryption-key-for-pytest-only",
 )
+os.environ.setdefault(
+    "HUBSPOT_TOKEN_ENCRYPTION_KEY",
+    "test-hubspot-encryption-key-for-pytest-only",
+)
 
 # Mock google submodules recursively to avoid ImportError in unit tests.
 # Live Google STT integration tests set RUN_GOOGLE_STT_INTEGRATION=1 to skip mocks.

--- a/tests/services/test_hubspot_service.py
+++ b/tests/services/test_hubspot_service.py
@@ -373,7 +373,40 @@ class TestCrmContextBlock:
         assert "Company: Acme Corp" in block
         assert "Last interaction: 2026-06-01" in block
         assert call_session.call_metadata["hubspot_crm_context"] == block
-        db.commit.assert_called_once()
+        db.flush.assert_called_once()
+        db.commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_flush_error(self):
+        # Mocks a failure in the db.flush() call to test that context generation
+        # fails open and still returns the context block without throwing.
+        db = MagicMock()
+        db.flush.side_effect = Exception("Flush failed")
+        # To support db.begin_nested() mock context manager
+        nested_mock = MagicMock()
+        db.begin_nested.return_value = nested_mock
+        nested_mock.__enter__ = MagicMock()
+        nested_mock.__exit__ = MagicMock()
+
+        call_session = _call_session(metadata={})
+        contact = {
+            "id": "1",
+            "name": "Ada Lovelace",
+            "company": "Acme Corp",
+            "last_interaction_date": "2026-06-01",
+        }
+
+        with (
+            patch("app.services.hubspot_service.tenant_has_hubspot_connected", return_value=True),
+            patch(
+                "app.services.hubspot_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+        ):
+            block = await hubspot_service.get_crm_context_block_for_call(db, call_session)
+
+        assert "CRM CONTEXT: Caller name: Ada Lovelace" in block
+        db.flush.assert_called_once()
 
     @pytest.mark.anyio
     async def test_not_connected_returns_empty_block(self):
@@ -612,3 +645,28 @@ class TestBackoff:
 
         assert response.status_code == 429
         assert mock_client.request.await_count == hubspot_service._MAX_RETRIES + 1
+
+
+class TestPhoneNormalization:
+    def test_normalize_to_e164(self):
+        # Already E.164
+        assert hubspot_service.normalize_to_e164("+15550001111") == "+15550001111"
+        # US formats
+        assert hubspot_service.normalize_to_e164("5550001111") == "+15550001111"
+        assert hubspot_service.normalize_to_e164("15550001111") == "+15550001111"
+        assert hubspot_service.normalize_to_e164("+1 (555) 000-1111") == "+15550001111"
+        # International format
+        assert hubspot_service.normalize_to_e164("+44 7123 456789") == "+447123456789"
+        assert hubspot_service.normalize_to_e164("447123456789") == "+447123456789"
+        # Non-numeric / weird formats
+        assert hubspot_service.normalize_to_e164("") == ""
+        assert hubspot_service.normalize_to_e164("abc") == "abc"
+
+    def test_get_phone_search_values(self):
+        # Test exact match search variations generated for a formatted US phone number
+        vals = hubspot_service._get_phone_search_values("+1 (555) 000-1111")
+        # E.164 (+15550001111), raw digits (15550001111), US national digits (5550001111), raw stripped input
+        assert "+15550001111" in vals
+        assert "15550001111" in vals
+        assert "5550001111" in vals
+        assert "+1 (555) 000-1111" in vals

--- a/tests/services/test_hubspot_service.py
+++ b/tests/services/test_hubspot_service.py
@@ -1,0 +1,614 @@
+"""
+Tests for HubSpot CRM integration service.
+
+External HTTP calls (OAuth token endpoint, CRM Search API, Engagements/Calls API) are
+mocked at the boundary (`_request_with_backoff`) per CLAUDE.md convention.
+
+Coverage:
+  1.  OAuth state: sign/verify round trip, tamper rejection, wrong purpose rejection
+  2.  Authorization URL: client_id/scope/state present
+  3.  Token refresh: returns cached token when fresh; refreshes when expired;
+      returns None when no refresh_token; fails open on refresh error
+  4.  Contact lookup: correct {id, name, email, company, last_interaction_date} shape;
+      Redis cache hit/miss/store; fails open on HubSpot error
+  5.  CRM context block: cached on call_metadata after first fetch; fails open
+  6.  Post-call write-back: creates a Call engagement with the Gemini summary
+  7.  Disconnect: revokes + deletes; returns False when not connected
+  8.  429 backoff: retries with exponential delay, honors Retry-After
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import hubspot_service
+
+
+_TENANT_ID = uuid.UUID("aa100000-0000-0000-0000-000000000001")
+_SESSION_ID = uuid.UUID("bb100000-0000-0000-0000-000000000002")
+
+
+# ── OAuth state ────────────────────────────────────────────────────────────────
+
+
+class TestOAuthState:
+    def test_roundtrip(self):
+        state = hubspot_service.build_oauth_state(_TENANT_ID)
+        assert hubspot_service.verify_oauth_state(state) == _TENANT_ID
+
+    def test_tampered_state_rejected(self):
+        state = hubspot_service.build_oauth_state(_TENANT_ID)
+        with pytest.raises(ValueError):
+            hubspot_service.verify_oauth_state(state + "x")
+
+    def test_wrong_purpose_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        bad_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "something_else",
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            hubspot_service.verify_oauth_state(bad_state)
+
+    def test_expired_state_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        expired_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "hubspot_oauth_state",
+                "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            hubspot_service.verify_oauth_state(expired_state)
+
+
+class TestAuthorizationUrl:
+    def test_contains_client_id_scope_and_state(self):
+        with patch(
+            "app.services.hubspot_service.get_hubspot_oauth_credentials",
+            return_value=("client-123", "secret-456"),
+        ):
+            state = hubspot_service.build_oauth_state(_TENANT_ID)
+            url = hubspot_service.build_authorization_url(state)
+
+        assert url.startswith(hubspot_service.AUTHORIZE_URL)
+        assert "client_id=client-123" in url
+        assert "crm.objects.contacts.read" in url
+        assert "crm.objects.contacts.write" in url
+        assert f"state={state}" in url
+
+
+# ── Token refresh ──────────────────────────────────────────────────────────────
+
+
+def _integration_row(*, expires_in_seconds: float, has_refresh_token: bool = True):
+    row = MagicMock()
+    row.access_token = "encrypted-access-token"
+    row.refresh_token = "encrypted-refresh-token" if has_refresh_token else None
+    row.token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
+    return row
+
+
+class TestTokenRefresh:
+    @pytest.mark.anyio
+    async def test_returns_existing_token_when_not_expired(self):
+        row = _integration_row(expires_in_seconds=600)
+        db = MagicMock()
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.decrypt_hubspot_token",
+                return_value="plain-access-token",
+            ) as mock_decrypt,
+        ):
+            token = await hubspot_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert token == "plain-access-token"
+        mock_decrypt.assert_called_once_with(row.access_token, db)
+
+    @pytest.mark.anyio
+    async def test_refreshes_when_expired(self):
+        row = _integration_row(expires_in_seconds=-60)
+        db = MagicMock()
+        new_row = _integration_row(expires_in_seconds=1800)
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.decrypt_hubspot_token",
+                side_effect=["plain-refresh-token", "new-plain-access-token"],
+            ),
+            patch(
+                "app.services.hubspot_service.refresh_access_token",
+                new=AsyncMock(return_value={"access_token": "new", "expires_in": 1800}),
+            ) as mock_refresh,
+            patch("app.services.hubspot_service.upsert_tokens", return_value=new_row) as mock_upsert,
+        ):
+            token = await hubspot_service.get_valid_access_token(db, _TENANT_ID)
+
+        mock_refresh.assert_awaited_once_with("plain-refresh-token")
+        mock_upsert.assert_called_once()
+        assert token == "new-plain-access-token"
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_expired_and_no_refresh_token(self):
+        row = _integration_row(expires_in_seconds=-60, has_refresh_token=False)
+        db = MagicMock()
+
+        with patch("app.services.hubspot_service.get_integration", return_value=row):
+            token = await hubspot_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert token is None
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_no_integration(self):
+        db = MagicMock()
+        with patch("app.services.hubspot_service.get_integration", return_value=None):
+            token = await hubspot_service.get_valid_access_token(db, _TENANT_ID)
+        assert token is None
+
+    @pytest.mark.anyio
+    async def test_refresh_failure_fails_open(self):
+        row = _integration_row(expires_in_seconds=-60)
+        db = MagicMock()
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.decrypt_hubspot_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.hubspot_service.refresh_access_token",
+                new=AsyncMock(side_effect=Exception("HubSpot down")),
+            ),
+        ):
+            token = await hubspot_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert token is None
+
+
+# ── Contact lookup ──────────────────────────────────────────────────────────────
+
+
+_RAW_CONTACT = {
+    "id": "100451",
+    "properties": {
+        "firstname": "Ada",
+        "lastname": "Lovelace",
+        "email": "ada@example.com",
+        "company": "Acme Corp",
+        "notes_last_contacted": "2026-06-01T10:00:00Z",
+        "lastmodifieddate": "2026-06-10T10:00:00Z",
+    },
+}
+
+
+class TestContactShape:
+    def test_contact_dict_from_hubspot_shape(self):
+        contact = hubspot_service._contact_dict_from_hubspot(_RAW_CONTACT)
+        assert contact == {
+            "id": "100451",
+            "name": "Ada Lovelace",
+            "email": "ada@example.com",
+            "company": "Acme Corp",
+            "last_interaction_date": "2026-06-01T10:00:00Z",
+        }
+
+    def test_falls_back_to_lastmodifieddate(self):
+        raw = {
+            "id": "1",
+            "properties": {"firstname": "A", "lastname": "B", "lastmodifieddate": "2026-01-01"},
+        }
+        contact = hubspot_service._contact_dict_from_hubspot(raw)
+        assert contact["last_interaction_date"] == "2026-01-01"
+
+
+class TestGetContactForPhone:
+    @pytest.mark.anyio
+    async def test_cache_hit_skips_hubspot_call(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(
+            return_value='{"id": "1", "name": "Cached Person", "email": null, "company": null, "last_interaction_date": null}'
+        )
+
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=mock_redis),
+            patch("app.services.hubspot_service.get_valid_access_token") as mock_token,
+        ):
+            contact = await hubspot_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        mock_token.assert_not_called()
+        assert contact["name"] == "Cached Person"
+
+    @pytest.mark.anyio
+    async def test_cache_miss_fetches_and_stores(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock()
+
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=mock_redis),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value="access-token"),
+            ),
+            patch(
+                "app.services.hubspot_service.search_contact_by_phone",
+                new=AsyncMock(return_value=_RAW_CONTACT),
+            ),
+        ):
+            contact = await hubspot_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact["id"] == "100451"
+        assert contact["name"] == "Ada Lovelace"
+        mock_redis.set.assert_awaited_once()
+        _, kwargs = mock_redis.set.call_args
+        assert kwargs.get("ex") == 300
+
+    @pytest.mark.anyio
+    async def test_no_match_caches_not_found_sentinel(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock()
+
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=mock_redis),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value="access-token"),
+            ),
+            patch(
+                "app.services.hubspot_service.search_contact_by_phone",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            contact = await hubspot_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+        mock_redis.set.assert_awaited_once_with(
+            hubspot_service._contact_cache_key(_TENANT_ID, "+15550001111"),
+            hubspot_service._CONTACT_NOT_FOUND_SENTINEL,
+            ex=300,
+        )
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_hubspot_error(self):
+        """A HubSpot outage during contact search must never raise — call proceeds without CRM data."""
+        db = MagicMock()
+
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=None),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value="access-token"),
+            ),
+            patch(
+                "app.services.hubspot_service.search_contact_by_phone",
+                new=AsyncMock(side_effect=Exception("HubSpot 500")),
+            ),
+        ):
+            contact = await hubspot_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+
+    @pytest.mark.anyio
+    async def test_no_access_token_returns_none(self):
+        db = MagicMock()
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=None),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            contact = await hubspot_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+        assert contact is None
+
+
+# ── CRM context block (conversation_orchestrator injection) ───────────────────
+
+
+def _call_session(*, phone="+15550001111", metadata=None):
+    cs = MagicMock()
+    cs.id = _SESSION_ID
+    cs.tenant_id = _TENANT_ID
+    cs.customer_phone_number = phone
+    cs.call_metadata = metadata
+    return cs
+
+
+class TestCrmContextBlock:
+    @pytest.mark.anyio
+    async def test_returns_cached_value_without_refetching(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={"hubspot_crm_context": "# CRM CONTEXT\ncached"})
+
+        with patch("app.services.hubspot_service.tenant_has_hubspot_connected") as mock_connected:
+            block = await hubspot_service.get_crm_context_block_for_call(db, call_session)
+
+        mock_connected.assert_not_called()
+        assert block == "# CRM CONTEXT\ncached"
+
+    @pytest.mark.anyio
+    async def test_fetches_and_caches_on_first_call(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+        contact = {
+            "id": "1",
+            "name": "Ada Lovelace",
+            "company": "Acme Corp",
+            "last_interaction_date": "2026-06-01",
+        }
+
+        with (
+            patch("app.services.hubspot_service.tenant_has_hubspot_connected", return_value=True),
+            patch(
+                "app.services.hubspot_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+        ):
+            block = await hubspot_service.get_crm_context_block_for_call(db, call_session)
+
+        assert "CRM CONTEXT: Caller name: Ada Lovelace" in block
+        assert "Company: Acme Corp" in block
+        assert "Last interaction: 2026-06-01" in block
+        assert call_session.call_metadata["hubspot_crm_context"] == block
+        db.commit.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_empty_block(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch("app.services.hubspot_service.tenant_has_hubspot_connected", return_value=False):
+            block = await hubspot_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == ""
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_exception(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch(
+            "app.services.hubspot_service.tenant_has_hubspot_connected",
+            side_effect=Exception("DB down"),
+        ):
+            block = await hubspot_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == ""
+
+
+# ── Post-call write-back ───────────────────────────────────────────────────────
+
+
+class TestPostCallWriteback:
+    @pytest.mark.anyio
+    async def test_creates_engagement_with_summary(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.id = _SESSION_ID
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.start_time = datetime.now(timezone.utc)
+        call_session.duration = 120
+        call_session.call_type = "outbound"
+        call_session.status = "completed"
+
+        contact = {"id": "contact-1", "name": "Ada Lovelace"}
+
+        with (
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value="access-token"),
+            ),
+            patch(
+                "app.services.hubspot_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+            patch(
+                "app.services.hubspot_service.generate_transcript_summary",
+                return_value="Caller asked about pricing. Agent booked a follow-up demo.",
+            ),
+            patch(
+                "app.services.hubspot_service.create_call_engagement",
+                new=AsyncMock(return_value={"id": "engagement-1"}),
+            ) as mock_create_engagement,
+        ):
+            await hubspot_service._run_post_call_writeback_async(db, call_session)
+
+        mock_create_engagement.assert_awaited_once()
+        _, kwargs = mock_create_engagement.call_args
+        assert kwargs["direction"] == "OUTBOUND"
+        assert kwargs["hs_status"] == "COMPLETED"
+        assert kwargs["duration_seconds"] == 120
+        assert "pricing" in kwargs["body_text"]
+        assert mock_create_engagement.call_args[0][1] == "contact-1"
+
+    @pytest.mark.anyio
+    async def test_skips_when_no_matching_contact(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.id = _SESSION_ID
+
+        with (
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value="access-token"),
+            ),
+            patch(
+                "app.services.hubspot_service.get_contact_for_phone",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.services.hubspot_service.create_call_engagement") as mock_create,
+        ):
+            await hubspot_service._run_post_call_writeback_async(db, call_session)
+
+        mock_create.assert_not_called()
+
+    def test_run_post_call_writeback_skips_when_not_connected(self):
+        """Sync entrypoint must not touch HubSpot when the tenant has no connection."""
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        db.query.return_value.filter.return_value.first.return_value = call_session
+
+        with (
+            patch("app.services.hubspot_service.SessionLocal", return_value=db),
+            patch("app.services.hubspot_service.tenant_has_hubspot_connected", return_value=False),
+            patch("asyncio.run") as mock_asyncio_run,
+        ):
+            hubspot_service.run_post_call_writeback(_SESSION_ID)
+
+        mock_asyncio_run.assert_not_called()
+        db.close.assert_called_once()
+
+    def test_call_status_and_direction_mapping(self):
+        assert hubspot_service._hs_call_status("no_answer") == "NO_ANSWER"
+        assert hubspot_service._hs_call_status("unknown") == "COMPLETED"
+        assert hubspot_service._hs_call_direction("inbound") == "INBOUND"
+        assert hubspot_service._hs_call_direction("outbound") == "OUTBOUND"
+
+
+# ── Disconnect ──────────────────────────────────────────────────────────────────
+
+
+class TestDisconnect:
+    @pytest.mark.anyio
+    async def test_revokes_and_deletes_row(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.refresh_token = "encrypted-refresh-token"
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.decrypt_hubspot_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.hubspot_service._request_with_backoff",
+                new=AsyncMock(return_value=MagicMock(status_code=204)),
+            ) as mock_request,
+        ):
+            result = await hubspot_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        mock_request.assert_awaited_once()
+        assert mock_request.call_args[0][0] == "DELETE"
+        db.delete.assert_called_once_with(row)
+        db.commit.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_returns_false_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.hubspot_service.get_integration", return_value=None):
+            result = await hubspot_service.disconnect(db, _TENANT_ID)
+        assert result is False
+        db.delete.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_revoke_failure_still_deletes_local_row(self):
+        """HubSpot revoke endpoint being down must not block local disconnect."""
+        db = MagicMock()
+        row = MagicMock()
+        row.refresh_token = "encrypted-refresh-token"
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.decrypt_hubspot_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.hubspot_service._request_with_backoff",
+                new=AsyncMock(side_effect=Exception("network error")),
+            ),
+        ):
+            result = await hubspot_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        db.delete.assert_called_once_with(row)
+
+
+# ── 429 backoff ─────────────────────────────────────────────────────────────────
+
+
+class TestBackoff:
+    @pytest.mark.anyio
+    async def test_retries_on_429_then_succeeds(self):
+        responses = [MagicMock(status_code=429, headers={}), MagicMock(status_code=200, headers={})]
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            response = await hubspot_service._request_with_backoff("GET", "https://api.hubapi.com/x")
+
+        assert response.status_code == 200
+        mock_sleep.assert_awaited_once()
+        assert mock_sleep.call_args[0][0] == 1.0  # first backoff: base * 2**0
+
+    @pytest.mark.anyio
+    async def test_honors_retry_after_header(self):
+        responses = [
+            MagicMock(status_code=429, headers={"Retry-After": "3"}),
+            MagicMock(status_code=200, headers={}),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await hubspot_service._request_with_backoff("GET", "https://api.hubapi.com/x")
+
+        assert mock_sleep.call_args[0][0] == 3.0
+
+    @pytest.mark.anyio
+    async def test_gives_up_after_max_retries(self):
+        always_429 = MagicMock(status_code=429, headers={})
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=always_429)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            response = await hubspot_service._request_with_backoff("GET", "https://api.hubapi.com/x")
+
+        assert response.status_code == 429
+        assert mock_client.request.await_count == hubspot_service._MAX_RETRIES + 1


### PR DESCRIPTION
## Summary
- New `workspaceintegration` table (one row per workspace+provider) stores OAuth-connected CRM accounts: `access_token`/`refresh_token` (encrypted), `token_expires_at`, `metadata`.
- HubSpot OAuth 2.0 flow: `GET /api/v1/integrations/hubspot/connect` (admin-only, redirects to HubSpot's consent screen with a signed `state` carrying the tenant id) and `GET /api/v1/integrations/hubspot/callback` (public — exempted from API-key middleware since HubSpot's redirect carries no auth headers; verifies `state`, exchanges the code, stores tokens).
- Tokens are encrypted with real **AES-256-GCM** (Python `cryptography`, not pgcrypto — `pgp_sym_encrypt` has no GCM mode). Decrypt transparently falls back to the legacy `pgp_sym_encrypt` format for tokens stored before this change, so already-connected workspaces don't need to reconnect.
- Auto-refresh: every HubSpot call goes through `get_valid_access_token`, which checks `token_expires_at` and refreshes via `refresh_token` first if needed.
- `GET /api/v1/integrations/hubspot/contact?phone=` — CRM Search API lookup by phone, Redis-cached 5 minutes per phone number, returns `{id, name, email, company, last_interaction_date}`.
- CRM context (`CRM CONTEXT: Caller name: ..., Company: ..., Last interaction: ...`) is injected into the LLM system prompt once per call (cached on `call_session.call_metadata`), fetched in `conversation_orchestrator.py` with a tight timeout — fails open, never blocks the call.
- Post-call write-back: when a call transitions to `status='completed'` (hooked into `CallSessionService.update_call_session_status`, same pattern as the existing inbound-CRM-sync/smart-callback hooks), a fire-and-forget background task generates a 2-sentence Gemini summary of the transcript and creates a HubSpot Call engagement (duration, outcome, summary) associated with the contact.
- `DELETE /api/v1/integrations/hubspot` revokes the refresh token at HubSpot and deletes the local row. `GET /api/v1/integrations` now reports `{name: "hubspot", connected, connected_at}` alongside Make/n8n.
- All HubSpot HTTP calls go through a shared backoff helper (110 req/10s rate limit; exponential backoff on 429, honoring `Retry-After`).

## Test plan
- [x] 99 pytest tests pass: OAuth state sign/verify, token refresh (fresh/expired/no-refresh-token/refresh-failure), contact shape + Redis cache hit/miss/fail-open, CRM context injection + caching, post-call write-back, disconnect, 429 backoff, `GET /integrations` HubSpot entry, OpenAPI contract
- [x] Migration verified both ways (upgrade/downgrade) against a throwaway local Postgres container, then applied to the dev database
- [x] AES-256-GCM round-trip and legacy-token backward compatibility verified directly against the dev DB's already-connected row
- [x] Manually connected a real HubSpot account end-to-end via `/connect` → consent → `/callback`

🤖 Generated with [Claude Code](https://claude.com/claude-code)