### PR TITLE
feat/Stripe In-call Payments: PaymentIntent + Charge + Webhook Verification

### DIFF
--- a/alembic/versions/1def74a4fa8c_merge_sso_and_dev_heads_and_rename_to_.py
+++ b/alembic/versions/1def74a4fa8c_merge_sso_and_dev_heads_and_rename_to_.py
@@ -1,0 +1,30 @@
+"""merge sso and dev heads and rename to ssoconfig
+
+Revision ID: 1def74a4fa8c
+Revises: b1c2d3e4f5a6, e3ab5bd291be
+Create Date: 2026-06-30 00:59:54.357202
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1def74a4fa8c'
+down_revision: Union[str, Sequence[str], None] = ('b1c2d3e4f5a6', 'e3ab5bd291be')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.rename_table('sso_configs', 'ssoconfig')
+    op.execute("ALTER INDEX IF EXISTS idx_sso_configs_workspace_id RENAME TO idx_ssoconfig_workspace_id")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.execute("ALTER INDEX IF EXISTS idx_ssoconfig_workspace_id RENAME TO idx_sso_configs_workspace_id")
+    op.rename_table('ssoconfig', 'sso_configs')

--- a/alembic/versions/20260618_audit_actor_prefix_wid.py
+++ b/alembic/versions/20260618_audit_actor_prefix_wid.py
@@ -15,8 +15,8 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260618_audit_actor_prefix_widen"
-down_revision: Union[str, Sequence[str], None] = "20260618_user_email_partial_unique"
+revision: str = "20260618_audit_actor_prefix_wid"
+down_revision: Union[str, Sequence[str], None] = "20260618_user_email_partial_uq"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/20260618_public_call_token.py
+++ b/alembic/versions/20260618_public_call_token.py
@@ -18,7 +18,7 @@ from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
 revision: str = "20260618_public_call_token"
-down_revision: Union[str, Sequence[str], None] = "20260618_audit_actor_prefix_widen"
+down_revision: Union[str, Sequence[str], None] = "20260618_audit_actor_prefix_wid"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/20260618_user_email_partial_uq.py
+++ b/alembic/versions/20260618_user_email_partial_uq.py
@@ -17,7 +17,7 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "20260618_user_email_partial_unique"
+revision: str = "20260618_user_email_partial_uq"
 down_revision: Union[str, Sequence[str], None] = "20260618_data_export_job"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/alembic/versions/20260625_add_sso_configs.py
+++ b/alembic/versions/20260625_add_sso_configs.py
@@ -1,0 +1,53 @@
+"""Add sso_configs table
+
+Revision ID: b1c2d3e4f5a6
+Revises: a9f2b3c4d5e6
+Create Date: 2026-06-25 20:31:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'b1c2d3e4f5a6'
+down_revision: Union[str, Sequence[str], None] = 'a9f2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'sso_configs',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            'workspace_id',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('tenant.id', ondelete='CASCADE'),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column(
+            'protocol',
+            sa.String(10),
+            sa.CheckConstraint("protocol IN ('saml', 'oidc')", name='chk_sso_protocol'),
+            nullable=False,
+        ),
+        sa.Column('idp_entity_id', sa.Text(), nullable=True),
+        sa.Column('idp_sso_url', sa.Text(), nullable=True),
+        sa.Column('idp_x509_certificate', sa.Text(), nullable=True),
+        sa.Column('oidc_client_id', sa.Text(), nullable=True),
+        sa.Column('oidc_client_secret', sa.Text(), nullable=True),   # Fernet-encrypted
+        sa.Column('oidc_discovery_url', sa.Text(), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), onupdate=sa.text('now()'), nullable=True),
+    )
+    op.create_index('idx_sso_configs_workspace_id', 'sso_configs', ['workspace_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('idx_sso_configs_workspace_id', table_name='sso_configs')
+    op.drop_table('sso_configs')

--- a/alembic/versions/20260625_add_workspace_slug.py
+++ b/alembic/versions/20260625_add_workspace_slug.py
@@ -1,0 +1,70 @@
+"""Add workspace_slug to Tenant
+
+Revision ID: a9f2b3c4d5e6
+Revises: 7cc13a4806d8
+Create Date: 2026-06-25 20:30:00.000000
+
+"""
+import re
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = 'a9f2b3c4d5e6'
+down_revision: Union[str, Sequence[str], None] = '7cc13a4806d8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _slugify(name: str) -> str:
+    """URL-safe lowercase slug from a workspace name."""
+    slug = name.lower().strip()
+    slug = re.sub(r'[^a-z0-9]+', '-', slug)
+    return slug.strip('-') or 'workspace'
+
+
+def upgrade() -> None:
+    """Add workspace_slug column, backfill existing rows, then add unique index."""
+    # Step 1: add nullable column
+    op.add_column('tenant', sa.Column('workspace_slug', sa.String(length=100), nullable=True))
+
+    # Step 2: backfill existing rows using a server-side expression
+    # We use lower + regexp_replace for Postgres; for SQLite tests we skip (test fixtures
+    # set workspace_slug directly when needed).
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == 'postgresql':
+        # Postgres: slugify name in SQL, then resolve duplicates in Python
+        rows = bind.execute(text("SELECT id, name FROM tenant ORDER BY created_at")).fetchall()
+        used: dict[str, int] = {}
+        for row_id, name in rows:
+            base = re.sub(r'[^a-z0-9]+', '-', (name or 'workspace').lower()).strip('-') or 'workspace'
+            slug = base
+            if slug in used:
+                used[slug] += 1
+                slug = f"{base}-{used[slug]}"
+            else:
+                used[slug] = 0
+            bind.execute(
+                text("UPDATE tenant SET workspace_slug = :slug WHERE id = :id"),
+                {"slug": slug, "id": row_id},
+            )
+
+    # Step 3: unique index (partial — only among non-deleted rows)
+    op.create_index(
+        'uq_tenant_workspace_slug_active',
+        'tenant',
+        ['workspace_slug'],
+        unique=True,
+        postgresql_where=sa.text('deleted_at IS NULL'),
+        sqlite_where=sa.text('deleted_at IS NULL'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('uq_tenant_workspace_slug_active', table_name='tenant')
+    op.drop_column('tenant', 'workspace_slug')

--- a/alembic/versions/20260626_add_payment_records.py
+++ b/alembic/versions/20260626_add_payment_records.py
@@ -11,7 +11,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = "20260626_add_payment_records"
-down_revision = "20260625_add_workspace_slug"
+down_revision = "1def74a4fa8c"
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/20260626_add_payment_records.py
+++ b/alembic/versions/20260626_add_payment_records.py
@@ -1,0 +1,87 @@
+"""
+Alembic migration: create paymentrecord table for in-call Stripe payments.
+
+Revision ID: 20260626_add_payment_records
+Revises: 20260625_add_workspace_slug
+Create Date: 2026-06-26
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20260626_add_payment_records"
+down_revision = "20260625_add_workspace_slug"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "paymentrecord",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("tenant.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "call_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("callsession.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("payment_intent_id", sa.String(255), nullable=False),
+        sa.Column("amount_cents", sa.Integer(), nullable=False),
+        sa.Column("currency", sa.String(10), nullable=False, server_default="usd"),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(50), nullable=False, server_default="pending"),
+        sa.Column("card_last4", sa.String(4), nullable=True),
+        sa.Column("card_brand", sa.String(50), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Primary key index
+    op.create_index("ix_paymentrecord_id", "paymentrecord", ["id"])
+
+    # Unique index on Stripe PaymentIntent ID (for idempotent webhook processing)
+    op.create_index(
+        "uq_paymentrecord_payment_intent_id",
+        "paymentrecord",
+        ["payment_intent_id"],
+        unique=True,
+    )
+
+    # Composite index for workspace-scoped listing with time ordering
+    op.create_index(
+        "idx_paymentrecord_workspace_created",
+        "paymentrecord",
+        ["workspace_id", "created_at"],
+    )
+
+    # Index for call_id FK lookups
+    op.create_index("ix_paymentrecord_call_id", "paymentrecord", ["call_id"])
+    op.create_index("ix_paymentrecord_workspace_id", "paymentrecord", ["workspace_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_paymentrecord_workspace_created", table_name="paymentrecord")
+    op.drop_index("uq_paymentrecord_payment_intent_id", table_name="paymentrecord")
+    op.drop_index("ix_paymentrecord_payment_intent_id", table_name="paymentrecord")
+    op.drop_index("ix_paymentrecord_call_id", table_name="paymentrecord")
+    op.drop_index("ix_paymentrecord_workspace_id", table_name="paymentrecord")
+    op.drop_index("ix_paymentrecord_id", table_name="paymentrecord")
+    op.drop_table("paymentrecord")

--- a/alembic/versions/20260626_add_payment_records.py
+++ b/alembic/versions/20260626_add_payment_records.py
@@ -80,7 +80,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("idx_paymentrecord_workspace_created", table_name="paymentrecord")
     op.drop_index("uq_paymentrecord_payment_intent_id", table_name="paymentrecord")
-    op.drop_index("ix_paymentrecord_payment_intent_id", table_name="paymentrecord")
     op.drop_index("ix_paymentrecord_call_id", table_name="paymentrecord")
     op.drop_index("ix_paymentrecord_workspace_id", table_name="paymentrecord")
     op.drop_index("ix_paymentrecord_id", table_name="paymentrecord")

--- a/alembic/versions/20260630_add_allowed_email_domains.py
+++ b/alembic/versions/20260630_add_allowed_email_domains.py
@@ -1,0 +1,33 @@
+"""Add allowed_email_domains to sso_configs
+
+Revision ID: 20260630_add_allowed_email_domains
+Revises: 20260626_add_payment_records
+Create Date: 2026-06-30
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '20260630_add_allowed_email_domains'
+down_revision: Union[str, Sequence[str], None] = '20260626_add_payment_records'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'ssoconfig',
+        sa.Column(
+            'allowed_email_domains',
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+            server_default='[]',
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('ssoconfig', 'allowed_email_domains')

--- a/alembic/versions/7cc13a4806d8_add_contact_email_to_tenant.py
+++ b/alembic/versions/7cc13a4806d8_add_contact_email_to_tenant.py
@@ -1,0 +1,29 @@
+"""Add contact_email to Tenant
+
+Revision ID: 7cc13a4806d8
+Revises: fdff731d11a7
+Create Date: 2026-06-24 18:52:52.448789
+
+"""
+import pgvector
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '7cc13a4806d8'
+down_revision: Union[str, Sequence[str], None] = 'fdff731d11a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('tenant', sa.Column('contact_email', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('tenant', 'contact_email')

--- a/alembic/versions/e3ab5bd291be_merge_heads_7cc13a4806d8_and_.py
+++ b/alembic/versions/e3ab5bd291be_merge_heads_7cc13a4806d8_and_.py
@@ -1,0 +1,28 @@
+"""merge heads 7cc13a4806d8 and f75178a95482
+
+Revision ID: e3ab5bd291be
+Revises: 7cc13a4806d8, f75178a95482
+Create Date: 2026-06-26 23:32:20.262668
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e3ab5bd291be'
+down_revision: Union[str, Sequence[str], None] = ('7cc13a4806d8', 'f75178a95482')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/alembic/versions/f75178a95482_add_workspaceintegration_table.py
+++ b/alembic/versions/f75178a95482_add_workspaceintegration_table.py
@@ -1,0 +1,46 @@
+"""add_workspaceintegration_table
+
+Revision ID: f75178a95482
+Revises: fdff731d11a7
+Create Date: 2026-06-24 20:31:39.546692
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = 'f75178a95482'
+down_revision: Union[str, Sequence[str], None] = 'fdff731d11a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'workspaceintegration',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('workspace_id', sa.UUID(), nullable=False),
+        sa.Column('provider', sa.String(length=50), nullable=False),
+        sa.Column('access_token', sa.Text(), nullable=True),
+        sa.Column('refresh_token', sa.Text(), nullable=True),
+        sa.Column('token_expires_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['workspace_id'], ['tenant.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('workspace_id', 'provider', name='uq_workspace_integration_provider'),
+    )
+    op.create_index(op.f('ix_workspaceintegration_id'), 'workspaceintegration', ['id'], unique=False)
+    op.create_index(op.f('ix_workspaceintegration_workspace_id'), 'workspaceintegration', ['workspace_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_workspaceintegration_workspace_id'), table_name='workspaceintegration')
+    op.drop_index(op.f('ix_workspaceintegration_id'), table_name='workspaceintegration')
+    op.drop_table('workspaceintegration')

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -16,6 +16,7 @@ from app.api.api_v1.endpoints import (
     workspace,
     workspace_invites,
 )
+from app.routers.sso import router as sso_router
 from app.routers.agents import router as agent_router
 from app.routers.call_flows import router as call_flows_router
 from app.routers.folders import router as folders_router
@@ -59,6 +60,7 @@ api_router.include_router(tenant.router, prefix="/tenants", tags=["tenants"])
 # that their literal paths take priority over /workspace/{workspace_id}.
 api_router.include_router(workspace_invites.router, prefix="/workspace", tags=["Workspace Invitations"])
 api_router.include_router(allowed_domains.router, prefix="/workspace", tags=["Workspace — Allowed Domains"])
+api_router.include_router(sso_router, prefix="/workspace/sso", tags=["SSO"])
 api_router.include_router(workspace.router, prefix="/workspace", tags=["Workspace"])
 api_router.include_router(role.router, prefix="/roles", tags=["roles"])
 api_router.include_router(agent_router, prefix="/agent", tags=["Voice Agent"])

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -51,6 +51,7 @@ from app.routers.recordings import router as recordings_router
 from app.routers.integrations import router as integrations_router
 from app.routers.call_history import router as call_history_router
 from app.routers.call_history import batch_router as batch_call_metrics_router
+from app.routers.payments import router as payments_router
 
 api_router = APIRouter()
 api_router.include_router(user.router, prefix="/users", tags=["users"])
@@ -160,3 +161,4 @@ api_router.include_router(recordings_router, prefix="/recordings", tags=["Call R
 api_router.include_router(integrations_router, prefix="/integrations", tags=["Integrations"])
 api_router.include_router(call_history_router, prefix="/calls", tags=["Call History Analytics"])
 api_router.include_router(batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"])
+api_router.include_router(payments_router, prefix="/payments", tags=["In-Call Payments"])

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -426,6 +426,44 @@ require_config = _require_rank(role_service.CONFIG_ONLY)
 require_readonly = _require_rank(role_service.READ_ONLY)
 
 
+async def get_admin_workspace(
+    request: Request,
+    workspace: Workspace = Depends(get_current_workspace),
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security_optional),
+    db: Session = Depends(get_db),
+) -> Workspace:
+    """Sub-account API endpoints: requires BOTH a valid M2M API key (resolving target workspace)
+    AND a valid admin JWT (ensuring caller is an admin in their current tenant)."""
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Bearer token required to perform agency operations.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    payload = verify_token(credentials.credentials)
+    if not payload:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    try:
+        user_id = uuid.UUID(payload.get("user_id"))
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=401, detail="Invalid user ID format")
+
+    user = get_active_user_by_id(db, user_id)
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+
+    role_name = rbac_cache_service.get_effective_role(db, user.id, workspace.id)
+    if role_name is None:
+        raise _not_a_member()
+
+    if not role_service.has_rank(role_name, role_service.ADMIN):
+        raise _forbidden(role_service.ADMIN, role_name)
+
+    return workspace
+
+
 def _require_rank_or_api_key(required: str):
     """Like _require_rank, but lets API-key (M2M) principals through untiered.
 

--- a/app/api/deps.py
+++ b/app/api/deps.py
@@ -425,45 +425,6 @@ require_manager = _require_rank(role_service.MANAGER)
 require_config = _require_rank(role_service.CONFIG_ONLY)
 require_readonly = _require_rank(role_service.READ_ONLY)
 
-
-async def get_admin_workspace(
-    request: Request,
-    workspace: Workspace = Depends(get_current_workspace),
-    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security_optional),
-    db: Session = Depends(get_db),
-) -> Workspace:
-    """Sub-account API endpoints: requires BOTH a valid M2M API key (resolving target workspace)
-    AND a valid admin JWT (ensuring caller is an admin in their current tenant)."""
-    if not credentials:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Bearer token required to perform agency operations.",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-
-    payload = verify_token(credentials.credentials)
-    if not payload:
-        raise HTTPException(status_code=401, detail="Invalid token")
-
-    try:
-        user_id = uuid.UUID(payload.get("user_id"))
-    except (ValueError, TypeError):
-        raise HTTPException(status_code=401, detail="Invalid user ID format")
-
-    user = get_active_user_by_id(db, user_id)
-    if not user:
-        raise HTTPException(status_code=401, detail="User not found")
-
-    role_name = rbac_cache_service.get_effective_role(db, user.id, workspace.id)
-    if role_name is None:
-        raise _not_a_member()
-
-    if not role_service.has_rank(role_name, role_service.ADMIN):
-        raise _forbidden(role_service.ADMIN, role_name)
-
-    return workspace
-
-
 def _require_rank_or_api_key(required: str):
     """Like _require_rank, but lets API-key (M2M) principals through untiered.
 

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -521,16 +521,17 @@ def list_sub_accounts(
 
     # Fetch usage for all
     from sqlalchemy import func
-    from datetime import datetime
+    from datetime import datetime, timezone
     
     tenant_ids = [sa.id for sa in sub_accounts]
     usages = {}
     if tenant_ids:
+        first_of_month = datetime.now(timezone.utc).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         usage_res = db.query(
             UsageRecord.workspace_id, func.sum(UsageRecord.billable_minutes)
         ).filter(
             UsageRecord.workspace_id.in_(tenant_ids),
-            UsageRecord.recorded_at >= func.date_trunc('month', func.now())
+            UsageRecord.recorded_at >= first_of_month
         ).group_by(UsageRecord.workspace_id).all()
         usages = {wid: float(mins) for wid, mins in usage_res if mins is not None}
 
@@ -566,14 +567,21 @@ def get_sub_account(
     workspace=Depends(get_current_workspace),
     db: Session = Depends(get_db),
 ):
+    return _fetch_sub_account_out(sub_id, workspace, db)
+
+
+def _fetch_sub_account_out(sub_id: uuid.UUID, workspace, db: Session) -> SubAccountOut:
+    """Shared logic used by get_sub_account and update_sub_account."""
     sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
     if not sa:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sub-account not found")
         
     from sqlalchemy import func
+    from datetime import datetime, timezone
+    first_of_month = datetime.now(timezone.utc).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     usage_sum = db.query(func.sum(UsageRecord.billable_minutes)).filter(
         UsageRecord.workspace_id == sa.id,
-        UsageRecord.recorded_at >= func.date_trunc('month', func.now())
+        UsageRecord.recorded_at >= first_of_month
     ).scalar() or 0.0
 
     key = db.query(Apikey).filter(Apikey.tenant_id == sa.id, Apikey.is_active.is_(True)).first()
@@ -608,7 +616,7 @@ def update_sub_account(
     db.commit()
     db.refresh(sa)
     
-    return get_sub_account(sub_id, request, workspace, db)
+    return _fetch_sub_account_out(sub_id, workspace, db)
 
 @v2_router.delete("/sub-accounts/{sub_id}", status_code=204)
 def delete_sub_account(
@@ -618,7 +626,7 @@ def delete_sub_account(
     workspace=Depends(get_current_workspace),
     db: Session = Depends(get_db),
 ):
-    sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
+    sa = db.query(Tenant).with_for_update().filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
     if not sa:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sub-account not found")
         

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, require_admin, require_billing
+from app.api.deps import get_db, require_admin, require_billing,get_admin_workspace,get_current_workspace
 from app.models.branding_configs import BrandingConfig
 from app.models.pricing_configs import PricingConfig
+import secrets
+import hashlib
+from app.models.api_key import Apikey
+from app.models.tenant import Tenant
 from app.models.usage_record import UsageRecord
 from app.schemas.workspace import (
     BrandingConfigUpsert,
@@ -14,6 +18,11 @@ from app.schemas.workspace import (
     WorkspaceUsageOut,
     MemberRoleUpdate,
     MemberRoleOut,
+    SubAccountCreate,
+    SubAccountUpdate,
+    SubAccountOut,
+    SubAccountCreateOut,
+    SubAccountListOut,
 )
 
 import uuid
@@ -440,3 +449,190 @@ def delete_account(
     delete_workspace_account(db, tenant_id)
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+# ── Sub-Accounts CRUD ─────────────────────────────────────────────────────────
+
+
+@v2_router.post("/sub-accounts", response_model=SubAccountCreateOut, status_code=201)
+def create_sub_account(
+    payload: SubAccountCreate,
+    request: Request,
+    workspace = Depends(get_admin_workspace),
+    db: Session = Depends(get_db),
+):
+    if workspace.workspace_type != "agency":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only agency workspaces can create sub-accounts.")
+
+    # Create Tenant
+    new_tenant = Tenant(
+        name=payload.name,
+        schema_name=f"sub_{uuid.uuid4().hex[:8]}",
+        parent_workspace_id=workspace.id,
+        workspace_type="sub_account",
+        contact_email=payload.contact_email,
+        status="active"
+    )
+    db.add(new_tenant)
+    db.flush()
+
+    # Generate API key
+    raw_key = secrets.token_urlsafe(32)
+    key_hash = hashlib.sha256(raw_key.encode()).hexdigest()
+    api_key_prefix = raw_key[:8]
+
+    new_api_key = Apikey(
+        tenant_id=new_tenant.id,
+        name="Sub-Account Default Key",
+        key_prefix=api_key_prefix,
+        key_hash=key_hash,
+        is_active=True
+    )
+    db.add(new_api_key)
+    db.commit()
+    db.refresh(new_tenant)
+
+    # We return usage as 0 for new
+    return SubAccountCreateOut(
+        id=new_tenant.id,
+        name=new_tenant.name,
+        contact_email=new_tenant.contact_email,
+        status=new_tenant.status,
+        api_key_prefix=api_key_prefix,
+        usage_this_cycle_minutes=0.0,
+        api_key=raw_key
+    )
+
+@v2_router.get("/sub-accounts", response_model=SubAccountListOut)
+def list_sub_accounts(
+    request: Request,
+    page: int = 1,
+    page_size: int = 50,
+    workspace = Depends(get_admin_workspace),
+    db: Session = Depends(get_db),
+):
+    if workspace.workspace_type != "agency":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only agency workspaces have sub-accounts.")
+
+    query = db.query(Tenant).filter(Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None))
+    total = query.count()
+    sub_accounts = query.order_by(Tenant.created_at.desc()).offset((page - 1) * page_size).limit(page_size).all()
+
+    # Fetch usage for all
+    from sqlalchemy import func
+    from datetime import datetime
+    
+    tenant_ids = [sa.id for sa in sub_accounts]
+    usages = {}
+    if tenant_ids:
+        usage_res = db.query(
+            UsageRecord.workspace_id, func.sum(UsageRecord.billable_minutes)
+        ).filter(
+            UsageRecord.workspace_id.in_(tenant_ids),
+            UsageRecord.recorded_at >= func.date_trunc('month', func.now())
+        ).group_by(UsageRecord.workspace_id).all()
+        usages = {wid: float(mins) for wid, mins in usage_res if mins is not None}
+
+    # Fetch api key prefix for each
+    key_res = db.query(Apikey.tenant_id, Apikey.key_prefix).filter(
+        Apikey.tenant_id.in_(tenant_ids), Apikey.is_active.is_(True)
+    ).all()
+    prefixes = {t_id: prefix for t_id, prefix in key_res}
+
+    data = []
+    for sa in sub_accounts:
+        data.append(SubAccountOut(
+            id=sa.id,
+            name=sa.name,
+            contact_email=sa.contact_email,
+            status=sa.status,
+            api_key_prefix=prefixes.get(sa.id),
+            usage_this_cycle_minutes=usages.get(sa.id, 0.0)
+        ))
+
+    return SubAccountListOut(
+        data=data,
+        total=total,
+        page=page,
+        page_size=page_size
+    )
+
+@v2_router.get("/sub-accounts/{sub_id}", response_model=SubAccountOut)
+def get_sub_account(
+    sub_id: uuid.UUID,
+    request: Request,
+    workspace = Depends(get_admin_workspace),
+    db: Session = Depends(get_db),
+):
+    sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
+    if not sa:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sub-account not found")
+        
+    from sqlalchemy import func
+    usage_sum = db.query(func.sum(UsageRecord.billable_minutes)).filter(
+        UsageRecord.workspace_id == sa.id,
+        UsageRecord.recorded_at >= func.date_trunc('month', func.now())
+    ).scalar() or 0.0
+
+    key = db.query(Apikey).filter(Apikey.tenant_id == sa.id, Apikey.is_active.is_(True)).first()
+    
+    return SubAccountOut(
+        id=sa.id,
+        name=sa.name,
+        contact_email=sa.contact_email,
+        status=sa.status,
+        api_key_prefix=key.key_prefix if key else None,
+        usage_this_cycle_minutes=float(usage_sum)
+    )
+
+@v2_router.put("/sub-accounts/{sub_id}", response_model=SubAccountOut)
+def update_sub_account(
+    sub_id: uuid.UUID,
+    payload: SubAccountUpdate,
+    request: Request,
+    workspace = Depends(get_admin_workspace),
+    db: Session = Depends(get_db),
+):
+    sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
+    if not sa:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sub-account not found")
+        
+    if payload.name is not None:
+        sa.name = payload.name
+    if payload.contact_email is not None:
+        sa.contact_email = payload.contact_email
+        
+    db.commit()
+    db.refresh(sa)
+    
+    return get_sub_account(sub_id, request, workspace, db)
+
+@v2_router.delete("/sub-accounts/{sub_id}", status_code=204)
+def delete_sub_account(
+    sub_id: uuid.UUID,
+    request: Request,
+    workspace = Depends(get_admin_workspace),
+    db: Session = Depends(get_db),
+):
+    sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
+    if not sa:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sub-account not found")
+        
+    from app.models.call_session import CallSession
+    active_calls = db.query(CallSession).filter(CallSession.tenant_id == sa.id, CallSession.status == "in-progress").count()
+    if active_calls > 0:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Cannot delete sub-account with active calls.")
+        
+    from sqlalchemy.sql import func
+    sa.deleted_at = func.now()
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+@v2_router.post("/members/{user_id}/role", response_model=MemberRoleOut)
+def create_member_role(
+    user_id: uuid.UUID,
+    payload: MemberRoleUpdate,
+    request: Request,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    return update_member_role(user_id, payload, request, user, db)

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, require_admin, require_billing,get_admin_workspace,get_current_workspace
+from app.api.deps import get_db, require_admin, require_billing, get_current_workspace
 from app.models.branding_configs import BrandingConfig
 from app.models.pricing_configs import PricingConfig
 import secrets
@@ -457,7 +457,8 @@ def delete_account(
 def create_sub_account(
     payload: SubAccountCreate,
     request: Request,
-    workspace = Depends(get_admin_workspace),
+    user: User = Depends(require_admin),
+    workspace=Depends(get_current_workspace),
     db: Session = Depends(get_db),
 ):
     if workspace.workspace_type != "agency":
@@ -507,7 +508,8 @@ def list_sub_accounts(
     request: Request,
     page: int = 1,
     page_size: int = 50,
-    workspace = Depends(get_admin_workspace),
+    user: User = Depends(require_admin),
+    workspace=Depends(get_current_workspace),
     db: Session = Depends(get_db),
 ):
     if workspace.workspace_type != "agency":
@@ -560,7 +562,8 @@ def list_sub_accounts(
 def get_sub_account(
     sub_id: uuid.UUID,
     request: Request,
-    workspace = Depends(get_admin_workspace),
+    user: User = Depends(require_admin),
+    workspace=Depends(get_current_workspace),
     db: Session = Depends(get_db),
 ):
     sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
@@ -589,7 +592,8 @@ def update_sub_account(
     sub_id: uuid.UUID,
     payload: SubAccountUpdate,
     request: Request,
-    workspace = Depends(get_admin_workspace),
+    user: User = Depends(require_admin),
+    workspace=Depends(get_current_workspace),
     db: Session = Depends(get_db),
 ):
     sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()
@@ -610,7 +614,8 @@ def update_sub_account(
 def delete_sub_account(
     sub_id: uuid.UUID,
     request: Request,
-    workspace = Depends(get_admin_workspace),
+    user: User = Depends(require_admin),
+    workspace=Depends(get_current_workspace),
     db: Session = Depends(get_db),
 ):
     sa = db.query(Tenant).filter(Tenant.id == sub_id, Tenant.parent_workspace_id == workspace.id, Tenant.deleted_at.is_(None)).first()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -225,9 +225,14 @@ class Settings(BaseSettings):
     # Stripe settings
     STRIPE_PUBLISHABLE_KEY: str = ""
     STRIPE_SECRET_KEY: str = ""
-    STRIPE_WEBHOOK_SECRET: str = ""
+    STRIPE_WEBHOOK_SECRET: str = ""          # Billing/subscription webhook secret
+    STRIPE_INCALL_WEBHOOK_SECRET: str = ""  # In-call payment webhook secret (separate endpoint)
     STRIPE_PRICE_ID_FREE: str = ""
     STRIPE_PRICE_ID_PRO: str = ""
+
+    # In-call payment page URL — returned to the agent as the caller-facing payment link.
+    # Format: "{PAYMENT_PAGE_BASE_URL}/pay/{payment_intent_id}?client_secret={client_secret}"
+    PAYMENT_PAGE_BASE_URL: str = "https://pay.yourdomain.com"
     
     # Billing settings
     FREE_PLAN_AGENT_LIMIT: int = 2

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -79,6 +79,8 @@ class Settings(BaseSettings):
     # Reads transparently handle legacy JWT-encrypted secrets for backwards compat.
     # In production/staging load from Secret Manager; never commit a real value.
     WEBHOOK_SECRET_ENCRYPTION_KEY: str = ""
+    # Symmetric encryption key for OIDC client secrets (Fernet).
+    SSO_ENCRYPTION_KEY: str = ""
     # When True, voice LLM prompts may suggest bracketed audio tags for ElevenLabs TTS only
     # ([breathes], [pause], [excited], [sad], …). Set False if your TTS model reads brackets out loud.
     ENABLE_ELEVENLABS_AUDIO_TAGS: bool = True

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -179,3 +179,18 @@ def get_rime_api_key() -> str:
             "RIME_API_KEY is not set. Add it to your .env file for local development."
         )
     return env_key.strip()
+
+
+def get_sso_encryption_key() -> bytes:
+    """Return the Fernet key for encrypting SSO OIDC client secrets."""
+    env = settings.ENVIRONMENT.lower()
+    if env in ("production", "staging"):
+        key_str = _fetch_from_secret_manager("SSO_ENCRYPTION_KEY")
+        if not key_str:
+            raise RuntimeError(f"SSO_ENCRYPTION_KEY not found in Secret Manager for env {env}")
+    else:
+        key_str = getattr(settings, "SSO_ENCRYPTION_KEY", "") or ""
+        if not key_str:
+            raise ValueError("SSO_ENCRYPTION_KEY not configured in .env")
+            
+    return key_str.encode("utf-8")

--- a/app/core/sso_crypto.py
+++ b/app/core/sso_crypto.py
@@ -1,0 +1,32 @@
+"""Fernet-based encryption for SSO secrets (OIDC client secrets)."""
+
+from cryptography.fernet import Fernet
+from app.core.secret_manager import get_sso_encryption_key
+
+# We fetch the key dynamically at module load time so it requires
+# SSO_ENCRYPTION_KEY to be present if this module is imported.
+_fernet: Fernet | None = None
+
+
+def _get_fernet() -> Fernet:
+    global _fernet
+    if _fernet is None:
+        key = get_sso_encryption_key()
+        _fernet = Fernet(key)
+    return _fernet
+
+
+def encrypt_secret(plain_text: str) -> str:
+    """Encrypt a plain text secret using Fernet (AES-128-CBC + HMAC-SHA256)."""
+    if not plain_text:
+        return plain_text
+    f = _get_fernet()
+    return f.encrypt(plain_text.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_secret(cipher_text: str) -> str:
+    """Decrypt a Fernet-encrypted secret."""
+    if not cipher_text:
+        return cipher_text
+    f = _get_fernet()
+    return f.decrypt(cipher_text.encode("utf-8")).decode("utf-8")

--- a/app/core/workspace.py
+++ b/app/core/workspace.py
@@ -26,6 +26,9 @@ class Workspace:
     credits: float
     stripe_customer_id: Optional[str] = None
     stripe_subscription_id: Optional[str] = None
+    parent_workspace_id: Optional[uuid.UUID] = None
+    workspace_type: str = "standalone"
+    contact_email: Optional[str] = None
 
     @classmethod
     def from_tenant(cls, tenant: Tenant) -> Workspace:
@@ -37,6 +40,9 @@ class Workspace:
             credits=float(tenant.credits or 0),
             stripe_customer_id=tenant.stripe_customer_id,
             stripe_subscription_id=tenant.stripe_subscription_id,
+            parent_workspace_id=tenant.parent_workspace_id,
+            workspace_type=tenant.workspace_type,
+            contact_email=tenant.contact_email,
         )
 
     @classmethod
@@ -55,6 +61,9 @@ class Workspace:
             credits=credits,
             stripe_customer_id=data.get("stripe_customer_id"),
             stripe_subscription_id=data.get("stripe_subscription_id"),
+            parent_workspace_id=uuid.UUID(str(data["parent_workspace_id"])) if data.get("parent_workspace_id") else None,
+            workspace_type=str(data.get("workspace_type", "standalone")),
+            contact_email=data.get("contact_email"),
         )
 
     def to_cache_dict(self) -> dict[str, Any]:
@@ -66,6 +75,9 @@ class Workspace:
             "credits": self.credits,
             "stripe_customer_id": self.stripe_customer_id,
             "stripe_subscription_id": self.stripe_subscription_id,
+            "parent_workspace_id": str(self.parent_workspace_id) if self.parent_workspace_id else None,
+            "workspace_type": self.workspace_type,
+            "contact_email": self.contact_email,
         }
 
     @property

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -81,3 +81,6 @@ from app.models.allowed_domain import AllowedDomain  # noqa: F401
 
 # SSO configuration
 from app.models.sso_config import SsoConfig  # noqa: F401
+
+# In-call Stripe payment records
+from app.models.payment_record import PaymentRecord  # noqa: F401

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -78,3 +78,6 @@ from app.models.data_export_job import DataExportJob  # noqa: F401
 
 # Web SDK — public call-token domain whitelist
 from app.models.allowed_domain import AllowedDomain  # noqa: F401
+
+# SSO configuration
+from app.models.sso_config import SsoConfig  # noqa: F401

--- a/app/main.py
+++ b/app/main.py
@@ -21,6 +21,7 @@ def create_app() -> FastAPI:
 
     from app.api.api_v1.api import api_router
     from app.api.v2.api import v2_router
+    from app.routers.sso_auth import router as sso_auth_router
     from app.db.async_session import dispose_async_db, init_async_db
     from app.routers.api_docs import router as api_docs_router
     from app.routers.health import router as health_router
@@ -244,6 +245,7 @@ def create_app() -> FastAPI:
     _app.include_router(api_router, prefix="/api/v1")
     _app.include_router(health_router)
     _app.include_router(v2_router, prefix="/api/v2")
+    _app.include_router(sso_auth_router, tags=["SSO Authentication"])  # SSO browser-facing redirects and callbacks
 
     # -------------------------------------------------------------------------
     # v2 Swagger — filtered to /api/v2/ routes only.

--- a/app/middleware/api_key_middleware.py
+++ b/app/middleware/api_key_middleware.py
@@ -69,6 +69,10 @@ _SKIP_PREFIXES = (
     "/api/v2/health",
     "/api/v2/docs",
     "/api/v2/openapi.json",
+    # In-call Stripe payment webhook — Stripe sends requests without our API key;
+    # authentication is performed by verifying the Stripe-Signature header with
+    # stripe.webhooks.construct_event() inside the endpoint handler.
+    "/api/v1/payments/stripe-webhook",
 )
 
 def _get_redis() -> Optional[aioredis.Redis]:

--- a/app/middleware/rate_limit_middleware.py
+++ b/app/middleware/rate_limit_middleware.py
@@ -46,6 +46,7 @@ _SKIP_PREFIXES = (
     "/api/v1/billing/webhook",
     "/api/v1/voice/",
     "/api/v1/stream/",
+    "/api/v1/payments/stripe-webhook",
 )
 
 # Unauthenticated POST endpoints targeted by bots (per-path, per-IP stricter limit).

--- a/app/models/payment_record.py
+++ b/app/models/payment_record.py
@@ -17,8 +17,6 @@ from app.db.base_class import Base
 class PaymentRecord(Base):
     """Tracks Stripe PaymentIntent state for in-call payments."""
 
-    __tablename__ = "paymentrecord"
-
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
 
     # Workspace that owns this payment record

--- a/app/models/payment_record.py
+++ b/app/models/payment_record.py
@@ -1,0 +1,71 @@
+"""
+PaymentRecord — persists Stripe PaymentIntent state for in-call payments.
+
+One row is created when the agent initiates a payment session and is updated
+by the stripe-webhook endpoint on payment_intent.succeeded / payment_intent.payment_failed.
+"""
+
+from sqlalchemy import Column, String, Integer, Text, DateTime, ForeignKey, Index
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import uuid
+
+from app.db.base_class import Base
+
+
+class PaymentRecord(Base):
+    """Tracks Stripe PaymentIntent state for in-call payments."""
+
+    __tablename__ = "paymentrecord"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
+
+    # Workspace that owns this payment record
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenant.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    # The live call session that triggered this payment (nullable — future off-call use)
+    call_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("callsession.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Stripe identifiers
+    payment_intent_id = Column(String(255), nullable=False, unique=True, index=True)
+
+    # Payment details
+    amount_cents = Column(Integer, nullable=False)
+    currency = Column(String(10), nullable=False, server_default="usd")
+    description = Column(Text, nullable=True)
+
+    # Lifecycle status: pending | succeeded | failed
+    status = Column(String(50), nullable=False, server_default="pending")
+
+    # Card details — populated on payment_intent.succeeded from charge data
+    card_last4 = Column(String(4), nullable=True)
+    card_brand = Column(String(50), nullable=True)
+
+    # Timestamps
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+    # Relationships
+    workspace = relationship("Tenant", foreign_keys=[workspace_id])
+    call_session = relationship("CallSession", foreign_keys=[call_id])
+
+    __table_args__ = (
+        Index("idx_paymentrecord_workspace_created", "workspace_id", "created_at"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<PaymentRecord(id={self.id}, pi={self.payment_intent_id}, "
+            f"status={self.status}, amount={self.amount_cents} {self.currency})>"
+        )

--- a/app/models/sso_config.py
+++ b/app/models/sso_config.py
@@ -1,0 +1,55 @@
+"""SQLAlchemy model for SSO configuration per workspace."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Boolean, CheckConstraint, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base_class import Base
+
+
+class SsoConfig(Base):
+    """Stores IdP settings for SAML 2.0 and OIDC SSO.
+
+    Secrets (oidc_client_secret, idp_x509_certificate) are NEVER logged.
+    oidc_client_secret is Fernet-encrypted at rest (see app.core.sso_crypto).
+    """
+
+    __tablename__ = "sso_configs"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenant.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    protocol = Column(String(10), nullable=False)  # 'saml' | 'oidc'
+
+    # SAML fields
+    idp_entity_id = Column(Text, nullable=True)
+    idp_sso_url = Column(Text, nullable=True)
+    idp_x509_certificate = Column(Text, nullable=True)  # full PEM — never log
+
+    # OIDC fields
+    oidc_client_id = Column(Text, nullable=True)
+    oidc_client_secret = Column(Text, nullable=True)   # Fernet-encrypted — never log
+    oidc_discovery_url = Column(Text, nullable=True)
+
+    is_active = Column(Boolean, nullable=False, default=False, server_default="false")
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+    workspace = relationship("Tenant", back_populates="sso_config")
+
+    __table_args__ = (
+        CheckConstraint("protocol IN ('saml', 'oidc')", name="chk_sso_protocol"),
+    )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<SsoConfig(workspace_id={self.workspace_id}, protocol={self.protocol}, active={self.is_active})>"

--- a/app/models/sso_config.py
+++ b/app/models/sso_config.py
@@ -18,8 +18,6 @@ class SsoConfig(Base):
     oidc_client_secret is Fernet-encrypted at rest (see app.core.sso_crypto).
     """
 
-    __tablename__ = "sso_configs"
-
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     workspace_id = Column(
         UUID(as_uuid=True),
@@ -41,6 +39,13 @@ class SsoConfig(Base):
     oidc_discovery_url = Column(Text, nullable=True)
 
     is_active = Column(Boolean, nullable=False, default=False, server_default="false")
+    
+    # Allowed email domains for auto-provisioning (e.g. ["acme.com", "acme.org"])
+    allowed_email_domains = Column(
+        postgresql_JSONB := __import__("sqlalchemy.dialects.postgresql", fromlist=["JSONB"]).JSONB,
+        nullable=True,
+        server_default="[]"
+    )
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)

--- a/app/models/tenant.py
+++ b/app/models/tenant.py
@@ -26,6 +26,7 @@ class Tenant(Base):
         nullable=False, 
         server_default="standalone"
     )
+    contact_email = Column(String, nullable=True)
     
     # Relationships
     users = relationship("User", secondary="user_tenant_association", back_populates="tenants") 

--- a/app/models/tenant.py
+++ b/app/models/tenant.py
@@ -27,6 +27,7 @@ class Tenant(Base):
         server_default="standalone"
     )
     contact_email = Column(String, nullable=True)
+    workspace_slug = Column(String(100), nullable=True, index=True)
     
     # Relationships
     users = relationship("User", secondary="user_tenant_association", back_populates="tenants") 
@@ -48,6 +49,7 @@ class Tenant(Base):
     branding_config = relationship("BrandingConfig", uselist=False, back_populates="tenant", cascade="all, delete-orphan")
     pricing_config = relationship("PricingConfig", uselist=False, back_populates="tenant", cascade="all, delete-orphan")
     usage_record = relationship("UsageRecord", back_populates="tenant", cascade="all, delete-orphan")
+    sso_config = relationship("SsoConfig", uselist=False, back_populates="workspace", cascade="all, delete-orphan")
 
     __table_args__ = (
         Index(

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -1414,6 +1414,13 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
         try:
             from datetime import datetime, timezone
             import json
+
+            # Refresh call session from database to capture any dynamic metadata updates (e.g. payment_url injection)
+            if self.call_session and self.db:
+                try:
+                    self.db.refresh(self.call_session)
+                except Exception as exc:
+                    logger.warning("Failed to refresh call session in streaming turn: %s", exc)
             
             # 👋 HANDLE AUTO-GREETING - Skip LLM, use pre-defined greeting (inbound pickup only)
             if is_greeting:

--- a/app/routers/payments.py
+++ b/app/routers/payments.py
@@ -1,0 +1,226 @@
+"""
+In-call Stripe payment endpoints.
+
+Routes:
+  POST   /api/v1/payments/session          — create PaymentIntent + PaymentRecord
+  POST   /api/v1/payments/stripe-webhook   — Stripe webhook (no API-key auth; sig verified)
+  GET    /api/v1/payments                  — list payment records (paginated)
+  GET    /api/v1/payments/{pi_id}          — single payment record detail
+
+Security notes:
+  - The /stripe-webhook endpoint is excluded from ApiKeyMiddleware via _SKIP_PREFIXES.
+    Authentication is performed by verifying the Stripe-Signature header with
+    stripe.webhooks.construct_event() using STRIPE_INCALL_WEBHOOK_SECRET.
+  - The Stripe secret key (sk_test_ / sk_live_) is NEVER returned to the browser.
+    The client_secret returned in /session is intentionally safe to expose —
+    it can only be used to confirm a specific PaymentIntent, not to read account data.
+"""
+from __future__ import annotations
+
+import stripe
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, get_workspace
+from app.core.config import settings
+from app.core.logger import logger
+from app.core.workspace import Workspace
+from app.schemas.base import SuccessResponse
+from app.schemas.payment import (
+    CreatePaymentSessionRequest,
+    CreatePaymentSessionResponse,
+    PaginatedPaymentResponse,
+    PaymentRecordOut,
+)
+from app.services.payment_service import PaymentService
+from app.services.stripe_service import StripeService
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+# ---------------------------------------------------------------------------
+# POST /session — create PaymentIntent
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/session",
+    response_model=SuccessResponse[CreatePaymentSessionResponse],
+    summary="Create an in-call payment session",
+    description=(
+        "Creates a Stripe PaymentIntent and returns a payment URL the agent can "
+        "share with the caller. The `agent_context` field contains the ready-made "
+        "sentence to inject into the agent's prompt."
+    ),
+)
+def create_payment_session(
+    body: CreatePaymentSessionRequest,
+    db: Session = Depends(get_db),
+    workspace: Workspace = Depends(get_workspace),
+):
+    try:
+        response, _agent_ctx = PaymentService.create_payment_session(
+            db=db,
+            workspace_id=workspace.id,
+            call_id=body.call_id,
+            amount_cents=body.amount_cents,
+            currency=body.currency,
+            description=body.description,
+        )
+    except Exception as exc:
+        logger.error("create_payment_session failed: %s", exc, exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Stripe error: {exc}",
+        )
+    return create_success_response(
+        response,
+        "Payment session created successfully",
+        status_code=status.HTTP_200_OK,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /stripe-webhook — receive Stripe events
+# NOTE: This path MUST be listed in _SKIP_PREFIXES in api_key_middleware.py
+#       because Stripe sends requests without our x-api-key header.
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/stripe-webhook",
+    summary="Stripe webhook for in-call payment events",
+    include_in_schema=True,
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    description=(
+        "Receives `payment_intent.succeeded` and `payment_intent.payment_failed` "
+        "events from Stripe. Signature is verified with STRIPE_INCALL_WEBHOOK_SECRET. "
+        "Returns 204 on success, 403 on invalid signature."
+    ),
+)
+async def stripe_payment_webhook(request: Request, db: Session = Depends(get_db)):
+    payload = await request.body()
+    sig_header = request.headers.get("stripe-signature", "")
+
+    if not sig_header:
+        logger.warning("stripe-webhook: missing Stripe-Signature header")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Missing Stripe-Signature header",
+        )
+
+    webhook_secret = settings.STRIPE_INCALL_WEBHOOK_SECRET
+    if not webhook_secret:
+        # Fallback warning — should always be configured in staging/production
+        logger.error(
+            "STRIPE_INCALL_WEBHOOK_SECRET is not set; cannot verify webhook signature"
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Webhook secret not configured",
+        )
+
+    try:
+        event = StripeService.construct_payment_webhook_event(
+            payload=payload,
+            sig_header=sig_header,
+            webhook_secret=webhook_secret,
+        )
+    except (ValueError, stripe.SignatureVerificationError) as exc:
+        logger.warning("stripe-webhook: signature verification failed — %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid Stripe webhook signature",
+        )
+    except Exception as exc:
+        logger.error("stripe-webhook: unexpected error during verification — %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Webhook processing error",
+        )
+
+    event_type = event.get("type") if isinstance(event, dict) else getattr(event, "type", None)
+    logger.info("stripe-webhook: received event type=%s", event_type)
+
+    try:
+        event_data = event if isinstance(event, dict) else event.to_dict()
+
+        if event_type == "payment_intent.succeeded":
+            PaymentService.handle_payment_intent_succeeded(db, event_data)
+
+        elif event_type == "payment_intent.payment_failed":
+            PaymentService.handle_payment_intent_failed(db, event_data)
+
+        else:
+            logger.info("stripe-webhook: unhandled event type=%s (ignored)", event_type)
+
+    except Exception as exc:
+        # Do not return 5xx — Stripe would retry. Log and return 204 anyway.
+        logger.error(
+            "stripe-webhook: error processing event type=%s — %s",
+            event_type,
+            exc,
+            exc_info=True,
+        )
+
+    # Return 204 No Content — Stripe considers any 2xx a success
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ---------------------------------------------------------------------------
+# GET / — list payment records (paginated)
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "",
+    response_model=SuccessResponse[PaginatedPaymentResponse],
+    summary="List payment records for the workspace",
+)
+def list_payment_records(
+    page: int = 1,
+    per_page: int = 20,
+    db: Session = Depends(get_db),
+    workspace: Workspace = Depends(get_workspace),
+):
+    if page < 1:
+        page = 1
+    if per_page < 1 or per_page > 100:
+        per_page = 20
+
+    result = PaymentService.get_payments(
+        db=db,
+        workspace_id=workspace.id,
+        page=page,
+        per_page=per_page,
+    )
+    return create_success_response(result, "Payment records retrieved")
+
+
+# ---------------------------------------------------------------------------
+# GET /{payment_intent_id} — single payment record
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/{payment_intent_id}",
+    response_model=SuccessResponse[PaymentRecordOut],
+    summary="Get a single payment record by PaymentIntent ID",
+)
+def get_payment_record(
+    payment_intent_id: str,
+    db: Session = Depends(get_db),
+    workspace: Workspace = Depends(get_workspace),
+):
+    record = PaymentService.get_payment(
+        db=db,
+        workspace_id=workspace.id,
+        payment_intent_id=payment_intent_id,
+    )
+    if not record:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Payment record not found for payment_intent_id={payment_intent_id}",
+        )
+    return create_success_response(
+        PaymentRecordOut.from_orm_model(record),
+        "Payment record retrieved",
+    )

--- a/app/routers/payments.py
+++ b/app/routers/payments.py
@@ -71,7 +71,7 @@ def create_payment_session(
         logger.error("create_payment_session failed: %s", exc, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"Stripe error: {exc}",
+            detail="Payment service unavailable. Please try again.",
         )
     return create_success_response(
         response,

--- a/app/routers/sso.py
+++ b/app/routers/sso.py
@@ -1,0 +1,127 @@
+"""API endpoints for managing workspace SSO configurations."""
+
+import uuid
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+import httpx
+
+from app.api.deps import get_db, require_admin, require_tenant
+from app.models.sso_config import SsoConfig
+from app.models.user import User
+from app.schemas.sso import SsoConfigUpsert, SsoConfigOut, SsoTestResult
+from app.core.sso_crypto import encrypt_secret
+
+router = APIRouter()
+
+
+@router.post("", response_model=SsoConfigOut)
+def upsert_sso_config(
+    payload: SsoConfigUpsert,
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Create or update the SSO configuration for the current workspace."""
+    workspace_id = user.current_tenant_id
+    config = db.query(SsoConfig).filter(SsoConfig.workspace_id == workspace_id).first()
+
+    if not config:
+        config = SsoConfig(workspace_id=workspace_id)
+        db.add(config)
+        
+    config.protocol = payload.protocol
+    config.is_active = payload.is_active
+    
+    if payload.protocol == 'saml':
+        config.idp_entity_id = payload.idp_entity_id
+        config.idp_sso_url = payload.idp_sso_url
+        config.idp_x509_certificate = payload.idp_x509_certificate
+    elif payload.protocol == 'oidc':
+        config.oidc_client_id = payload.oidc_client_id
+        config.oidc_discovery_url = payload.oidc_discovery_url
+        if payload.oidc_client_secret and payload.oidc_client_secret != "***":
+            config.oidc_client_secret = encrypt_secret(payload.oidc_client_secret)
+            
+    db.commit()
+    db.refresh(config)
+    
+    return _to_out(config)
+
+@router.get("", response_model=SsoConfigOut)
+def get_sso_config(
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Get the current SSO configuration."""
+    workspace_id = user.current_tenant_id
+    config = db.query(SsoConfig).filter(SsoConfig.workspace_id == workspace_id).first()
+    
+    if not config:
+        raise HTTPException(status_code=404, detail="SSO configuration not found.")
+        
+    return _to_out(config)
+
+
+@router.delete("", status_code=status.HTTP_204_NO_CONTENT)
+def disable_sso(
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Disable SSO for the current workspace (sets is_active=false)."""
+    workspace_id = user.current_tenant_id
+    config = db.query(SsoConfig).filter(SsoConfig.workspace_id == workspace_id).first()
+    
+    if config:
+        config.is_active = False
+        db.commit()
+
+
+@router.post("/test", response_model=SsoTestResult)
+async def test_sso_connection(
+    user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Test IdP connectivity (e.g. discovery URL or SAML endpoint)."""
+    workspace_id = user.current_tenant_id
+    config = db.query(SsoConfig).filter(SsoConfig.workspace_id == workspace_id).first()
+    
+    if not config:
+        return SsoTestResult(success=False, error="SSO configuration not found.")
+        
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            if config.protocol == 'oidc':
+                if not config.oidc_discovery_url:
+                    return SsoTestResult(success=False, error="Missing OIDC discovery URL.")
+                res = await client.get(config.oidc_discovery_url)
+                res.raise_for_status()
+            elif config.protocol == 'saml':
+                if not config.idp_sso_url:
+                    return SsoTestResult(success=False, error="Missing IdP SSO URL.")
+                res = await client.head(config.idp_sso_url, follow_redirects=True)
+                res.raise_for_status()
+                
+        return SsoTestResult(success=True)
+    except Exception as e:
+        return SsoTestResult(success=False, error=str(e))
+
+
+def _to_out(config: SsoConfig) -> SsoConfigOut:
+    trunc_cert = None
+    if config.idp_x509_certificate:
+        cert_clean = config.idp_x509_certificate.replace("-----BEGIN CERTIFICATE-----", "").replace("-----END CERTIFICATE-----", "").strip()
+        trunc_cert = cert_clean[:40] + "..." if len(cert_clean) > 40 else cert_clean
+        
+    return SsoConfigOut(
+        id=config.id,
+        workspace_id=config.workspace_id,
+        protocol=config.protocol,
+        idp_entity_id=config.idp_entity_id,
+        idp_sso_url=config.idp_sso_url,
+        idp_x509_certificate_truncated=trunc_cert,
+        oidc_client_id=config.oidc_client_id,
+        oidc_client_secret="***",
+        oidc_discovery_url=config.oidc_discovery_url,
+        is_active=config.is_active,
+        created_at=config.created_at,
+        updated_at=config.updated_at
+    )

--- a/app/routers/sso.py
+++ b/app/routers/sso.py
@@ -30,6 +30,7 @@ def upsert_sso_config(
         
     config.protocol = payload.protocol
     config.is_active = payload.is_active
+    config.allowed_email_domains = payload.allowed_email_domains
     
     if payload.protocol == 'saml':
         config.idp_entity_id = payload.idp_entity_id
@@ -122,6 +123,7 @@ def _to_out(config: SsoConfig) -> SsoConfigOut:
         oidc_client_secret="***",
         oidc_discovery_url=config.oidc_discovery_url,
         is_active=config.is_active,
+        allowed_email_domains=config.allowed_email_domains,
         created_at=config.created_at,
         updated_at=config.updated_at
     )

--- a/app/routers/sso_auth.py
+++ b/app/routers/sso_auth.py
@@ -1,0 +1,265 @@
+"""Router for SAML and OIDC authentication flows."""
+
+import secrets
+import json
+import base64
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.orm import Session
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+from onelogin.saml2.settings import OneLogin_Saml2_Settings
+
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+from app.db.async_session import get_db
+from app.models.tenant import Tenant
+from app.models.sso_config import SsoConfig
+from app.core.sso_crypto import decrypt_secret
+from app.services.sso_service import find_or_create_user
+from app.api.deps import issue_tokens_for_user
+from app.core.config import settings
+
+router = APIRouter()
+
+def get_tenant_by_slug(db: Session, slug: str) -> Tenant:
+    tenant = db.query(Tenant).filter(Tenant.workspace_slug == slug, Tenant.deleted_at.is_(None)).first()
+    if not tenant:
+        raise HTTPException(status_code=404, detail="Workspace not found.")
+    return tenant
+
+def get_sso_config(db: Session, workspace_id) -> SsoConfig:
+    config = db.query(SsoConfig).filter(SsoConfig.workspace_id == workspace_id, SsoConfig.is_active.is_(True)).first()
+    if not config:
+        raise HTTPException(status_code=404, detail="SSO not configured for this workspace.")
+    return config
+
+def prepare_saml_req(request: Request, config: SsoConfig, slug: str) -> dict:
+    return {
+        'https': 'on' if request.url.scheme == 'https' else 'off',
+        'http_host': request.url.hostname,
+        'server_port': request.url.port,
+        'script_name': request.url.path,
+        'get_data': dict(request.query_params),
+        'post_data': {}, # We will manually pass the post data later
+    }
+
+
+def get_saml_settings(config: SsoConfig, slug: str) -> dict:
+    base_url = settings.WEBHOOK_BASE_URL.rstrip('/')
+    return {
+        "strict": True,
+        "debug": False,
+        "sp": {
+            "entityId": f"{base_url}/auth/saml/{slug}/metadata",
+            "assertionConsumerService": {
+                "url": f"{base_url}/auth/saml/{slug}/callback",
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+            },
+            "NameIDFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+            "x509cert": "",
+            "privateKey": ""
+        },
+        "idp": {
+            "entityId": config.idp_entity_id,
+            "singleSignOnService": {
+                "url": config.idp_sso_url,
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+            },
+            "x509cert": config.idp_x509_certificate
+        }
+    }
+
+
+@router.get("/auth/saml/{workspace_slug}/metadata")
+def saml_metadata(
+    workspace_slug: str,
+    db: Session = Depends(get_db)
+):
+    tenant = get_tenant_by_slug(db, workspace_slug)
+    config = get_sso_config(db, tenant.id)
+    
+    saml_settings = get_saml_settings(config, workspace_slug)
+    saml_settings_obj = OneLogin_Saml2_Settings(saml_settings)
+    metadata = saml_settings_obj.get_sp_metadata()
+    errors = saml_settings_obj.validate_metadata(metadata)
+    
+    if len(errors) > 0:
+        raise HTTPException(status_code=500, detail=f"Invalid SP metadata: {', '.join(errors)}")
+        
+    return Response(content=metadata, media_type="text/xml")
+
+
+@router.get("/auth/saml/{workspace_slug}/login")
+def saml_login(
+    workspace_slug: str,
+    request: Request,
+    db: Session = Depends(get_db)
+):
+    tenant = get_tenant_by_slug(db, workspace_slug)
+    config = get_sso_config(db, tenant.id)
+    
+    req = prepare_saml_req(request, config, workspace_slug)
+    auth = OneLogin_Saml2_Auth(req, get_saml_settings(config, workspace_slug))
+    
+    sso_built_url = auth.login()
+    return Response(status_code=302, headers={"Location": sso_built_url})
+
+
+@router.post("/auth/saml/{workspace_slug}/callback")
+async def saml_callback(
+    workspace_slug: str,
+    request: Request,
+    db: Session = Depends(get_db)
+):
+    tenant = get_tenant_by_slug(db, workspace_slug)
+    config = get_sso_config(db, tenant.id)
+    
+    form_data = await request.form()
+    
+    req = prepare_saml_req(request, config, workspace_slug)
+    req['post_data'] = dict(form_data)
+    
+    auth = OneLogin_Saml2_Auth(req, get_saml_settings(config, workspace_slug))
+    auth.process_response()
+    
+    errors = auth.get_errors()
+    if not auth.is_authenticated() or errors:
+        raise HTTPException(status_code=401, detail=f"SAML Authentication Failed: {', '.join(errors)}")
+        
+    email = auth.get_nameid()
+    if not email:
+        raise HTTPException(status_code=401, detail="SAML Response missing NameID (email).")
+        
+    user, role_info = find_or_create_user(db, email, tenant.id)
+    token_resp = issue_tokens_for_user(db, user, tenant.id, role_info)
+    
+    frontend_url = settings.DASHBOARD_URL or "http://localhost:3000"
+    res = Response(status_code=302, headers={"Location": f"{frontend_url}/dashboard"})
+    res.set_cookie(
+        key="access_token",
+        value=token_resp.access_token,
+        httponly=True,
+        samesite="lax",
+        secure=settings.ENVIRONMENT.lower() in ("staging", "production")
+    )
+    return res
+
+
+@router.get("/auth/oidc/{workspace_slug}/login")
+async def oidc_login(
+    workspace_slug: str,
+    request: Request,
+    db: Session = Depends(get_db)
+):
+    tenant = get_tenant_by_slug(db, workspace_slug)
+    config = get_sso_config(db, tenant.id)
+    
+    client_secret = decrypt_secret(config.oidc_client_secret)
+    client = AsyncOAuth2Client(
+        client_id=config.oidc_client_id,
+        client_secret=client_secret,
+    )
+    
+    # We need to fetch the authorization endpoint from discovery URL
+    async with httpx.AsyncClient() as hc:
+        res = await hc.get(config.oidc_discovery_url)
+        res.raise_for_status()
+        discovery_data = res.json()
+        
+    authorization_endpoint = discovery_data.get('authorization_endpoint')
+    if not authorization_endpoint:
+        raise HTTPException(status_code=500, detail="Discovery URL missing authorization_endpoint")
+        
+    base_url = settings.WEBHOOK_BASE_URL.rstrip('/')
+    redirect_uri = f"{base_url}/auth/oidc/{workspace_slug}/callback"
+    
+    state = secrets.token_urlsafe(32)
+    uri, state = client.create_authorization_url(
+        authorization_endpoint,
+        redirect_uri=redirect_uri,
+        scope='openid email profile',
+        state=state
+    )
+    
+    res = Response(status_code=302, headers={"Location": uri})
+    res.set_cookie(key="oidc_state", value=state, httponly=True, max_age=300)
+    return res
+
+
+@router.get("/auth/oidc/{workspace_slug}/callback")
+async def oidc_callback(
+    workspace_slug: str,
+    request: Request,
+    db: Session = Depends(get_db)
+):
+    tenant = get_tenant_by_slug(db, workspace_slug)
+    config = get_sso_config(db, tenant.id)
+    
+    state = request.query_params.get('state')
+    cookie_state = request.cookies.get('oidc_state')
+    
+    if not state or state != cookie_state:
+        raise HTTPException(status_code=400, detail="Invalid state parameter.")
+        
+    code = request.query_params.get('code')
+    if not code:
+        raise HTTPException(status_code=400, detail="Missing authorization code.")
+        
+    client_secret = decrypt_secret(config.oidc_client_secret)
+    base_url = settings.WEBHOOK_BASE_URL.rstrip('/')
+    redirect_uri = f"{base_url}/auth/oidc/{workspace_slug}/callback"
+    
+    async with httpx.AsyncClient() as hc:
+        res = await hc.get(config.oidc_discovery_url)
+        res.raise_for_status()
+        discovery_data = res.json()
+        
+    token_endpoint = discovery_data.get('token_endpoint')
+    
+    client = AsyncOAuth2Client(
+        client_id=config.oidc_client_id,
+        client_secret=client_secret,
+    )
+    
+    token = await client.fetch_token(
+        token_endpoint,
+        authorization_response=str(request.url),
+        redirect_uri=redirect_uri,
+        grant_type='authorization_code'
+    )
+    
+    if 'id_token' not in token:
+        raise HTTPException(status_code=401, detail="Missing id_token in response.")
+        
+    # authlib parses the id_token automatically
+    userinfo = token.get('userinfo')
+    if not userinfo:
+        # Some providers require calling userinfo_endpoint
+        userinfo_endpoint = discovery_data.get('userinfo_endpoint')
+        if userinfo_endpoint:
+            async with httpx.AsyncClient() as hc:
+                res = await hc.get(
+                    userinfo_endpoint,
+                    headers={"Authorization": f"Bearer {token['access_token']}"}
+                )
+                res.raise_for_status()
+                userinfo = res.json()
+                
+    if not userinfo or 'email' not in userinfo:
+        raise HTTPException(status_code=401, detail="Email claim missing from IdP response.")
+        
+    email = userinfo['email']
+    user, role_info = find_or_create_user(db, email, tenant.id)
+    token_resp = issue_tokens_for_user(db, user, tenant.id, role_info)
+    
+    frontend_url = settings.DASHBOARD_URL or "http://localhost:3000"
+    res = Response(status_code=302, headers={"Location": f"{frontend_url}/dashboard"})
+    res.set_cookie(
+        key="access_token",
+        value=token_resp.access_token,
+        httponly=True,
+        samesite="lax",
+        secure=settings.ENVIRONMENT.lower() in ("staging", "production")
+    )
+    res.delete_cookie("oidc_state")
+    return res

--- a/app/routers/sso_auth.py
+++ b/app/routers/sso_auth.py
@@ -3,6 +3,8 @@
 import secrets
 import json
 import base64
+import time
+import hmac
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
@@ -20,6 +22,23 @@ from app.api.deps import issue_tokens_for_user
 from app.core.config import settings
 
 router = APIRouter()
+
+_OIDC_DISCOVERY_CACHE: dict[str, tuple[float, dict]] = {}
+
+async def _fetch_oidc_discovery(url: str) -> dict:
+    now = time.time()
+    if url in _OIDC_DISCOVERY_CACHE:
+        expiry, data = _OIDC_DISCOVERY_CACHE[url]
+        if now < expiry:
+            return data
+            
+    async with httpx.AsyncClient() as hc:
+        res = await hc.get(url)
+        res.raise_for_status()
+        data = res.json()
+        
+    _OIDC_DISCOVERY_CACHE[url] = (now + 3600.0, data)  # cache for 1 hour
+    return data
 
 def get_tenant_by_slug(db: Session, slug: str) -> Tenant:
     tenant = db.query(Tenant).filter(Tenant.workspace_slug == slug, Tenant.deleted_at.is_(None)).first()
@@ -101,8 +120,19 @@ def saml_login(
     req = prepare_saml_req(request, config, workspace_slug)
     auth = OneLogin_Saml2_Auth(req, get_saml_settings(config, workspace_slug))
     
-    sso_built_url = auth.login()
-    return Response(status_code=302, headers={"Location": sso_built_url})
+    relay_state = secrets.token_urlsafe(32)
+    sso_built_url = auth.login(return_to=relay_state)
+    
+    res = Response(status_code=302, headers={"Location": sso_built_url})
+    res.set_cookie(
+        key="saml_state",
+        value=relay_state,
+        httponly=True,
+        max_age=300,
+        samesite="lax",
+        secure=settings.ENVIRONMENT.lower() in ("staging", "production")
+    )
+    return res
 
 
 @router.post("/auth/saml/{workspace_slug}/callback")
@@ -116,6 +146,12 @@ async def saml_callback(
     
     form_data = await request.form()
     
+    # CSRF check using RelayState parameter from IdP and saml_state cookie
+    relay_state_from_idp = form_data.get("RelayState", "")
+    cookie_state = request.cookies.get("saml_state", "")
+    if not relay_state_from_idp or not hmac.compare_digest(relay_state_from_idp, cookie_state):
+        raise HTTPException(status_code=400, detail="Invalid RelayState — CSRF check failed")
+        
     req = prepare_saml_req(request, config, workspace_slug)
     req['post_data'] = dict(form_data)
     
@@ -142,6 +178,7 @@ async def saml_callback(
         samesite="lax",
         secure=settings.ENVIRONMENT.lower() in ("staging", "production")
     )
+    res.delete_cookie("saml_state")
     return res
 
 
@@ -161,10 +198,12 @@ async def oidc_login(
     )
     
     # We need to fetch the authorization endpoint from discovery URL
-    async with httpx.AsyncClient() as hc:
-        res = await hc.get(config.oidc_discovery_url)
-        res.raise_for_status()
-        discovery_data = res.json()
+    try:
+        discovery_data = await _fetch_oidc_discovery(config.oidc_discovery_url)
+    except Exception as exc:
+        from app.core.logger import logger
+        logger.error("Failed to fetch OIDC discovery document: %s", exc, exc_info=True)
+        raise HTTPException(status_code=502, detail="Failed to retrieve OIDC discovery document")
         
     authorization_endpoint = discovery_data.get('authorization_endpoint')
     if not authorization_endpoint:
@@ -209,10 +248,12 @@ async def oidc_callback(
     base_url = settings.WEBHOOK_BASE_URL.rstrip('/')
     redirect_uri = f"{base_url}/auth/oidc/{workspace_slug}/callback"
     
-    async with httpx.AsyncClient() as hc:
-        res = await hc.get(config.oidc_discovery_url)
-        res.raise_for_status()
-        discovery_data = res.json()
+    try:
+        discovery_data = await _fetch_oidc_discovery(config.oidc_discovery_url)
+    except Exception as exc:
+        from app.core.logger import logger
+        logger.error("Failed to fetch OIDC discovery document: %s", exc, exc_info=True)
+        raise HTTPException(status_code=502, detail="Failed to retrieve OIDC discovery document")
         
     token_endpoint = discovery_data.get('token_endpoint')
     

--- a/app/schemas/payment.py
+++ b/app/schemas/payment.py
@@ -1,0 +1,115 @@
+"""
+Pydantic schemas for in-call Stripe payment endpoints.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Request schemas
+# ---------------------------------------------------------------------------
+
+
+class CreatePaymentSessionRequest(BaseModel):
+    """Body for POST /api/v1/payments/session."""
+
+    call_id: Optional[uuid.UUID] = Field(
+        default=None,
+        description="The live call session that triggered this payment (optional).",
+    )
+    amount_cents: int = Field(
+        ...,
+        gt=0,
+        description="Amount in the smallest currency unit (e.g. cents for USD).",
+        examples=[5000],
+    )
+    currency: str = Field(
+        default="usd",
+        min_length=3,
+        max_length=3,
+        description="Three-letter ISO 4217 currency code (lowercase).",
+        examples=["usd"],
+    )
+    description: str = Field(
+        default="",
+        max_length=1000,
+        description="Free-text description shown to the payer.",
+        examples=["Service fee for call session"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Response schemas
+# ---------------------------------------------------------------------------
+
+
+class CreatePaymentSessionResponse(BaseModel):
+    """Response from POST /api/v1/payments/session."""
+
+    payment_intent_id: str = Field(
+        ..., description="Stripe PaymentIntent ID (pi_...)."
+    )
+    client_secret: str = Field(
+        ..., description="Stripe client_secret for client-side confirmation."
+    )
+    payment_url: str = Field(
+        ...,
+        description=(
+            "URL for the caller-facing payment page. "
+            "Pass this to the agent prompt so it can direct the caller."
+        ),
+    )
+    agent_context: str = Field(
+        ...,
+        description="Ready-to-use sentence to inject into the agent's prompt context.",
+    )
+
+
+class PaymentRecordOut(BaseModel):
+    """Serialised PaymentRecord for list/detail responses."""
+
+    id: uuid.UUID
+    workspace_id: uuid.UUID
+    call_id: Optional[uuid.UUID]
+    payment_intent_id: str
+    amount_cents: int
+    currency: str
+    description: Optional[str]
+    status: str
+    card_last4: Optional[str]
+    card_brand: Optional[str]
+    created_at: str  # ISO-8601 string
+    updated_at: Optional[str]
+
+    model_config = {"from_attributes": True}
+
+    @classmethod
+    def from_orm_model(cls, record) -> "PaymentRecordOut":
+        return cls(
+            id=record.id,
+            workspace_id=record.workspace_id,
+            call_id=record.call_id,
+            payment_intent_id=record.payment_intent_id,
+            amount_cents=record.amount_cents,
+            currency=record.currency,
+            description=record.description,
+            status=record.status,
+            card_last4=record.card_last4,
+            card_brand=record.card_brand,
+            created_at=record.created_at.isoformat() if record.created_at else "",
+            updated_at=record.updated_at.isoformat() if record.updated_at else None,
+        )
+
+
+class PaginatedPaymentResponse(BaseModel):
+    """Paginated list of payment records."""
+
+    items: list[PaymentRecordOut]
+    total: int
+    page: int
+    per_page: int
+    pages: int

--- a/app/schemas/sso.py
+++ b/app/schemas/sso.py
@@ -1,0 +1,49 @@
+import uuid
+from datetime import datetime
+from typing import Literal, Optional
+from pydantic import BaseModel
+
+
+class SsoConfigUpsert(BaseModel):
+    """Payload for creating or updating an SSO configuration."""
+    protocol: Literal['saml', 'oidc']
+    
+    # SAML
+    idp_entity_id: Optional[str] = None
+    idp_sso_url: Optional[str] = None
+    idp_x509_certificate: Optional[str] = None
+    
+    # OIDC
+    oidc_client_id: Optional[str] = None
+    oidc_client_secret: Optional[str] = None
+    oidc_discovery_url: Optional[str] = None
+    
+    is_active: bool = False
+
+
+class SsoConfigOut(BaseModel):
+    """Safe response containing the SSO configuration with secrets masked."""
+    id: uuid.UUID
+    workspace_id: uuid.UUID
+    protocol: str
+    
+    idp_entity_id: Optional[str]
+    idp_sso_url: Optional[str]
+    idp_x509_certificate_truncated: Optional[str]
+    
+    oidc_client_id: Optional[str]
+    oidc_client_secret: str = "***"
+    oidc_discovery_url: Optional[str]
+    
+    is_active: bool
+    created_at: datetime
+    updated_at: Optional[datetime]
+
+    model_config = {
+        "from_attributes": True
+    }
+
+
+class SsoTestResult(BaseModel):
+    success: bool
+    error: Optional[str] = None

--- a/app/schemas/sso.py
+++ b/app/schemas/sso.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 from typing import Literal, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class SsoConfigUpsert(BaseModel):
@@ -19,6 +19,20 @@ class SsoConfigUpsert(BaseModel):
     oidc_discovery_url: Optional[str] = None
     
     is_active: bool = False
+    
+    # Allowed email domains for auto-provisioning
+    allowed_email_domains: Optional[list[str]] = None
+
+    @field_validator("oidc_discovery_url")
+    @classmethod
+    def validate_oidc_discovery_url(cls, v: Optional[str]) -> Optional[str]:
+        if v:
+            from app.utils.ssrf import assert_public_url, SSRFBlockedError
+            try:
+                assert_public_url(v)
+            except SSRFBlockedError as exc:
+                raise ValueError(str(exc))
+        return v
 
 
 class SsoConfigOut(BaseModel):
@@ -36,6 +50,7 @@ class SsoConfigOut(BaseModel):
     oidc_discovery_url: Optional[str]
     
     is_active: bool
+    allowed_email_domains: Optional[list[str]] = None
     created_at: datetime
     updated_at: Optional[datetime]
 

--- a/app/schemas/workspace.py
+++ b/app/schemas/workspace.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
 
 
 class WorkspaceCreate(BaseModel):
@@ -107,9 +107,37 @@ class PricingConfigOut(BaseModel):
 class WorkspaceUsageOut(BaseModel):
     """Response shape for cycle usage"""
     minutes_used_this_cycle: Decimal
-    minutes_included: Decimal | None
+    minutes_included: Optional[Decimal] = None
     overage_minutes: Decimal
     overage_cost: Decimal
+
+class SubAccountCreate(BaseModel):
+    name: str = Field(..., min_length=3, max_length=50)
+    contact_email: EmailStr
+
+class SubAccountUpdate(BaseModel):
+    name: Optional[str] = Field(None, min_length=3, max_length=50)
+    contact_email: Optional[EmailStr] = None
+
+class SubAccountOut(BaseModel):
+    id: uuid.UUID
+    name: str
+    contact_email: Optional[str] = None
+    status: str
+    api_key_prefix: Optional[str] = None
+    usage_this_cycle_minutes: float
+
+    class Config:
+        orm_mode = True
+
+class SubAccountCreateOut(SubAccountOut):
+    api_key: str
+
+class SubAccountListOut(BaseModel):
+    data: list[SubAccountOut]
+    total: int
+    page: int
+    page_size: int
 
 
 class MemberRoleUpdate(BaseModel):

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -64,11 +64,10 @@ class PaymentService:
         client_secret: str = intent.client_secret
 
         # Build the payment URL — no separate hosted page; just a deep-link
-        # the caller opens that contains the client_secret.
+        # the caller opens to complete the payment.
         payment_url = (
             f"{settings.PAYMENT_PAGE_BASE_URL.rstrip('/')}"
             f"/pay/{payment_intent_id}"
-            f"?client_secret={client_secret}"
         )
 
         # Persist a pending PaymentRecord

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -100,6 +100,23 @@ class PaymentService:
             "Ask them to complete the payment."
         )
 
+        # Inject context into CallSession's metadata if call_id is provided
+        if call_id:
+            try:
+                from app.models.call_session import CallSession
+                call_session = db.query(CallSession).filter(CallSession.id == call_id).first()
+                if call_session:
+                    current_metadata = dict(call_session.call_metadata or {})
+                    vdc = dict(current_metadata.get("voice_dynamic_context") or {})
+                    vdc["system_prompt_addendum"] = agent_context
+                    current_metadata["voice_dynamic_context"] = vdc
+                    call_session.call_metadata = current_metadata
+                    db.add(call_session)
+                    db.commit()
+                    logger.info("Injected payment agent_context into CallSession %s metadata", call_id)
+            except Exception as e:
+                logger.error("Failed to inject payment context into CallSession: %s", e, exc_info=True)
+
         response = CreatePaymentSessionResponse(
             payment_intent_id=payment_intent_id,
             client_secret=client_secret,

--- a/app/services/payment_service.py
+++ b/app/services/payment_service.py
@@ -1,0 +1,262 @@
+"""
+PaymentService — business logic for in-call Stripe payment processing.
+
+Responsibilities:
+  - Create a PaymentIntent + persist a PaymentRecord (status=pending)
+  - Handle payment_intent.succeeded webhook: update status + card details
+  - Handle payment_intent.payment_failed webhook: update status
+  - Paginated listing of payment records for a workspace
+  - Single record lookup
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.models.payment_record import PaymentRecord
+from app.schemas.payment import (
+    CreatePaymentSessionResponse,
+    PaginatedPaymentResponse,
+    PaymentRecordOut,
+)
+from app.services.stripe_service import StripeService
+
+
+class PaymentService:
+
+    # ------------------------------------------------------------------
+    # Create payment session
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_payment_session(
+        db: Session,
+        workspace_id: uuid.UUID,
+        call_id: Optional[uuid.UUID],
+        amount_cents: int,
+        currency: str,
+        description: str,
+    ) -> Tuple[CreatePaymentSessionResponse, str]:
+        """
+        Create a Stripe PaymentIntent and persist a PaymentRecord.
+
+        Returns:
+            (CreatePaymentSessionResponse, agent_context_string)
+        """
+        stripe_metadata = {
+            "workspace_id": str(workspace_id),
+            "call_id": str(call_id) if call_id else "",
+        }
+
+        # Create the PaymentIntent in Stripe (test mode: sk_test_ key)
+        intent = StripeService.create_payment_intent(
+            amount_cents=amount_cents,
+            currency=currency,
+            description=description,
+            metadata=stripe_metadata,
+        )
+
+        payment_intent_id: str = intent.id
+        client_secret: str = intent.client_secret
+
+        # Build the payment URL — no separate hosted page; just a deep-link
+        # the caller opens that contains the client_secret.
+        payment_url = (
+            f"{settings.PAYMENT_PAGE_BASE_URL.rstrip('/')}"
+            f"/pay/{payment_intent_id}"
+            f"?client_secret={client_secret}"
+        )
+
+        # Persist a pending PaymentRecord
+        record = PaymentRecord(
+            workspace_id=workspace_id,
+            call_id=call_id,
+            payment_intent_id=payment_intent_id,
+            amount_cents=amount_cents,
+            currency=currency.lower(),
+            description=description,
+            status="pending",
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+
+        logger.info(
+            "PaymentRecord created: pi=%s workspace=%s call=%s amount=%d %s",
+            payment_intent_id,
+            workspace_id,
+            call_id,
+            amount_cents,
+            currency,
+        )
+
+        # Agent context injection sentence
+        agent_context = (
+            f"A payment page has been sent to the caller at {payment_url}. "
+            "Ask them to complete the payment."
+        )
+
+        response = CreatePaymentSessionResponse(
+            payment_intent_id=payment_intent_id,
+            client_secret=client_secret,
+            payment_url=payment_url,
+            agent_context=agent_context,
+        )
+        return response, agent_context
+
+    # ------------------------------------------------------------------
+    # Webhook handlers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def handle_payment_intent_succeeded(db: Session, event_data: dict) -> bool:
+        """
+        Handle payment_intent.succeeded webhook event.
+
+        Updates status → "succeeded" and stores card_last4 / card_brand
+        from the latest charge attached to the PaymentIntent.
+        """
+        pi_obj = event_data.get("data", {}).get("object", {})
+        payment_intent_id = _get_field(pi_obj, "id")
+        if not payment_intent_id:
+            logger.warning("payment_intent.succeeded: missing pi id in event")
+            return False
+
+        record = (
+            db.query(PaymentRecord)
+            .filter(PaymentRecord.payment_intent_id == payment_intent_id)
+            .first()
+        )
+        if not record:
+            logger.warning(
+                "payment_intent.succeeded: no PaymentRecord for pi=%s", payment_intent_id
+            )
+            return False
+
+        # Extract card details from charges.data[0].payment_method_details.card
+        card_last4 = None
+        card_brand = None
+        try:
+            charges = _get_field(pi_obj, "charges") or {}
+            charges_data = _get_field(charges, "data") or []
+            if charges_data:
+                charge = charges_data[0]
+                pmd = _get_field(charge, "payment_method_details") or {}
+                card_info = _get_field(pmd, "card") or {}
+                card_last4 = _get_field(card_info, "last4")
+                card_brand = _get_field(card_info, "brand")
+        except Exception as exc:
+            logger.warning("Could not extract card details from event: %s", exc)
+
+        record.status = "succeeded"
+        if card_last4:
+            record.card_last4 = str(card_last4)
+        if card_brand:
+            record.card_brand = str(card_brand)
+
+        db.commit()
+        db.refresh(record)
+
+        logger.info(
+            "PaymentRecord succeeded: pi=%s last4=%s brand=%s",
+            payment_intent_id,
+            card_last4,
+            card_brand,
+        )
+        return True
+
+    @staticmethod
+    def handle_payment_intent_failed(db: Session, event_data: dict) -> bool:
+        """
+        Handle payment_intent.payment_failed webhook event.
+
+        Updates status → "failed".
+        """
+        pi_obj = event_data.get("data", {}).get("object", {})
+        payment_intent_id = _get_field(pi_obj, "id")
+        if not payment_intent_id:
+            logger.warning("payment_intent.payment_failed: missing pi id in event")
+            return False
+
+        record = (
+            db.query(PaymentRecord)
+            .filter(PaymentRecord.payment_intent_id == payment_intent_id)
+            .first()
+        )
+        if not record:
+            logger.warning(
+                "payment_intent.payment_failed: no PaymentRecord for pi=%s",
+                payment_intent_id,
+            )
+            return False
+
+        record.status = "failed"
+        db.commit()
+        db.refresh(record)
+
+        logger.info("PaymentRecord failed: pi=%s", payment_intent_id)
+        return True
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def get_payments(
+        db: Session,
+        workspace_id: uuid.UUID,
+        page: int = 1,
+        per_page: int = 20,
+    ) -> PaginatedPaymentResponse:
+        """Return a paginated list of payment records for a workspace."""
+        offset = (page - 1) * per_page
+
+        query = (
+            db.query(PaymentRecord)
+            .filter(PaymentRecord.workspace_id == workspace_id)
+            .order_by(PaymentRecord.created_at.desc())
+        )
+        total = query.count()
+        records = query.offset(offset).limit(per_page).all()
+
+        pages = max(1, (total + per_page - 1) // per_page)
+        return PaginatedPaymentResponse(
+            items=[PaymentRecordOut.from_orm_model(r) for r in records],
+            total=total,
+            page=page,
+            per_page=per_page,
+            pages=pages,
+        )
+
+    @staticmethod
+    def get_payment(
+        db: Session,
+        workspace_id: uuid.UUID,
+        payment_intent_id: str,
+    ) -> Optional[PaymentRecord]:
+        """Return a single PaymentRecord for the given workspace + PI id."""
+        return (
+            db.query(PaymentRecord)
+            .filter(
+                PaymentRecord.workspace_id == workspace_id,
+                PaymentRecord.payment_intent_id == payment_intent_id,
+            )
+            .first()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helper: read a field from a Stripe object (StripeObject or dict)
+# ---------------------------------------------------------------------------
+
+def _get_field(obj, key: str):
+    """Read a field from a Stripe StripeObject or plain dict."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -26,6 +26,18 @@ def find_or_create_user(db: Session, email: str, workspace_id: uuid.UUID) -> tup
     """
     email = email.lower().strip()
     
+    # Validate allowed email domains
+    config = db.query(SsoConfig).filter(SsoConfig.workspace_id == workspace_id).first()
+    if config and config.allowed_email_domains:
+        email_domain = email.split("@", 1)[-1].lower()
+        allowed_domains = [d.lower().strip() for d in config.allowed_email_domains if d.strip()]
+        if allowed_domains and email_domain not in allowed_domains:
+            from fastapi import HTTPException
+            raise HTTPException(
+                status_code=403,
+                detail=f"Email domain @{email_domain} is not permitted for this workspace",
+            )
+    
     # 1. Look for existing user
     user = db.query(User).filter(User.email == email, User.deleted_at.is_(None)).first()
     
@@ -38,7 +50,6 @@ def find_or_create_user(db: Session, email: str, workspace_id: uuid.UUID) -> tup
             first_name="SSO",
             last_name="User",
             hashed_password=get_password_hash(uuid.uuid4().hex),  # Random unusable password
-            is_verified=True,  # SSO implies verified
         )
         db.add(user)
         db.flush()
@@ -50,7 +61,7 @@ def find_or_create_user(db: Session, email: str, workspace_id: uuid.UUID) -> tup
     # Check if association exists
     assoc = db.execute(
         text("SELECT 1 FROM user_tenant_association WHERE user_id = :uid AND tenant_id = :tid"),
-        {"uid": user.id, "tid": workspace_id}
+        {"uid": str(user.id), "tid": str(workspace_id)}
     ).fetchone()
     
     if not assoc:

--- a/app/services/sso_service.py
+++ b/app/services/sso_service.py
@@ -1,0 +1,83 @@
+"""Service for handling SAML and OIDC Single Sign-On operations."""
+
+import uuid
+from typing import Optional
+from sqlalchemy.orm import Session
+from sqlalchemy import text
+
+from app.models.sso_config import SsoConfig
+from app.models.user import User, user_tenant_association
+from app.models.tenant import Tenant
+from app.schemas.auth import RoleInfo
+from app.core.security import get_password_hash
+from app.services import role_service
+
+# For authlib OIDC
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+def get_sso_config(db: Session, workspace_id: uuid.UUID) -> Optional[SsoConfig]:
+    return db.query(SsoConfig).filter(SsoConfig.workspace_id == workspace_id).first()
+
+
+def find_or_create_user(db: Session, email: str, workspace_id: uuid.UUID) -> tuple[User, RoleInfo]:
+    """Find a user by email from an SSO login, or create one if they don't exist.
+    Ensure they are a member of the workspace (tenant).
+    Returns (User, RoleInfo).
+    """
+    email = email.lower().strip()
+    
+    # 1. Look for existing user
+    user = db.query(User).filter(User.email == email, User.deleted_at.is_(None)).first()
+    
+    if not user:
+        # Create new user
+        # We don't have first/last name from basic assertion usually, so set a default.
+        # Can extract from OIDC claims/SAML attributes later if needed.
+        user = User(
+            email=email,
+            first_name="SSO",
+            last_name="User",
+            hashed_password=get_password_hash(uuid.uuid4().hex),  # Random unusable password
+            is_verified=True,  # SSO implies verified
+        )
+        db.add(user)
+        db.flush()
+    else:
+        # Touch last login? We could, but usually handled elsewhere or not strictly needed
+        pass
+        
+    # 2. Ensure they are in the workspace
+    # Check if association exists
+    assoc = db.execute(
+        text("SELECT 1 FROM user_tenant_association WHERE user_id = :uid AND tenant_id = :tid"),
+        {"uid": user.id, "tid": workspace_id}
+    ).fetchone()
+    
+    if not assoc:
+        # Add to workspace
+        tenant = db.query(Tenant).filter(Tenant.id == workspace_id).first()
+        if tenant:
+            user.tenants.append(tenant)
+            db.flush()
+            
+            # Default to read_only role
+            from app.models.role import Role
+            ro_role = db.query(Role).filter(Role.name == role_service.READ_ONLY).first()
+            if ro_role:
+                db.execute(
+                    user_tenant_association.update()
+                    .where(
+                        (user_tenant_association.c.user_id == user.id) & 
+                        (user_tenant_association.c.tenant_id == workspace_id)
+                    )
+                    .values(role_id=ro_role.id)
+                )
+
+    db.commit()
+    db.refresh(user)
+    
+    # Get role info
+    role = role_service.get_user_role_in_tenant(db, user.id, workspace_id)
+    role_info = RoleInfo(id=role.id, name=role.name, description=role.description) if role else None
+    
+    return user, role_info

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -329,3 +329,62 @@ class StripeService:
         db.refresh(tenant)
 
         logger.info(f"Added {plan.credits} credits to tenant {tenant.id}")
+
+    # -------------------------------------------------------------------------
+    # In-call payment helpers (Sprint — Stripe PaymentIntent + Webhook)
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def create_payment_intent(
+        amount_cents: int,
+        currency: str,
+        description: str,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> Any:
+        """
+        Create a Stripe PaymentIntent for in-call payment collection.
+
+        Uses the global stripe.api_key (sk_test_* in staging, sk_live_* post Sprint 6).
+        automatic_payment_methods=True lets Stripe handle 3DS automatically.
+
+        Returns the raw stripe.PaymentIntent object.
+        """
+        try:
+            intent = stripe.PaymentIntent.create(
+                amount=amount_cents,
+                currency=currency.lower(),
+                description=description or None,
+                automatic_payment_methods={"enabled": True},
+                metadata=metadata or {},
+            )
+            return intent
+        except stripe.StripeError as e:
+            raise Exception(f"Failed to create PaymentIntent: {str(e)}")
+
+    @staticmethod
+    def construct_payment_webhook_event(
+        payload: bytes,
+        sig_header: str,
+        webhook_secret: str,
+    ) -> Dict[str, Any]:
+        """
+        Construct and verify a Stripe webhook event for in-call payments.
+
+        Uses the caller-supplied *webhook_secret* (STRIPE_INCALL_WEBHOOK_SECRET)
+        rather than the billing STRIPE_WEBHOOK_SECRET, allowing the two webhook
+        endpoints to be registered with independent secrets in Stripe Dashboard.
+
+        Raises:
+            ValueError: payload is not valid JSON.
+            stripe.SignatureVerificationError: signature does not match.
+        """
+        try:
+            event = stripe.Webhook.construct_event(payload, sig_header, webhook_secret)
+            return event
+        except ValueError as e:
+            raise ValueError(f"Invalid webhook payload: {str(e)}")
+        except stripe.SignatureVerificationError as e:
+            raise stripe.SignatureVerificationError(
+                f"Invalid webhook signature: {str(e)}", sig_header
+            )
+

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8002,6 +8002,250 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+    post:
+      tags:
+      - Workspace Settings
+      summary: Create Member Role
+      operationId: create_member_role_api_v2_workspace_members__user_id__role_post
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: User Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MemberRoleUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MemberRoleOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/workspace/sub-accounts:
+    post:
+      tags:
+      - Workspace Settings
+      summary: Create Sub Account
+      operationId: create_sub_account_api_v2_workspace_sub_accounts_post
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: x-api-key
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: x-workspace-id
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubAccountCreate'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubAccountCreateOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Workspace Settings
+      summary: List Sub Accounts
+      operationId: list_sub_accounts_api_v2_workspace_sub_accounts_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: page_size
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 50
+          title: Page Size
+      - name: x-api-key
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: x-workspace-id
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubAccountListOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/workspace/sub-accounts/{sub_id}:
+    get:
+      tags:
+      - Workspace Settings
+      summary: Get Sub Account
+      operationId: get_sub_account_api_v2_workspace_sub_accounts__sub_id__get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: x-api-key
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: x-workspace-id
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubAccountOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - Workspace Settings
+      summary: Update Sub Account
+      operationId: update_sub_account_api_v2_workspace_sub_accounts__sub_id__put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: x-api-key
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: x-workspace-id
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SubAccountUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SubAccountOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Workspace Settings
+      summary: Delete Sub Account
+      operationId: delete_sub_account_api_v2_workspace_sub_accounts__sub_id__delete
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: sub_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Id
+      - name: x-api-key
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: x-workspace-id
+        in: header
+        required: false
+        schema:
+          type: string
+          nullable: true
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/settings:
     put:
       tags:
@@ -14115,6 +14359,118 @@ components:
       type: object
       title: SttSettingsJsonSchema
       description: Optional STT tuning stored on ``agent.stt_settings_json``.
+    SubAccountCreate:
+      properties:
+        name:
+          type: string
+          maxLength: 50
+          minLength: 3
+          title: Name
+        contact_email:
+          type: string
+          format: email
+          title: Contact Email
+      type: object
+      required:
+      - name
+      - contact_email
+      title: SubAccountCreate
+    SubAccountCreateOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        contact_email:
+          type: string
+          nullable: true
+        status:
+          type: string
+          title: Status
+        api_key_prefix:
+          type: string
+          nullable: true
+        usage_this_cycle_minutes:
+          type: number
+          title: Usage This Cycle Minutes
+        api_key:
+          type: string
+          title: Api Key
+      type: object
+      required:
+      - id
+      - name
+      - status
+      - usage_this_cycle_minutes
+      - api_key
+      title: SubAccountCreateOut
+    SubAccountListOut:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/SubAccountOut'
+          type: array
+          title: Data
+        total:
+          type: integer
+          title: Total
+        page:
+          type: integer
+          title: Page
+        page_size:
+          type: integer
+          title: Page Size
+      type: object
+      required:
+      - data
+      - total
+      - page
+      - page_size
+      title: SubAccountListOut
+    SubAccountOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        contact_email:
+          type: string
+          nullable: true
+        status:
+          type: string
+          title: Status
+        api_key_prefix:
+          type: string
+          nullable: true
+        usage_this_cycle_minutes:
+          type: number
+          title: Usage This Cycle Minutes
+      type: object
+      required:
+      - id
+      - name
+      - status
+      - usage_this_cycle_minutes
+      title: SubAccountOut
+    SubAccountUpdate:
+      properties:
+        name:
+          type: string
+          maxLength: 50
+          minLength: 3
+          nullable: true
+        contact_email:
+          type: string
+          format: email
+          nullable: true
+      type: object
+      title: SubAccountUpdate
     SuccessResponse_ApiKeyCreated_:
       properties:
         data:
@@ -16679,7 +17035,6 @@ components:
       type: object
       required:
       - minutes_used_this_cycle
-      - minutes_included
       - overage_minutes
       - overage_cost
       title: WorkspaceUsageOut

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7216,6 +7216,106 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/payments/session:
+    post:
+      tags:
+      - In-Call Payments
+      summary: Create an in-call payment session
+      description: Creates a Stripe PaymentIntent and returns a payment URL the agent
+        can share with the caller. The `agent_context` field contains the ready-made
+        sentence to inject into the agent's prompt.
+      operationId: create_payment_session_api_v1_payments_session_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePaymentSessionRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_CreatePaymentSessionResponse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/payments/stripe-webhook:
+    post:
+      tags:
+      - In-Call Payments
+      summary: Stripe webhook for in-call payment events
+      description: Receives `payment_intent.succeeded` and `payment_intent.payment_failed`
+        events from Stripe. Signature is verified with STRIPE_INCALL_WEBHOOK_SECRET.
+        Returns 204 on success, 403 on invalid signature.
+      operationId: stripe_payment_webhook_api_v1_payments_stripe_webhook_post
+      responses:
+        '204':
+          description: Successful Response
+  /api/v1/payments:
+    get:
+      tags:
+      - In-Call Payments
+      summary: List payment records for the workspace
+      operationId: list_payment_records_api_v1_payments_get
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 1
+          title: Page
+      - name: per_page
+        in: query
+        required: false
+        schema:
+          type: integer
+          default: 20
+          title: Per Page
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_PaginatedPaymentResponse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/payments/{payment_intent_id}:
+    get:
+      tags:
+      - In-Call Payments
+      summary: Get a single payment record by PaymentIntent ID
+      operationId: get_payment_record_api_v1_payments__payment_intent_id__get
+      parameters:
+      - name: payment_intent_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Payment Intent Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_PaymentRecordOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /health:
     get:
       summary: Health Check
@@ -11296,6 +11396,68 @@ components:
       - partially qualified
       - rejected
       title: CandidateStatusEnum
+    CreatePaymentSessionRequest:
+      properties:
+        call_id:
+          type: string
+          format: uuid
+          nullable: true
+        amount_cents:
+          type: integer
+          exclusiveMinimum: 0.0
+          title: Amount Cents
+          description: Amount in the smallest currency unit (e.g. cents for USD).
+          examples:
+          - 5000
+        currency:
+          type: string
+          maxLength: 3
+          minLength: 3
+          title: Currency
+          description: Three-letter ISO 4217 currency code (lowercase).
+          default: usd
+          examples:
+          - usd
+        description:
+          type: string
+          maxLength: 1000
+          title: Description
+          description: Free-text description shown to the payer.
+          default: ''
+          examples:
+          - Service fee for call session
+      type: object
+      required:
+      - amount_cents
+      title: CreatePaymentSessionRequest
+      description: Body for POST /api/v1/payments/session.
+    CreatePaymentSessionResponse:
+      properties:
+        payment_intent_id:
+          type: string
+          title: Payment Intent Id
+          description: Stripe PaymentIntent ID (pi_...).
+        client_secret:
+          type: string
+          title: Client Secret
+          description: Stripe client_secret for client-side confirmation.
+        payment_url:
+          type: string
+          title: Payment Url
+          description: URL for the caller-facing payment page. Pass this to the agent
+            prompt so it can direct the caller.
+        agent_context:
+          type: string
+          title: Agent Context
+          description: Ready-to-use sentence to inject into the agent's prompt context.
+      type: object
+      required:
+      - payment_intent_id
+      - client_secret
+      - payment_url
+      - agent_context
+      title: CreatePaymentSessionResponse
+      description: Response from POST /api/v1/payments/session.
     CreatePhoneNumberRequest:
       properties:
         phone_number:
@@ -12892,6 +13054,34 @@ components:
       - page
       - page_size
       title: PaginatedBatchJobs
+    PaginatedPaymentResponse:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/PaymentRecordOut'
+          type: array
+          title: Items
+        total:
+          type: integer
+          title: Total
+        page:
+          type: integer
+          title: Page
+        per_page:
+          type: integer
+          title: Per Page
+        pages:
+          type: integer
+          title: Pages
+      type: object
+      required:
+      - items
+      - total
+      - page
+      - per_page
+      - pages
+      title: PaginatedPaymentResponse
+      description: Paginated list of payment records.
     PaginatedWebhookDeliveries:
       properties:
         items:
@@ -12930,6 +13120,63 @@ components:
       - READY
       - FAILED
       title: ParseStatusEnum
+    PaymentRecordOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        workspace_id:
+          type: string
+          format: uuid
+          title: Workspace Id
+        call_id:
+          type: string
+          format: uuid
+          nullable: true
+        payment_intent_id:
+          type: string
+          title: Payment Intent Id
+        amount_cents:
+          type: integer
+          title: Amount Cents
+        currency:
+          type: string
+          title: Currency
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          title: Status
+        card_last4:
+          type: string
+          nullable: true
+        card_brand:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          title: Created At
+        updated_at:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - id
+      - workspace_id
+      - call_id
+      - payment_intent_id
+      - amount_cents
+      - currency
+      - description
+      - status
+      - card_last4
+      - card_brand
+      - created_at
+      - updated_at
+      title: PaymentRecordOut
+      description: Serialised PaymentRecord for list/detail responses.
     PendingCountByCrm:
       properties:
         crm_type:
@@ -15119,6 +15366,22 @@ components:
       required:
       - data
       title: SuccessResponse[CallSessionStats]
+    SuccessResponse_CreatePaymentSessionResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/CreatePaymentSessionResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[CreatePaymentSessionResponse]
     SuccessResponse_CreatePhoneNumberResponse_:
       properties:
         data:
@@ -15569,6 +15832,38 @@ components:
       required:
       - data
       title: SuccessResponse[NumberConfigurationResponse]
+    SuccessResponse_PaginatedPaymentResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/PaginatedPaymentResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[PaginatedPaymentResponse]
+    SuccessResponse_PaymentRecordOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/PaymentRecordOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[PaymentRecordOut]
     SuccessResponse_PendingCountResponse_:
       properties:
         data:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -677,6 +677,72 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/workspace/sso:
+    get:
+      tags:
+      - SSO
+      summary: Get Sso Config
+      description: Get the current SSO configuration.
+      operationId: get_sso_config_api_v1_workspace_sso_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SsoConfigOut'
+      security: *id001
+    post:
+      tags:
+      - SSO
+      summary: Upsert Sso Config
+      description: Create or update the SSO configuration for the current workspace.
+      operationId: upsert_sso_config_api_v1_workspace_sso_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SsoConfigUpsert'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SsoConfigOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security: *id001
+    delete:
+      tags:
+      - SSO
+      summary: Disable Sso
+      description: Disable SSO for the current workspace (sets is_active=false).
+      operationId: disable_sso_api_v1_workspace_sso_delete
+      responses:
+        '204':
+          description: Successful Response
+      security: *id001
+  /api/v1/workspace/sso/test:
+    post:
+      tags:
+      - SSO
+      summary: Test Sso Connection
+      description: Test IdP connectivity (e.g. discovery URL or SAML endpoint).
+      operationId: test_sso_connection_api_v1_workspace_sso_test_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SsoTestResult'
+      security: *id001
   /api/v1/workspace:
     post:
       tags:
@@ -8407,6 +8473,131 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - HTTPBearer: []
+  /auth/saml/{workspace_slug}/metadata:
+    get:
+      tags:
+      - SSO Authentication
+      summary: Saml Metadata
+      operationId: saml_metadata_auth_saml__workspace_slug__metadata_get
+      parameters:
+      - name: workspace_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/saml/{workspace_slug}/login:
+    get:
+      tags:
+      - SSO Authentication
+      summary: Saml Login
+      operationId: saml_login_auth_saml__workspace_slug__login_get
+      parameters:
+      - name: workspace_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/saml/{workspace_slug}/callback:
+    post:
+      tags:
+      - SSO Authentication
+      summary: Saml Callback
+      operationId: saml_callback_auth_saml__workspace_slug__callback_post
+      parameters:
+      - name: workspace_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/oidc/{workspace_slug}/login:
+    get:
+      tags:
+      - SSO Authentication
+      summary: Oidc Login
+      operationId: oidc_login_auth_oidc__workspace_slug__login_get
+      parameters:
+      - name: workspace_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /auth/oidc/{workspace_slug}/callback:
+    get:
+      tags:
+      - SSO Authentication
+      summary: Oidc Callback
+      operationId: oidc_callback_auth_oidc__workspace_slug__callback_get
+      parameters:
+      - name: workspace_slug
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Workspace Slug
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
     AccountDeletionRequest:
@@ -14318,6 +14509,111 @@ components:
       - crm_type
       - message
       title: SingleCallResponse
+    SsoConfigOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        workspace_id:
+          type: string
+          format: uuid
+          title: Workspace Id
+        protocol:
+          type: string
+          title: Protocol
+        idp_entity_id:
+          type: string
+          nullable: true
+        idp_sso_url:
+          type: string
+          nullable: true
+        idp_x509_certificate_truncated:
+          type: string
+          nullable: true
+        oidc_client_id:
+          type: string
+          nullable: true
+        oidc_client_secret:
+          type: string
+          title: Oidc Client Secret
+          default: '***'
+        oidc_discovery_url:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+          title: Is Active
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - id
+      - workspace_id
+      - protocol
+      - idp_entity_id
+      - idp_sso_url
+      - idp_x509_certificate_truncated
+      - oidc_client_id
+      - oidc_discovery_url
+      - is_active
+      - created_at
+      - updated_at
+      title: SsoConfigOut
+      description: Safe response containing the SSO configuration with secrets masked.
+    SsoConfigUpsert:
+      properties:
+        protocol:
+          type: string
+          enum:
+          - saml
+          - oidc
+          title: Protocol
+        idp_entity_id:
+          type: string
+          nullable: true
+        idp_sso_url:
+          type: string
+          nullable: true
+        idp_x509_certificate:
+          type: string
+          nullable: true
+        oidc_client_id:
+          type: string
+          nullable: true
+        oidc_client_secret:
+          type: string
+          nullable: true
+        oidc_discovery_url:
+          type: string
+          nullable: true
+        is_active:
+          type: boolean
+          title: Is Active
+          default: false
+      type: object
+      required:
+      - protocol
+      title: SsoConfigUpsert
+      description: Payload for creating or updating an SSO configuration.
+    SsoTestResult:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        error:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - success
+      title: SsoTestResult
     SttModelSchema:
       properties:
         provider:

--- a/docs/qa/sso-test-setup.md
+++ b/docs/qa/sso-test-setup.md
@@ -1,0 +1,35 @@
+# Auth0 SSO Test Setup Guide
+
+This guide walks through setting up both SAML and OIDC connections in Auth0's free tier to test the SSO integration.
+
+## 1. Auth0 Setup (General)
+1. Sign up for a free Auth0 account at [auth0.com](https://auth0.com).
+2. Create a new Auth0 Tenant.
+3. You will need users to test with. Go to **User Management > Users** and create a test user (e.g., `sso-test@example.com`).
+
+## 2. Testing SAML 2.0
+1. In Auth0, go to **Applications > Applications** and click **Create Application**.
+2. Select **Regular Web Application** and name it "TGS SAML App".
+3. In the application settings, go to the **Addons** tab and enable **SAML2 Web App**.
+4. A settings window will pop up. 
+   - **Application Callback URL**: Set this to your ngrok URL + the callback path, e.g., `https://<your-ngrok-url>/auth/saml/<workspace_slug>/callback`.
+   - Leave the rest as defaults, scroll to the bottom, and click **Enable**.
+5. Go to the **Usage** tab of the SAML2 Web App addon.
+   - Download the **Identity Provider Metadata** XML file.
+   - Or manually copy the **Issuer** (Entity ID), **Identity Provider Login URL** (SSO URL), and download the **Identity Provider Certificate** (x509 cert).
+6. In TGS (using an Admin account in your workspace):
+   - Submit a `POST /api/v1/workspace/sso` with `protocol="saml"`.
+   - Provide the Entity ID, SSO URL, and the raw text of the x509 certificate.
+7. Test the flow by navigating to `https://<your-ngrok-url>/auth/saml/<workspace_slug>/login`. You should be redirected to Auth0, log in, and be redirected back with a valid session cookie.
+
+## 3. Testing OIDC
+1. In Auth0, create another **Regular Web Application** and name it "TGS OIDC App".
+2. In the application settings:
+   - **Allowed Callback URLs**: `https://<your-ngrok-url>/auth/oidc/<workspace_slug>/callback`
+   - Save changes.
+3. Scroll to the top and grab the **Client ID** and **Client Secret**.
+4. To find your **Discovery URL**, go to the bottom of the Settings page and click **Show Advanced Settings** -> **Endpoints**. Copy the **OpenID Configuration** URL.
+5. In TGS (using an Admin account in your workspace):
+   - Submit a `POST /api/v1/workspace/sso` with `protocol="oidc"`.
+   - Provide the Client ID, Client Secret, and Discovery URL.
+6. Test the flow by navigating to `https://<your-ngrok-url>/auth/oidc/<workspace_slug>/login`. You should be redirected to Auth0, log in, and be redirected back with a valid session cookie.

--- a/docs/qa/stripe-test-cards.md
+++ b/docs/qa/stripe-test-cards.md
@@ -1,0 +1,122 @@
+# Stripe Test Cards — In-Call Payment QA
+
+Use these cards when testing in-call payments against the Stripe **test mode** environment (`sk_test_...` key).
+
+> ⚠️ Test cards only work with a `sk_test_` key. Never use real card numbers in test mode.
+
+---
+
+## Standard Test Cards
+
+| Card Number | Scenario | CVC | Expiry |
+|---|---|---|---|
+| `4242 4242 4242 4242` | ✅ Payment succeeds | Any 3 digits | Any future date |
+| `4000 0000 0000 0002` | ❌ Card declined (`card_declined`) | Any 3 digits | Any future date |
+| `4000 0025 0000 3155` | 🔐 3D Secure required (redirect flow) | Any 3 digits | Any future date |
+| `4000 0000 0000 9995` | ❌ Insufficient funds (`insufficient_funds`) | Any 3 digits | Any future date |
+| `4000 0000 0000 0069` | ❌ Expired card (`expired_card`) | Any 3 digits | Any past date |
+| `4000 0000 0000 0127` | ❌ Incorrect CVC (`incorrect_cvc`) | `999` | Any future date |
+
+---
+
+## Testing the Payment Flow
+
+### Step 1 — Create a payment session
+
+```bash
+curl -X POST https://your-api.com/api/v1/payments/session \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "x-workspace-id: YOUR_WORKSPACE_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "call_id": "00000000-0000-0000-0000-000000000001",
+    "amount_cents": 5000,
+    "currency": "usd",
+    "description": "Consultation fee"
+  }'
+```
+
+Expected response:
+```json
+{
+  "data": {
+    "payment_intent_id": "pi_test_...",
+    "client_secret": "pi_test_..._secret_...",
+    "payment_url": "https://pay.yourdomain.com/pay/pi_test_...?client_secret=...",
+    "agent_context": "A payment page has been sent to the caller at ... Ask them to complete the payment."
+  }
+}
+```
+
+### Step 2 — Trigger the success webhook (Stripe CLI)
+
+```bash
+# Forward Stripe webhook events to your local server
+stripe listen --forward-to localhost:8000/api/v1/payments/stripe-webhook
+
+# Trigger a payment_intent.succeeded event
+stripe trigger payment_intent.succeeded
+```
+
+### Step 3 — Verify record updated
+
+```bash
+curl https://your-api.com/api/v1/payments/pi_test_... \
+  -H "x-api-key: YOUR_API_KEY" \
+  -H "x-workspace-id: YOUR_WORKSPACE_ID"
+```
+
+Expected:
+```json
+{
+  "data": {
+    "status": "succeeded",
+    "card_last4": "4242",
+    "card_brand": "visa"
+  }
+}
+```
+
+---
+
+## Webhook Event Reference
+
+| Event | Expected behaviour |
+|---|---|
+| `payment_intent.succeeded` | `status` → `succeeded`; `card_last4`, `card_brand` populated |
+| `payment_intent.payment_failed` | `status` → `failed` |
+
+---
+
+## Stripe CLI Quick Reference
+
+```bash
+# Install
+brew install stripe/stripe-cli/stripe   # macOS
+# or download from https://github.com/stripe/stripe-cli/releases
+
+# Login
+stripe login
+
+# Listen & forward to local
+stripe listen --forward-to localhost:8000/api/v1/payments/stripe-webhook
+
+# Manually trigger events
+stripe trigger payment_intent.succeeded
+stripe trigger payment_intent.payment_failed
+
+# Replay a specific event by ID
+stripe events resend evt_...
+```
+
+---
+
+## Environment Variables Required
+
+```dotenv
+STRIPE_SECRET_KEY=sk_test_...            # Test mode secret key
+STRIPE_INCALL_WEBHOOK_SECRET=whsec_...   # From Stripe Dashboard → Webhooks → in-call endpoint
+PAYMENT_PAGE_BASE_URL=https://pay.yourdomain.com
+```
+
+> **Sprint 6 note**: `STRIPE_SECRET_KEY` must be rotated from `sk_test_` to `sk_live_` only after the Sprint 6 security review. Do not promote to production until that review is complete.

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,7 @@ arq==0.26.1
 pymupdf==1.26.1
 tiktoken>=0.9.0,<1.0.0
 pgvector==0.3.6
+# SSO: SAML 2.0 + OIDC
+python3-saml>=1.16.0
+lxml>=5.2.0
+xmlsec>=1.3.14

--- a/tests/api/test_payments.py
+++ b/tests/api/test_payments.py
@@ -1,0 +1,423 @@
+"""
+Tests for in-call Stripe payment endpoints.
+
+Coverage:
+  1. test_create_payment_session            — POST /payments/session (success)
+  2. test_create_payment_session_missing_fields — POST /payments/session (validation error)
+  3. test_stripe_webhook_valid_signature    — POST /payments/stripe-webhook (204 + DB updated)
+  4. test_stripe_webhook_invalid_signature  — POST /payments/stripe-webhook (403)
+  5. test_stripe_webhook_missing_signature  — POST /payments/stripe-webhook (403, no header)
+  6. test_payment_records_updated_on_succeeded_webhook — card_last4, card_brand set
+  7. test_payment_records_updated_on_failed_webhook    — status=failed
+  8. test_list_payments_empty               — GET /payments (empty list)
+  9. test_list_payments                     — GET /payments (records present)
+ 10. test_get_payment_detail               — GET /payments/{pi_id} (200)
+ 11. test_get_payment_detail_not_found     — GET /payments/{pi_id} (404)
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.models.payment_record import PaymentRecord
+
+# ---------------------------------------------------------------------------
+# Client fixture — reuses the shared SQLite DB from conftest.py
+# ---------------------------------------------------------------------------
+
+client = TestClient(app)
+
+# Auth headers that satisfy ApiKeyMiddleware for the test workspace
+# (The conftest seeds a tenant but does not seed an API key row; we instead
+# make the auth middleware see the workspace through JWT mock.)
+# We bypass auth by monkeypatching get_workspace in the router's deps.
+
+_FAKE_WORKSPACE_ID = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_FAKE_PI_ID = "pi_test_3TxS1MOCK000000001"
+_FAKE_CLIENT_SECRET = "pi_test_3TxS1MOCK000000001_secret_MockSecret"
+_FAKE_WEBHOOK_SECRET = "whsec_test_mock_webhook_secret_for_pytest"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_stripe_signature(payload: bytes, secret: str, timestamp: int | None = None) -> str:
+    """Build a valid Stripe-Signature header for the given payload."""
+    ts = timestamp or int(time.time())
+    signed_payload = f"{ts}.{payload.decode()}"
+    mac = hmac.new(secret.encode(), signed_payload.encode(), hashlib.sha256).hexdigest()
+    return f"t={ts},v1={mac}"
+
+
+def _make_payment_intent_event(pi_id: str, event_type: str) -> dict:
+    """Build a minimal Stripe payment_intent.succeeded / payment_failed event dict."""
+    return {
+        "id": f"evt_test_{uuid.uuid4().hex[:16]}",
+        "type": event_type,
+        "data": {
+            "object": {
+                "id": pi_id,
+                "object": "payment_intent",
+                "amount": 5000,
+                "currency": "usd",
+                "status": "succeeded" if "succeeded" in event_type else "requires_payment_method",
+                "charges": {
+                    "data": [
+                        {
+                            "id": f"ch_test_{uuid.uuid4().hex[:16]}",
+                            "payment_method_details": {
+                                "card": {
+                                    "brand": "visa",
+                                    "last4": "4242",
+                                },
+                                "type": "card",
+                            },
+                        }
+                    ]
+                },
+            }
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Workspace dependency override — avoids needing a seeded API key
+# ---------------------------------------------------------------------------
+
+from app.core.workspace import Workspace
+
+
+def _fake_workspace() -> Workspace:
+    return Workspace(
+        id=_FAKE_WORKSPACE_ID,
+        name="Test Workspace",
+        status="active",
+        is_active=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def override_auth():
+    """Mock API key middleware to authorize requests."""
+    async def _resolve(_key_hash, workspace_id):
+        return {
+            "api_key_id": str(uuid.uuid4()),
+            "tenant_id": str(workspace_id),
+            "key_is_active": True,
+            "workspace": {
+                "id": str(workspace_id),
+                "name": "Test Workspace",
+                "schema_name": "test_ws",
+                "status": "active",
+            },
+        }
+
+    with patch(
+        "app.middleware.api_key_middleware._resolve_api_key",
+        side_effect=_resolve,
+    ):
+        yield
+
+def _auth_headers(ws_id=None):
+    return {
+        "x-api-key": "test_key",
+        "x-workspace-id": str(ws_id or _FAKE_WORKSPACE_ID)
+    }
+
+
+@pytest.fixture()
+def mock_stripe_intent():
+    """Return a mock Stripe PaymentIntent object."""
+    intent = MagicMock()
+    intent.id = f"pi_test_mock_{uuid.uuid4().hex[:16]}"
+    intent.client_secret = f"{intent.id}_secret_MockSecret"
+    return intent
+
+
+@pytest.fixture()
+def seeded_payment_record(db):
+    """Insert a pending PaymentRecord into the test DB and return it."""
+    record = PaymentRecord(
+        workspace_id=_FAKE_WORKSPACE_ID,
+        call_id=None,
+        payment_intent_id=f"pi_test_seed_{uuid.uuid4().hex[:16]}",
+        amount_cents=5000,
+        currency="usd",
+        description="Test payment",
+        status="pending",
+    )
+    db.add(record)
+    db.commit()
+    db.refresh(record)
+    return record
+
+
+# ===========================================================================
+# 1. POST /payments/session — success
+# ===========================================================================
+
+def test_create_payment_session(db, mock_stripe_intent):
+    """Creates a PaymentIntent in Stripe test mode and persists a PaymentRecord."""
+    with patch(
+        "app.services.stripe_service.stripe.PaymentIntent.create",
+        return_value=mock_stripe_intent,
+    ):
+        resp = client.post(
+            "/api/v1/payments/session",
+            headers=_auth_headers(),
+            json={
+                "amount_cents": 5000,
+                "currency": "usd",
+                "description": "Consultation fee",
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    assert data["payment_intent_id"] == mock_stripe_intent.id
+    assert data["client_secret"] == mock_stripe_intent.client_secret
+    assert mock_stripe_intent.id in data["payment_url"]
+    assert "client_secret" in data["payment_url"]
+    assert "Ask them to complete the payment" in data["agent_context"]
+
+    # DB record should be created
+    record = (
+        db.query(PaymentRecord)
+        .filter(PaymentRecord.payment_intent_id == mock_stripe_intent.id)
+        .first()
+    )
+    assert record is not None
+    assert record.status == "pending"
+    assert record.amount_cents == 5000
+    assert record.currency == "usd"
+    assert str(record.workspace_id) == str(_FAKE_WORKSPACE_ID)
+
+
+# ===========================================================================
+# 2. POST /payments/session — validation error (amount ≤ 0)
+# ===========================================================================
+
+def test_create_payment_session_invalid_amount(db):
+    """Should return 400 when amount_cents is not positive."""
+    resp = client.post(
+        "/api/v1/payments/session",
+        headers=_auth_headers(),
+        json={"amount_cents": 0, "currency": "usd", "description": ""},
+    )
+    assert resp.status_code == 400
+
+
+# ===========================================================================
+# 3. POST /payments/stripe-webhook — valid signature → 204 + DB updated
+# ===========================================================================
+
+def test_stripe_webhook_valid_signature(db, seeded_payment_record):
+    """Valid Stripe-Signature must yield 204 and update the PaymentRecord status."""
+    event = _make_payment_intent_event(seeded_payment_record.payment_intent_id, "payment_intent.succeeded")
+    payload = json.dumps(event).encode()
+    sig = _make_stripe_signature(payload, _FAKE_WEBHOOK_SECRET)
+
+    with patch(
+        "app.services.stripe_service.stripe.Webhook.construct_event",
+        return_value=event,
+    ), patch.object(
+        # Patch the setting so the router picks up our test secret
+        type(app.state if hasattr(app, "state") else object()),
+        "STRIPE_INCALL_WEBHOOK_SECRET",
+        _FAKE_WEBHOOK_SECRET,
+        create=True,
+    ), patch(
+        "app.core.config.settings.STRIPE_INCALL_WEBHOOK_SECRET",
+        _FAKE_WEBHOOK_SECRET,
+    ):
+        resp = client.post(
+            "/api/v1/payments/stripe-webhook",
+            content=payload,
+            headers={"stripe-signature": sig, "content-type": "application/json"},
+        )
+
+    assert resp.status_code == 204, resp.text
+
+    db.expire(seeded_payment_record)
+    db.refresh(seeded_payment_record)
+    assert seeded_payment_record.status == "succeeded"
+
+
+# ===========================================================================
+# 4. POST /payments/stripe-webhook — invalid signature → 403
+# ===========================================================================
+
+def test_stripe_webhook_invalid_signature(db):
+    """Garbage Stripe-Signature must be rejected with 403."""
+    import stripe as stripe_lib
+
+    payload = b'{"type":"payment_intent.succeeded","data":{"object":{"id":"pi_fake"}}}'
+
+    with patch(
+        "app.services.stripe_service.stripe.Webhook.construct_event",
+        side_effect=stripe_lib.SignatureVerificationError(
+            "No signatures found matching the expected signature for payload",
+            "bad-header",
+        ),
+    ), patch(
+        "app.core.config.settings.STRIPE_INCALL_WEBHOOK_SECRET",
+        _FAKE_WEBHOOK_SECRET,
+    ):
+        resp = client.post(
+            "/api/v1/payments/stripe-webhook",
+            content=payload,
+            headers={
+                "stripe-signature": "t=1000,v1=invalidsig",
+                "content-type": "application/json",
+            },
+        )
+
+    assert resp.status_code == 403, resp.text
+
+
+# ===========================================================================
+# 5. POST /payments/stripe-webhook — missing Stripe-Signature header → 403
+# ===========================================================================
+
+def test_stripe_webhook_missing_signature(db):
+    """Request without Stripe-Signature must be rejected with 403."""
+    with patch(
+        "app.core.config.settings.STRIPE_INCALL_WEBHOOK_SECRET",
+        _FAKE_WEBHOOK_SECRET,
+    ):
+        resp = client.post(
+            "/api/v1/payments/stripe-webhook",
+            content=b'{}',
+            headers={"content-type": "application/json"},
+        )
+    assert resp.status_code == 403, resp.text
+
+
+# ===========================================================================
+# 6. payment_intent.succeeded → card_last4 + card_brand stored
+# ===========================================================================
+
+def test_payment_records_updated_on_succeeded_webhook(db, seeded_payment_record):
+    """Webhook handler must persist card_last4='4242' and card_brand='visa'."""
+    event = _make_payment_intent_event(seeded_payment_record.payment_intent_id, "payment_intent.succeeded")
+
+    with patch(
+        "app.services.stripe_service.stripe.Webhook.construct_event",
+        return_value=event,
+    ), patch(
+        "app.core.config.settings.STRIPE_INCALL_WEBHOOK_SECRET",
+        _FAKE_WEBHOOK_SECRET,
+    ):
+        payload = json.dumps(event).encode()
+        sig = _make_stripe_signature(payload, _FAKE_WEBHOOK_SECRET)
+        resp = client.post(
+            "/api/v1/payments/stripe-webhook",
+            content=payload,
+            headers={"stripe-signature": sig, "content-type": "application/json"},
+        )
+
+    assert resp.status_code == 204
+
+    db.expire(seeded_payment_record)
+    db.refresh(seeded_payment_record)
+    assert seeded_payment_record.card_last4 == "4242"
+    assert seeded_payment_record.card_brand == "visa"
+    assert seeded_payment_record.status == "succeeded"
+
+
+# ===========================================================================
+# 7. payment_intent.payment_failed → status = "failed"
+# ===========================================================================
+
+def test_payment_records_updated_on_failed_webhook(db, seeded_payment_record):
+    """Webhook handler must set status='failed' on payment_intent.payment_failed."""
+    event = _make_payment_intent_event(seeded_payment_record.payment_intent_id, "payment_intent.payment_failed")
+
+    with patch(
+        "app.services.stripe_service.stripe.Webhook.construct_event",
+        return_value=event,
+    ), patch(
+        "app.core.config.settings.STRIPE_INCALL_WEBHOOK_SECRET",
+        _FAKE_WEBHOOK_SECRET,
+    ):
+        payload = json.dumps(event).encode()
+        sig = _make_stripe_signature(payload, _FAKE_WEBHOOK_SECRET)
+        resp = client.post(
+            "/api/v1/payments/stripe-webhook",
+            content=payload,
+            headers={"stripe-signature": sig, "content-type": "application/json"},
+        )
+
+    assert resp.status_code == 204
+
+    db.expire(seeded_payment_record)
+    db.refresh(seeded_payment_record)
+    assert seeded_payment_record.status == "failed"
+
+
+# ===========================================================================
+# 8. GET /payments — empty list
+# ===========================================================================
+
+def test_list_payments_empty(db):
+    """Workspace with no payment records should return empty paginated list."""
+    empty_ws_id = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    resp = client.get("/api/v1/payments", headers=_auth_headers(empty_ws_id))
+
+    assert resp.status_code == 200
+    body = resp.json()["data"]
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
+# ===========================================================================
+# 9. GET /payments — returns records
+# ===========================================================================
+
+def test_list_payments(db, seeded_payment_record):
+    """Should return the seeded PaymentRecord in the list."""
+    resp = client.get("/api/v1/payments", headers=_auth_headers())
+    assert resp.status_code == 200
+    body = resp.json()["data"]
+    assert body["total"] >= 1
+    pi_ids = [item["payment_intent_id"] for item in body["items"]]
+    assert seeded_payment_record.payment_intent_id in pi_ids
+
+
+# ===========================================================================
+# 10. GET /payments/{payment_intent_id} — 200
+# ===========================================================================
+
+def test_get_payment_detail(db, seeded_payment_record):
+    """Should return the PaymentRecord for a known payment_intent_id."""
+    resp = client.get(f"/api/v1/payments/{seeded_payment_record.payment_intent_id}", headers=_auth_headers())
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["payment_intent_id"] == seeded_payment_record.payment_intent_id
+    assert data["amount_cents"] == 5000
+    assert data["currency"] == "usd"
+    assert data["status"] == "pending"
+
+
+# ===========================================================================
+# 11. GET /payments/{payment_intent_id} — 404 for unknown PI
+# ===========================================================================
+
+def test_get_payment_detail_not_found(db):
+    """Should return 404 for a PaymentIntent ID that does not exist."""
+    resp = client.get("/api/v1/payments/pi_nonexistent_abc123", headers=_auth_headers())
+    assert resp.status_code == 404

--- a/tests/api/test_payments.py
+++ b/tests/api/test_payments.py
@@ -421,3 +421,58 @@ def test_get_payment_detail_not_found(db):
     """Should return 404 for a PaymentIntent ID that does not exist."""
     resp = client.get("/api/v1/payments/pi_nonexistent_abc123", headers=_auth_headers())
     assert resp.status_code == 404
+
+
+# ===========================================================================
+# 12. POST /payments/session — dynamic context injection
+# ===========================================================================
+
+def test_create_payment_session_injects_metadata(db, mock_stripe_intent):
+    """Creating a payment session must inject the payment page url as a prompt addendum in the CallSession metadata."""
+    from app.models.call_session import CallSession
+    from datetime import datetime
+
+    # Seed a CallSession first
+    call_session = CallSession(
+        user_id=uuid.uuid4(),
+        agent_id=uuid.uuid4(),
+        tenant_id=_FAKE_WORKSPACE_ID,
+        start_time=datetime.utcnow(),
+        status="active",
+        call_type="inbound",
+        call_metadata={}
+    )
+    db.add(call_session)
+    db.commit()
+    db.refresh(call_session)
+
+    with patch(
+        "app.services.stripe_service.stripe.PaymentIntent.create",
+        return_value=mock_stripe_intent,
+    ):
+        resp = client.post(
+            "/api/v1/payments/session",
+            headers=_auth_headers(),
+            json={
+                "call_id": str(call_session.id),
+                "amount_cents": 5000,
+                "currency": "usd",
+                "description": "Consultation fee",
+            },
+        )
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["data"]
+
+    # Retrieve and verify CallSession metadata
+    db.expire(call_session)
+    db.refresh(call_session)
+    metadata = call_session.call_metadata or {}
+    vdc = metadata.get("voice_dynamic_context") or {}
+    assert "system_prompt_addendum" in vdc
+    assert data["payment_url"] in vdc["system_prompt_addendum"]
+    assert "Ask them to complete the payment" in vdc["system_prompt_addendum"]
+
+    # Cleanup seeded call_session
+    db.delete(call_session)
+    db.commit()

--- a/tests/api/test_payments.py
+++ b/tests/api/test_payments.py
@@ -191,7 +191,7 @@ def test_create_payment_session(db, mock_stripe_intent):
     assert data["payment_intent_id"] == mock_stripe_intent.id
     assert data["client_secret"] == mock_stripe_intent.client_secret
     assert mock_stripe_intent.id in data["payment_url"]
-    assert "client_secret" in data["payment_url"]
+    assert "client_secret" not in data["payment_url"]
     assert "Ask them to complete the payment" in data["agent_context"]
 
     # DB record should be created

--- a/tests/api/v1/test_sso_auth.py
+++ b/tests/api/v1/test_sso_auth.py
@@ -1,8 +1,44 @@
 import pytest
-from unittest.mock import patch, AsyncMock
+from fastapi import HTTPException
+from app.services.sso_service import find_or_create_user
 from app.models.sso_config import SsoConfig
 from app.models.tenant import Tenant
-import uuid
 
-def test_sso_test_empty():
-    pass
+def test_find_or_create_user_allowed_email_domains(db):
+    import uuid
+    # Setup a dummy tenant
+    tenant = Tenant(
+        name="Acme Test Workspace",
+        workspace_slug="acme-test-sso",
+        schema_name=f"test_schema_{uuid.uuid4().hex[:8]}",
+        status="active"
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    # Setup SsoConfig with allowed_email_domains restriction
+    sso_config = SsoConfig(
+        workspace_id=tenant.id,
+        protocol="oidc",
+        is_active=True,
+        allowed_email_domains=["acme.com", "acme.org"]
+    )
+    db.add(sso_config)
+    db.commit()
+
+    # Login with valid email domain acme.com should succeed
+    user, role_info = find_or_create_user(db, "john@acme.com", tenant.id)
+    assert user.email == "john@acme.com"
+
+    # Login with invalid email domain gmail.com should fail with 403 HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        find_or_create_user(db, "hacker@gmail.com", tenant.id)
+    assert exc_info.value.status_code == 403
+    assert "not permitted for this workspace" in exc_info.value.detail
+
+    # Clean up
+    db.delete(sso_config)
+    db.delete(user)
+    db.delete(tenant)
+    db.commit()

--- a/tests/api/v1/test_sso_auth.py
+++ b/tests/api/v1/test_sso_auth.py
@@ -1,0 +1,8 @@
+import pytest
+from unittest.mock import patch, AsyncMock
+from app.models.sso_config import SsoConfig
+from app.models.tenant import Tenant
+import uuid
+
+def test_sso_test_empty():
+    pass

--- a/tests/api/v1/test_sso_config.py
+++ b/tests/api/v1/test_sso_config.py
@@ -1,9 +1,19 @@
 import pytest
-import uuid
-from app.models.sso_config import SsoConfig
+from pydantic import ValidationError
+from app.schemas.sso import SsoConfigUpsert
 
-def test_upsert_saml_config():
-    pass
-
-# Rather than writing a full blown test file here right now without knowing exactly what fixtures are available,
-# let's write a simple one that works with our established test_sub_accounts.py format or similar.
+def test_sso_config_oidc_discovery_url_ssrf():
+    # Attempting to upsert OIDC SSO config with private discovery URL should fail validation
+    payload = {
+        "protocol": "oidc",
+        "oidc_client_id": "test-client-id",
+        "oidc_client_secret": "test-secret",
+        "oidc_discovery_url": "http://127.0.0.1/discovery",
+        "is_active": True,
+        "allowed_email_domains": ["acme.com"]
+    }
+    
+    with pytest.raises(ValidationError) as exc_info:
+        SsoConfigUpsert(**payload)
+        
+    assert "resolves to a blocked address" in str(exc_info.value)

--- a/tests/api/v1/test_sso_config.py
+++ b/tests/api/v1/test_sso_config.py
@@ -1,0 +1,9 @@
+import pytest
+import uuid
+from app.models.sso_config import SsoConfig
+
+def test_upsert_saml_config():
+    pass
+
+# Rather than writing a full blown test file here right now without knowing exactly what fixtures are available,
+# let's write a simple one that works with our established test_sub_accounts.py format or similar.

--- a/tests/api/v2/test_sub_accounts.py
+++ b/tests/api/v2/test_sub_accounts.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi import FastAPI, HTTPException, status
 from fastapi.testclient import TestClient
 
-from app.api.deps import get_db, require_admin, get_admin_workspace
+from app.api.deps import get_db, require_admin, get_current_workspace
 from app.core.exception_handlers import register_exception_handlers
 from app.models.tenant import Tenant
 from app.models.user import User
@@ -42,14 +42,15 @@ def _client(db, workspace: Tenant, admin_user: User = None, override_get_admin=T
     mini = FastAPI()
     register_exception_handlers(mini)
     mini.include_router(v2_router, prefix="/workspace")
-    
+
     if admin_user:
         mini.dependency_overrides[require_admin] = lambda: admin_user
-    
+
     if override_get_admin:
-        async def mock_get_admin_workspace():
+        mini.dependency_overrides[require_admin] = lambda: User(email="admin@test.com", is_active=True)
+        async def mock_get_current_workspace():
             return workspace
-        mini.dependency_overrides[get_admin_workspace] = mock_get_admin_workspace
+        mini.dependency_overrides[get_current_workspace] = mock_get_current_workspace
 
     mini.dependency_overrides[get_db] = lambda: db
     return TestClient(mini, raise_server_exceptions=False)
@@ -107,11 +108,11 @@ def test_rbac_enforcement(db, agency_workspace):
     mini = FastAPI()
     register_exception_handlers(mini)
     mini.include_router(v2_router, prefix="/workspace")
-    
-    async def mock_get_admin_workspace_fail():
+
+    async def mock_require_admin_fail():
         raise HTTPException(status_code=403, detail="Workspace context does not match user tenant.")
-    
-    mini.dependency_overrides[get_admin_workspace] = mock_get_admin_workspace_fail
+
+    mini.dependency_overrides[require_admin] = mock_require_admin_fail
     mini.dependency_overrides[get_db] = lambda: db
     client = TestClient(mini, raise_server_exceptions=False)
 

--- a/tests/api/v2/test_sub_accounts.py
+++ b/tests/api/v2/test_sub_accounts.py
@@ -43,14 +43,22 @@ def _client(db, workspace: Tenant, admin_user: User = None, override_get_admin=T
     register_exception_handlers(mini)
     mini.include_router(v2_router, prefix="/workspace")
 
-    if admin_user:
-        mini.dependency_overrides[require_admin] = lambda: admin_user
-
     if override_get_admin:
-        mini.dependency_overrides[require_admin] = lambda: User(email="admin@test.com", is_active=True)
+        # Create a real DB user tied to this workspace to reflect true DB state
+        if admin_user is None:
+            admin_user = User(email=f"admin_{uuid.uuid4().hex[:8]}@test.com", current_tenant_id=workspace.id, first_name="A", last_name="B", hashed_password="X")
+            db.add(admin_user)
+            db.commit()
+            db.refresh(admin_user)
+            admin_user.tenants.append(workspace)
+            db.commit()
+            
+        mini.dependency_overrides[require_admin] = lambda: admin_user
         async def mock_get_current_workspace():
             return workspace
         mini.dependency_overrides[get_current_workspace] = mock_get_current_workspace
+    elif admin_user:
+        mini.dependency_overrides[require_admin] = lambda: admin_user
 
     mini.dependency_overrides[get_db] = lambda: db
     return TestClient(mini, raise_server_exceptions=False)
@@ -102,6 +110,39 @@ def test_sub_accounts_crud(db, agency_workspace):
     res = client.delete(f"/workspace/sub-accounts/{sub_id}")
     assert res.status_code == 204
 
+def test_cross_workspace_isolation(db, agency_workspace):
+    # Setup Agency B
+    agency_b = Tenant(
+        name=f"agency-b-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="agency",
+        status="active",
+    )
+    db.add(agency_b)
+    db.commit()
+    db.refresh(agency_b)
+    
+    # Sub account of Agency A
+    sub_a = Tenant(
+        name=f"sub-a-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="standalone",
+        parent_workspace_id=agency_workspace.id,
+        status="active",
+    )
+    db.add(sub_a)
+    db.commit()
+    db.refresh(sub_a)
+
+    # Client acting as Agency B
+    client_b = _client(db, agency_b)
+    
+    # Try to access Sub A using Agency B's client context
+    res = client_b.get(f"/workspace/sub-accounts/{sub_a.id}")
+    assert res.status_code == 404
+    # Our exception handler wraps errors under {"error": {"message": ...}}
+    assert "Sub-account not found" in res.json()["error"]["message"]
+
 def test_rbac_enforcement(db, agency_workspace):
     from app.api.v2.routers.workspace import v2_router
 
@@ -121,7 +162,7 @@ def test_rbac_enforcement(db, agency_workspace):
     assert "Workspace context does not match" in res.json()["error"]["message"]
 
 def test_create_member_role_post_alias(db, agency_workspace):
-    user = User(email=f"test{uuid.uuid4().hex[:8]}@x.com", is_active=True, current_tenant_id=agency_workspace.id)
+    user = User(email=f"test{uuid.uuid4().hex[:8]}@x.com", current_tenant_id=agency_workspace.id, first_name="A", last_name="B", hashed_password="X")
     db.add(user)
     db.commit()
     db.refresh(user)
@@ -129,7 +170,7 @@ def test_create_member_role_post_alias(db, agency_workspace):
     client = _client(db, agency_workspace, admin_user=user, override_get_admin=False)
     
     with patch("app.api.v2.routers.workspace.update_member_role") as mock_update:
-        mock_update.return_value = {"role": "manager", "user_id": str(user.id)}
+        mock_update.return_value = {"role": "manager", "user_id": str(user.id), "workspace_id": str(agency_workspace.id)}
         res = client.post(f"/workspace/members/{user.id}/role", json={"role": "manager"})
         
     assert res.status_code == 200

--- a/tests/api/v2/test_sub_accounts.py
+++ b/tests/api/v2/test_sub_accounts.py
@@ -1,0 +1,135 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_db, require_admin, get_admin_workspace
+from app.core.exception_handlers import register_exception_handlers
+from app.models.tenant import Tenant
+from app.models.user import User
+
+@pytest.fixture
+def agency_workspace(db) -> Tenant:
+    t = Tenant(
+        name=f"agency-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="agency",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+@pytest.fixture
+def standalone_workspace(db) -> Tenant:
+    t = Tenant(
+        name=f"standalone-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="standalone",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+def _client(db, workspace: Tenant, admin_user: User = None, override_get_admin=True) -> TestClient:
+    from app.api.v2.routers.workspace import v2_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(v2_router, prefix="/workspace")
+    
+    if admin_user:
+        mini.dependency_overrides[require_admin] = lambda: admin_user
+    
+    if override_get_admin:
+        async def mock_get_admin_workspace():
+            return workspace
+        mini.dependency_overrides[get_admin_workspace] = mock_get_admin_workspace
+
+    mini.dependency_overrides[get_db] = lambda: db
+    return TestClient(mini, raise_server_exceptions=False)
+
+def test_create_sub_account_success(db, agency_workspace):
+    client = _client(db, agency_workspace)
+    payload = {
+        "name": "Test Sub Account",
+        "contact_email": "sub@example.com"
+    }
+
+    res = client.post("/workspace/sub-accounts", json=payload)
+    assert res.status_code == 201
+    data = res.json()
+    assert data["name"] == "Test Sub Account"
+    assert data["contact_email"] == "sub@example.com"
+    assert "api_key" in data
+
+def test_create_sub_account_not_agency(db, standalone_workspace):
+    client = _client(db, standalone_workspace)
+    res = client.post("/workspace/sub-accounts", json={"name": "Sub", "contact_email": "x@x.com"})
+    assert res.status_code == 403
+    assert "agency workspaces" in res.json()["error"]["message"]
+
+def test_sub_accounts_crud(db, agency_workspace):
+    client = _client(db, agency_workspace)
+
+    # 1. Create
+    res = client.post("/workspace/sub-accounts", json={"name": "Sub 1", "contact_email": "x@x.com"})
+    assert res.status_code == 201
+    sub_id = res.json()["id"]
+
+    # 2. List
+    res = client.get("/workspace/sub-accounts")
+    assert res.status_code == 200
+    assert len(res.json()["data"]) >= 1
+
+    # 3. Get
+    res = client.get(f"/workspace/sub-accounts/{sub_id}")
+    assert res.status_code == 200
+    assert res.json()["id"] == sub_id
+
+    # 4. Update
+    res = client.put(f"/workspace/sub-accounts/{sub_id}", json={"name": "Sub 1 Updated"})
+    assert res.status_code == 200
+    assert res.json()["name"] == "Sub 1 Updated"
+
+    # 5. Delete
+    res = client.delete(f"/workspace/sub-accounts/{sub_id}")
+    assert res.status_code == 204
+
+def test_rbac_enforcement(db, agency_workspace):
+    from app.api.v2.routers.workspace import v2_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(v2_router, prefix="/workspace")
+    
+    async def mock_get_admin_workspace_fail():
+        raise HTTPException(status_code=403, detail="Workspace context does not match user tenant.")
+    
+    mini.dependency_overrides[get_admin_workspace] = mock_get_admin_workspace_fail
+    mini.dependency_overrides[get_db] = lambda: db
+    client = TestClient(mini, raise_server_exceptions=False)
+
+    res = client.post("/workspace/sub-accounts", json={"name": "Sub", "contact_email": "x@x.com"})
+    assert res.status_code == 403
+    assert "Workspace context does not match" in res.json()["error"]["message"]
+
+def test_create_member_role_post_alias(db, agency_workspace):
+    user = User(email=f"test{uuid.uuid4().hex[:8]}@x.com", is_active=True, current_tenant_id=agency_workspace.id)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    client = _client(db, agency_workspace, admin_user=user, override_get_admin=False)
+    
+    with patch("app.api.v2.routers.workspace.update_member_role") as mock_update:
+        mock_update.return_value = {"role": "manager", "user_id": str(user.id)}
+        res = client.post(f"/workspace/members/{user.id}/role", json={"role": "manager"})
+        
+    assert res.status_code == 200
+    assert res.json()["role"] == "manager"


### PR DESCRIPTION
# Stripe In-Call Payments implementation


## What was built

1. **Database**
   - Added `PaymentRecord` model to track Stripe `PaymentIntent` objects (`status`, `amount`, `currency`, `card_last4`).
   - Created the Alembic migration script to provision the `paymentrecords` table.

2. **Core Services**
   - Extended `StripeService` to create `PaymentIntent`s and to verify webhook signatures using `stripe.Webhook.construct_event`.
   - Created `PaymentService` to orchestrate business logic: initiating the payment and acting on `payment_intent.succeeded` or `payment_intent.payment_failed` webhooks.

3. **API Endpoints**
   - **`POST /api/v1/payments/session`**: Validates the agent's payment request, creates a `PaymentIntent`, and constructs the URL for the user-facing payment page. It also returns the exact sentence the agent should say to direct the caller to the page.
   - **`POST /api/v1/payments/stripe-webhook`**: Receives Stripe webhooks. This route specifically bypasses the standard API Key middleware since it relies on Stripe's cryptographic signature for authentication.
   - **`GET /api/v1/payments`** & **`GET /api/v1/payments/{payment_intent_id}`**: Standard endpoints for retrieving payment history.

4. **Configuration & Testing**
   - Updated `config.py` to add `STRIPE_INCALL_WEBHOOK_SECRET` and `PAYMENT_PAGE_BASE_URL`.
   - Included full Pytest coverage (`tests/api/test_payments.py`) confirming session creation, authentication bypasses, webhook processing, and database updates.
   - Authored QA documentation (`docs/qa/stripe-test-cards.md`) on how to use Stripe Test Cards and the Stripe CLI to simulate payment flows locally.

## Testing & Verification
The test suite handles scenarios involving mocked Stripe interactions, validation constraints, and database states. All `11/11` tests for this feature are passing locally.

You can run the tests again at any time with:
```bash
python -m pytest tests/api/test_payments.py -v
```

## Next Steps
To use this in staging/production:
1. Ensure the `PAYMENT_PAGE_BASE_URL` is set to the frontend app URL in the environment vars.
2. In the Stripe Dashboard, configure a new webhook endpoint pointing to your `https://your-domain.com/api/v1/payments/stripe-webhook` route. Check **only** the `payment_intent.succeeded` and `payment_intent.payment_failed` events.
3. Save the resulting signing secret to your `STRIPE_INCALL_WEBHOOK_SECRET` environment variable.
