### PR TITLE
feat: A/B prompt testing for call flows

### DIFF
--- a/alembic/versions/20260702_add_ab_prompt_testing.py
+++ b/alembic/versions/20260702_add_ab_prompt_testing.py
@@ -1,0 +1,91 @@
+"""Add A/B prompt testing columns to callflow and callsession
+
+Revision ID: 20260702_ab_prompt_testing
+Revises: 86cc29de8616
+Create Date: 2026-07-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "20260702_ab_prompt_testing"
+down_revision: Union[str, Sequence[str], None] = "86cc29de8616"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "callflow",
+        sa.Column(
+            "ab_test_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column(
+        "callflow",
+        sa.Column(
+            "ab_prompt_a_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "callflow",
+        sa.Column(
+            "ab_prompt_b_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "callflow",
+        sa.Column(
+            "ab_split_ratio",
+            sa.Numeric(3, 2),
+            nullable=False,
+            server_default="0.50",
+        ),
+    )
+    op.create_foreign_key(
+        "fk_callflow_ab_prompt_a",
+        "callflow",
+        "promptversion",
+        ["ab_prompt_a_id"],
+        ["id"],
+    )
+    op.create_foreign_key(
+        "fk_callflow_ab_prompt_b",
+        "callflow",
+        "promptversion",
+        ["ab_prompt_b_id"],
+        ["id"],
+    )
+    op.create_check_constraint(
+        "ck_callflow_ab_split_ratio",
+        "callflow",
+        "ab_split_ratio > 0 AND ab_split_ratio < 1",
+    )
+
+    op.add_column(
+        "callsession",
+        sa.Column("ab_variant", sa.String(length=1), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("callsession", "ab_variant")
+
+    op.drop_constraint("ck_callflow_ab_split_ratio", "callflow", type_="check")
+    op.drop_constraint("fk_callflow_ab_prompt_b", "callflow", type_="foreignkey")
+    op.drop_constraint("fk_callflow_ab_prompt_a", "callflow", type_="foreignkey")
+    op.drop_column("callflow", "ab_split_ratio")
+    op.drop_column("callflow", "ab_prompt_b_id")
+    op.drop_column("callflow", "ab_prompt_a_id")
+    op.drop_column("callflow", "ab_test_enabled")

--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -7,6 +7,7 @@ from app.api.v2.routers.health import router as health_router
 from app.api.v2.routers.webhooks import router as webhooks_router
 from app.api.v2.routers.callback_scheduler import agents_router as cb_agents_router
 from app.api.v2.routers.callback_scheduler import calls_router as cb_calls_router
+from app.api.v2.routers.flows import router as ab_flows_router
 from app.api.v2.routers.workspace import v2_router as workspace_router
 from app.api.v2.routers.hipaa import flows_router as hipaa_flows_router
 from app.api.v2.routers.hipaa import workspace_router as hipaa_workspace_router
@@ -20,6 +21,7 @@ v2_router.include_router(batch_calls_router)
 v2_router.include_router(webhooks_router)
 v2_router.include_router(cb_agents_router)
 v2_router.include_router(cb_calls_router)
+v2_router.include_router(ab_flows_router)
 v2_router.include_router(workspace_router, prefix="/workspace", tags=["Workspace Settings"])
 v2_router.include_router(hipaa_flows_router)
 v2_router.include_router(hipaa_workspace_router)

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -1,0 +1,77 @@
+"""
+v2 A/B prompt testing endpoints.
+
+Auth: any authenticated tenant principal (API key or JWT); config-rank required
+to mutate A/B settings, read-only rank is sufficient to view results.
+
+PUT  /api/v2/flows/{flow_id}/ab-test
+GET  /api/v2/flows/{flow_id}/ab-results
+PUT  /api/v2/flows/{flow_id}/ab-test/winner
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Union
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_config_or_api_key, require_readonly_or_api_key
+from app.core.request_auth import ApiKeyPrincipal
+from app.models.user import User
+from app.schemas.ab_testing import (
+    AbResultsResponse,
+    AbTestResponse,
+    AbTestUpdate,
+    AbTestWinnerUpdate,
+)
+from app.services.call_flow_service import call_flow_service
+
+router = APIRouter(prefix="/flows", tags=["A/B Prompt Testing"])
+
+
+def _tenant_id(principal: Union[User, ApiKeyPrincipal]) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+@router.put(
+    "/{flow_id}/ab-test",
+    response_model=AbTestResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Configure A/B prompt testing on a call flow",
+)
+def update_ab_test(
+    flow_id: uuid.UUID,
+    body: AbTestUpdate,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+) -> AbTestResponse:
+    return call_flow_service.update_ab_test(db, flow_id, _tenant_id(principal), body)
+
+
+@router.get(
+    "/{flow_id}/ab-results",
+    response_model=AbResultsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get A/B prompt test results and statistical significance",
+)
+def get_ab_results(
+    flow_id: uuid.UUID,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> AbResultsResponse:
+    return call_flow_service.get_ab_results(db, flow_id, _tenant_id(principal))
+
+
+@router.put(
+    "/{flow_id}/ab-test/winner",
+    status_code=status.HTTP_200_OK,
+    summary="Promote the winning A/B variant to the flow's active prompt",
+)
+def promote_ab_winner(
+    flow_id: uuid.UUID,
+    body: AbTestWinnerUpdate,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+) -> dict:
+    return call_flow_service.promote_ab_winner(db, flow_id, _tenant_id(principal), body)

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Boolean, Index, CheckConstraint
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Boolean, Index, CheckConstraint, Numeric
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -24,6 +24,22 @@ class CallFlow(Base):
     flow_data = Column(JSONB, nullable=True)
     settings = Column(JSONB, nullable=True)
     knowledge_base_ids = Column(JSONB, nullable=True, default=list)
+
+    # A/B prompt testing
+    ab_test_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    ab_prompt_a_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("promptversion.id", use_alter=True, name="fk_callflow_ab_prompt_a"),
+        nullable=True,
+    )
+    ab_prompt_b_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("promptversion.id", use_alter=True, name="fk_callflow_ab_prompt_b"),
+        nullable=True,
+    )
+    # Fraction of calls routed to variant A (0.10-0.90)
+    ab_split_ratio = Column(Numeric(3, 2), default=0.50, nullable=False, server_default="0.50")
+
     hipaa_compliance = Column(Boolean, default=False, nullable=False, server_default="false")
     public_access = Column(Boolean, default=False, nullable=False, server_default="false")
     is_deleted = Column(Boolean, default=False, nullable=False, server_default="false")
@@ -46,6 +62,16 @@ class CallFlow(Base):
         foreign_keys="[CallFlow.current_prompt_id]",
         post_update=True,
     )
+    ab_prompt_a = relationship(
+        "PromptVersion",
+        foreign_keys="[CallFlow.ab_prompt_a_id]",
+        post_update=True,
+    )
+    ab_prompt_b = relationship(
+        "PromptVersion",
+        foreign_keys="[CallFlow.ab_prompt_b_id]",
+        post_update=True,
+    )
     call_sessions = relationship("CallSession", back_populates="call_flow")
 
     __table_args__ = (
@@ -59,5 +85,9 @@ class CallFlow(Base):
             "welcome_message_type IS NULL OR "
             "welcome_message_type IN ('user_initiated', 'ai_dynamic', 'ai_custom')",
             name="ck_callflow_welcome_message_type",
+        ),
+        CheckConstraint(
+            "ab_split_ratio > 0 AND ab_split_ratio < 1",
+            name="ck_callflow_ab_split_ratio",
         ),
     )

--- a/app/models/call_session.py
+++ b/app/models/call_session.py
@@ -51,6 +51,9 @@ class CallSession(Base):
     # Optional link to the call flow that triggered this session
     call_flow_id = Column(UUID(as_uuid=True), ForeignKey("callflow.id"), nullable=True, index=True)
 
+    # A/B prompt testing: variant assigned at dispatch time ('a' or 'b'), locked for call duration
+    ab_variant = Column(String(1), nullable=True)
+
     # Smart Callback: points to the original missed call in a retry chain
     parent_call_id = Column(
         UUID(as_uuid=True),

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -1856,10 +1856,18 @@ Previous conversation:
 # GOAL
 Continue the conversation based on the history above. Be {agent_name}."""
 
+            # A/B prompt testing: variant + resolved prompt text are locked onto
+            # call_metadata at dispatch time (see ab_testing_service) and never
+            # re-resolved mid-call, so the same variant is used for the whole call.
+            ab_prompt_override = None
+            if self.call_session and self.call_session.call_metadata:
+                ab_prompt_override = self.call_session.call_metadata.get("ab_prompt_text")
+
             # Use agent's custom system prompt if available, otherwise use base prompt
             if self.agent and self.agent.system_prompt:
                 # Agent has custom system prompt - grounding rules placed BEFORE custom
                 # instructions so factual constraints cannot be overridden by agent config.
+                effective_custom_prompt = ab_prompt_override or self.agent.system_prompt
                 system_prompt = f"""# ROLE
 You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
 
@@ -1873,7 +1881,7 @@ These rules override any conflicting custom instructions below. Never deviate fr
 {_bk_block}
 
 # CUSTOM INSTRUCTIONS
-{self.agent.system_prompt}
+{effective_custom_prompt}
 {v_block}
 # STYLE & TONE
 - VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
@@ -1911,6 +1919,7 @@ Previous conversation:
 Follow your custom instructions. Continue from the history above. Be {agent_name}."""
             elif self.agent and self.agent.model and self.agent.model.system_prompt:
                 # Model has system prompt - grounding rules placed BEFORE model instructions.
+                effective_model_prompt = ab_prompt_override or self.agent.model.system_prompt
                 system_prompt = f"""# ROLE
 You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
 
@@ -1924,7 +1933,7 @@ These rules override any conflicting model instructions below. Never deviate fro
 {_bk_block}
 
 # MODEL INSTRUCTIONS
-{self.agent.model.system_prompt}
+{effective_model_prompt}
 {v_block}
 # STYLE & TONE
 - VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).

--- a/app/schemas/ab_testing.py
+++ b/app/schemas/ab_testing.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import uuid
+from typing import Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AbTestUpdate(BaseModel):
+    """Request body for ``PUT /api/v2/flows/{flow_id}/ab-test``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool
+    prompt_a_id: uuid.UUID
+    prompt_b_id: uuid.UUID
+    split_ratio: float = Field(..., ge=0.1, le=0.9)
+
+
+class AbTestResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    ab_test_enabled: bool
+    ab_prompt_a_id: Optional[uuid.UUID]
+    ab_prompt_b_id: Optional[uuid.UUID]
+    ab_split_ratio: float
+
+
+class VariantMetrics(BaseModel):
+    calls: int
+    completed: int
+    failed: int
+    avg_duration: Optional[float]
+    transfer_rate: float
+    success_rate: float
+
+
+class AbResultsResponse(BaseModel):
+    variant_a: VariantMetrics
+    variant_b: VariantMetrics
+    statistical_significance: bool
+    recommended_variant: Literal["a", "b", "inconclusive"]
+
+
+class AbTestWinnerUpdate(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    variant: Literal["a", "b"]

--- a/app/schemas/call_history.py
+++ b/app/schemas/call_history.py
@@ -37,6 +37,7 @@ class CallHistoryItem(BaseModel):
     duration_seconds: Optional[int]
     started_at: Optional[datetime]
     ended_at: Optional[datetime]
+    ab_variant: Optional[str] = None
 
 
 class CallHistoryList(BaseModel):

--- a/app/services/ab_testing_service.py
+++ b/app/services/ab_testing_service.py
@@ -1,0 +1,79 @@
+"""A/B prompt testing — variant assignment at dispatch time and results aggregation.
+
+Random assignment happens once, at call-session creation, and is persisted onto
+``CallSession.ab_variant`` (plus the resolved prompt text in ``call_metadata``)
+before any LLM request is made — so the variant is always known even if the
+call fails mid-way, and never changes for the lifetime of the call.
+"""
+from __future__ import annotations
+
+import random
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.logger import logger
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.models.prompt_version import PromptVersion
+
+
+class AbTestingService:
+    def pick_variant(self, call_flow: CallFlow) -> Optional[str]:
+        """Return 'a' or 'b' if the flow is eligible for A/B testing, else None."""
+        if not call_flow.ab_test_enabled:
+            return None
+        if not call_flow.ab_prompt_a_id or not call_flow.ab_prompt_b_id:
+            return None
+        split_ratio = float(call_flow.ab_split_ratio)
+        return "a" if random.random() < split_ratio else "b"
+
+    def get_variant_prompt_text(
+        self, db: Session, call_flow: CallFlow, variant: str
+    ) -> Optional[str]:
+        prompt_id = (
+            call_flow.ab_prompt_a_id if variant == "a" else call_flow.ab_prompt_b_id
+        )
+        if prompt_id is None:
+            return None
+        version = db.execute(
+            select(PromptVersion).where(PromptVersion.id == prompt_id)
+        ).scalar_one_or_none()
+        return version.prompt_text if version else None
+
+    def assign_and_lock_variant(
+        self, db: Session, call_session: CallSession, call_flow: CallFlow
+    ) -> None:
+        """Assign a variant (if the flow has A/B testing enabled) and persist it
+        onto the call session immediately, before any LLM request."""
+        variant = self.pick_variant(call_flow)
+        if variant is None:
+            return
+
+        prompt_text = self.get_variant_prompt_text(db, call_flow, variant)
+        if prompt_text is None:
+            logger.warning(
+                "A/B test enabled on flow %s but prompt version for variant '%s' "
+                "could not be resolved; skipping variant assignment",
+                call_flow.id,
+                variant,
+            )
+            return
+
+        call_session.ab_variant = variant
+        call_session.call_metadata = {
+            **(call_session.call_metadata or {}),
+            "ab_prompt_text": prompt_text,
+        }
+        db.commit()
+        db.refresh(call_session)
+        logger.info(
+            "A/B variant '%s' assigned to call session %s (flow=%s)",
+            variant,
+            call_session.id,
+            call_flow.id,
+        )
+
+
+ab_testing_service = AbTestingService()

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -5,6 +5,7 @@ import uuid
 from typing import Optional
 
 from fastapi import HTTPException, status
+from scipy.stats import chi2_contingency
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
@@ -16,6 +17,13 @@ from app.models.prompt_version import PromptVersion
 from app.repositories.call_flow_repository import CallFlowRepository
 from app.repositories.prompt_version_repository import PromptVersionRepository
 from app.schemas.agent import agent_to_out
+from app.schemas.ab_testing import (
+    AbResultsResponse,
+    AbTestResponse,
+    AbTestUpdate,
+    AbTestWinnerUpdate,
+    VariantMetrics,
+)
 from app.schemas.call_flow import (
     CallFlowCreate,
     CallFlowListResponse,
@@ -29,6 +37,8 @@ from app.schemas.prompt_version import PromptVersionOut
 from app.utils.gemini_prompt_sanitizer import sanitize_prompt_for_gemini
 
 _MAX_VERSIONS = 50
+_AB_MIN_CALLS_FOR_SIGNIFICANCE = 30
+_AB_SIGNIFICANCE_P_VALUE = 0.05
 
 
 class CallFlowService:
@@ -366,6 +376,161 @@ class CallFlowService:
             self._version_to_out(v).model_dump(by_alias=True, mode="json")
             for v in versions
         ]
+
+    # ── A/B prompt testing ──────────────────────────────────────────────────
+
+    def update_ab_test(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: AbTestUpdate,
+    ) -> AbTestResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        pv_repo = PromptVersionRepository(db)
+
+        prompt_a = pv_repo.find_by_id(body.prompt_a_id)
+        if prompt_a is None or prompt_a.flow_id != flow.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"prompt_a_id {body.prompt_a_id} does not belong to flow {flow_id}",
+            )
+        prompt_b = pv_repo.find_by_id(body.prompt_b_id)
+        if prompt_b is None or prompt_b.flow_id != flow.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"prompt_b_id {body.prompt_b_id} does not belong to flow {flow_id}",
+            )
+
+        repo = CallFlowRepository(db)
+        flow = repo.update(
+            flow,
+            {
+                "ab_test_enabled": body.enabled,
+                "ab_prompt_a_id": body.prompt_a_id,
+                "ab_prompt_b_id": body.prompt_b_id,
+                "ab_split_ratio": body.split_ratio,
+            },
+        )
+        db.commit()
+        db.refresh(flow)
+        return AbTestResponse(
+            ab_test_enabled=flow.ab_test_enabled,
+            ab_prompt_a_id=flow.ab_prompt_a_id,
+            ab_prompt_b_id=flow.ab_prompt_b_id,
+            ab_split_ratio=float(flow.ab_split_ratio),
+        )
+
+    def get_ab_results(
+        self, db: Session, flow_id: uuid.UUID, tenant_id: uuid.UUID
+    ) -> AbResultsResponse:
+        self._get_flow_or_404(db, flow_id, tenant_id)
+
+        metrics_a = self._variant_metrics(db, flow_id, tenant_id, "a")
+        metrics_b = self._variant_metrics(db, flow_id, tenant_id, "b")
+
+        significance, recommended = self._ab_significance(
+            metrics_a.calls, metrics_a.completed, metrics_b.calls, metrics_b.completed
+        )
+
+        return AbResultsResponse(
+            variant_a=metrics_a,
+            variant_b=metrics_b,
+            statistical_significance=significance,
+            recommended_variant=recommended,
+        )
+
+    def _variant_metrics(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        variant: str,
+    ) -> VariantMetrics:
+        sessions = db.execute(
+            select(CallSession).where(
+                CallSession.call_flow_id == flow_id,
+                CallSession.tenant_id == tenant_id,
+                CallSession.ab_variant == variant,
+            )
+        ).scalars().all()
+
+        calls = len(sessions)
+        completed = sum(1 for s in sessions if s.status == "completed")
+        failed = sum(1 for s in sessions if s.status == "failed")
+        transferred = sum(1 for s in sessions if s.transferred)
+        successes = sum(1 for s in sessions if s.success_evaluation == "success")
+
+        durations = [s.duration for s in sessions if s.duration is not None]
+        avg_duration = sum(durations) / len(durations) if durations else None
+
+        return VariantMetrics(
+            calls=calls,
+            completed=completed,
+            failed=failed,
+            avg_duration=avg_duration,
+            transfer_rate=(transferred / calls) if calls else 0.0,
+            success_rate=(successes / calls) if calls else 0.0,
+        )
+
+    def _ab_significance(
+        self, calls_a: int, completed_a: int, calls_b: int, completed_b: int
+    ) -> tuple[bool, str]:
+        """Chi-squared test on completed-vs-total contingency table.
+
+        Guardrail: fewer than 30 calls on either variant is always inconclusive,
+        regardless of p-value — too few samples for the test to be meaningful.
+        """
+        if calls_a < _AB_MIN_CALLS_FOR_SIGNIFICANCE or calls_b < _AB_MIN_CALLS_FOR_SIGNIFICANCE:
+            return False, "inconclusive"
+
+        contingency = [
+            [completed_a, calls_a - completed_a],
+            [completed_b, calls_b - completed_b],
+        ]
+        _, p_value, _, _ = chi2_contingency(contingency)
+
+        if p_value >= _AB_SIGNIFICANCE_P_VALUE:
+            return False, "inconclusive"
+
+        rate_a = completed_a / calls_a
+        rate_b = completed_b / calls_b
+        recommended = "a" if rate_a > rate_b else "b"
+        return True, recommended
+
+    def promote_ab_winner(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: AbTestWinnerUpdate,
+    ) -> dict:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id, load_relations=True)
+
+        winning_prompt_id = (
+            flow.ab_prompt_a_id if body.variant == "a" else flow.ab_prompt_b_id
+        )
+        if winning_prompt_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Flow {flow_id} has no prompt version assigned to variant '{body.variant}'",
+            )
+
+        repo = CallFlowRepository(db)
+        flow = repo.update(
+            flow,
+            {
+                "current_prompt_id": winning_prompt_id,
+                "ab_test_enabled": False,
+            },
+        )
+        db.commit()
+        db.refresh(flow)
+        if flow.agent is None:
+            flow.agent = db.execute(
+                select(Agent).where(Agent.id == flow.agent_id)
+            ).scalar_one_or_none()
+        return self._flow_to_out(db, flow)
 
 
 call_flow_service = CallFlowService()

--- a/app/services/call_history_service.py
+++ b/app/services/call_history_service.py
@@ -231,6 +231,7 @@ class CallHistoryService:
                 CallSession.duration.label("duration_seconds"),
                 CallSession.start_time.label("started_at"),
                 CallSession.end_time.label("ended_at"),
+                CallSession.ab_variant,
             )
             .select_from(CallSession)
             .outerjoin(Agent, Agent.id == CallSession.agent_id)
@@ -265,6 +266,7 @@ class CallHistoryService:
                 duration_seconds=row.duration_seconds,
                 started_at=row.started_at,
                 ended_at=row.ended_at,
+                ab_variant=row.ab_variant,
             )
             for row in rows
         ]

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -5,19 +5,21 @@ from typing import Optional
 
 from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.error_responses import build_call_initiate_error_payload
 from app.middleware.request_id_middleware import new_request_id
 from app.core.logger import logger
+from app.models.call_flow import CallFlow
 from app.models.call_session import CallSession
 from app.schemas.twilio import (
     CallInitiateRequest,
     CallInitiateResponse,
 )
 from app.schemas.base import SuccessResponse
+from app.services.ab_testing_service import ab_testing_service
 from app.services.agent_service import agent_service
 from app.services.call_session_service import call_session_service
 from app.services.credit_service import credit_service
@@ -405,6 +407,17 @@ async def initiate_call(
             call_session.call_flow_id = flow_uuid
             db.commit()
             db.refresh(call_session)
+
+            # A/B prompt testing: assign + persist the variant now, before any
+            # LLM request, so it's known even if the call fails mid-way. Locked
+            # for the duration of the call via call_metadata["ab_prompt_text"].
+            call_flow_row = db.execute(
+                select(CallFlow).where(CallFlow.id == flow_uuid)
+            ).scalar_one_or_none()
+            if call_flow_row is not None:
+                ab_testing_service.assign_and_lock_variant(
+                    db, call_session, call_flow_row
+                )
 
         # JD / resume enrichment (non-blocking on failure)
         _ctx = call_request.jd_context or {}

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -369,14 +369,23 @@ Continue the conversation based on the history above. Be {agent_name}."""
 
             # Batch calls may inject a per-row substituted prompt via call_metadata
             batch_prompt_override = None
+            ab_prompt_override = None
             if self._h.call_session and self._h.call_session.call_metadata:
                 batch_prompt_override = self._h.call_session.call_metadata.get(
                     "batch_prompt_override"
                 )
+                # A/B prompt testing: variant + resolved prompt text are locked onto
+                # call_metadata at dispatch time (see ab_testing_service) and never
+                # re-resolved mid-call.
+                ab_prompt_override = self._h.call_session.call_metadata.get(
+                    "ab_prompt_text"
+                )
 
             # Use agent's custom system prompt if available, otherwise use base prompt
             if self._h.agent and self._h.agent.system_prompt:
-                effective_custom_prompt = batch_prompt_override or self._h.agent.system_prompt
+                effective_custom_prompt = (
+                    batch_prompt_override or ab_prompt_override or self._h.agent.system_prompt
+                )
                 system_prompt = f"""# ROLE
 You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
 
@@ -414,7 +423,9 @@ Previous conversation:
 Follow your custom instructions. Continue from the history above. Be {agent_name}."""
             elif self._h.agent and self._h.agent.model and self._h.agent.model.system_prompt:
                 effective_model_prompt = (
-                    batch_prompt_override or self._h.agent.model.system_prompt
+                    batch_prompt_override
+                    or ab_prompt_override
+                    or self._h.agent.model.system_prompt
                 )
                 system_prompt = f"""# ROLE
 You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8149,6 +8149,108 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/ab-test:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Configure A/B prompt testing on a call flow
+      operationId: update_ab_test_api_v2_flows__flow_id__ab_test_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AbTestUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AbTestResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/ab-results:
+    get:
+      tags:
+      - A/B Prompt Testing
+      summary: Get A/B prompt test results and statistical significance
+      operationId: get_ab_results_api_v2_flows__flow_id__ab_results_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AbResultsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/ab-test/winner:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Promote the winning A/B variant to the flow's active prompt
+      operationId: promote_ab_winner_api_v2_flows__flow_id__ab_test_winner_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AbTestWinnerUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Promote Ab Winner Api V2 Flows  Flow Id  Ab Test Winner
+                  Put
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/workspace/branding:
     get:
       tags:
@@ -8832,6 +8934,92 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
 components:
   schemas:
+    AbResultsResponse:
+      properties:
+        variant_a:
+          $ref: '#/components/schemas/VariantMetrics'
+        variant_b:
+          $ref: '#/components/schemas/VariantMetrics'
+        statistical_significance:
+          type: boolean
+          title: Statistical Significance
+        recommended_variant:
+          type: string
+          enum:
+          - a
+          - b
+          - inconclusive
+          title: Recommended Variant
+      type: object
+      required:
+      - variant_a
+      - variant_b
+      - statistical_significance
+      - recommended_variant
+      title: AbResultsResponse
+    AbTestResponse:
+      properties:
+        ab_test_enabled:
+          type: boolean
+          title: Ab Test Enabled
+        ab_prompt_a_id:
+          type: string
+          format: uuid
+          nullable: true
+        ab_prompt_b_id:
+          type: string
+          format: uuid
+          nullable: true
+        ab_split_ratio:
+          type: number
+          title: Ab Split Ratio
+      type: object
+      required:
+      - ab_test_enabled
+      - ab_prompt_a_id
+      - ab_prompt_b_id
+      - ab_split_ratio
+      title: AbTestResponse
+    AbTestUpdate:
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+        prompt_a_id:
+          type: string
+          format: uuid
+          title: Prompt A Id
+        prompt_b_id:
+          type: string
+          format: uuid
+          title: Prompt B Id
+        split_ratio:
+          type: number
+          maximum: 0.9
+          minimum: 0.1
+          title: Split Ratio
+      additionalProperties: false
+      type: object
+      required:
+      - enabled
+      - prompt_a_id
+      - prompt_b_id
+      - split_ratio
+      title: AbTestUpdate
+      description: Request body for ``PUT /api/v2/flows/{flow_id}/ab-test``.
+    AbTestWinnerUpdate:
+      properties:
+        variant:
+          type: string
+          enum:
+          - a
+          - b
+          title: Variant
+      additionalProperties: false
+      type: object
+      required:
+      - variant
+      title: AbTestWinnerUpdate
     AccountDeletionRequest:
       properties:
         confirmation:
@@ -10755,6 +10943,9 @@ components:
         ended_at:
           type: string
           format: date-time
+          nullable: true
+        ab_variant:
+          type: string
           nullable: true
       type: object
       required:
@@ -17760,6 +17951,35 @@ components:
       - msg
       - type
       title: ValidationError
+    VariantMetrics:
+      properties:
+        calls:
+          type: integer
+          title: Calls
+        completed:
+          type: integer
+          title: Completed
+        failed:
+          type: integer
+          title: Failed
+        avg_duration:
+          type: number
+          nullable: true
+        transfer_rate:
+          type: number
+          title: Transfer Rate
+        success_rate:
+          type: number
+          title: Success Rate
+      type: object
+      required:
+      - calls
+      - completed
+      - failed
+      - avg_duration
+      - transfer_rate
+      - success_rate
+      title: VariantMetrics
     VoiceTypeEnum:
       type: string
       enum:

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ arq==0.26.1
 pymupdf==1.26.1
 tiktoken>=0.9.0,<1.0.0
 pgvector==0.3.6
-scipy==1.18.0
+scipy==1.17.1
 # SSO: SAML 2.0 + OIDC
 python3-saml>=1.16.0
 lxml>=5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,6 +58,7 @@ arq==0.26.1
 pymupdf==1.26.1
 tiktoken>=0.9.0,<1.0.0
 pgvector==0.3.6
+scipy==1.18.0
 # SSO: SAML 2.0 + OIDC
 python3-saml>=1.16.0
 lxml>=5.2.0

--- a/tests/api/test_ab_prompt_testing.py
+++ b/tests/api/test_ab_prompt_testing.py
@@ -1,0 +1,454 @@
+"""Tests for the A/B Prompt Testing system.
+
+Coverage:
+  1. Random variant assignment matches split_ratio within 5% tolerance over 1000 calls
+  2. No assignment when A/B testing is disabled or prompts are missing
+  3. PUT /api/v2/flows/{id}/ab-test validates prompt ownership and split_ratio bounds
+  4. GET /api/v2/flows/{id}/ab-results computes calls/completed/failed/avg_duration/
+     transfer_rate/success_rate correctly per variant
+  5. Statistical significance guardrail: <30 calls on either variant -> inconclusive
+  6. Statistical significance: clear separation -> significant + correct recommended variant
+  7. PUT /api/v2/flows/{id}/ab-test/winner promotes current_prompt_id and disables the test
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.agent import Agent
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.models.tenant import Tenant
+from app.models.user import User
+from app.services.ab_testing_service import ab_testing_service
+
+_API_KEY = "test-ab-testing-key"
+
+
+# ─────────────────────────────────────────────────────────────── helpers ──
+
+
+def _payload_for(tenant: Tenant) -> dict:
+    return {
+        "api_key_id": str(uuid.uuid4()),
+        "tenant_id": str(tenant.id),
+        "key_is_active": True,
+        "workspace": {
+            "id": str(tenant.id),
+            "name": tenant.name,
+            "schema_name": tenant.schema_name,
+            "status": "active",
+            "credits": 0.0,
+            "stripe_customer_id": None,
+            "stripe_subscription_id": None,
+        },
+    }
+
+
+def _headers(tenant: Tenant) -> dict:
+    return {"x-api-key": _API_KEY, "x-workspace-id": str(tenant.id)}
+
+
+@pytest.fixture
+def auth_tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"AbWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"ab_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def test_agent(db, auth_tenant: Tenant) -> Agent:
+    a = Agent(
+        tenant_id=auth_tenant.id,
+        name="AB Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def test_user(db, auth_tenant: Tenant) -> User:
+    u = User(
+        email=f"ab-user-{uuid.uuid4().hex[:6]}@example.com",
+        first_name="AB",
+        last_name="User",
+        hashed_password="",
+        current_tenant_id=auth_tenant.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def authed_client(client, auth_tenant: Tenant):
+    payload = _payload_for(auth_tenant)
+
+    async def _resolve(_key_hash, _workspace_id):
+        return payload
+
+    with patch(
+        "app.middleware.api_key_middleware._resolve_api_key",
+        side_effect=_resolve,
+    ):
+        yield client
+
+
+def _create_flow_with_two_prompts(client, tenant, agent) -> dict:
+    created = client.post(
+        "/api/v1/call-flows",
+        json={
+            "name": "AB Flow",
+            "direction": "outbound",
+            "agentId": str(agent.id),
+            "prompt": "Prompt version A",
+        },
+        headers=_headers(tenant),
+    ).json()
+    prompt_a_id = created["currentPromptId"]
+
+    updated = client.put(
+        f"/api/v1/call-flows/{created['id']}",
+        json={"prompt": "Prompt version B"},
+        headers=_headers(tenant),
+    ).json()
+    prompt_b_id = updated["currentPromptId"]
+
+    return {"flow_id": created["id"], "prompt_a_id": prompt_a_id, "prompt_b_id": prompt_b_id}
+
+
+def _make_call_session(
+    db,
+    *,
+    tenant: Tenant,
+    agent: Agent,
+    user: User,
+    flow_id: uuid.UUID,
+    variant: str,
+    status: str = "completed",
+    duration: int = None,
+    transferred: bool = False,
+    success_evaluation: str = None,
+) -> CallSession:
+    session = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=tenant.id,
+        call_flow_id=flow_id,
+        ab_variant=variant,
+        status=status,
+        duration=duration,
+        transferred=transferred,
+        success_evaluation=success_evaluation,
+        start_time=datetime.utcnow(),
+    )
+    db.add(session)
+    db.commit()
+    return session
+
+
+# ──────────────────────────────────────────────────────────────── tests ──
+
+
+class TestRandomAssignment:
+    def _flow_stub(self, *, split_ratio: float = 0.5) -> MagicMock:
+        flow = MagicMock(spec=CallFlow)
+        flow.ab_test_enabled = True
+        flow.ab_prompt_a_id = uuid.uuid4()
+        flow.ab_prompt_b_id = uuid.uuid4()
+        flow.ab_split_ratio = split_ratio
+        return flow
+
+    @pytest.mark.parametrize("split_ratio", [0.5, 0.3, 0.7])
+    def test_split_matches_ratio_within_tolerance(self, split_ratio):
+        flow = self._flow_stub(split_ratio=split_ratio)
+        n = 1000
+        a_count = sum(1 for _ in range(n) if ab_testing_service.pick_variant(flow) == "a")
+        observed_ratio = a_count / n
+        assert abs(observed_ratio - split_ratio) < 0.05
+
+    def test_disabled_flow_returns_none(self):
+        flow = self._flow_stub()
+        flow.ab_test_enabled = False
+        assert ab_testing_service.pick_variant(flow) is None
+
+    def test_missing_prompt_ids_returns_none(self):
+        flow = self._flow_stub()
+        flow.ab_prompt_b_id = None
+        assert ab_testing_service.pick_variant(flow) is None
+
+
+@pytest.mark.usefixtures("db")
+class TestAbTestConfigEndpoint:
+    def test_enable_ab_test_returns_updated_config(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+
+        resp = authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test",
+            json={
+                "enabled": True,
+                "prompt_a_id": flow["prompt_a_id"],
+                "prompt_b_id": flow["prompt_b_id"],
+                "split_ratio": 0.4,
+            },
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ab_test_enabled"] is True
+        assert body["ab_prompt_a_id"] == flow["prompt_a_id"]
+        assert body["ab_prompt_b_id"] == flow["prompt_b_id"]
+        assert body["ab_split_ratio"] == pytest.approx(0.4)
+
+    def test_split_ratio_out_of_bounds_returns_400(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        resp = authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test",
+            json={
+                "enabled": True,
+                "prompt_a_id": flow["prompt_a_id"],
+                "prompt_b_id": flow["prompt_b_id"],
+                "split_ratio": 0.95,
+            },
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+
+    def test_prompt_not_belonging_to_flow_returns_400(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        other_flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+
+        resp = authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test",
+            json={
+                "enabled": True,
+                "prompt_a_id": other_flow["prompt_a_id"],
+                "prompt_b_id": flow["prompt_b_id"],
+                "split_ratio": 0.5,
+            },
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.usefixtures("db")
+class TestAbResults:
+    def test_metrics_calculated_correctly(
+        self, authed_client, auth_tenant, test_agent, test_user, db
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        flow_id = uuid.UUID(flow["flow_id"])
+
+        # Variant A: 2 completed (100s, 200s), 1 failed, 1 transferred, 1 success
+        _make_call_session(
+            db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+            variant="a", status="completed", duration=100, success_evaluation="success",
+        )
+        _make_call_session(
+            db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+            variant="a", status="completed", duration=200, transferred=True,
+        )
+        _make_call_session(
+            db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+            variant="a", status="failed", duration=None,
+        )
+
+        # Variant B: 1 completed (50s), 1 failed
+        _make_call_session(
+            db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+            variant="b", status="completed", duration=50, success_evaluation="success",
+        )
+        _make_call_session(
+            db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+            variant="b", status="failed",
+        )
+
+        resp = authed_client.get(
+            f"/api/v2/flows/{flow['flow_id']}/ab-results",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        va = body["variant_a"]
+        assert va["calls"] == 3
+        assert va["completed"] == 2
+        assert va["failed"] == 1
+        assert va["avg_duration"] == pytest.approx(150.0)
+        assert va["transfer_rate"] == pytest.approx(1 / 3)
+        assert va["success_rate"] == pytest.approx(1 / 3)
+
+        vb = body["variant_b"]
+        assert vb["calls"] == 2
+        assert vb["completed"] == 1
+        assert vb["failed"] == 1
+        assert vb["avg_duration"] == pytest.approx(50.0)
+        assert vb["transfer_rate"] == pytest.approx(0.0)
+        assert vb["success_rate"] == pytest.approx(0.5)
+
+        # Below the 30-call guardrail -> always inconclusive
+        assert body["statistical_significance"] is False
+        assert body["recommended_variant"] == "inconclusive"
+
+    def test_guardrail_below_30_calls_is_inconclusive(
+        self, authed_client, auth_tenant, test_agent, test_user, db
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        flow_id = uuid.UUID(flow["flow_id"])
+
+        # 29 calls each, all completed (huge rate difference would otherwise be significant)
+        for _ in range(29):
+            _make_call_session(
+                db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+                variant="a", status="completed", duration=10,
+            )
+        for _ in range(29):
+            _make_call_session(
+                db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+                variant="b", status="failed",
+            )
+
+        resp = authed_client.get(
+            f"/api/v2/flows/{flow['flow_id']}/ab-results",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["statistical_significance"] is False
+        assert body["recommended_variant"] == "inconclusive"
+
+    def test_significant_difference_recommends_higher_completion_variant(
+        self, authed_client, auth_tenant, test_agent, test_user, db
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        flow_id = uuid.UUID(flow["flow_id"])
+
+        # Variant A: 40/50 completed
+        for i in range(50):
+            _make_call_session(
+                db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+                variant="a", status="completed" if i < 40 else "failed", duration=100,
+            )
+        # Variant B: 20/50 completed
+        for i in range(50):
+            _make_call_session(
+                db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+                variant="b", status="completed" if i < 20 else "failed", duration=100,
+            )
+
+        resp = authed_client.get(
+            f"/api/v2/flows/{flow['flow_id']}/ab-results",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["statistical_significance"] is True
+        assert body["recommended_variant"] == "a"
+
+    def test_no_significant_difference_is_inconclusive(
+        self, authed_client, auth_tenant, test_agent, test_user, db
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        flow_id = uuid.UUID(flow["flow_id"])
+
+        # Variant A: 26/50 completed, Variant B: 24/50 completed -> not significant
+        for i in range(50):
+            _make_call_session(
+                db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+                variant="a", status="completed" if i < 26 else "failed", duration=100,
+            )
+        for i in range(50):
+            _make_call_session(
+                db, tenant=auth_tenant, agent=test_agent, user=test_user, flow_id=flow_id,
+                variant="b", status="completed" if i < 24 else "failed", duration=100,
+            )
+
+        resp = authed_client.get(
+            f"/api/v2/flows/{flow['flow_id']}/ab-results",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["statistical_significance"] is False
+        assert body["recommended_variant"] == "inconclusive"
+
+
+@pytest.mark.usefixtures("db")
+class TestWinnerPromotion:
+    def test_promote_winner_updates_current_prompt_and_disables_test(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test",
+            json={
+                "enabled": True,
+                "prompt_a_id": flow["prompt_a_id"],
+                "prompt_b_id": flow["prompt_b_id"],
+                "split_ratio": 0.5,
+            },
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test/winner",
+            json={"variant": "b"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["currentPromptId"] == flow["prompt_b_id"]
+
+        row = db.query(CallFlow).filter(CallFlow.id == uuid.UUID(flow["flow_id"])).first()
+        assert row.ab_test_enabled is False
+        assert str(row.current_prompt_id) == flow["prompt_b_id"]
+
+    def test_promote_winner_missing_variant_prompt_returns_400(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        # Create a flow with only prompt A wired into ab_prompt_a_id, leave ab_prompt_b_id unset
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test",
+            json={
+                "enabled": True,
+                "prompt_a_id": flow["prompt_a_id"],
+                "prompt_b_id": flow["prompt_b_id"],
+                "split_ratio": 0.5,
+            },
+            headers=_headers(auth_tenant),
+        )
+        # Manually clear ab_prompt_b_id to simulate an incomplete config
+        row = db.query(CallFlow).filter(CallFlow.id == uuid.UUID(flow["flow_id"])).first()
+        row.ab_prompt_b_id = None
+        db.commit()
+
+        resp = authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test/winner",
+            json={"variant": "b"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400

--- a/tests/api/test_call_history.py
+++ b/tests/api/test_call_history.py
@@ -101,6 +101,7 @@ def _call_row(
     duration_seconds=60,
     started_at=None,
     ended_at=None,
+    ab_variant=None,
 ):
     return SimpleNamespace(
         call_id=call_id or uuid.uuid4(),
@@ -113,6 +114,7 @@ def _call_row(
         duration_seconds=duration_seconds,
         started_at=started_at or datetime(2026, 6, 1, 10, 0, tzinfo=timezone.utc),
         ended_at=ended_at or datetime(2026, 6, 1, 10, 1, tzinfo=timezone.utc),
+        ab_variant=ab_variant,
     )
 
 


### PR DESCRIPTION
## Summary

Adds an A/B prompt testing system for call flows: traffic can be split between two `PromptVersion`s on a flow, results are measured per variant, and a winner can be promoted to the flow's active prompt.

### Data model
- `CallFlow`: `ab_test_enabled` (bool), `ab_prompt_a_id` / `ab_prompt_b_id` (FK → `promptversion.id`), `ab_split_ratio` (Numeric(3,2), constrained to `0 < ratio < 1`, default `0.50`).
- `CallSession`: `ab_variant` (`'a'` | `'b'` | `NULL`) — the variant locked in for that call.
- Migration `20260702_ab_prompt_testing` (applied to the dev DB already).

### How prompt resolution works now
1. **Assignment (dispatch time, outbound calls only)** — in `voice_call_service.py`, right after `call_flow_id` is stamped onto the new `CallSession` and *before* any LiveKit/Twilio/LLM call is made, `ab_testing_service.assign_and_lock_variant()`:
   - Checks the flow's `ab_test_enabled` + both prompt IDs are set.
   - Rolls `random.random() < ab_split_ratio` → `'a'` or `'b'`.
   - Resolves the winning `PromptVersion.prompt_text` and writes both the variant and the resolved text onto the `CallSession` immediately (`ab_variant` column + `call_metadata["ab_prompt_text"]`), committed right away — so the variant is known even if the call fails a moment later.
   - Inbound calls don't currently associate a `CallFlow` with the session at all in this codebase, so A/B assignment only applies to the outbound dispatch path today.
2. **Resolution (live call, locked for the call's duration)** — both `bidirectional_stream.py` and `conversation_orchestrator.py` (the two places that build the LLM system prompt) now read `call_metadata["ab_prompt_text"]` and substitute it in place of `agent.system_prompt` / `agent.model.system_prompt`, using the exact same override seam that already existed for `batch_prompt_override` (batch override still wins if both happen to be set on the same call). Because the value is read once from `call_metadata` and never re-queried, the same variant's prompt is used for the entire call — no mid-call switching.

### API (`/api/v2/flows`)
- `PUT /{flow_id}/ab-test` — enable/configure A/B testing; validates both prompt IDs belong to the flow and `split_ratio` is in `[0.1, 0.9]`.
- `GET /{flow_id}/ab-results` — per-variant `calls`, `completed`, `failed`, `avg_duration`, `transfer_rate`, `success_rate`, plus a chi-squared significance test (`scipy.stats.chi2_contingency`) on completed-vs-total; guardrail: either variant under 30 calls → always `inconclusive`, otherwise significant only at `p < 0.05`, recommending the variant with the higher completion rate.
- `PUT /{flow_id}/ab-test/winner` — sets the flow's `current_prompt_id` to the winning variant's prompt and disables the test.

### Call history
- `CallHistoryItem.ab_variant` added and populated from `CallSession.ab_variant` in `call_history_service.get_list`.

## Test plan
- [x] `tests/api/test_ab_prompt_testing.py` (14 tests): random-split tolerance over 1000 samples, disabled/incomplete-config no-ops, `ab-test` config validation (400s for bad split ratio / prompt not on flow), `ab-results` metric math, 30-call significance guardrail, significant vs. inconclusive chi-squared outcomes, winner promotion (+ 400 on incomplete variant config).
- [x] Full suite run: 1344 passed; the 32 pre-existing failures were verified identical on the base branch (unrelated: contact recovery, Google STT, rate limiting, TTS/barge-in tests, a stale mock target).
- [x] Migration applied to dev DB and columns verified via `information_schema`.