### PR TITLE
feat: cross-session caller memory for voice agent call flows

### DIFF
--- a/alembic/versions/20260703_caller_memory.py
+++ b/alembic/versions/20260703_caller_memory.py
@@ -1,0 +1,62 @@
+"""Add cross-session caller memory columns and lookup index
+
+Revision ID: 20260703_caller_memory
+Revises: 20260702_ab_prompt_testing
+Create Date: 2026-07-03 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "20260703_caller_memory"
+down_revision: Union[str, Sequence[str], None] = "20260702_ab_prompt_testing"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "callflow",
+        sa.Column(
+            "caller_memory_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+    op.add_column(
+        "callflow",
+        sa.Column(
+            "caller_memory_window",
+            sa.Integer(),
+            nullable=False,
+            server_default="3",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_callflow_caller_memory_window",
+        "callflow",
+        "caller_memory_window >= 1 AND caller_memory_window <= 10",
+    )
+
+    op.add_column(
+        "callsession",
+        sa.Column("transcript_summary", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "ix_callsession_memory_lookup",
+        "callsession",
+        ["tenant_id", "call_flow_id", "from_number", "start_time"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_callsession_memory_lookup", table_name="callsession")
+    op.drop_column("callsession", "transcript_summary")
+
+    op.drop_constraint("ck_callflow_caller_memory_window", "callflow", type_="check")
+    op.drop_column("callflow", "caller_memory_window")
+    op.drop_column("callflow", "caller_memory_enabled")

--- a/app/api/v2/routers/callback_scheduler.py
+++ b/app/api/v2/routers/callback_scheduler.py
@@ -6,17 +6,21 @@ Auth: any authenticated tenant principal (API key or JWT).
 PUT  /api/v2/agents/{agent_id}/callback-config
 GET  /api/v2/agents/{agent_id}/callback-status
 GET  /api/v2/calls/{call_id}/callback-history
+GET  /api/v2/calls/{call_id}/memory-context
 """
 from __future__ import annotations
 
 import uuid
 from typing import List, Union
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_tenant
 from app.core.request_auth import ApiKeyPrincipal
+from app.models.call_session import CallSession
 from app.models.user import User
 from app.schemas.callback_scheduler import (
     CallbackConfigResponse,
@@ -25,6 +29,10 @@ from app.schemas.callback_scheduler import (
     CallbackStatusResponse,
 )
 from app.services.callback_scheduler_service import callback_scheduler_service
+
+
+class CallMemoryContextResponse(BaseModel):
+    memory_context: str
 
 
 def _tenant_id(principal: Union[User, ApiKeyPrincipal]) -> uuid.UUID:
@@ -105,3 +113,37 @@ def get_callback_history(
     return callback_scheduler_service.get_callback_history(
         db, call_id, _tenant_id(principal)
     )
+
+
+@calls_router.get(
+    "/{call_id}/memory-context",
+    response_model=CallMemoryContextResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Debug: view the cached cross-session caller memory context for a call",
+)
+def get_call_memory_context(
+    call_id: uuid.UUID,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_tenant),
+    db: Session = Depends(get_db),
+) -> CallMemoryContextResponse:
+    """
+    Returns the caller-memory context block cached on the call's
+    `call_metadata["caller_memory_context"]` at prompt-build time.
+    Returns 404 if the call does not belong to the caller's tenant.
+    """
+    tenant_id = principal.current_tenant_id
+    call_session = db.execute(
+        select(CallSession).where(
+            CallSession.id == call_id,
+            CallSession.tenant_id == tenant_id,
+        )
+    ).scalar_one_or_none()
+
+    if call_session is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Call session {call_id} not found",
+        )
+
+    metadata = call_session.call_metadata or {}
+    return CallMemoryContextResponse(memory_context=metadata.get("caller_memory_context") or "")

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -1,22 +1,33 @@
 """
-v2 A/B prompt testing endpoints.
+v2 A/B prompt testing + cross-session caller memory endpoints.
 
 Auth: any authenticated tenant principal (API key or JWT); config-rank required
-to mutate A/B settings, read-only rank is sufficient to view results.
+to mutate A/B settings, read-only rank is sufficient to view results. Caller
+memory settings require admin rank (owner-equivalent — see require_admin_or_api_key).
 
 PUT  /api/v2/flows/{flow_id}/ab-test
 GET  /api/v2/flows/{flow_id}/ab-results
 PUT  /api/v2/flows/{flow_id}/ab-test/winner
+PUT  /api/v2/flows/{flow_id}/caller-memory-settings
+
+Note: the caller memory settings path is deliberately NOT `/{flow_id}/settings` —
+that path is already registered by app.api.v2.routers.hipaa for the HIPAA
+compliance toggle, and reusing it here would silently shadow that endpoint.
 """
 from __future__ import annotations
 
 import uuid
 from typing import Union
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, require_config_or_api_key, require_readonly_or_api_key
+from app.api.deps import (
+    get_db,
+    require_admin_or_api_key,
+    require_config_or_api_key,
+    require_readonly_or_api_key,
+)
 from app.core.request_auth import ApiKeyPrincipal
 from app.models.user import User
 from app.schemas.ab_testing import (
@@ -25,6 +36,8 @@ from app.schemas.ab_testing import (
     AbTestUpdate,
     AbTestWinnerUpdate,
 )
+from app.schemas.call_flow import CallerMemorySettingsResponse, CallerMemorySettingsUpdate
+from app.services.audit_service import log_audit_event
 from app.services.call_flow_service import call_flow_service
 
 router = APIRouter(prefix="/flows", tags=["A/B Prompt Testing"])
@@ -75,3 +88,35 @@ def promote_ab_winner(
     db: Session = Depends(get_db),
 ) -> dict:
     return call_flow_service.promote_ab_winner(db, flow_id, _tenant_id(principal), body)
+
+
+@router.put(
+    "/{flow_id}/caller-memory-settings",
+    response_model=CallerMemorySettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Configure cross-session caller memory on a call flow",
+)
+def update_caller_memory_settings(
+    flow_id: uuid.UUID,
+    body: CallerMemorySettingsUpdate,
+    request: Request,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> CallerMemorySettingsResponse:
+    tenant_id = _tenant_id(principal)
+    result = call_flow_service.update_caller_memory_settings(db, flow_id, tenant_id, body)
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="caller_memory_settings.updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        new_value={
+            "caller_memory_enabled": result.caller_memory_enabled,
+            "caller_memory_window": result.caller_memory_window,
+        },
+        actor_user_id=principal.id,
+    )
+    return result

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Boolean, Index, CheckConstraint, Numeric
+from sqlalchemy import Column, String, Text, DateTime, Integer, ForeignKey, Boolean, Index, CheckConstraint, Numeric
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -39,6 +39,10 @@ class CallFlow(Base):
     )
     # Fraction of calls routed to variant A (0.10-0.90)
     ab_split_ratio = Column(Numeric(3, 2), default=0.50, nullable=False, server_default="0.50")
+
+    # Cross-session caller memory: inject summaries of a caller's past calls into the prompt
+    caller_memory_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    caller_memory_window = Column(Integer, default=3, nullable=False, server_default="3")
 
     hipaa_compliance = Column(Boolean, default=False, nullable=False, server_default="false")
     public_access = Column(Boolean, default=False, nullable=False, server_default="false")
@@ -89,5 +93,9 @@ class CallFlow(Base):
         CheckConstraint(
             "ab_split_ratio > 0 AND ab_split_ratio < 1",
             name="ck_callflow_ab_split_ratio",
+        ),
+        CheckConstraint(
+            "caller_memory_window >= 1 AND caller_memory_window <= 10",
+            name="ck_callflow_caller_memory_window",
         ),
     )

--- a/app/models/call_session.py
+++ b/app/models/call_session.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, Text, DateTime, Integer, ForeignKey, Float, Boolean
+from sqlalchemy import Column, String, Text, DateTime, Integer, ForeignKey, Float, Boolean, Index
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -47,6 +47,9 @@ class CallSession(Base):
     # Additional metadata
     call_metadata = Column(JSONB, nullable=True)  # Store additional call metadata
     transferred = Column(Boolean, nullable=False, server_default="false")  # Whether call was transferred
+
+    # Finalized, HIPAA-redacted end-of-call summary — powers cross-session caller memory
+    transcript_summary = Column(Text, nullable=True)
     
     # Optional link to the call flow that triggered this session
     call_flow_id = Column(UUID(as_uuid=True), ForeignKey("callflow.id"), nullable=True, index=True)
@@ -77,6 +80,16 @@ class CallSession(Base):
     # Self-referential: retry calls point back to the original missed call
     parent_call = relationship("CallSession", remote_side="CallSession.id", foreign_keys=[parent_call_id])
     callback_schedules = relationship("CallbackSchedule", back_populates="original_call", foreign_keys="CallbackSchedule.original_call_id")
-    
+
+    __table_args__ = (
+        Index(
+            "ix_callsession_memory_lookup",
+            "tenant_id",
+            "call_flow_id",
+            "from_number",
+            "start_time",
+        ),
+    )
+
     def __repr__(self):
         return f"<CallSession(id={self.id}, status={self.status})>"

--- a/app/schemas/ab_testing.py
+++ b/app/schemas/ab_testing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class AbTestUpdate(BaseModel):
@@ -15,6 +15,12 @@ class AbTestUpdate(BaseModel):
     prompt_a_id: uuid.UUID
     prompt_b_id: uuid.UUID
     split_ratio: float = Field(..., ge=0.1, le=0.9)
+
+    @model_validator(mode='after')
+    def prompts_must_differ(self) -> AbTestUpdate:
+        if self.prompt_a_id == self.prompt_b_id:
+            raise ValueError('prompt_a_id and prompt_b_id must be different prompt versions')
+        return self
 
 
 class AbTestResponse(BaseModel):

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -86,6 +86,22 @@ class CallFlowSettingsUpdate(BaseModel):
     public_access: bool = Field(..., alias="public_access")
 
 
+class CallerMemorySettingsUpdate(BaseModel):
+    """Request body for ``PUT /api/v2/flows/{flow_id}/caller-memory-settings``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    caller_memory_enabled: bool
+    caller_memory_window: int = Field(..., ge=1, le=10)
+
+
+class CallerMemorySettingsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    caller_memory_enabled: bool
+    caller_memory_window: int
+
+
 class CallFlowOut(BaseModel):
     """Full flow response including all prompt versions."""
 

--- a/app/schemas/hubspot_integration.py
+++ b/app/schemas/hubspot_integration.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
+import re
+
+_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]{0,127}$')
+_HUBSPOT_FIELD_RE = re.compile(r'^[a-z_][a-z0-9_]{0,127}$')
 
 
 class HubSpotAuthorizeResponse(BaseModel):
@@ -27,9 +31,29 @@ class HubSpotFieldMapping(BaseModel):
     hubspot_field: str
     prompt_variable: str
 
+    @field_validator('hubspot_field')
+    @classmethod
+    def validate_hubspot_field(cls, v: str) -> str:
+        if not _HUBSPOT_FIELD_RE.match(v):
+            raise ValueError('hubspot_field must be a valid HubSpot property name (lowercase, underscores, max 128 chars)')
+        return v
+
+    @field_validator('prompt_variable')
+    @classmethod
+    def validate_prompt_variable(cls, v: str) -> str:
+        if not _IDENTIFIER_RE.match(v):
+            raise ValueError('prompt_variable must be a valid identifier (letters, digits, underscores, max 128 chars)')
+        return v
+
 
 class HubSpotFieldMappingRequest(BaseModel):
     mappings: List[HubSpotFieldMapping]
+
+    @model_validator(mode='after')
+    def validate_mapping_count(self) -> HubSpotFieldMappingRequest:
+        if len(self.mappings) > 50:
+            raise ValueError('A maximum of 50 field mappings are allowed')
+        return self
 
 
 class HubSpotFieldMappingResponse(BaseModel):

--- a/app/services/ab_testing_service.py
+++ b/app/services/ab_testing_service.py
@@ -66,7 +66,7 @@ class AbTestingService:
             **(call_session.call_metadata or {}),
             "ab_prompt_text": prompt_text,
         }
-        db.commit()
+        db.flush()
         db.refresh(call_session)
         logger.info(
             "A/B variant '%s' assigned to call session %s (flow=%s)",

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -30,6 +30,8 @@ from app.schemas.call_flow import (
     CallFlowListItem,
     CallFlowOut,
     AgentRef,
+    CallerMemorySettingsResponse,
+    CallerMemorySettingsUpdate,
     CallFlowSettingsUpdate,
     CallFlowUpdate,
 )
@@ -497,6 +499,32 @@ class CallFlowService:
         rate_b = completed_b / calls_b
         recommended = "a" if rate_a > rate_b else "b"
         return True, recommended
+
+    # ── Cross-session caller memory ─────────────────────────────────────────
+
+    def update_caller_memory_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: CallerMemorySettingsUpdate,
+    ) -> CallerMemorySettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        repo = CallFlowRepository(db)
+        flow = repo.update(
+            flow,
+            {
+                "caller_memory_enabled": body.caller_memory_enabled,
+                "caller_memory_window": body.caller_memory_window,
+            },
+        )
+        db.commit()
+        db.refresh(flow)
+        return CallerMemorySettingsResponse(
+            caller_memory_enabled=flow.caller_memory_enabled,
+            caller_memory_window=flow.caller_memory_window,
+        )
 
     def promote_ab_winner(
         self,

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from fastapi import HTTPException, status
 from scipy.stats import chi2_contingency
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.orm import Session
 
 from app.core.logger import logger
@@ -449,30 +449,37 @@ class CallFlowService:
         tenant_id: uuid.UUID,
         variant: str,
     ) -> VariantMetrics:
-        sessions = db.execute(
-            select(CallSession).where(
+        row = db.execute(
+            select(
+                func.count().label('calls'),
+                func.sum(
+                    case((CallSession.status == 'completed', 1), else_=0)
+                ).label('completed'),
+                func.sum(
+                    case((CallSession.status == 'failed', 1), else_=0)
+                ).label('failed'),
+                func.avg(CallSession.duration).label('avg_duration'),
+                func.sum(
+                    case((CallSession.transferred == True, 1), else_=0)  # noqa: E712
+                ).label('transferred'),
+                func.sum(
+                    case((CallSession.success_evaluation == 'success', 1), else_=0)
+                ).label('successes'),
+            ).where(
                 CallSession.call_flow_id == flow_id,
                 CallSession.tenant_id == tenant_id,
                 CallSession.ab_variant == variant,
             )
-        ).scalars().all()
+        ).one()
 
-        calls = len(sessions)
-        completed = sum(1 for s in sessions if s.status == "completed")
-        failed = sum(1 for s in sessions if s.status == "failed")
-        transferred = sum(1 for s in sessions if s.transferred)
-        successes = sum(1 for s in sessions if s.success_evaluation == "success")
-
-        durations = [s.duration for s in sessions if s.duration is not None]
-        avg_duration = sum(durations) / len(durations) if durations else None
-
+        calls = row.calls or 0
         return VariantMetrics(
             calls=calls,
-            completed=completed,
-            failed=failed,
-            avg_duration=avg_duration,
-            transfer_rate=(transferred / calls) if calls else 0.0,
-            success_rate=(successes / calls) if calls else 0.0,
+            completed=row.completed or 0,
+            failed=row.failed or 0,
+            avg_duration=float(row.avg_duration) if row.avg_duration else None,
+            transfer_rate=(row.transferred / calls) if calls else 0.0,
+            success_rate=(row.successes / calls) if calls else 0.0,
         )
 
     def _ab_significance(

--- a/app/services/caller_memory_service.py
+++ b/app/services/caller_memory_service.py
@@ -1,0 +1,123 @@
+"""
+Cross-session caller memory: injects summaries of a caller's previous completed
+calls into the LLM system prompt so agents recall prior interactions.
+
+Retrieval is fetched once per call and cached on call_session.call_metadata
+(mirrors get_crm_context_block_for_call in hubspot_service.py) so later turns
+in the same call — the prompt is rebuilt every turn — reuse the cached string
+instead of re-querying the database. Fails open on timeout/error: a slow or
+broken lookup never blocks the call, it just proceeds without caller memory.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import List, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+
+_CACHE_KEY = "caller_memory_context"
+_DEFAULT_FETCH_TIMEOUT_SEC = 0.1
+
+
+def _fetch_recent_summaries(
+    db: Session, call_session: CallSession, window: int
+) -> List[CallSession]:
+    """Blocking DB query — run inside a threadpool executor with a timeout."""
+    stmt = (
+        select(CallSession)
+        .where(
+            CallSession.tenant_id == call_session.tenant_id,
+            CallSession.call_flow_id == call_session.call_flow_id,
+            CallSession.from_number == call_session.from_number,
+            CallSession.status == "completed",
+            CallSession.id != call_session.id,
+            CallSession.transcript_summary.isnot(None),
+            CallSession.transcript_summary != "",
+        )
+        .order_by(CallSession.start_time.desc())
+        .limit(window)
+    )
+    return list(db.execute(stmt).scalars().all())
+
+
+def _format_caller_memory_block(sessions: List[CallSession]) -> str:
+    if not sessions:
+        return ""
+
+    lines = [f"CALLER HISTORY (last {len(sessions)} interactions):"]
+    for session in sessions:
+        date_str = (
+            session.start_time.strftime("%Y-%m-%d") if session.start_time else "unknown date"
+        )
+        summary = (session.transcript_summary or "").strip()
+        lines.append(f"- Call on {date_str}: {summary}")
+    lines.append("End of caller history.")
+    return "\n".join(lines)
+
+
+async def get_caller_memory_context_block_for_call(
+    db: Session,
+    call_session: Optional[CallSession],
+    call_flow: Optional[CallFlow],
+) -> str:
+    """
+    Fetch the caller-memory context block for a call's system prompt, once per call.
+
+    Returns "" (no block injected) when: caller memory is disabled on the flow,
+    the call has no from_number, the lookup times out, or the lookup fails.
+    """
+    if call_session is None or call_flow is None or not call_flow.caller_memory_enabled:
+        return ""
+    if not call_session.from_number:
+        return ""
+
+    metadata = call_session.call_metadata or {}
+    if _CACHE_KEY in metadata:
+        return metadata.get(_CACHE_KEY) or ""
+
+    window = call_flow.caller_memory_window
+    context_block = ""
+    try:
+        loop = asyncio.get_running_loop()
+        sessions = await asyncio.wait_for(
+            loop.run_in_executor(None, _fetch_recent_summaries, db, call_session, window),
+            timeout=float(
+                getattr(settings, "VOICE_CALLER_MEMORY_FETCH_TIMEOUT_SEC", None)
+                or _DEFAULT_FETCH_TIMEOUT_SEC
+            ),
+        )
+        context_block = _format_caller_memory_block(sessions)
+    except asyncio.TimeoutError:
+        logger.warning(
+            "caller_memory lookup timed out after %sms; proceeding without caller memory",
+            int(_DEFAULT_FETCH_TIMEOUT_SEC * 1000),
+        )
+    except Exception:
+        logger.warning(
+            "caller_memory lookup failed; proceeding without caller memory", exc_info=True
+        )
+
+    try:
+        # Nested savepoint keeps this fail-open and avoids committing the
+        # caller's main transaction during prompt generation.
+        with db.begin_nested():
+            updated_metadata = dict(call_session.call_metadata or {})
+            updated_metadata[_CACHE_KEY] = context_block
+            call_session.call_metadata = updated_metadata
+            flag_modified(call_session, "call_metadata")
+            db.add(call_session)
+            db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to cache caller memory context on call_session (non-critical)",
+            exc_info=True,
+        )
+
+    return context_block

--- a/app/services/caller_memory_service.py
+++ b/app/services/caller_memory_service.py
@@ -11,7 +11,10 @@ broken lookup never blocks the call, it just proceeds without caller memory.
 from __future__ import annotations
 
 import asyncio
-from typing import List, Optional
+import datetime
+import re
+import uuid
+from typing import List, NamedTuple, Optional
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -19,46 +22,74 @@ from sqlalchemy.orm.attributes import flag_modified
 
 from app.core.config import settings
 from app.core.logger import logger
+from app.db.session import SessionLocal
 from app.models.call_flow import CallFlow
 from app.models.call_session import CallSession
 
 _CACHE_KEY = "caller_memory_context"
 _DEFAULT_FETCH_TIMEOUT_SEC = 0.1
+_CONTROL_CHARS_RE = re.compile(r'[\x00-\x1f\x7f]')
+_MAX_SUMMARY_LEN = 400
+
+
+class CallerMemorySession(NamedTuple):
+    start_time: Optional[datetime.datetime]
+    transcript_summary: Optional[str]
+
+
+def _sanitize_summary(text: str) -> str:
+    text = _CONTROL_CHARS_RE.sub(' ', text).strip()
+    if len(text) > _MAX_SUMMARY_LEN:
+        text = text[:_MAX_SUMMARY_LEN] + '…'
+    return text
 
 
 def _fetch_recent_summaries(
-    db: Session, call_session: CallSession, window: int
-) -> List[CallSession]:
-    """Blocking DB query — run inside a threadpool executor with a timeout."""
-    stmt = (
-        select(CallSession)
-        .where(
-            CallSession.tenant_id == call_session.tenant_id,
-            CallSession.call_flow_id == call_session.call_flow_id,
-            CallSession.from_number == call_session.from_number,
-            CallSession.status == "completed",
-            CallSession.id != call_session.id,
-            CallSession.transcript_summary.isnot(None),
-            CallSession.transcript_summary != "",
+    tenant_id: uuid.UUID,
+    call_flow_id: uuid.UUID,
+    from_number: str,
+    current_session_id: uuid.UUID,
+    window: int,
+) -> List[CallerMemorySession]:
+    """Blocking DB query — runs in a thread pool with its own session."""
+    db = SessionLocal()
+    try:
+        stmt = (
+            select(CallSession.start_time, CallSession.transcript_summary)
+            .where(
+                CallSession.tenant_id == tenant_id,
+                CallSession.call_flow_id == call_flow_id,
+                CallSession.from_number == from_number,
+                CallSession.status == "completed",
+                CallSession.id != current_session_id,
+                CallSession.transcript_summary.isnot(None),
+                CallSession.transcript_summary != "",
+            )
+            .order_by(CallSession.start_time.desc())
+            .limit(window)
         )
-        .order_by(CallSession.start_time.desc())
-        .limit(window)
-    )
-    return list(db.execute(stmt).scalars().all())
+        rows = db.execute(stmt).all()
+        return [
+            CallerMemorySession(start_time=row.start_time, transcript_summary=row.transcript_summary)
+            for row in rows
+        ]
+    finally:
+        db.close()
 
 
-def _format_caller_memory_block(sessions: List[CallSession]) -> str:
+def _format_caller_memory_block(sessions: List[CallerMemorySession]) -> str:
     if not sessions:
         return ""
 
-    lines = [f"CALLER HISTORY (last {len(sessions)} interactions):"]
+    lines = ["<caller_history>", f"CALLER HISTORY (last {len(sessions)} interactions):"]
     for session in sessions:
         date_str = (
             session.start_time.strftime("%Y-%m-%d") if session.start_time else "unknown date"
         )
-        summary = (session.transcript_summary or "").strip()
+        summary = _sanitize_summary((session.transcript_summary or "").strip())
         lines.append(f"- Call on {date_str}: {summary}")
     lines.append("End of caller history.")
+    lines.append("</caller_history>")
     return "\n".join(lines)
 
 
@@ -84,20 +115,29 @@ async def get_caller_memory_context_block_for_call(
 
     window = call_flow.caller_memory_window
     context_block = ""
+    fetch_timeout = float(
+        getattr(settings, "VOICE_CALLER_MEMORY_FETCH_TIMEOUT_SEC", None)
+        or _DEFAULT_FETCH_TIMEOUT_SEC
+    )
     try:
         loop = asyncio.get_running_loop()
         sessions = await asyncio.wait_for(
-            loop.run_in_executor(None, _fetch_recent_summaries, db, call_session, window),
-            timeout=float(
-                getattr(settings, "VOICE_CALLER_MEMORY_FETCH_TIMEOUT_SEC", None)
-                or _DEFAULT_FETCH_TIMEOUT_SEC
+            loop.run_in_executor(
+                None,
+                _fetch_recent_summaries,
+                call_session.tenant_id,
+                call_session.call_flow_id,
+                call_session.from_number,
+                call_session.id,
+                window,
             ),
+            timeout=fetch_timeout,
         )
         context_block = _format_caller_memory_block(sessions)
     except asyncio.TimeoutError:
         logger.warning(
-            "caller_memory lookup timed out after %sms; proceeding without caller memory",
-            int(_DEFAULT_FETCH_TIMEOUT_SEC * 1000),
+            "caller_memory lookup timed out after %dms; proceeding without caller memory",
+            int(fetch_timeout * 1000),
         )
     except Exception:
         logger.warning(

--- a/app/services/hubspot_service.py
+++ b/app/services/hubspot_service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import hashlib
+import re
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple
@@ -845,6 +846,17 @@ async def create_call_engagement(
     return response.json()
 
 
+_MAX_ERROR_LEN = 500
+
+
+def _safe_error_msg(exc: Exception) -> str:
+    """Extract a brief, safe error summary for tenant-visible storage."""
+    msg = str(exc)
+    # Redact anything that looks like a bearer token
+    msg = re.sub(r'Bearer [A-Za-z0-9\-._~+/]+=*', 'Bearer [redacted]', msg)
+    return msg[:_MAX_ERROR_LEN]
+
+
 async def _run_post_call_writeback_async(db: Session, call_session: CallSession) -> None:
     tenant_id = call_session.tenant_id
 
@@ -891,7 +903,7 @@ async def _run_post_call_writeback_async(db: Session, call_session: CallSession)
             exc,
             exc_info=True,
         )
-        set_last_write_back_error(db, tenant_id, str(exc))
+        set_last_write_back_error(db, tenant_id, _safe_error_msg(exc))
         return
 
     set_last_write_back_error(db, tenant_id, None)

--- a/app/services/voice_analysis_service.py
+++ b/app/services/voice_analysis_service.py
@@ -474,6 +474,8 @@ Keep it concise - similar to summary format. Maximum 1 sentence per recommendati
             call_session.call_metadata = {}
         call_session.call_metadata["llm_call_analysis"] = analysis_block
         flag_modified(call_session, "call_metadata")
+        # Finalized, HIPAA-redacted summary — powers cross-session caller memory lookups.
+        call_session.transcript_summary = analysis_data["summary"]
         db.add(call_session)
 
         log_row = db.query(CallLog).filter(CallLog.call_session_id == call_session.id).first()

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -543,6 +543,34 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 else:
                     system_prompt = system_prompt + "\n\n" + crm_context_block
 
+            # Cross-session caller memory: fetched once at call start (DB lookup,
+            # 100ms timeout budget, fail-open) and cached on call_session.call_metadata
+            # so every later turn is a cheap in-memory dict read. Injected right after
+            # the KB/CRM context blocks and before conversation history.
+            caller_memory_block = ""
+            if self._h.call_session and self._h.db and flow and flow.caller_memory_enabled:
+                try:
+                    from app.services.caller_memory_service import (
+                        get_caller_memory_context_block_for_call,
+                    )
+
+                    caller_memory_block = await get_caller_memory_context_block_for_call(
+                        self._h.db, self._h.call_session, flow
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "caller_memory lookup failed; proceeding without context: %s", exc
+                    )
+
+            if caller_memory_block:
+                anchor = "# CONVERSATION STATE"
+                if anchor in system_prompt:
+                    system_prompt = system_prompt.replace(
+                        anchor, caller_memory_block + "\n\n" + anchor, 1
+                    )
+                else:
+                    system_prompt = system_prompt + "\n\n" + caller_memory_block
+
             # HubSpot field-mapping substitution: replaces `{prompt_variable}` tokens
             # in the prompt with tenant-configured HubSpot contact field values.
             # Resolved once per call (Redis/DB-cached) and fails open on timeout/error.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8149,6 +8149,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/calls/{call_id}/memory-context:
+    get:
+      tags:
+      - Smart Callback Scheduler
+      summary: 'Debug: view the cached cross-session caller memory context for a call'
+      description: 'Returns the caller-memory context block cached on the call''s
+
+        `call_metadata["caller_memory_context"]` at prompt-build time.
+
+        Returns 404 if the call does not belong to the caller''s tenant.'
+      operationId: get_call_memory_context_api_v2_calls__call_id__memory_context_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: call_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Call Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallMemoryContextResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/ab-test:
     put:
       tags:
@@ -8245,6 +8279,41 @@ paths:
                 additionalProperties: true
                 title: Response Promote Ab Winner Api V2 Flows  Flow Id  Ab Test Winner
                   Put
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/caller-memory-settings:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Configure cross-session caller memory on a call flow
+      operationId: update_caller_memory_settings_api_v2_flows__flow_id__caller_memory_settings_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallerMemorySettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallerMemorySettingsResponse'
         '422':
           description: Validation Error
           content:
@@ -11439,6 +11508,15 @@ components:
       - total_cost
       title: CallLogStats
       description: Statistics for call logs dashboard
+    CallMemoryContextResponse:
+      properties:
+        memory_context:
+          type: string
+          title: Memory Context
+      type: object
+      required:
+      - memory_context
+      title: CallMemoryContextResponse
     CallSessionList:
       properties:
         sessions:
@@ -11712,6 +11790,36 @@ components:
       description: 'GET /api/v1/agents/{id}/callback-status response.
 
         Returns live counters alongside the static config.'
+    CallerMemorySettingsResponse:
+      properties:
+        caller_memory_enabled:
+          type: boolean
+          title: Caller Memory Enabled
+        caller_memory_window:
+          type: integer
+          title: Caller Memory Window
+      type: object
+      required:
+      - caller_memory_enabled
+      - caller_memory_window
+      title: CallerMemorySettingsResponse
+    CallerMemorySettingsUpdate:
+      properties:
+        caller_memory_enabled:
+          type: boolean
+          title: Caller Memory Enabled
+        caller_memory_window:
+          type: integer
+          maximum: 10.0
+          minimum: 1.0
+          title: Caller Memory Window
+      additionalProperties: false
+      type: object
+      required:
+      - caller_memory_enabled
+      - caller_memory_window
+      title: CallerMemorySettingsUpdate
+      description: Request body for ``PUT /api/v2/flows/{flow_id}/caller-memory-settings``.
     CandidateStatusEnum:
       type: string
       enum:

--- a/tests/api/test_ab_prompt_testing.py
+++ b/tests/api/test_ab_prompt_testing.py
@@ -79,6 +79,9 @@ def test_agent(db, auth_tenant: Tenant) -> Agent:
     db.add(a)
     db.commit()
     db.refresh(a)
+    print("DEBUG AGENT IN FIXTURE:", a)
+    print("DEBUG SESSION ID IN FIXTURE:", id(db))
+    print("DEBUG ALL AGENTS IN FIXTURE DB:", db.query(Agent).all())
     return a
 
 
@@ -113,7 +116,7 @@ def authed_client(client, auth_tenant: Tenant):
 
 def _create_flow_with_two_prompts(client, tenant, agent) -> dict:
     created = client.post(
-        "/api/v1/call-flows",
+        "/api/v1/call-flows/",
         json={
             "name": "AB Flow",
             "direction": "outbound",
@@ -252,6 +255,23 @@ class TestAbTestConfigEndpoint:
             headers=_headers(auth_tenant),
         )
         assert resp.status_code == 400
+
+    def test_same_prompts_for_both_variants_returns_400(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        flow = _create_flow_with_two_prompts(authed_client, auth_tenant, test_agent)
+        resp = authed_client.put(
+            f"/api/v2/flows/{flow['flow_id']}/ab-test",
+            json={
+                "enabled": True,
+                "prompt_a_id": flow["prompt_a_id"],
+                "prompt_b_id": flow["prompt_a_id"],
+                "split_ratio": 0.5,
+            },
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+        assert "must be different prompt versions" in resp.text
 
 
 @pytest.mark.usefixtures("db")

--- a/tests/api/test_hubspot_integration.py
+++ b/tests/api/test_hubspot_integration.py
@@ -391,3 +391,53 @@ class TestIntegrationListIncludesHubSpot:
         hubspot_item = next(i for i in result.integrations if i.name == "hubspot")
         assert hubspot_item.connected is True
         assert hubspot_item.connected_at == connected_at
+
+
+class TestHubSpotFieldMappingValidation:
+    def test_valid_mapping(self):
+        from app.schemas.hubspot_integration import HubSpotFieldMapping
+        mapping = HubSpotFieldMapping(
+            hubspot_field="custom_property",
+            prompt_variable="custom_var"
+        )
+        assert mapping.hubspot_field == "custom_property"
+        assert mapping.prompt_variable == "custom_var"
+
+    def test_invalid_hubspot_field_raises(self):
+        from app.schemas.hubspot_integration import HubSpotFieldMapping
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc:
+            HubSpotFieldMapping(
+                hubspot_field="Invalid-Field-Name!",
+                prompt_variable="valid_var"
+            )
+        assert "hubspot_field must be a valid HubSpot property name" in str(exc.value)
+
+    def test_invalid_prompt_variable_raises(self):
+        from app.schemas.hubspot_integration import HubSpotFieldMapping
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc:
+            HubSpotFieldMapping(
+                hubspot_field="valid_field",
+                prompt_variable="invalid-var-name!"
+            )
+        assert "prompt_variable must be a valid identifier" in str(exc.value)
+
+    def test_mappings_count_limit(self):
+        from app.schemas.hubspot_integration import HubSpotFieldMapping, HubSpotFieldMappingRequest
+        from pydantic import ValidationError
+
+        valid_mappings = [
+            HubSpotFieldMapping(hubspot_field="field", prompt_variable=f"var_{i}")
+            for i in range(50)
+        ]
+        request = HubSpotFieldMappingRequest(mappings=valid_mappings)
+        assert len(request.mappings) == 50
+
+        with pytest.raises(ValidationError) as exc:
+            HubSpotFieldMappingRequest(mappings=valid_mappings + [
+                HubSpotFieldMapping(hubspot_field="field", prompt_variable="excess_var")
+            ])
+        assert "A maximum of 50 field mappings are allowed" in str(exc.value)

--- a/tests/api/v2/test_caller_memory_debug.py
+++ b/tests/api/v2/test_caller_memory_debug.py
@@ -1,0 +1,204 @@
+"""Tests for GET /api/v2/calls/{call_id}/memory-context.
+
+Coverage:
+  - Success: returns the exact cached caller_memory_context string
+  - Empty cache: returns "" when caller_memory_context is not cached
+  - Workspace isolation: a call belonging to another tenant returns 404
+  - Missing session: an unknown call_id returns 404
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal):
+    from app.api.deps import get_db, require_tenant
+    from app.api.v2.routers.callback_scheduler import calls_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(calls_router)
+
+    mini.dependency_overrides[require_tenant] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"MemDebugWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"mem_debug_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Memory Debug Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def user(db, workspace):
+    from app.models.user import User
+
+    u = User(
+        email=f"memdebug-{uuid.uuid4().hex[:6]}@example.com",
+        first_name="Mem",
+        last_name="Debug",
+        hashed_password="",
+        current_tenant_id=workspace.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _make_call_session(db, *, tenant_id, agent_id, user_id, call_metadata=None):
+    from app.models.call_session import CallSession
+
+    cs = CallSession(
+        user_id=user_id,
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        status="completed",
+        start_time=datetime.now(timezone.utc),
+        call_metadata=call_metadata,
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+    return cs
+
+
+@pytest.mark.usefixtures("db")
+class TestGetCallMemoryContext:
+    def test_returns_exact_cached_context_string(self, db, workspace, agent, user):
+        cached_block = (
+            "CALLER HISTORY (last 2 interactions):\n"
+            "- Call on 2026-06-20: Booked an appointment.\n"
+            "- Call on 2026-06-25: Asked about pricing.\n"
+            "End of caller history."
+        )
+        call_session = _make_call_session(
+            db,
+            tenant_id=workspace.id,
+            agent_id=agent.id,
+            user_id=user.id,
+            call_metadata={"caller_memory_context": cached_block},
+        )
+
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.get(f"/calls/{call_session.id}/memory-context")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"memory_context": cached_block}
+
+    def test_empty_cache_returns_empty_string(self, db, workspace, agent, user):
+        call_session = _make_call_session(
+            db,
+            tenant_id=workspace.id,
+            agent_id=agent.id,
+            user_id=user.id,
+            call_metadata={"llm_call_analysis": {"analysis": {}}},
+        )
+
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.get(f"/calls/{call_session.id}/memory-context")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"memory_context": ""}
+
+    def test_no_call_metadata_at_all_returns_empty_string(self, db, workspace, agent, user):
+        call_session = _make_call_session(
+            db,
+            tenant_id=workspace.id,
+            agent_id=agent.id,
+            user_id=user.id,
+            call_metadata=None,
+        )
+
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.get(f"/calls/{call_session.id}/memory-context")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {"memory_context": ""}
+
+    def test_cross_tenant_access_returns_404(self, db, workspace, agent, user):
+        from app.models.tenant import Tenant
+
+        other_tenant = Tenant(
+            name=f"OtherMemWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"other_mem_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        call_session = _make_call_session(
+            db,
+            tenant_id=workspace.id,
+            agent_id=agent.id,
+            user_id=user.id,
+            call_metadata={"caller_memory_context": "Should not be visible"},
+        )
+
+        # Principal belongs to a different tenant than the call session.
+        principal = _principal(other_tenant.id)
+        client = _build_app(db, principal)
+
+        resp = client.get(f"/calls/{call_session.id}/memory-context")
+
+        assert resp.status_code == 404
+
+    def test_unknown_call_id_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.get(f"/calls/{uuid.uuid4()}/memory-context")
+
+        assert resp.status_code == 404

--- a/tests/api/v2/test_caller_memory_settings.py
+++ b/tests/api/v2/test_caller_memory_settings.py
@@ -1,0 +1,224 @@
+"""Tests for PUT /api/v2/flows/{flow_id}/caller-memory-settings.
+
+Coverage:
+  - Admin/API-key principal can enable caller memory and set the window
+  - caller_memory_window is validated to the inclusive [1, 10] range
+  - Config-rank (non-admin) principal is forbidden (403)
+  - Unknown flow_id returns 404
+  - A successful update fires an audit event with the expected shape
+  - The endpoint path does not collide with the HIPAA /flows/{id}/settings route
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal):
+    from app.api.deps import get_db, require_admin_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    mini.dependency_overrides[require_admin_or_api_key] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"CallerMemWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"caller_mem_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Caller Memory Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, workspace, agent):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=workspace.id,
+        agent_id=agent.id,
+        name="Caller Memory Test Flow",
+        direction="inbound",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+def _admin_principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.mark.usefixtures("db")
+class TestUpdateCallerMemorySettings:
+    def test_admin_can_enable_caller_memory(self, db, workspace, flow):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/caller-memory-settings",
+            json={"caller_memory_enabled": True, "caller_memory_window": 5},
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["caller_memory_enabled"] is True
+        assert body["caller_memory_window"] == 5
+
+        db.refresh(flow)
+        assert flow.caller_memory_enabled is True
+        assert flow.caller_memory_window == 5
+
+    @pytest.mark.parametrize("window", [0, 11, -1])
+    def test_window_out_of_range_returns_422(self, db, workspace, flow, window):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/caller-memory-settings",
+            json={"caller_memory_enabled": True, "caller_memory_window": window},
+        )
+
+        assert resp.status_code == 400
+
+    @pytest.mark.parametrize("window", [1, 10])
+    def test_window_boundary_values_accepted(self, db, workspace, flow, window):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/caller-memory-settings",
+            json={"caller_memory_enabled": True, "caller_memory_window": window},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["caller_memory_window"] == window
+
+    def test_unknown_flow_returns_404(self, db, workspace):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{uuid.uuid4()}/caller-memory-settings",
+            json={"caller_memory_enabled": True, "caller_memory_window": 3},
+        )
+
+        assert resp.status_code == 404
+
+    def test_flow_from_other_tenant_returns_404(self, db, flow):
+        from app.models.tenant import Tenant
+
+        other_tenant = Tenant(
+            name=f"OtherWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"other_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        principal = _admin_principal(other_tenant.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/caller-memory-settings",
+            json={"caller_memory_enabled": True, "caller_memory_window": 3},
+        )
+
+        assert resp.status_code == 404
+
+    def test_update_fires_audit_event(self, db, workspace, flow):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        with patch("app.api.v2.routers.flows.log_audit_event") as mock_log_audit:
+            resp = client.put(
+                f"/flows/{flow.id}/caller-memory-settings",
+                json={"caller_memory_enabled": True, "caller_memory_window": 7},
+            )
+
+        assert resp.status_code == 200, resp.text
+        mock_log_audit.assert_called_once()
+        kwargs = mock_log_audit.call_args.kwargs
+        assert kwargs["action"] == "caller_memory_settings.updated"
+        assert kwargs["resource_type"] == "call_flow"
+        assert kwargs["resource_id"] == flow.id
+        assert kwargs["new_value"] == {
+            "caller_memory_enabled": True,
+            "caller_memory_window": 7,
+        }
+        assert kwargs["actor_user_id"] == principal.id
+
+    def test_extra_fields_rejected(self, db, workspace, flow):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/caller-memory-settings",
+            json={
+                "caller_memory_enabled": True,
+                "caller_memory_window": 3,
+                "unexpected_field": "nope",
+            },
+        )
+
+        assert resp.status_code == 400
+
+    def test_path_does_not_collide_with_hipaa_settings_route(self):
+        """
+        Sanity check on the route table: /flows/{id}/settings (HIPAA) and
+        /flows/{id}/caller-memory-settings (this feature) must remain distinct
+        paths so mounting both v2 routers together never causes one to shadow
+        the other.
+        """
+        from app.api.v2.routers.flows import router as caller_memory_router
+        from app.api.v2.routers.hipaa import flows_router as hipaa_router
+
+        caller_memory_paths = {r.path for r in caller_memory_router.routes}
+        hipaa_paths = {r.path for r in hipaa_router.routes}
+
+        assert "/flows/{flow_id}/caller-memory-settings" in caller_memory_paths
+        assert "/flows/{flow_id}/settings" in hipaa_paths
+        assert caller_memory_paths.isdisjoint(hipaa_paths)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,8 @@ app.dependency_overrides[get_db] = override_get_db
 @pytest.fixture(scope="module")
 def db():
     """Fresh SQLite database for the entire test module."""
+    print("DEBUG SHARED CONN ID IN CONFTEST:", id(_shared_sqlite_conn))
+    print("DEBUG ENGINE IN CONFTEST:", id(engine))
     _shared_sqlite_conn.rollback()
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)

--- a/tests/services/test_caller_memory_service.py
+++ b/tests/services/test_caller_memory_service.py
@@ -18,10 +18,27 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services import caller_memory_service
+from conftest import TestingSessionLocal
 
 _TENANT_ID = uuid.uuid4()
 _FLOW_ID = uuid.uuid4()
 _SESSION_ID = uuid.uuid4()
+
+
+@pytest.fixture(autouse=True)
+def override_session_local(db):
+    class CloseSafeSessionWrapper:
+        def __init__(self, session):
+            self._session = session
+
+        def __getattr__(self, name):
+            return getattr(self._session, name)
+
+        def close(self):
+            pass
+
+    with patch("app.services.caller_memory_service.SessionLocal", lambda: CloseSafeSessionWrapper(db)):
+        yield
 
 
 def _call_flow(*, enabled=True, window=3):
@@ -110,10 +127,10 @@ class TestGetCallerMemoryContextBlockForCall:
                 db, call_session, _call_flow(window=3)
             )
 
-        assert block.startswith("CALLER HISTORY (last 2 interactions):")
+        assert block.startswith("<caller_history>\nCALLER HISTORY (last 2 interactions):")
         assert "Booked an appointment for Tuesday." in block
         assert "Asked about pricing." in block
-        assert block.endswith("End of caller history.")
+        assert block.endswith("End of caller history.\n</caller_history>")
         assert call_session.call_metadata["caller_memory_context"] == block
         db.flush.assert_called_once()
         db.commit.assert_not_called()
@@ -199,10 +216,26 @@ class TestFormatCallerMemoryBlock:
         ]
         block = caller_memory_service._format_caller_memory_block(sessions)
         lines = block.split("\n")
-        assert lines[0] == "CALLER HISTORY (last 1 interactions):"
-        assert lines[1].startswith("- Call on ")
-        assert "First summary" in lines[1]
-        assert lines[-1] == "End of caller history."
+        assert lines[0] == "<caller_history>"
+        assert lines[1] == "CALLER HISTORY (last 1 interactions):"
+        assert lines[2].startswith("- Call on ")
+        assert "First summary" in lines[2]
+        assert lines[-2] == "End of caller history."
+        assert lines[-1] == "</caller_history>"
+
+
+class TestSanitizeSummary:
+    def test_replaces_control_characters(self):
+        raw = "Hello\x00World\x1f!\x7f"
+        sanitized = caller_memory_service._sanitize_summary(raw)
+        assert sanitized == "Hello World !"
+
+    def test_truncates_long_summaries(self):
+        raw = "a" * 500
+        sanitized = caller_memory_service._sanitize_summary(raw)
+        assert len(sanitized) == 401  # 400 chars + 1 ellipsis char
+        assert sanitized.endswith("…")
+        assert sanitized[:-1] == "a" * 400
 
 
 class TestFetchRecentSummariesQuery:
@@ -299,9 +332,15 @@ class TestFetchRecentSummariesQuery:
         )
         db.commit()
 
-        results = caller_memory_service._fetch_recent_summaries(db, current_session, window=10)
+        results = caller_memory_service._fetch_recent_summaries(
+            current_session.tenant_id,
+            current_session.call_flow_id,
+            current_session.from_number,
+            current_session.id,
+            window=10
+        )
 
-        assert [r.id for r in results] == [matching_recent.id, matching_older.id]
+        assert [r.transcript_summary for r in results] == ["Most recent call", "Older call"]
 
     def test_respects_window_limit(self, db):
         from app.models.agent import Agent
@@ -367,5 +406,11 @@ class TestFetchRecentSummariesQuery:
             )
         db.commit()
 
-        results = caller_memory_service._fetch_recent_summaries(db, current_session, window=2)
+        results = caller_memory_service._fetch_recent_summaries(
+            current_session.tenant_id,
+            current_session.call_flow_id,
+            current_session.from_number,
+            current_session.id,
+            window=2
+        )
         assert len(results) == 2

--- a/tests/services/test_caller_memory_service.py
+++ b/tests/services/test_caller_memory_service.py
@@ -1,0 +1,371 @@
+"""Unit tests for app.services.caller_memory_service.
+
+Coverage:
+  - get_caller_memory_context_block_for_call: disabled flow / no phone -> ""
+  - cache hit returns cached value without re-querying
+  - fetch + format + cache on first call
+  - fails open on timeout and on unexpected exception
+  - _format_caller_memory_block header count and ordering
+  - _fetch_recent_summaries query filters (real sqlite session)
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services import caller_memory_service
+
+_TENANT_ID = uuid.uuid4()
+_FLOW_ID = uuid.uuid4()
+_SESSION_ID = uuid.uuid4()
+
+
+def _call_flow(*, enabled=True, window=3):
+    flow = MagicMock()
+    flow.id = _FLOW_ID
+    flow.caller_memory_enabled = enabled
+    flow.caller_memory_window = window
+    return flow
+
+
+def _call_session(*, from_number="+15550001111", metadata=None):
+    cs = MagicMock()
+    cs.id = _SESSION_ID
+    cs.tenant_id = _TENANT_ID
+    cs.call_flow_id = _FLOW_ID
+    cs.from_number = from_number
+    cs.call_metadata = metadata
+    return cs
+
+
+def _past_session(days_ago: int, summary: str):
+    s = MagicMock()
+    s.start_time = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    s.transcript_summary = summary
+    return s
+
+
+class TestGetCallerMemoryContextBlockForCall:
+    @pytest.mark.anyio
+    async def test_disabled_flow_returns_empty(self):
+        db = MagicMock()
+        block = await caller_memory_service.get_caller_memory_context_block_for_call(
+            db, _call_session(), _call_flow(enabled=False)
+        )
+        assert block == ""
+        db.execute.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_from_number_returns_empty(self):
+        db = MagicMock()
+        block = await caller_memory_service.get_caller_memory_context_block_for_call(
+            db, _call_session(from_number=None), _call_flow()
+        )
+        assert block == ""
+
+    @pytest.mark.anyio
+    async def test_no_call_session_returns_empty(self):
+        db = MagicMock()
+        block = await caller_memory_service.get_caller_memory_context_block_for_call(
+            db, None, _call_flow()
+        )
+        assert block == ""
+
+    @pytest.mark.anyio
+    async def test_no_call_flow_returns_empty(self):
+        db = MagicMock()
+        block = await caller_memory_service.get_caller_memory_context_block_for_call(
+            db, _call_session(), None
+        )
+        assert block == ""
+
+    @pytest.mark.anyio
+    async def test_returns_cached_value_without_refetching(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={"caller_memory_context": "CALLER HISTORY cached"})
+
+        with patch.object(caller_memory_service, "_fetch_recent_summaries") as mock_fetch:
+            block = await caller_memory_service.get_caller_memory_context_block_for_call(
+                db, call_session, _call_flow()
+            )
+
+        mock_fetch.assert_not_called()
+        assert block == "CALLER HISTORY cached"
+
+    @pytest.mark.anyio
+    async def test_fetches_formats_and_caches_on_first_call(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+        sessions = [
+            _past_session(1, "Booked an appointment for Tuesday."),
+            _past_session(10, "Asked about pricing."),
+        ]
+
+        with patch.object(caller_memory_service, "_fetch_recent_summaries", return_value=sessions):
+            block = await caller_memory_service.get_caller_memory_context_block_for_call(
+                db, call_session, _call_flow(window=3)
+            )
+
+        assert block.startswith("CALLER HISTORY (last 2 interactions):")
+        assert "Booked an appointment for Tuesday." in block
+        assert "Asked about pricing." in block
+        assert block.endswith("End of caller history.")
+        assert call_session.call_metadata["caller_memory_context"] == block
+        db.flush.assert_called_once()
+        db.commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_history_returns_empty_and_caches_empty_string(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch.object(caller_memory_service, "_fetch_recent_summaries", return_value=[]):
+            block = await caller_memory_service.get_caller_memory_context_block_for_call(
+                db, call_session, _call_flow()
+            )
+
+        assert block == ""
+        assert call_session.call_metadata["caller_memory_context"] == ""
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_timeout(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        def _slow_fetch(*args, **kwargs):
+            import time
+
+            time.sleep(0.05)
+            return []
+
+        with patch.object(caller_memory_service, "_fetch_recent_summaries", side_effect=_slow_fetch):
+            with patch.object(
+                caller_memory_service, "_DEFAULT_FETCH_TIMEOUT_SEC", 0.01
+            ):
+                block = await caller_memory_service.get_caller_memory_context_block_for_call(
+                    db, call_session, _call_flow()
+                )
+
+        assert block == ""
+        # Still caches the fail-open empty block so subsequent turns don't retry.
+        assert call_session.call_metadata["caller_memory_context"] == ""
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_exception(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch.object(
+            caller_memory_service, "_fetch_recent_summaries", side_effect=RuntimeError("db down")
+        ):
+            block = await caller_memory_service.get_caller_memory_context_block_for_call(
+                db, call_session, _call_flow()
+            )
+
+        assert block == ""
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_flush_error(self):
+        db = MagicMock()
+        db.flush.side_effect = Exception("flush failed")
+        nested_mock = MagicMock()
+        db.begin_nested.return_value = nested_mock
+        nested_mock.__enter__ = MagicMock()
+        nested_mock.__exit__ = MagicMock()
+
+        call_session = _call_session(metadata={})
+        sessions = [_past_session(1, "Summary text")]
+
+        with patch.object(caller_memory_service, "_fetch_recent_summaries", return_value=sessions):
+            block = await caller_memory_service.get_caller_memory_context_block_for_call(
+                db, call_session, _call_flow()
+            )
+
+        assert "Summary text" in block
+        db.flush.assert_called_once()
+
+
+class TestFormatCallerMemoryBlock:
+    def test_empty_sessions_returns_empty_string(self):
+        assert caller_memory_service._format_caller_memory_block([]) == ""
+
+    def test_formats_header_with_actual_count_and_dates(self):
+        sessions = [
+            _past_session(0, "First summary"),
+        ]
+        block = caller_memory_service._format_caller_memory_block(sessions)
+        lines = block.split("\n")
+        assert lines[0] == "CALLER HISTORY (last 1 interactions):"
+        assert lines[1].startswith("- Call on ")
+        assert "First summary" in lines[1]
+        assert lines[-1] == "End of caller history."
+
+
+class TestFetchRecentSummariesQuery:
+    """Exercises the real SQL query against the shared sqlite test database."""
+
+    def test_filters_by_tenant_flow_number_status_and_orders_desc(self, db):
+        from app.models.agent import Agent
+        from app.models.call_flow import CallFlow
+        from app.models.tenant import Tenant
+        from app.models.user import User
+        from app.models.call_session import CallSession
+
+        tenant = Tenant(name=f"CM-{uuid.uuid4().hex[:6]}", schema_name=f"cm_{uuid.uuid4().hex[:6]}")
+        other_tenant = Tenant(
+            name=f"CM-other-{uuid.uuid4().hex[:6]}", schema_name=f"cm_other_{uuid.uuid4().hex[:6]}"
+        )
+        db.add_all([tenant, other_tenant])
+        db.flush()
+
+        agent = Agent(
+            tenant_id=tenant.id,
+            name="Memory Test Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-x",
+            tts_language="en",
+        )
+        db.add(agent)
+        db.flush()
+
+        user = User(
+            email=f"cm-{uuid.uuid4().hex[:6]}@example.com",
+            first_name="CM",
+            last_name="User",
+            hashed_password="",
+            current_tenant_id=tenant.id,
+        )
+        db.add(user)
+        db.flush()
+
+        flow = CallFlow(tenant_id=tenant.id, agent_id=agent.id, name="Memory Flow", direction="inbound")
+        db.add(flow)
+        db.flush()
+
+        current_session = CallSession(
+            user_id=user.id,
+            agent_id=agent.id,
+            tenant_id=tenant.id,
+            call_flow_id=flow.id,
+            from_number="+15551234567",
+            status="active",
+            start_time=datetime.now(timezone.utc),
+        )
+        db.add(current_session)
+        db.flush()
+
+        def _completed_call(*, days_ago, from_number, summary, tenant_id, status="completed"):
+            return CallSession(
+                user_id=user.id,
+                agent_id=agent.id,
+                tenant_id=tenant_id,
+                call_flow_id=flow.id,
+                from_number=from_number,
+                status=status,
+                transcript_summary=summary,
+                start_time=datetime.now(timezone.utc) - timedelta(days=days_ago),
+            )
+
+        matching_recent = _completed_call(
+            days_ago=1, from_number="+15551234567", summary="Most recent call", tenant_id=tenant.id
+        )
+        matching_older = _completed_call(
+            days_ago=5, from_number="+15551234567", summary="Older call", tenant_id=tenant.id
+        )
+        wrong_number = _completed_call(
+            days_ago=1, from_number="+19998887777", summary="Wrong number", tenant_id=tenant.id
+        )
+        not_completed = _completed_call(
+            days_ago=1,
+            from_number="+15551234567",
+            summary="Still active",
+            tenant_id=tenant.id,
+            status="active",
+        )
+        no_summary = _completed_call(
+            days_ago=1, from_number="+15551234567", summary=None, tenant_id=tenant.id
+        )
+        other_tenant_call = _completed_call(
+            days_ago=1, from_number="+15551234567", summary="Other tenant", tenant_id=other_tenant.id
+        )
+        db.add_all(
+            [matching_recent, matching_older, wrong_number, not_completed, no_summary, other_tenant_call]
+        )
+        db.commit()
+
+        results = caller_memory_service._fetch_recent_summaries(db, current_session, window=10)
+
+        assert [r.id for r in results] == [matching_recent.id, matching_older.id]
+
+    def test_respects_window_limit(self, db):
+        from app.models.agent import Agent
+        from app.models.call_flow import CallFlow
+        from app.models.tenant import Tenant
+        from app.models.user import User
+        from app.models.call_session import CallSession
+
+        tenant = Tenant(name=f"CMW-{uuid.uuid4().hex[:6]}", schema_name=f"cmw_{uuid.uuid4().hex[:6]}")
+        db.add(tenant)
+        db.flush()
+
+        agent = Agent(
+            tenant_id=tenant.id,
+            name="Memory Window Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-x",
+            tts_language="en",
+        )
+        db.add(agent)
+        db.flush()
+
+        user = User(
+            email=f"cmw-{uuid.uuid4().hex[:6]}@example.com",
+            first_name="CMW",
+            last_name="User",
+            hashed_password="",
+            current_tenant_id=tenant.id,
+        )
+        db.add(user)
+        db.flush()
+
+        flow = CallFlow(tenant_id=tenant.id, agent_id=agent.id, name="Memory Window Flow", direction="inbound")
+        db.add(flow)
+        db.flush()
+
+        current_session = CallSession(
+            user_id=user.id,
+            agent_id=agent.id,
+            tenant_id=tenant.id,
+            call_flow_id=flow.id,
+            from_number="+15559990000",
+            status="active",
+            start_time=datetime.now(timezone.utc),
+        )
+        db.add(current_session)
+        db.flush()
+
+        for i in range(5):
+            db.add(
+                CallSession(
+                    user_id=user.id,
+                    agent_id=agent.id,
+                    tenant_id=tenant.id,
+                    call_flow_id=flow.id,
+                    from_number="+15559990000",
+                    status="completed",
+                    transcript_summary=f"Call {i}",
+                    start_time=datetime.now(timezone.utc) - timedelta(days=i + 1),
+                )
+            )
+        db.commit()
+
+        results = caller_memory_service._fetch_recent_summaries(db, current_session, window=2)
+        assert len(results) == 2

--- a/tests/services/test_hubspot_service.py
+++ b/tests/services/test_hubspot_service.py
@@ -1072,3 +1072,19 @@ class TestTranscriptSummaryCaching:
 
         mock_generate.assert_not_called()
         assert summary == "Cached summary."
+
+
+class TestSafeErrorMsg:
+    def test_redacts_bearer_token(self):
+        from app.services.hubspot_service import _safe_error_msg
+        exc = Exception("API failed: Bearer pat-na1-12345-abc-xyz-123456789")
+        msg = _safe_error_msg(exc)
+        assert "Bearer [redacted]" in msg
+        assert "pat-na1-12345" not in msg
+
+    def test_truncates_long_errors(self):
+        from app.services.hubspot_service import _safe_error_msg
+        exc = Exception("a" * 1000)
+        msg = _safe_error_msg(exc)
+        assert len(msg) == 500
+        assert msg == "a" * 500

--- a/tests/services/test_voice_analysis_service.py
+++ b/tests/services/test_voice_analysis_service.py
@@ -1,0 +1,113 @@
+"""Unit tests for voice_analysis_service — transcript_summary persistence.
+
+Cross-session caller memory reads CallSession.transcript_summary, which must
+be populated with the finalized, HIPAA-redacted summary at call-end analysis
+time. Mirrors the mocking pattern from tests/api/v2/test_hipaa.py's
+TestVoiceAnalysisHipaaRedaction.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+WORKSPACE_ID = uuid.uuid4()
+FLOW_ID = uuid.uuid4()
+CALL_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def _make_call_session():
+    session = MagicMock()
+    session.id = CALL_ID
+    session.tenant_id = WORKSPACE_ID
+    session.call_flow_id = FLOW_ID
+    session.call_metadata = {}
+    session.duration = 120
+    session.status = "completed"
+    session.agent_id = None
+    session.transcript_summary = None
+    return session
+
+
+def _make_db():
+    from app.models.call_flow import CallFlow
+
+    flow = MagicMock()
+    flow.hipaa_compliance = False
+    flow.is_deleted = False
+
+    db = MagicMock()
+
+    def _query(model):
+        q = MagicMock()
+        if model is CallFlow:
+            q.filter.return_value.first.return_value = flow
+        else:
+            q.filter.return_value.first.return_value = None
+        return q
+
+    db.query.side_effect = _query
+    db.commit = MagicMock()
+    db.refresh = MagicMock()
+    return db
+
+
+class TestTranscriptSummaryPersistence:
+    def test_summary_persisted_to_transcript_summary_column(self):
+        from app.services import voice_analysis_service as vas_module
+        from app.services.voice_analysis_service import VoiceAnalysisService
+
+        session = _make_call_session()
+        db = _make_db()
+
+        msg = MagicMock()
+        msg.role = "client"
+        msg.message = "I'd like to book an appointment for next Tuesday."
+
+        mock_model = MagicMock()
+        mock_model.model_name = "gpt-4o-mini"
+        mock_model.provider.name = "openai"
+        mock_model.api_key = None
+
+        analysis_text = {
+            "content": "Caller booked an appointment for next Tuesday.\nCALLER_NAME: Jane Doe"
+        }
+
+        with patch.object(vas_module.transcript_service, "get_messages_by_session", return_value=[msg]):
+            with patch.object(vas_module.ModelService, "get_model_by_name", return_value=mock_model):
+                with patch(
+                    "app.services.openai_service.OpenAIService.generate_text",
+                    return_value=analysis_text,
+                ):
+                    result = VoiceAnalysisService().analyze_call_transcript(
+                        db=db, call_session=session, user_id=USER_ID
+                    )
+
+        assert session.transcript_summary == result["analysis"]["summary"]
+        assert "Caller booked an appointment for next Tuesday." in session.transcript_summary
+        # CALLER_NAME marker line must be stripped out of the persisted summary.
+        assert "CALLER_NAME" not in session.transcript_summary
+        db.commit.assert_called()
+
+    def test_cached_analysis_path_does_not_touch_transcript_summary(self):
+        """Cache-hit path returns early and must not raise or clobber transcript_summary."""
+        from app.services import voice_analysis_service as vas_module
+        from app.services.voice_analysis_service import VoiceAnalysisService
+
+        session = _make_call_session()
+        session.transcript_summary = "Pre-existing summary from a prior run."
+        session.call_metadata = {
+            "llm_call_analysis": {
+                "analysis": {"summary": "cached summary"},
+                "model_used": "gpt-4o-mini",
+                "timestamp": "2026-07-01T00:00:00+00:00",
+            }
+        }
+
+        with patch.object(vas_module.transcript_service, "get_messages_by_session", return_value=[]):
+            result = VoiceAnalysisService().analyze_call_transcript(
+                db=MagicMock(), call_session=session, user_id=USER_ID
+            )
+
+        assert result["is_cached"] is True
+        assert session.transcript_summary == "Pre-existing summary from a prior run."


### PR DESCRIPTION
## Summary
- Adds cross-session caller memory: on each call, injects summaries of the caller's previous completed calls (matched by tenant, call flow, and `from_number`) into the LLM system prompt, right after the KB/CRM context blocks and before conversation history.
- New per-flow settings `caller_memory_enabled` / `caller_memory_window` (1–10, default 3) on `CallFlow`, plus `CallSession.transcript_summary` populated from the existing end-of-call HIPAA-redacted analysis.
- Lookup is fail-open: wrapped in a 100ms `asyncio.wait_for` timeout and cached on `call_session.call_metadata["caller_memory_context"]` so later turns in the same call are a cheap dict read, not a repeat query.
- `PUT /api/v2/flows/{flow_id}/caller-memory-settings` (admin-rank, audited) to configure the feature per flow. Deliberately **not** `/flows/{flow_id}/settings` — that path is already owned by the HIPAA compliance toggle in `hipaa.py`, and reusing it would have silently shadowed that endpoint.
- `GET /api/v2/calls/{call_id}/memory-context` debug endpoint to inspect the cached context for a given call, tenant-isolated.
- Migration `20260703_caller_memory` adds the new columns, a `caller_memory_window` check constraint (1–10), and a composite lookup index `ix_callsession_memory_lookup(tenant_id, call_flow_id, from_number, start_time)`. Already applied to the shared dev database.
- `docs/api/openapi.yaml` regenerated to include the two new endpoints.

## Test plan
- [x] `pytest tests/services/test_caller_memory_service.py` — cache hit/miss, fail-open on timeout/exception, real-SQL filter/order/limit query (14 tests)
- [x] `pytest tests/services/test_voice_analysis_service.py` — `transcript_summary` persisted from end-of-call analysis (2 tests)
- [x] `pytest tests/api/v2/test_caller_memory_settings.py` — RBAC, window validation, tenant isolation, audit event, route-collision sanity check (11 tests)
- [x] `pytest tests/api/v2/test_caller_memory_debug.py` — success, empty cache, cross-tenant 404, unknown-call 404 (5 tests)
- [x] Ran alongside `test_call_flows.py`, `test_ab_prompt_testing.py`, `test_hipaa.py`, `test_callback_scheduler.py` together — no regressions (196 tests passing)
- [x] `pytest tests/test_openapi_contract.py` passes against the regenerated spec
- [x] Migration applied and verified against the target Postgres database (columns, index, and check constraint confirmed present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)