### PR TITLE
Add Visual Flow Editor backend (Sprint 6)

### DIFF
--- a/alembic/versions/20260706_add_flow_data_compiled.py
+++ b/alembic/versions/20260706_add_flow_data_compiled.py
@@ -1,0 +1,30 @@
+"""Add flow_data_compiled column to callflow
+
+Revision ID: 20260706_flow_data_compiled
+Revises: 20260703_caller_memory
+Create Date: 2026-07-06 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+# revision identifiers, used by Alembic.
+revision: str = "20260706_flow_data_compiled"
+down_revision: Union[str, Sequence[str], None] = "20260703_caller_memory"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "callflow",
+        sa.Column("flow_data_compiled", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("callflow", "flow_data_compiled")

--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -8,6 +8,7 @@ from app.api.v2.routers.webhooks import router as webhooks_router
 from app.api.v2.routers.callback_scheduler import agents_router as cb_agents_router
 from app.api.v2.routers.callback_scheduler import calls_router as cb_calls_router
 from app.api.v2.routers.flows import router as ab_flows_router
+from app.api.v2.routers.flow_data import router as flow_data_router
 from app.api.v2.routers.workspace import v2_router as workspace_router
 from app.api.v2.routers.hipaa import flows_router as hipaa_flows_router
 from app.api.v2.routers.hipaa import workspace_router as hipaa_workspace_router
@@ -22,6 +23,7 @@ v2_router.include_router(webhooks_router)
 v2_router.include_router(cb_agents_router)
 v2_router.include_router(cb_calls_router)
 v2_router.include_router(ab_flows_router)
+v2_router.include_router(flow_data_router)
 v2_router.include_router(workspace_router, prefix="/workspace", tags=["Workspace Settings"])
 v2_router.include_router(hipaa_flows_router)
 v2_router.include_router(hipaa_workspace_router)

--- a/app/api/v2/routers/flow_data.py
+++ b/app/api/v2/routers/flow_data.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import uuid
+from typing import Optional, Union
+
+from fastapi import APIRouter, Body, Depends, Request, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import (
+    get_db,
+    require_config_or_api_key,
+    require_readonly_or_api_key,
+)
+from app.core.request_auth import ApiKeyPrincipal
+from app.models.user import User
+from app.schemas.call_flow import (
+    FlowDataResponse,
+    FlowDataUpdate,
+    FlowValidationResponse,
+)
+from app.services.audit_service import log_audit_event
+from app.services.call_flow_service import call_flow_service
+
+router = APIRouter(prefix="/flows", tags=["Visual Flow Editor"])
+
+
+def _tenant_id(principal: Union[User, ApiKeyPrincipal]) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+@router.put(
+    "/{flow_id}/flow-data",
+    response_model=FlowDataResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Validate, pre-compile, and save a visual flow graph",
+)
+def update_flow_data(
+    flow_id: uuid.UUID,
+    body: FlowDataUpdate,
+    request: Request,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+) -> FlowDataResponse:
+    tenant_id = _tenant_id(principal)
+    result = call_flow_service.update_flow_data(db, flow_id, tenant_id, body)
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="flow_data.updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        new_value={
+            "node_count": (
+                len(result.flow_data.get("nodes", [])) if result.flow_data else 0
+            )
+        },
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.get(
+    "/{flow_id}/flow-data",
+    response_model=FlowDataResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the raw and pre-compiled visual flow graph",
+)
+def get_flow_data(
+    flow_id: uuid.UUID,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> FlowDataResponse:
+    return call_flow_service.get_flow_data(db, flow_id, _tenant_id(principal))
+
+
+@router.get(
+    "/{flow_id}/flow-data/validate",
+    response_model=FlowValidationResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Validate the current (or posted) flow graph without saving",
+)
+def validate_flow_data(
+    flow_id: uuid.UUID,
+    body: Optional[FlowDataUpdate] = Body(default=None),
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> FlowValidationResponse:
+    return call_flow_service.validate_flow_data(
+        db, flow_id, _tenant_id(principal), body
+    )

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -10,6 +10,9 @@ GET  /api/v2/flows/{flow_id}/ab-results
 PUT  /api/v2/flows/{flow_id}/ab-test/winner
 PUT  /api/v2/flows/{flow_id}/caller-memory-settings
 
+Visual Flow Editor endpoints (flow-data, flow-data/validate) live in
+app.api.v2.routers.flow_data — a separate router under the same prefix.
+
 Note: the caller memory settings path is deliberately NOT `/{flow_id}/settings` —
 that path is already registered by app.api.v2.routers.hipaa for the HIPAA
 compliance toggle, and reusing it here would silently shadow that endpoint.

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -22,6 +22,8 @@ class CallFlow(Base):
         nullable=True,
     )
     flow_data = Column(JSONB, nullable=True)
+    # Pre-compiled decision tree derived from flow_data — {node_id: {node, outgoing_edges}}
+    flow_data_compiled = Column(JSONB, nullable=True)
     settings = Column(JSONB, nullable=True)
     knowledge_base_ids = Column(JSONB, nullable=True, default=list)
 

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -182,6 +182,7 @@ from app.utils.eleven_tts_text import (
 from app.voice.booking_mixin import BookingMixin
 from app.voice.tts_stream_mixin import TtsStreamMixin
 from app.voice.call_control_mixin import CallControlMixin
+from app.voice.flow_pipeline_mixin import FlowPipelineMixin
 from app.voice.pipeline_session import PipelineSession
 
 router = APIRouter()
@@ -236,7 +237,7 @@ _EMAIL_AGENT_PROMPT_FOR_EXTENDED_STT_RE = re.compile(
 )
 
 
-class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin):
+class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin, FlowPipelineMixin):
     """Handles real-time bidirectional voice streaming (400–500ms target, Vapi-style gapless TTS)."""
 
     # Expose tunables on the class so they remain easy to discover in-context,
@@ -326,6 +327,8 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
         self.call_session = None
         self.agent = None
         self.call_flow = None
+        self._flow_executor = None
+        self._flow_state = None
         self._last_offered_calendar_slots: List[datetime] = []
         self._last_requested_calendar_date: Optional[date] = None
         self._last_selected_calendar_slot: Optional[datetime] = None
@@ -594,6 +597,7 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
                     )
                     .first()
                 )
+            self._flow_init()
         except Exception as e:
             logger.error(f"Error loading session data: {e}", exc_info=True)
 
@@ -966,6 +970,12 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
             await self._cancel_inflight_llm_response()
 
         self._tts_cancel.clear()
+
+        # Visual flow editor: a compiled call flow intercepts the transcript and
+        # drives the next node itself, bypassing the default LLM turn entirely.
+        if self._flow_executor and await self._flow_on_transcript(transcript, confidence):
+            return
+
         try:
             await asyncio.wait_for(
                 self.generate_and_stream_response(transcript, confidence, is_greeting=False),
@@ -1424,6 +1434,12 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin)
             
             # 👋 HANDLE AUTO-GREETING - Skip LLM, use pre-defined greeting (inbound pickup only)
             if is_greeting:
+                # Visual flow editor: if the agent has a compiled call flow, the
+                # flow's start node drives the opening turn instead of the
+                # agent's static greeting_message/first_message.
+                if self._flow_executor and await self._flow_start():
+                    return
+
                 greeting_text = None
                 inbound = (
                     self.call_session is not None

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -151,3 +151,44 @@ class CallFlowListResponse(BaseModel):
     total: int
     page: int
     page_size: int = Field(..., serialization_alias="pageSize")
+
+
+class FlowValidationError(BaseModel):
+    """A single validation failure for a visual flow graph."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    code: str
+    message: str
+    node_id: Optional[str] = Field(None, serialization_alias="nodeId")
+
+
+class FlowDataUpdate(BaseModel):
+    """Request body for ``PUT /api/v2/flows/{flow_id}/flow-data``."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    flow_data: FlowDataSchema = Field(..., alias="flowData")
+
+
+class FlowDataResponse(BaseModel):
+    """Response body for the flow-data GET/PUT endpoints."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    flow_data: Optional[Dict[str, Any]] = Field(None, serialization_alias="flowData")
+    flow_data_compiled: Optional[Dict[str, Any]] = Field(None, serialization_alias="flowDataCompiled")
+    validation_errors: List[FlowValidationError] = Field(
+        default_factory=list, serialization_alias="validationErrors"
+    )
+
+
+class FlowValidationResponse(BaseModel):
+    """Response body for ``GET /api/v2/flows/{flow_id}/flow-data/validate``."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    valid: bool
+    validation_errors: List[FlowValidationError] = Field(
+        default_factory=list, serialization_alias="validationErrors"
+    )

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -34,8 +34,13 @@ from app.schemas.call_flow import (
     CallerMemorySettingsUpdate,
     CallFlowSettingsUpdate,
     CallFlowUpdate,
+    FlowDataResponse,
+    FlowDataUpdate,
+    FlowValidationError,
+    FlowValidationResponse,
 )
 from app.schemas.prompt_version import PromptVersionOut
+from app.services.flow_graph_service import compile_graph, validate_graph
 from app.utils.gemini_prompt_sanitizer import sanitize_prompt_for_gemini
 
 _MAX_VERSIONS = 50
@@ -566,6 +571,77 @@ class CallFlowService:
                 select(Agent).where(Agent.id == flow.agent_id)
             ).scalar_one_or_none()
         return self._flow_to_out(db, flow)
+
+
+    # ── Visual Flow Editor ────────────────────────────────────────────────
+
+    def get_flow_data(
+        self, db: Session, flow_id: uuid.UUID, tenant_id: uuid.UUID
+    ) -> FlowDataResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        validation_errors = validate_graph(flow.flow_data) if flow.flow_data else []
+        return FlowDataResponse(
+            flow_data=flow.flow_data,
+            flow_data_compiled=flow.flow_data_compiled,
+            validation_errors=[FlowValidationError(**e) for e in validation_errors],
+        )
+
+    def validate_flow_data(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: Optional[FlowDataUpdate] = None,
+    ) -> FlowValidationResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        flow_data = body.flow_data.model_dump() if body else (flow.flow_data or {})
+        validation_errors = validate_graph(flow_data)
+        return FlowValidationResponse(
+            valid=not validation_errors,
+            validation_errors=[FlowValidationError(**e) for e in validation_errors],
+        )
+
+    def update_flow_data(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: FlowDataUpdate,
+    ) -> FlowDataResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        flow_data = body.flow_data.model_dump()
+
+        validation_errors = validate_graph(flow_data)
+        if validation_errors:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail={
+                    "code": "flow_validation_failed",
+                    "message": "Flow graph validation failed",
+                    "validationErrors": [
+                        {
+                            "code": e["code"],
+                            "message": e["message"],
+                            "nodeId": e.get("node_id"),
+                        }
+                        for e in validation_errors
+                    ],
+                },
+            )
+
+        compiled = compile_graph(flow_data)
+
+        repo = CallFlowRepository(db)
+        flow = repo.update(
+            flow, {"flow_data": flow_data, "flow_data_compiled": compiled}
+        )
+        db.commit()
+        db.refresh(flow)
+        return FlowDataResponse(
+            flow_data=flow.flow_data,
+            flow_data_compiled=flow.flow_data_compiled,
+            validation_errors=[],
+        )
 
 
 call_flow_service = CallFlowService()

--- a/app/services/flow_graph_service.py
+++ b/app/services/flow_graph_service.py
@@ -1,0 +1,184 @@
+"""Visual Flow Editor graph validation and pre-compilation.
+
+Pure, CPU-bound functions operating on the raw React-Flow-shaped
+``{"nodes": [...], "edges": [...]}`` payload — no DB/IO. Node shape:
+``{"id": str, "type": str, "data": dict}``. Edge shape:
+``{"id": str, "source": str, "target": str, "condition": {"type": str, ...}}``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# Nodes that leave the flow entirely (hang up or hand off) — exempt from the
+# "must have an outgoing edge" rule.
+TERMINAL_NODE_TYPES = {"end_call", "transfer"}
+
+# Lower number == evaluated first at call time (see FlowExecutor.next_node_id).
+_EDGE_PRIORITY = {"intent_match": 1, "keyword": 2}
+_DEFAULT_EDGE_PRIORITY = 99
+
+
+def _is_start_node(node: Dict[str, Any]) -> bool:
+    if node.get("type") == "start":
+        return True
+    data = node.get("data") or {}
+    return bool(data.get("isStart") or data.get("is_start"))
+
+
+def validate_graph(flow_data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Validate a flow graph. Returns a list of error dicts (empty if valid).
+
+    Checks: exactly one start node, no directed cycles (DFS + recursion
+    stack, O(V+E)), no orphan nodes (unreachable from the start node), and
+    every non-end node has at least one outgoing edge.
+    """
+    errors: List[Dict[str, Any]] = []
+    nodes = flow_data.get("nodes") or []
+    edges = flow_data.get("edges") or []
+
+    node_by_id: Dict[str, Dict[str, Any]] = {}
+    for node in nodes:
+        node_id = node.get("id")
+        if node_id is None:
+            errors.append(
+                {
+                    "code": "invalid_node",
+                    "message": "Node is missing an 'id'",
+                    "node_id": None,
+                }
+            )
+            continue
+        node_by_id[node_id] = node
+
+    if not node_by_id:
+        errors.append(
+            {
+                "code": "empty_graph",
+                "message": "Flow must contain at least one node",
+                "node_id": None,
+            }
+        )
+        return errors
+
+    start_nodes = [n for n in node_by_id.values() if _is_start_node(n)]
+    if len(start_nodes) == 0:
+        errors.append(
+            {
+                "code": "no_start_node",
+                "message": "Flow must contain exactly one start node",
+                "node_id": None,
+            }
+        )
+    elif len(start_nodes) > 1:
+        errors.append(
+            {
+                "code": "multiple_start_nodes",
+                "message": f"Flow must contain exactly one start node, found {len(start_nodes)}",
+                "node_id": None,
+            }
+        )
+
+    adjacency: Dict[str, List[str]] = {node_id: [] for node_id in node_by_id}
+    for edge in edges:
+        source = edge.get("source")
+        target = edge.get("target")
+        if source not in node_by_id or target not in node_by_id:
+            errors.append(
+                {
+                    "code": "invalid_edge",
+                    "message": f"Edge {edge.get('id')} references an unknown node",
+                    "node_id": None,
+                }
+            )
+            continue
+        adjacency[source].append(target)
+
+    for node_id, node in node_by_id.items():
+        if node.get("type") in TERMINAL_NODE_TYPES:
+            continue
+        if not adjacency.get(node_id):
+            errors.append(
+                {
+                    "code": "missing_outgoing_edge",
+                    "message": f"Node {node_id} has no outgoing edges",
+                    "node_id": node_id,
+                }
+            )
+
+    # Cycle detection: DFS with recursion stack via 3-color marking, O(V+E).
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {node_id: WHITE for node_id in node_by_id}
+
+    def _has_cycle(node_id: str) -> bool:
+        color[node_id] = GRAY
+        for neighbor in adjacency.get(node_id, []):
+            if color[neighbor] == GRAY:
+                return True
+            if color[neighbor] == WHITE and _has_cycle(neighbor):
+                return True
+        color[node_id] = BLACK
+        return False
+
+    for node_id in node_by_id:
+        if color[node_id] == WHITE and _has_cycle(node_id):
+            errors.append(
+                {
+                    "code": "cycle_detected",
+                    "message": "Flow graph contains a cycle",
+                    "node_id": None,
+                }
+            )
+            break
+
+    # Orphan/reachability check, only meaningful with a single, unambiguous start node.
+    if len(start_nodes) == 1:
+        start_id = start_nodes[0].get("id")
+        visited: set = set()
+        stack = [start_id]
+        while stack:
+            current = stack.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            stack.extend(adjacency.get(current, []))
+        for node_id in node_by_id:
+            if node_id not in visited:
+                errors.append(
+                    {
+                        "code": "orphan_node",
+                        "message": f"Node {node_id} is not reachable from the start node",
+                        "node_id": node_id,
+                    }
+                )
+
+    return errors
+
+
+def _edge_priority(edge: Dict[str, Any]) -> int:
+    condition = edge.get("condition") or {}
+    return _EDGE_PRIORITY.get(condition.get("type"), _DEFAULT_EDGE_PRIORITY)
+
+
+def compile_graph(flow_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Compile raw flow_data into a lookup-friendly decision tree.
+
+    Returns ``{node_id: {"node": node_dict, "outgoing_edges": [sorted_edges]}}``,
+    where outgoing edges are sorted by condition specificity
+    (intent_match=1, keyword=2, everything else incl. fallback=99).
+    """
+    nodes = flow_data.get("nodes") or []
+    edges = flow_data.get("edges") or []
+
+    outgoing: Dict[str, List[Dict[str, Any]]] = {node["id"]: [] for node in nodes}
+    for edge in edges:
+        source = edge.get("source")
+        if source in outgoing:
+            outgoing[source].append(edge)
+
+    compiled: Dict[str, Any] = {}
+    for node in nodes:
+        node_id = node["id"]
+        sorted_edges = sorted(outgoing.get(node_id, []), key=_edge_priority)
+        compiled[node_id] = {"node": node, "outgoing_edges": sorted_edges}
+    return compiled

--- a/app/voice/flow_executor.py
+++ b/app/voice/flow_executor.py
@@ -1,0 +1,199 @@
+"""Pure, CPU-bound traversal engine for pre-compiled visual call-flow graphs.
+
+Consumes the ``flow_data_compiled`` JSONB produced by
+``app.services.flow_graph_service.compile_graph`` — ``{node_id: {"node":
+node_dict, "outgoing_edges": [sorted_edges]}}``. No I/O: callers are
+responsible for actually speaking text, waiting for STT, transferring the
+call, etc. Every node transition is budgeted at under 50ms; transitions
+exceeding the budget are logged as warnings.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from app.core.logger import logger
+
+NODE_TRANSITION_BUDGET_MS = 50.0
+
+GREETING = "greeting"
+COLLECT_INPUT = "collect_input"
+BRANCH = "branch"
+TRANSFER = "transfer"
+END_CALL = "end_call"
+
+
+@dataclass
+class PipelineState:
+    """Per-call runtime state for a flow-driven conversation."""
+
+    current_node_id: str
+    history: List[str] = field(default_factory=list)
+    variables: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class NodeExecutionResult:
+    """Outcome of executing a single node — the caller acts on ``action``."""
+
+    node_id: str
+    node_type: str
+    action: str
+    config: Dict[str, Any]
+    speech_text: Optional[str] = None
+
+
+class FlowExecutorError(Exception):
+    """Raised for malformed compiled graphs or unknown node types."""
+
+
+class FlowExecutor:
+    """Traverses a pre-compiled flow graph one node at a time."""
+
+    def __init__(self, compiled_graph: Dict[str, Any]) -> None:
+        self._graph = compiled_graph
+
+    def start_node_id(self) -> str:
+        """Return the id of the graph's single start node.
+
+        A node is a start node if it has ``type == "start"`` or
+        ``data.isStart``/``data.is_start`` truthy — mirrors
+        ``flow_graph_service._is_start_node``.
+        """
+        for node_id, entry in self._graph.items():
+            node = entry["node"]
+            if node.get("type") == "start":
+                return node_id
+            data = node.get("data") or {}
+            if data.get("isStart") or data.get("is_start"):
+                return node_id
+        raise FlowExecutorError("Compiled graph has no start node")
+
+    def execute_node(self, node_id: str, state: PipelineState) -> NodeExecutionResult:
+        """Run the node's action logic and record it in ``state.history``."""
+        started = time.perf_counter()
+        entry = self._graph.get(node_id)
+        if entry is None:
+            raise FlowExecutorError(f"Unknown node id: {node_id}")
+
+        node = entry["node"]
+        node_type = node.get("type")
+        data = node.get("data") or {}
+
+        if node_type == GREETING:
+            result = NodeExecutionResult(
+                node_id=node_id,
+                node_type=node_type,
+                action="speak",
+                config=data,
+                speech_text=data.get("message"),
+            )
+        elif node_type == COLLECT_INPUT:
+            result = NodeExecutionResult(
+                node_id=node_id,
+                node_type=node_type,
+                action="wait_for_input",
+                config=data,
+            )
+        elif node_type == BRANCH:
+            result = NodeExecutionResult(
+                node_id=node_id, node_type=node_type, action="branch", config=data
+            )
+        elif node_type == TRANSFER:
+            result = NodeExecutionResult(
+                node_id=node_id, node_type=node_type, action="transfer", config=data
+            )
+        elif node_type == END_CALL:
+            result = NodeExecutionResult(
+                node_id=node_id, node_type=node_type, action="end_call", config=data
+            )
+        else:
+            raise FlowExecutorError(f"Unsupported node type: {node_type}")
+
+        state.current_node_id = node_id
+        state.history.append(node_id)
+        self._log_timing("execute_node", node_id, started)
+        return result
+
+    def next_node_id(
+        self,
+        current_node_id: str,
+        transcript: Optional[str],
+        variables: Optional[Dict[str, Any]] = None,
+    ) -> Optional[str]:
+        """Evaluate outgoing edges from ``current_node_id`` in priority order.
+
+        Returns the target node id of the first matching edge, falling back
+        to a ``fallback`` edge if present, or ``None`` if nothing matches.
+        """
+        started = time.perf_counter()
+        entry = self._graph.get(current_node_id)
+        if entry is None:
+            raise FlowExecutorError(f"Unknown node id: {current_node_id}")
+
+        variables = variables or {}
+        fallback_target: Optional[str] = None
+
+        for edge in entry["outgoing_edges"]:
+            condition = edge.get("condition") or {}
+            condition_type = condition.get("type", "always")
+
+            if condition_type == "fallback":
+                if fallback_target is None:
+                    fallback_target = edge.get("target")
+                continue
+
+            if self._condition_matches(
+                condition_type, condition, transcript, variables
+            ):
+                self._log_timing("next_node_id", current_node_id, started)
+                return edge.get("target")
+
+        self._log_timing("next_node_id", current_node_id, started)
+        return fallback_target
+
+    def _condition_matches(
+        self,
+        condition_type: str,
+        condition: Dict[str, Any],
+        transcript: Optional[str],
+        variables: Dict[str, Any],
+    ) -> bool:
+        if condition_type == "always":
+            return True
+
+        if transcript is None:
+            return False
+
+        if condition_type == "intent_match":
+            pattern = condition.get("pattern")
+            if not pattern:
+                return False
+            return re.search(pattern, transcript, re.IGNORECASE) is not None
+
+        if condition_type == "keyword":
+            keyword = condition.get("keyword")
+            if not keyword:
+                return False
+            words = re.findall(r"\w+", transcript.lower())
+            return keyword.lower() in words
+
+        return False
+
+    def _log_timing(self, op: str, node_id: str, started: float) -> None:
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        if elapsed_ms > NODE_TRANSITION_BUDGET_MS:
+            logger.warning(
+                "FlowExecutor.%s exceeded %sms budget for node %s: %.3fms",
+                op,
+                NODE_TRANSITION_BUDGET_MS,
+                node_id,
+                elapsed_ms,
+            )
+        else:
+            logger.debug(
+                "FlowExecutor.%s for node %s took %.3fms", op, node_id, elapsed_ms
+            )

--- a/app/voice/flow_pipeline_mixin.py
+++ b/app/voice/flow_pipeline_mixin.py
@@ -1,0 +1,143 @@
+"""Wires FlowExecutor (pre-compiled visual call-flow graphs) into the live
+bidirectional voice pipeline.
+
+Mixed into ``BidirectionalStreamHandler``. Every entry point degrades to a
+no-op when the agent's call flow has no ``flow_data_compiled`` — the caller
+falls through to the existing default LLM pipeline unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from app.core.logger import logger
+from app.voice.flow_executor import (
+    FlowExecutor,
+    FlowExecutorError,
+    NodeExecutionResult,
+    PipelineState,
+)
+
+
+class FlowPipelineMixin:
+    """Requires ``self.call_flow``, ``self._tts_pipeline`` on the host class."""
+
+    # Class-level defaults: some tests build the handler via ``object.__new__``
+    # and never run ``__init__``/``_flow_init`` — these ensure every flow hook
+    # can safely check ``self._flow_executor`` without an AttributeError.
+    _flow_executor: Optional[FlowExecutor] = None
+    _flow_state: Optional[PipelineState] = None
+
+    def _flow_init(self) -> None:
+        """Build the FlowExecutor + PipelineState from the loaded call_flow.
+
+        Called once from ``_load_session_data()``. Leaves ``self._flow_executor``
+        as ``None`` when there is no compiled flow — every other flow hook
+        checks that attribute first and is a no-op if it is unset.
+        """
+        self._flow_executor: Optional[FlowExecutor] = None
+        self._flow_state: Optional[PipelineState] = None
+
+        compiled = (
+            getattr(self.call_flow, "flow_data_compiled", None)
+            if self.call_flow
+            else None
+        )
+        if not compiled:
+            return
+
+        try:
+            executor = FlowExecutor(compiled)
+            start_node_id = executor.start_node_id()
+        except FlowExecutorError as exc:
+            logger.warning(
+                "Call flow %s has no usable compiled graph: %s",
+                getattr(self.call_flow, "id", None),
+                exc,
+            )
+            return
+
+        self._flow_executor = executor
+        self._flow_state = PipelineState(current_node_id=start_node_id)
+
+    async def _flow_start(self) -> bool:
+        """Run the flow from its start node. Returns True if it handled the greeting."""
+        if not self._flow_executor or not self._flow_state:
+            return False
+        await self._flow_run_chain(transcript=None)
+        return True
+
+    async def _flow_on_transcript(self, transcript: str, confidence: float) -> bool:
+        """Advance the flow using the caller's final transcript.
+
+        Returns True if the flow consumed this turn (caller must skip the
+        default LLM path); False if there's no active flow.
+        """
+        if not self._flow_executor or not self._flow_state:
+            return False
+        await self._flow_run_chain(transcript=transcript)
+        return True
+
+    async def _flow_run_chain(self, transcript: Optional[str]) -> None:
+        """Advance nodes until hitting one that needs caller input or ends the call.
+
+        Only the first transition in the chain is evaluated against
+        ``transcript`` — every subsequent link (e.g. a ``branch`` node's
+        onward edge, or a ``greeting``'s auto-advance to the next node) is
+        evaluated with ``transcript=None`` so only ``always``/``fallback``
+        edges fire, matching the intent that a single utterance only
+        answers the question posed by the node that requested it.
+        """
+        executor = self._flow_executor
+        state = self._flow_state
+        remaining_transcript = transcript
+
+        while True:
+            next_node_id = executor.next_node_id(
+                state.current_node_id, remaining_transcript, state.variables
+            )
+            if next_node_id is None:
+                logger.warning(
+                    "FlowExecutor: no matching edge from node %s — stalling turn",
+                    state.current_node_id,
+                )
+                return
+
+            try:
+                result = executor.execute_node(next_node_id, state)
+            except FlowExecutorError as exc:
+                logger.error("FlowExecutor: %s", exc)
+                return
+
+            remaining_transcript = (
+                None  # only the originating edge consumes the transcript
+            )
+
+            if result.action == "speak":
+                await self._flow_speak(result)
+                continue
+            if result.action == "branch":
+                continue
+            if result.action == "wait_for_input":
+                return
+            if result.action == "transfer":
+                await self._transfer_after_agent_request()
+                return
+            if result.action == "end_call":
+                await self._end_call_after_agent_request()
+                return
+
+    async def _flow_speak(self, result: NodeExecutionResult) -> None:
+        text = (result.speech_text or "").strip()
+        if not text or not self._tts_pipeline:
+            return
+        await self._add_to_transcript("agent", text, "flow_node")
+        await self._tts_pipeline.queue_tts(
+            {
+                "text": text,
+                "chunk_id": f"flow_{result.node_id}",
+                "use_ssml": self._use_ssml,
+                "is_final": True,
+            }
+        )
+        self._twilio_buffer_primed = False

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8320,6 +8320,105 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/flow-data:
+    put:
+      tags:
+      - Visual Flow Editor
+      summary: Validate, pre-compile, and save a visual flow graph
+      operationId: update_flow_data_api_v2_flows__flow_id__flow_data_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FlowDataUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowDataResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Visual Flow Editor
+      summary: Get the raw and pre-compiled visual flow graph
+      operationId: get_flow_data_api_v2_flows__flow_id__flow_data_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowDataResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/flow-data/validate:
+    get:
+      tags:
+      - Visual Flow Editor
+      summary: Validate the current (or posted) flow graph without saving
+      operationId: validate_flow_data_api_v2_flows__flow_id__flow_data_validate_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+              - $ref: '#/components/schemas/FlowDataUpdate'
+              nullable: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowValidationResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/workspace/branding:
     get:
       tags:
@@ -12007,6 +12106,24 @@ components:
       - skill
       - confidence
       title: ExtractedSkill
+    FlowDataResponse:
+      properties:
+        flowData:
+          additionalProperties: true
+          type: object
+          nullable: true
+        flowDataCompiled:
+          additionalProperties: true
+          type: object
+          nullable: true
+        validationErrors:
+          items:
+            $ref: '#/components/schemas/FlowValidationError'
+          type: array
+          title: Validationerrors
+      type: object
+      title: FlowDataResponse
+      description: Response body for the flow-data GET/PUT endpoints.
     FlowDataSchema:
       properties:
         nodes:
@@ -12022,6 +12139,16 @@ components:
       title: FlowDataSchema
       description: Structural validation for flowData JSONB — future visual-editor
         format.
+    FlowDataUpdate:
+      properties:
+        flowData:
+          $ref: '#/components/schemas/FlowDataSchema'
+      additionalProperties: false
+      type: object
+      required:
+      - flowData
+      title: FlowDataUpdate
+      description: Request body for ``PUT /api/v2/flows/{flow_id}/flow-data``.
     FlowKbUpdate:
       properties:
         kb_ids:
@@ -12034,6 +12161,38 @@ components:
       required:
       - kb_ids
       title: FlowKbUpdate
+    FlowValidationError:
+      properties:
+        code:
+          type: string
+          title: Code
+        message:
+          type: string
+          title: Message
+        nodeId:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - code
+      - message
+      title: FlowValidationError
+      description: A single validation failure for a visual flow graph.
+    FlowValidationResponse:
+      properties:
+        valid:
+          type: boolean
+          title: Valid
+        validationErrors:
+          items:
+            $ref: '#/components/schemas/FlowValidationError'
+          type: array
+          title: Validationerrors
+      type: object
+      required:
+      - valid
+      title: FlowValidationResponse
+      description: Response body for ``GET /api/v2/flows/{flow_id}/flow-data/validate``.
     FolderCreate:
       properties:
         name:

--- a/tests/api/v2/test_call_flows_visual.py
+++ b/tests/api/v2/test_call_flows_visual.py
@@ -1,0 +1,411 @@
+"""Tests for the Visual Flow Editor (Sprint 6).
+
+Coverage:
+  - PUT /api/v2/flows/{flow_id}/flow-data: valid graphs save + pre-compile;
+    invalid graphs (missing start, cycle, orphan node, missing outgoing
+    edge) are rejected with 422 and a detailed error array.
+  - GET /api/v2/flows/{flow_id}/flow-data: returns saved flow_data +
+    flow_data_compiled.
+  - GET /api/v2/flows/{flow_id}/flow-data/validate: validates without saving.
+  - Graph compilation: edge priority ordering (intent_match < keyword < fallback).
+  - FlowExecutor: isolated node-executor sequence greeting -> collect_input ->
+    branch -> transfer.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+from app.services.flow_graph_service import compile_graph, validate_graph
+from app.voice.flow_executor import FlowExecutor, PipelineState
+
+
+def _build_app(db_override, principal):
+    from app.api.deps import (
+        get_db,
+        require_config_or_api_key,
+        require_readonly_or_api_key,
+    )
+    from app.api.v2.routers.flow_data import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    mini.dependency_overrides[require_config_or_api_key] = lambda: principal
+    mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"FlowEditorWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"flow_editor_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Flow Editor Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, workspace, agent):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=workspace.id,
+        agent_id=agent.id,
+        name="Flow Editor Test Flow",
+        direction="inbound",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+def _valid_flow_data() -> dict:
+    return {
+        "nodes": [
+            {"id": "start", "type": "start", "data": {}},
+            {"id": "greet", "type": "greeting", "data": {"message": "Hi there!"}},
+            {
+                "id": "collect",
+                "type": "collect_input",
+                "data": {
+                    "timeout_seconds": 10,
+                    "silence_threshold_ms": 700,
+                    "max_attempts": 3,
+                },
+            },
+            {"id": "branch", "type": "branch", "data": {"variable": "transcript"}},
+            {"id": "transfer", "type": "transfer", "data": {}},
+            {"id": "end", "type": "end_call", "data": {}},
+        ],
+        "edges": [
+            {
+                "id": "e1",
+                "source": "start",
+                "target": "greet",
+                "condition": {"type": "always"},
+            },
+            {
+                "id": "e2",
+                "source": "greet",
+                "target": "collect",
+                "condition": {"type": "always"},
+            },
+            {
+                "id": "e3",
+                "source": "collect",
+                "target": "branch",
+                "condition": {"type": "always"},
+            },
+            {
+                "id": "e4",
+                "source": "branch",
+                "target": "transfer",
+                "condition": {
+                    "type": "intent_match",
+                    "pattern": "(?i)speak to (a )?human",
+                },
+            },
+            {
+                "id": "e5",
+                "source": "branch",
+                "target": "end",
+                "condition": {"type": "keyword", "keyword": "bye"},
+            },
+            {
+                "id": "e6",
+                "source": "branch",
+                "target": "end",
+                "condition": {"type": "fallback"},
+            },
+        ],
+    }
+
+
+# ── PUT /flow-data — validation gate ──────────────────────────────────────
+
+
+class TestUpdateFlowData:
+    def test_valid_graph_saves_and_compiles(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+
+        resp = client.put(
+            f"/flows/{flow.id}/flow-data", json={"flowData": _valid_flow_data()}
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["validationErrors"] == []
+        assert body["flowData"]["nodes"]
+        assert "greet" in body["flowDataCompiled"]
+        assert body["flowDataCompiled"]["greet"]["node"]["type"] == "greeting"
+
+        db.refresh(flow)
+        assert flow.flow_data is not None
+        assert flow.flow_data_compiled is not None
+
+    def test_missing_start_node_returns_422(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+        data = _valid_flow_data()
+        data["nodes"][0]["type"] = "greeting"  # no node left marked as start
+
+        resp = client.put(f"/flows/{flow.id}/flow-data", json={"flowData": data})
+
+        assert resp.status_code == 422
+        codes = [e["code"] for e in resp.json()["error"]["validationErrors"]]
+        assert "no_start_node" in codes
+
+    def test_multiple_start_nodes_returns_422(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+        data = _valid_flow_data()
+        data["nodes"][1]["data"]["isStart"] = True
+
+        resp = client.put(f"/flows/{flow.id}/flow-data", json={"flowData": data})
+
+        assert resp.status_code == 422
+        codes = [e["code"] for e in resp.json()["error"]["validationErrors"]]
+        assert "multiple_start_nodes" in codes
+
+    def test_cycle_returns_422(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+        data = _valid_flow_data()
+        # Introduce a cycle: end -> branch (end was previously terminal)
+        data["edges"].append(
+            {
+                "id": "e7",
+                "source": "end",
+                "target": "branch",
+                "condition": {"type": "always"},
+            }
+        )
+
+        resp = client.put(f"/flows/{flow.id}/flow-data", json={"flowData": data})
+
+        assert resp.status_code == 422
+        codes = [e["code"] for e in resp.json()["error"]["validationErrors"]]
+        assert "cycle_detected" in codes
+
+    def test_orphan_node_returns_422(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+        data = _valid_flow_data()
+        data["nodes"].append(
+            {"id": "orphan", "type": "greeting", "data": {"message": "unreachable"}}
+        )
+        data["edges"].append(
+            {
+                "id": "e8",
+                "source": "orphan",
+                "target": "end",
+                "condition": {"type": "always"},
+            }
+        )
+
+        resp = client.put(f"/flows/{flow.id}/flow-data", json={"flowData": data})
+
+        assert resp.status_code == 422
+        codes = [e["code"] for e in resp.json()["error"]["validationErrors"]]
+        assert "orphan_node" in codes
+
+    def test_missing_outgoing_edge_returns_422(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+        data = _valid_flow_data()
+        # Drop branch's edges entirely — non-end node with no outgoing edge.
+        data["edges"] = [e for e in data["edges"] if e["source"] != "branch"]
+
+        resp = client.put(f"/flows/{flow.id}/flow-data", json={"flowData": data})
+
+        assert resp.status_code == 422
+        codes = [e["code"] for e in resp.json()["error"]["validationErrors"]]
+        assert "missing_outgoing_edge" in codes
+
+    def test_unknown_flow_returns_404(self, db, workspace):
+        client = _build_app(db, _principal(workspace.id))
+
+        resp = client.put(
+            f"/flows/{uuid.uuid4()}/flow-data", json={"flowData": _valid_flow_data()}
+        )
+
+        assert resp.status_code == 404
+
+
+# ── GET /flow-data + /flow-data/validate ──────────────────────────────────
+
+
+class TestGetAndValidateFlowData:
+    def test_get_returns_saved_flow_and_compiled_graph(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+        client.put(f"/flows/{flow.id}/flow-data", json={"flowData": _valid_flow_data()})
+
+        resp = client.get(f"/flows/{flow.id}/flow-data")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["flowData"] is not None
+        assert body["flowDataCompiled"] is not None
+        assert body["validationErrors"] == []
+
+    def test_get_on_empty_flow_returns_nulls(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+
+        resp = client.get(f"/flows/{flow.id}/flow-data")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["flowData"] is None
+        assert body["flowDataCompiled"] is None
+
+    def test_validate_endpoint_reports_errors_without_saving(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+        data = _valid_flow_data()
+        data["nodes"][0]["type"] = "greeting"  # break the start-node invariant
+
+        resp = client.request(
+            "GET", f"/flows/{flow.id}/flow-data/validate", json={"flowData": data}
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["valid"] is False
+        assert any(e["code"] == "no_start_node" for e in body["validationErrors"])
+
+        db.refresh(flow)
+        assert flow.flow_data is None  # nothing was persisted
+
+    def test_validate_endpoint_valid_graph(self, db, workspace, flow):
+        client = _build_app(db, _principal(workspace.id))
+
+        resp = client.request(
+            "GET",
+            f"/flows/{flow.id}/flow-data/validate",
+            json={"flowData": _valid_flow_data()},
+        )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["valid"] is True
+
+
+# ── Graph compilation: edge priority ordering ─────────────────────────────
+
+
+class TestCompileGraphPriority:
+    def test_edges_sorted_by_condition_specificity(self):
+        data = _valid_flow_data()
+
+        compiled = compile_graph(data)
+
+        branch_edges = compiled["branch"]["outgoing_edges"]
+        types = [e["condition"]["type"] for e in branch_edges]
+        assert types == ["intent_match", "keyword", "fallback"]
+
+    def test_validate_graph_accepts_well_formed_flow(self):
+        assert validate_graph(_valid_flow_data()) == []
+
+
+# ── FlowExecutor: isolated node-executor sequence ─────────────────────────
+
+
+class TestFlowExecutor:
+    def test_full_sequence_greeting_collect_branch_transfer(self):
+        compiled = compile_graph(_valid_flow_data())
+        executor = FlowExecutor(compiled)
+        state = PipelineState(current_node_id=executor.start_node_id())
+
+        # start -> greeting (always edge, no transcript needed)
+        assert executor.start_node_id() == "start"
+        greet_result = executor.execute_node(
+            executor.next_node_id(state.current_node_id, None, state.variables), state
+        )
+        assert greet_result.node_type == "greeting"
+        assert greet_result.action == "speak"
+        assert greet_result.speech_text == "Hi there!"
+
+        # greeting -> collect_input (always edge)
+        next_id = executor.next_node_id(state.current_node_id, None, state.variables)
+        collect_result = executor.execute_node(next_id, state)
+        assert collect_result.node_type == "collect_input"
+        assert collect_result.action == "wait_for_input"
+
+        # collect_input -> branch (always edge)
+        next_id = executor.next_node_id(state.current_node_id, None, state.variables)
+        branch_result = executor.execute_node(next_id, state)
+        assert branch_result.node_type == "branch"
+        assert branch_result.action == "branch"
+
+        # branch -> transfer (transcript matches intent_match over keyword/fallback)
+        next_id = executor.next_node_id(
+            state.current_node_id,
+            "I'd like to speak to a human please",
+            state.variables,
+        )
+        transfer_result = executor.execute_node(next_id, state)
+        assert transfer_result.node_type == "transfer"
+        assert transfer_result.action == "transfer"
+
+        assert state.history == ["greet", "collect", "branch", "transfer"]
+
+    def test_keyword_condition_matches_exact_word(self):
+        compiled = compile_graph(_valid_flow_data())
+        executor = FlowExecutor(compiled)
+
+        target = executor.next_node_id("branch", "ok bye then", {})
+
+        assert target == "end"
+
+    def test_fallback_used_when_nothing_else_matches(self):
+        compiled = compile_graph(_valid_flow_data())
+        executor = FlowExecutor(compiled)
+
+        target = executor.next_node_id("branch", "totally unrelated text", {})
+
+        assert target == "end"
+
+    def test_intent_match_takes_priority_over_keyword(self):
+        compiled = compile_graph(_valid_flow_data())
+        executor = FlowExecutor(compiled)
+
+        # Contains both an intent phrase and a keyword; intent_match must win.
+        target = executor.next_node_id("branch", "speak to a human, then bye", {})
+
+        assert target == "transfer"


### PR DESCRIPTION
## Summary
- Adds `flow_data_compiled` JSONB column to `callflow` for the pre-compiled decision tree derived from the visual editor's raw node/edge graph.
- New `app/services/flow_graph_service.py`: validates a flow graph (exactly one start node, no directed cycles via DFS + recursion stack in O(V+E), no orphan/unreachable nodes, every non-terminal node has an outgoing edge) and compiles it into `{node_id: {node, outgoing_edges}}` with edges sorted by condition specificity (`intent_match`=1, `keyword`=2, else/`fallback`=99).
- New `app/api/v2/routers/flow_data.py`: `PUT/GET /api/v2/flows/{flow_id}/flow-data` and `GET /api/v2/flows/{flow_id}/flow-data/validate`. Invalid graphs return 422 with a structured `validationErrors` array; valid graphs are saved alongside their compiled form.
- New `app/voice/flow_executor.py`: pure, CPU-bound `FlowExecutor` that traverses the compiled graph one node at a time (`greeting`, `collect_input`, `branch`, `transfer`, `end_call`), with `perf_counter()`-based timing and a 50ms-budget warning log per transition.
- New `app/voice/flow_pipeline_mixin.py`, wired into `BidirectionalStreamHandler` (`app/routers/bidirectional_stream.py`): drives the opening greeting and each STT-final turn from the compiled flow when the agent's call flow has one, transferring/ending the call via the existing `CallControlMixin` hooks; falls through unchanged to the default LLM pipeline when there's no compiled flow.
- `tests/api/v2/test_call_flows_visual.py`: 17 tests covering validation failure modes, edge-priority compilation, and a full executor sequence (`greeting → collect_input → branch → transfer`).

## Verification
- Ran the alembic migration against the local dev DB; confirmed `flow_data_compiled` exists on `callflow`.
- Regenerated `docs/api/openapi.yaml` via `scripts/export_openapi.py` to include the new endpoints.
- `black` + `ruff` clean on every new/touched file (pre-existing lint debt elsewhere in the repo is untouched).
- Full suite before/after: **identical set of 31 pre-existing failures** (rate-limit flakiness, unrelated LiveKit/contact-recovery/Google-STT tests) in both runs — this change introduces zero regressions. All 17 new tests pass.

## Test plan
- [x] `pytest tests/api/v2/test_call_flows_visual.py -v` — 17/17 pass
- [x] `pytest tests/voice/test_call_pipeline.py tests/voice/test_rime_tts_and_barge_in.py -v` — greeting/pipeline tests unaffected
- [x] Full suite diffed against pre-change baseline — no new failures
- [ ] Manual call-flow test end-to-end against a live LiveKit/Twilio call (not exercised in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)