### PR TITLE
Remove single-inbound-agent-per-tenant limit

### DIFF
--- a/alembic/versions/d414601cdea1_remove_single_inbound_agent_index.py
+++ b/alembic/versions/d414601cdea1_remove_single_inbound_agent_index.py
@@ -1,0 +1,34 @@
+"""remove_single_inbound_agent_index
+
+Revision ID: d414601cdea1
+Revises: 20260706_flow_data_compiled
+Create Date: 2026-07-09 00:22:04.433957
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd414601cdea1'
+down_revision: Union[str, Sequence[str], None] = '20260706_flow_data_compiled'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_index("uq_agent_single_inbound_per_tenant", table_name="agent")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.create_index(
+        "uq_agent_single_inbound_per_tenant",
+        "agent",
+        ["tenant_id"],
+        unique=True,
+        postgresql_where=sa.text("is_inbound_agent = true AND is_deleted = false"),
+    )

--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -112,12 +112,6 @@ class Agent(Base):
     __table_args__ = (
         Index("ix_agent_tenant_id", "tenant_id"),
         Index(
-            "uq_agent_single_inbound_per_tenant",
-            "tenant_id",
-            unique=True,
-            postgresql_where=text("is_inbound_agent = true AND is_deleted = false"),
-        ),
-        Index(
             "uq_agent_single_follow_up_per_tenant",
             "tenant_id",
             unique=True,

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -215,17 +215,25 @@ async def handle_incoming_call(
                     detail="Invalid Twilio signature",
                 )
 
-        inbound_agent = agent_service.get_inbound_agent_by_tenant(
-            db=db, tenant_id=phone_number.tenant_id
-        )
+        # Resolve target agent: Check if a specific assistant/agent is linked directly to this PhoneNumber
+        inbound_agent = None
+        if phone_number.assistant_id:
+            inbound_agent = (
+                db.query(Agent)
+                .filter(
+                    Agent.id == phone_number.assistant_id,
+                    Agent.is_deleted == False,
+                )
+                .first()
+            )
+
         if not inbound_agent:
             logger.warning(
-                "No inbound agent configured for tenant %s (number=%s)",
-                phone_number.tenant_id,
+                "Inbound call rejected: No active agent linked to number %s",
                 to_number,
             )
             return _fallback_twiml(
-                "Sorry, inbound service is temporarily unavailable for this tenant."
+                "Sorry, this number is not configured to receive calls."
             )
 
         # Billing guardrail: enforce the same credit gating used in outbound flows.

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -140,6 +140,7 @@ class TtsModelSchema(BaseModel):
     provider: TtsProviderEnum
     voice_id: str = Field(..., min_length=1, max_length=255, alias="voiceId")
     language: LanguageEnum
+    tts_voice_id: Optional[uuid.UUID] = Field(None, alias="ttsVoiceId")
 
     @field_validator("provider", mode="before")
     @classmethod
@@ -334,6 +335,7 @@ def agent_to_out(agent: Agent) -> AgentOut:
                 provider=tts_slug_to_api_provider(agent.tts_provider_slug),
                 voice_id=agent.tts_voice_external_id,
                 language=LanguageEnum(agent.tts_language),
+                tts_voice_id=agent.tts_voice_id,
             )
         except ValueError:
             tts_model = None

--- a/app/services/agent_service.py
+++ b/app/services/agent_service.py
@@ -529,18 +529,7 @@ class AgentService:
         self._validate_tts_settings_payload(agent_data.get("tts_settings_json"))
         self._validate_transfer_route_for_tenant(db, tenant_id, agent_data.get("transfer_route_id"))
 
-        # Enforce one dedicated inbound agent per tenant.
-        if agent_data.get("is_inbound_agent"):
-            existing_inbound_agent = db.query(Agent).filter(
-                Agent.tenant_id == tenant_id,
-                Agent.is_deleted == False,
-                Agent.is_inbound_agent == True,
-            ).first()
-            if existing_inbound_agent:
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail="Only one dedicated inbound agent is allowed per tenant.",
-                )
+
 
         # Enforce one follow-up appointment agent per tenant.
         if agent_data.get("is_follow_up_agent"):
@@ -630,19 +619,7 @@ class AgentService:
         )
         self._apply_ticket_update(db, agent_update, agent, update_dict)
 
-        # Enforce one dedicated inbound agent per tenant.
-        if update_dict.get("is_inbound_agent") is True:
-            existing_inbound_agent = db.query(Agent).filter(
-                Agent.tenant_id == tenant_id,
-                Agent.is_deleted == False,
-                Agent.is_inbound_agent == True,
-                Agent.id != agent_id,
-            ).first()
-            if existing_inbound_agent:
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail="Only one dedicated inbound agent is allowed per tenant.",
-                )
+
 
         # Enforce one follow-up appointment agent per tenant.
         if update_dict.get("is_follow_up_agent") is True:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -17914,6 +17914,10 @@ components:
           title: Voiceid
         language:
           $ref: '#/components/schemas/LanguageEnum'
+        ttsVoiceId:
+          type: string
+          format: uuid
+          nullable: true
       additionalProperties: false
       type: object
       required:

--- a/tests/api/test_agents.py
+++ b/tests/api/test_agents.py
@@ -178,11 +178,10 @@ class TestCreateAgent:
         assert body["llmModel"] == "gpt-4o-mini"
         assert body["status"] == "active"
         assert "createdAt" in body
-        assert body["ttsModel"] == {
-            "provider": "elevenlabs",
-            "voiceId": "EXAVITQu4vr4xnSDxMaL",
-            "language": "en",
-        }
+        assert body["ttsModel"]["provider"] == "elevenlabs"
+        assert body["ttsModel"]["voiceId"] == "EXAVITQu4vr4xnSDxMaL"
+        assert body["ttsModel"]["language"] == "en"
+        assert "ttsVoiceId" in body["ttsModel"]
         # BYO key must never appear in any response.
         assert "elevenLabsApiKey" not in body
         assert "encrypted_elevenlabs_api_key" not in body


### PR DESCRIPTION
## Summary
- Drops the DB constraint and service-layer validation that limited each tenant to a single dedicated inbound agent (`uq_agent_single_inbound_per_tenant` index removed via new migration).
- Inbound call routing (`handle_incoming_call`) now resolves the target agent directly from `PhoneNumber.assistant_id` instead of looking up a tenant-wide inbound agent, so different phone numbers on the same tenant can route to different agents.
- Adds `ttsVoiceId` to the agent TTS model schema/response.
- Updates `test_agents.py` assertions for the new `ttsModel` field.

## Test plan
- [x] `pytest tests/api/test_agents.py -v` — 26 passed
- [x] `alembic upgrade head` against a staging DB to confirm the index drop applies cleanly
- [ ] Manual inbound call smoke test against a number with `assistant_id` set, and one without, to confirm the new fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)