### PR TITLE
feat: Answering Machine Detection (AMD) for outbound batch calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Multi-tenant SaaS Voice Agent Backend. Tenants configure AI voice agents that handle inbound/outbound phone calls via Twilio + LiveKit, transcribe speech (Deepgram / Google STT), generate responses via LLM (OpenAI / Gemini / Groq), and synthesise voice (ElevenLabs / Rime / Google TTS). Post-call data syncs to tenant-configured CRMs.
 
-**Runtime**: Python 3.14, FastAPI, Uvicorn  
+**Runtime**: Python 3.11 (Docker) / FastAPI, Uvicorn  
 **DB**: PostgreSQL via SQLAlchemy 2.x (sync) + asyncpg (async) + Alembic  
 **Background jobs**: ARQ (Redis-backed) for batch calls; APScheduler (PostgreSQL job store) for smart callbacks  
 **Vector store**: Pinecone + pgvector for RAG  
-**Infra**: GCS for recordings/KB files, Stripe for billing, SendGrid for email, Redis for rate-limiting
+**Infra**: S3 for recordings/KB files/data exports (migrated off GCS — `GCS_*` env vars are legacy/unused), Stripe for billing, SendGrid for email, Redis for rate-limiting, Calendly for voice-agent booking (replaced the local appointment/slot-reservation DB flow)
 
 ---
 
@@ -57,7 +57,7 @@ ruff check . && black .
 - v2 routers live in `app/api/v2/routers/` and carry their own `prefix=` on the `APIRouter`.
 - **Note**: the v1 agents router is registered at `/agent` (singular), not `/agents`.
 
-**v2 router inventory**: `active_calls`, `audit_events`, `batch_calls`, `callback_scheduler`, `webhooks`, `workspace` (branding, pricing, usage, member roles, sub-accounts, GDPR data export / account deletion), `hipaa` (HIPAA flag per call-flow, CMEK KMS key management).
+**v2 router inventory**: `active_calls`, `audit_events`, `batch_calls`, `callback_scheduler`, `webhooks`, `workspace` (branding, pricing, usage, member roles, sub-accounts, GDPR data export / account deletion), `hipaa` (HIPAA flag per call-flow, CMEK KMS key management), `flows` / `flow_data` (A/B prompt testing on call flows), `calendly_integration` (status, event types, availability, event creation — mounted twice, once under its own prefix and once under `calendar`), `health`.
 
 **v1 recruiting module**: job descriptions, resumes, resume interviews, and recruitment dashboard are all registered under `/api/v1/recruiting/`.
 
@@ -156,9 +156,11 @@ result = agent_service.get_agent_by_id(db, agent_id, tenant_id)
 
 Services never import `SessionLocal` — they always receive `db: Session` as a parameter.
 
+A handful of domains (`agent`, `call_flow`, `folder`, `prompt_version`, `workspace`) additionally split raw SQL access into a `Repository` class under `app/repositories/`, with the service holding/constructing the repo per-request (`self._repo(db)`). Most services query models directly instead — check whether a repository already exists for a model before adding new query methods on the service.
+
 ### Outbound call dispatch
 
-Internal code (batch worker, smart callback scheduler) places outbound calls by calling `voice_call_service.initiate_call()` with a fake Starlette `Request` carrying the `x-n8n-webhook-secret` header. This bypasses JWT and resolves to the webhook auth path. See `app/services/batch_call_worker_service.py::_build_fake_request()` for the pattern.
+Internal code (batch worker, smart callback scheduler) places outbound calls by calling `voice_call_service.initiate_call(call_request, db, is_system_call=True, tenant_id, user_id)` directly — `is_system_call=True` bypasses the normal JWT/API-key auth path since there's no inbound request to authenticate. Requires `N8N_WEBHOOK_SECRET` to be configured (checked before dispatch; used for the *other*, HTTP-facing n8n webhook auth path, not this internal call). See `BatchCallWorkerService.dispatch_record()` and `CallbackSchedulerService`'s dispatch methods for the pattern.
 
 ### Voice pipeline
 
@@ -231,7 +233,7 @@ Mock external HTTP APIs at the boundary with `unittest.mock.patch` or `respx`.
 |---|---|---|
 | `DATABASE_URL` | Yes | PostgreSQL DSN |
 | `SECRET_KEY` | Yes | JWT signing key |
-| `N8N_WEBHOOK_SECRET` | Yes | Auth header for internal outbound call dispatch (batch + callback) |
+| `N8N_WEBHOOK_SECRET` | Yes | Verifies inbound n8n-triggered webhook requests (`app/utils/n8n_webhook_verification.py`); also fail-fast checked (but not sent anywhere) before batch/callback dispatch |
 | `REDIS_URL` | Batch worker | ARQ queue |
 | `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` | Voice | Auto-switches to test creds in `staging` env |
 | `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` | Voice | Required in staging/production; gated by `LIVEKIT_ENABLED` (default `true`) |
@@ -243,7 +245,8 @@ Mock external HTTP APIs at the boundary with `unittest.mock.patch` or `respx`.
 | `ENVIRONMENT` | | `development` / `staging` / `production` |
 | `REFRESH_TOKEN_EXPIRE_DAYS` | | Default 7 days |
 | `SSO_ENCRYPTION_KEY` | SSO | AES key for SSO token encryption |
-| `GCP_PROJECT_ID` | HIPAA / GCS | Google Cloud project; required in staging/production |
+| `GCP_PROJECT_ID` | HIPAA | Google Cloud project for CMEK KMS key management; required in staging/production |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION_NAME` | S3 | Recordings, KB files, batch CSVs, data exports |
 | `OTEL_TRACING_ENABLED` | Observability | Default `false`; enable to export spans via OTLP |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Observability | Default `http://localhost:4317` |
 | `OTEL_SERVICE_NAME` | Observability | Default `tgs-agent-be` |

--- a/alembic/versions/20260716_add_amd_voicemail_fields.py
+++ b/alembic/versions/20260716_add_amd_voicemail_fields.py
@@ -1,0 +1,50 @@
+"""add amd voicemail fields to batchjob
+
+Revision ID: 20260716_amd_voicemail
+Revises: b2d3c4e5f6a8
+Create Date: 2026-07-16
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "20260716_amd_voicemail"
+down_revision: Union[str, Sequence[str], None] = "b2d3c4e5f6a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "batchjob",
+        sa.Column("voicemail_action", sa.Text(), nullable=False, server_default="skip"),
+    )
+    op.add_column(
+        "batchjob",
+        sa.Column("voicemail_message", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "batchjob",
+        sa.Column("voicemail_skipped_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "batchjob",
+        sa.Column("voicemail_message_left_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_check_constraint(
+        "ck_batchjob_voicemail_action",
+        "batchjob",
+        "voicemail_action IN ('skip', 'leave_message', 'continue')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_batchjob_voicemail_action", "batchjob", type_="check")
+    op.drop_column("batchjob", "voicemail_message_left_count")
+    op.drop_column("batchjob", "voicemail_skipped_count")
+    op.drop_column("batchjob", "voicemail_message")
+    op.drop_column("batchjob", "voicemail_action")

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -53,6 +53,7 @@ from app.routers.hubspot_integration import router as hubspot_integration_router
 from app.routers.call_history import router as call_history_router
 from app.routers.call_history import batch_router as batch_call_metrics_router
 from app.routers.payments import router as payments_router
+from app.routers.amd_webhook import router as amd_webhook_router
 
 api_router = APIRouter()
 api_router.include_router(user.router, prefix="/users", tags=["users"])
@@ -168,3 +169,4 @@ api_router.include_router(
 api_router.include_router(call_history_router, prefix="/calls", tags=["Call History Analytics"])
 api_router.include_router(batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"])
 api_router.include_router(payments_router, prefix="/payments", tags=["In-Call Payments"])
+api_router.include_router(amd_webhook_router, prefix="/webhooks/twilio", tags=["AMD Webhook"])

--- a/app/api/v2/routers/batch_calls.py
+++ b/app/api/v2/routers/batch_calls.py
@@ -86,6 +86,8 @@ async def create_batch_job(
     file: UploadFile = File(..., description="UTF-8 CSV file, max 20 MB"),
     agent_id: uuid.UUID = Form(...),
     scheduled_at: Optional[datetime] = Form(default=None),
+    voicemail_action: str = Form(default="skip", description="skip | leave_message | continue"),
+    voicemail_message: Optional[str] = Form(default=None, description="Max 500 chars"),
     workspace: Workspace = Depends(get_workspace),
     db: Session = Depends(get_db),
     svc=Depends(_batch_service_write),
@@ -97,6 +99,19 @@ async def create_batch_job(
     Additional columns are available as {variable} substitutions in the agent prompt.
     Requires admin / member / owner / config role for JWT users; any API key client.
     """
+    from app.schemas.batch_call import VOICEMAIL_ACTIONS
+
+    if voicemail_action not in VOICEMAIL_ACTIONS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"voicemail_action must be one of {VOICEMAIL_ACTIONS}",
+        )
+    if voicemail_message is not None and len(voicemail_message) > 500:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="voicemail_message must be at most 500 characters",
+        )
+
     if file.content_type and "csv" not in file.content_type and "text" not in file.content_type:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -124,6 +139,8 @@ async def create_batch_job(
         agent_id=agent_id,
         csv_bytes=raw,
         scheduled_at=scheduled_at,
+        voicemail_action=voicemail_action,
+        voicemail_message=voicemail_message,
     )
 
     await _enqueue_batch_job(str(job_out.id), scheduled_at)

--- a/app/middleware/api_key_middleware.py
+++ b/app/middleware/api_key_middleware.py
@@ -61,6 +61,9 @@ _SKIP_PREFIXES = (
     "/api/v1/billing/webhook",
     "/api/v1/voice/",
     "/api/v1/stream/",
+    # Twilio AMD status callback + hold TwiML — Twilio sends no API key/JWT;
+    # authenticated instead via X-Twilio-Signature verification in the handler.
+    "/api/v1/webhooks/twilio/",
     # Public Web SDK endpoints — security enforced via flow.public_access +
     # allowed_domains Origin check inside the handler, not API credentials.
     "/api/v1/sdk/",

--- a/app/models/batch_job.py
+++ b/app/models/batch_job.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -27,6 +27,12 @@ class BatchJob(Base):
     completed_count = Column(Integer, nullable=False, default=0, server_default="0")
     failed_count = Column(Integer, nullable=False, default=0, server_default="0")
 
+    # Answering Machine Detection (AMD) behaviour for this batch
+    voicemail_action = Column(Text, nullable=False, default="skip", server_default="skip")
+    voicemail_message = Column(Text, nullable=True)
+    voicemail_skipped_count = Column(Integer, nullable=False, default=0, server_default="0")
+    voicemail_message_left_count = Column(Integer, nullable=False, default=0, server_default="0")
+
     s3_path = Column(Text, nullable=True)
     scheduled_at = Column(DateTime(timezone=True), nullable=True)
     started_at = Column(DateTime(timezone=True), nullable=True)
@@ -42,6 +48,10 @@ class BatchJob(Base):
         Index("ix_batchjob_workspace_id", "workspace_id"),
         Index("ix_batchjob_agent_id", "agent_id"),
         Index("ix_batchjob_status", "status"),
+        CheckConstraint(
+            "voicemail_action IN ('skip', 'leave_message', 'continue')",
+            name="ck_batchjob_voicemail_action",
+        ),
     )
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/app/routers/amd_webhook.py
+++ b/app/routers/amd_webhook.py
@@ -1,0 +1,285 @@
+"""
+Twilio Answering Machine Detection (AMD) webhooks — batch outbound calls only.
+
+POST /amd       — async AMD status callback (AnsweredBy: human | machine_start |
+                   machine_end_beep | machine_end_silence | fax | unknown)
+POST /amd-hold   — TwiML the call answers into while AMD is still resolving;
+                    pauses/redirects itself until the callback above records a result,
+                    then redirects into the normal streaming webhook (human/unknown/continue)
+                    or is torn down by the callback (machine + skip/leave_message).
+
+Both routes are exempted from x-api-key/JWT auth (see api_key_middleware._SKIP_PREFIXES)
+since Twilio calls them directly — authenticated instead via X-Twilio-Signature.
+
+Docs: https://www.twilio.com/docs/voice/answering-machine-detection#async-amd
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+from sqlalchemy.orm import Session, joinedload
+from twilio.twiml.voice_response import VoiceResponse
+
+from app.api.deps import get_db
+from app.core.config import settings
+from app.core.logger import logger
+from app.models.batch_call_record import BatchCallRecord
+from app.models.batch_job import BatchJob
+from app.services.batch_call_worker_service import BatchCallWorkerService
+from app.services.call_session_service import call_session_service
+from app.services.twilio_service import twilio_service
+from app.services.voice_interview_context_service import parse_optional_uuid
+from app.utils.twilio_validation import (
+    validate_twilio_signature,
+    validate_twilio_signature_with_token,
+)
+
+router = APIRouter(tags=["AMD Webhook"])
+
+# amd_result values that release the amd-hold loop into the normal call flow.
+_HOLD_RELEASE_RESULTS = ("human", "unknown", "continue")
+
+# Give up holding after this long (covers a dropped/late async AMD callback)
+# and let the call proceed into the normal streaming flow rather than pause forever.
+_MAX_HOLD_SECONDS = 20
+
+
+def _resolve_credentials(
+    db: Session, call_session
+) -> tuple[Optional[str], Optional[str]]:
+    """Best-effort per-tenant Twilio credentials; falls back to global creds inside twilio_service."""
+    if call_session is None:
+        return None, None
+    try:
+        from app.utils.voice_twilio_utils import get_twilio_credentials_for_call
+
+        return get_twilio_credentials_for_call(db, call_session)
+    except Exception as exc:
+        logger.warning(
+            "AMD webhook: per-session Twilio credentials unavailable (%s); falling back to global",
+            exc,
+        )
+        return None, None
+
+
+async def _validate_amd_signature(
+    request: Request, db: Session, call_session, form: dict
+) -> bool:
+    if settings.ALLOW_UNAUTHENTICATED_WEBHOOKS:
+        return True
+    _, auth_token = _resolve_credentials(db, call_session)
+    if auth_token and validate_twilio_signature_with_token(request, form, auth_token):
+        return True
+    return validate_twilio_signature(request, form)
+
+
+def _streaming_url(
+    agentId: Optional[str], userId: Optional[str], callSessionId: Optional[str]
+) -> str:
+    return (
+        f"{settings.WEBHOOK_BASE_URL}/api/v1/voice/gather/streaming?"
+        f"agentId={agentId}&userId={userId}&callSessionId={callSessionId}"
+    )
+
+
+def _amd_hold_url(
+    agentId: Optional[str], userId: Optional[str], callSessionId: Optional[str]
+) -> str:
+    return (
+        f"{settings.WEBHOOK_BASE_URL}/api/v1/webhooks/twilio/amd-hold?"
+        f"agentId={agentId}&userId={userId}&callSessionId={callSessionId}"
+    )
+
+
+@router.post("/amd-hold", response_class=HTMLResponse, include_in_schema=False)
+async def amd_hold(
+    request: Request,
+    agentId: Optional[str] = None,
+    userId: Optional[str] = None,
+    callSessionId: Optional[str] = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    """Keep the call alive (pause + redirect loop) until the async AMD callback resolves."""
+    session_uuid = parse_optional_uuid(callSessionId)
+    call_session = (
+        call_session_service.get_call_session_by_id(db, session_uuid)
+        if session_uuid
+        else None
+    )
+
+    form = dict(await request.form())
+    if not await _validate_amd_signature(request, db, call_session, form):
+        logger.warning(
+            "AMD hold: invalid Twilio signature for callSessionId=%s", callSessionId
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid Twilio signature"
+        )
+
+    vr = VoiceResponse()
+
+    if call_session is None:
+        # Can't resolve the session — fail open into the normal flow instead of
+        # holding the call indefinitely.
+        vr.redirect(_streaming_url(agentId, userId, callSessionId))
+        return HTMLResponse(str(vr), media_type="application/xml")
+
+    amd_result = (call_session.call_metadata or {}).get("amd_result")
+    start_time = call_session.start_time
+    if start_time is not None and start_time.tzinfo is None:
+        start_time = start_time.replace(tzinfo=timezone.utc)
+    elapsed_seconds = (
+        (datetime.now(timezone.utc) - start_time).total_seconds() if start_time else 0
+    )
+
+    if amd_result in _HOLD_RELEASE_RESULTS or elapsed_seconds > _MAX_HOLD_SECONDS:
+        vr.redirect(_streaming_url(agentId, userId, callSessionId))
+    else:
+        # Still waiting on AMD (or it resolved to a machine — the AMD callback
+        # hangs up / injects TwiML directly via the REST API in that case).
+        vr.pause(length=1)
+        vr.redirect(_amd_hold_url(agentId, userId, callSessionId))
+
+    return HTMLResponse(str(vr), media_type="application/xml")
+
+
+@router.post("/amd", response_class=HTMLResponse)
+async def amd_callback(
+    request: Request,
+    callSessionId: Optional[str] = None,
+    batchCallRecordId: Optional[str] = None,
+    db: Session = Depends(get_db),
+) -> HTMLResponse:
+    """Twilio async AMD status callback — see module docstring."""
+    form = dict(await request.form())
+    answered_by = (form.get("AnsweredBy") or "").strip()
+    call_sid = form.get("CallSid")
+
+    session_uuid = parse_optional_uuid(callSessionId)
+    call_session = (
+        call_session_service.get_call_session_by_id(db, session_uuid)
+        if session_uuid
+        else None
+    )
+
+    if not await _validate_amd_signature(request, db, call_session, form):
+        logger.warning(
+            "AMD callback: invalid Twilio signature for callSessionId=%s", callSessionId
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid Twilio signature"
+        )
+
+    record_uuid = parse_optional_uuid(batchCallRecordId)
+    record: Optional[BatchCallRecord] = None
+    job: Optional[BatchJob] = None
+    if record_uuid:
+        record = (
+            db.query(BatchCallRecord)
+            .options(joinedload(BatchCallRecord.batch_job))
+            .filter(BatchCallRecord.id == record_uuid)
+            .first()
+        )
+        job = record.batch_job if record else None
+
+    logger.info(
+        "AMD callback: callSessionId=%s batchCallRecordId=%s AnsweredBy=%s",
+        callSessionId,
+        batchCallRecordId,
+        answered_by,
+    )
+
+    # Missing job (e.g. a non-batch call that set enable_amd, or a stale record)
+    # fails open into "continue" rather than silently hanging up a real caller.
+    voicemail_action = job.voicemail_action if job else "continue"
+    worker_svc = BatchCallWorkerService(db)
+
+    if answered_by == "machine_start":
+        if voicemail_action == "skip":
+            # Commit the DB transition first so a concurrent Twilio call-status
+            # webhook (fired once the REST hangup below lands) sees the record
+            # already off "active" instead of racing to double-count/bill it.
+            if record is not None:
+                await worker_svc.mark_voicemail_skipped(record.id)
+            _persist_amd_result(db, call_session, "machine_start")
+            if call_sid:
+                _hangup(db, call_session, call_sid)
+        elif voicemail_action == "leave_message":
+            _persist_amd_result(db, call_session, "machine_start")
+            # nothing else to do yet — wait for machine_end_beep below.
+        else:  # "continue" (or no job resolved) — let the normal flow proceed
+            _persist_amd_result(db, call_session, "continue")
+
+    elif answered_by == "machine_end_beep":
+        if voicemail_action == "leave_message" and call_sid:
+            message = (job.voicemail_message or "").strip() if job else ""
+            if message:
+                if record is not None:
+                    await worker_svc.mark_voicemail_message_left(record.id)
+                _play_voicemail_and_hangup(db, call_session, call_sid, message)
+            else:
+                # No message configured — nothing to deliver, treat as a skip.
+                if record is not None:
+                    await worker_svc.mark_voicemail_skipped(record.id)
+                _hangup(db, call_session, call_sid)
+
+    elif answered_by in ("human", "unknown"):
+        _persist_amd_result(db, call_session, answered_by)
+
+    # "fax" / anything else: no special handling — let the call proceed/expire naturally.
+
+    return HTMLResponse("", media_type="application/xml")
+
+
+def _persist_amd_result(db: Session, call_session, result: str) -> None:
+    if call_session is None:
+        return
+    md = {**(call_session.call_metadata or {})}
+    md["amd_result"] = result
+    call_session.call_metadata = md
+    db.commit()
+
+
+def _hangup(db: Session, call_session, call_sid: str) -> None:
+    account_sid, auth_token = _resolve_credentials(db, call_session)
+    ok = (
+        twilio_service.end_call_with_credentials(call_sid, account_sid, auth_token)
+        if account_sid and auth_token
+        else twilio_service.end_call(call_sid)
+    )
+    if not ok:
+        logger.warning("AMD webhook: failed to hang up call_sid=%s", call_sid)
+
+
+def _play_voicemail_and_hangup(
+    db: Session, call_session, call_sid: str, message: str
+) -> None:
+    lang = "en"
+    voice = "female"
+    if call_session is not None and call_session.agent_id is not None:
+        from app.models.agent import Agent
+
+        agent = db.get(Agent, call_session.agent_id)
+        if agent is not None:
+            lang = agent.language or lang
+            voice = agent.voice_type or voice
+
+    vr = VoiceResponse()
+    tts_url = (
+        f"{settings.WEBHOOK_BASE_URL}/api/v1/tts/google-tts/audio?"
+        f"text={quote(message)}&lang={lang}&voice={voice}"
+    )
+    vr.play(tts_url)
+    vr.hangup()
+
+    account_sid, auth_token = _resolve_credentials(db, call_session)
+    ok = twilio_service.update_call_twiml(call_sid, str(vr), account_sid, auth_token)
+    if not ok:
+        logger.warning(
+            "AMD webhook: failed to play voicemail message for call_sid=%s", call_sid
+        )

--- a/app/schemas/batch_call.py
+++ b/app/schemas/batch_call.py
@@ -4,7 +4,9 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+VOICEMAIL_ACTIONS = ("skip", "leave_message", "continue")
 
 
 # ── Request schemas ──────────────────────────────────────────────────────────
@@ -14,6 +16,15 @@ class BatchJobCreate(BaseModel):
 
     agent_id: uuid.UUID
     scheduled_at: Optional[datetime] = None
+    voicemail_action: str = "skip"
+    voicemail_message: Optional[str] = Field(default=None, max_length=500)
+
+    @field_validator("voicemail_action")
+    @classmethod
+    def validate_voicemail_action(cls, v: str) -> str:
+        if v not in VOICEMAIL_ACTIONS:
+            raise ValueError(f"voicemail_action must be one of {VOICEMAIL_ACTIONS}")
+        return v
 
 
 # ── Response schemas ─────────────────────────────────────────────────────────
@@ -46,6 +57,8 @@ class BatchJobOut(BaseModel):
     active_count: int
     completed_count: int
     failed_count: int
+    voicemail_action: str = "skip"
+    voicemail_message: Optional[str] = None
     s3_path: Optional[str] = None
     scheduled_at: Optional[datetime] = None
     started_at: Optional[datetime] = None
@@ -64,6 +77,8 @@ class BatchJobProgress(BaseModel):
     failed: int
     total: int
     percent_complete: float
+    voicemail_skipped: int = 0
+    voicemail_message_left: int = 0
 
 
 class PaginatedBatchJobs(BaseModel):

--- a/app/schemas/twilio.py
+++ b/app/schemas/twilio.py
@@ -89,6 +89,11 @@ class CallInitiateRequest(BaseModel):
     # Batch outbound calls — worker passes substituted prompt + record link
     batch_call_record_id: Optional[str] = None
     batch_prompt_override: Optional[str] = None
+    # Answering Machine Detection — worker enables this when the batch job's
+    # voicemail_action is 'skip' or 'leave_message'
+    enable_amd: bool = False
+    voicemail_action: Optional[str] = None
+    voicemail_message: Optional[str] = None
 
     @field_validator("toNumber")
     @classmethod

--- a/app/services/batch_call_service.py
+++ b/app/services/batch_call_service.py
@@ -112,6 +112,8 @@ class BatchCallService:
         agent_id: uuid.UUID,
         csv_bytes: bytes,
         scheduled_at: Optional[datetime] = None,
+        voicemail_action: str = "skip",
+        voicemail_message: Optional[str] = None,
     ) -> BatchJobOut:
         """
         Validate CSV, upload to GCS, persist BatchJob + BatchCallRecords.
@@ -200,6 +202,8 @@ class BatchCallService:
             failed_count=0,
             s3_path=gcs_key,
             scheduled_at=scheduled_at,
+            voicemail_action=voicemail_action,
+            voicemail_message=voicemail_message,
         )
         self._db.add(job)
         self._db.flush()
@@ -295,6 +299,8 @@ class BatchCallService:
             failed=job.failed_count,
             total=total,
             percent_complete=pct,
+            voicemail_skipped=job.voicemail_skipped_count or 0,
+            voicemail_message_left=job.voicemail_message_left_count or 0,
         )
 
     def list_batch_call_records(

--- a/app/services/batch_call_worker_service.py
+++ b/app/services/batch_call_worker_service.py
@@ -131,6 +131,9 @@ class BatchCallWorkerService:
         from app.schemas.twilio import CallInitiateRequest
         from app.services.voice_call_service import initiate_call
 
+        job = self._db.get(BatchJob, record.batch_job_id)
+        enable_amd = bool(job and job.voicemail_action in ("skip", "leave_message"))
+
         # Build prompt with variable substitution (validated at upload time)
         variables: dict = record.variables or {}
         prompt_override: Optional[str] = None
@@ -154,6 +157,9 @@ class BatchCallWorkerService:
             tenant_id=str(workspace_id),
             batch_call_record_id=str(record.id),
             batch_prompt_override=prompt_override,
+            enable_amd=enable_amd,
+            voicemail_action=job.voicemail_action if job else None,
+            voicemail_message=job.voicemail_message if job else None,
         )
 
         try:
@@ -213,9 +219,13 @@ class BatchCallWorkerService:
 
         Marks the record completed or schedules a retry, and updates job counters.
         Billing is handled inside this method for connected/voicemail calls.
+
+        Re-fetches with populate_existing so a concurrent AMD-driven transition
+        (mark_voicemail_skipped/mark_voicemail_message_left, committed in a
+        separate request) isn't clobbered by a stale in-session identity-map read.
         """
-        record = self._db.get(BatchCallRecord, record_id)
-        if record is None:
+        record = self._db.get(BatchCallRecord, record_id, populate_existing=True)
+        if record is None or record.status != "active":
             return
 
         if ended_reason in _BILLABLE_ENDED_REASONS:
@@ -275,6 +285,46 @@ class BatchCallWorkerService:
 
         _decrement_job_counter(self._db, record.batch_job_id, "active_count")
         _increment_job_counter(self._db, record.batch_job_id, "failed_count")
+        self._db.commit()
+        await _maybe_complete_job(self._db, record.batch_job_id)
+
+    async def mark_voicemail_skipped(self, record_id: uuid.UUID) -> None:
+        """AMD detected a machine and voicemail_action is 'skip' — call was hung up."""
+        record = self._db.get(BatchCallRecord, record_id)
+        if record is None or record.status != "active":
+            return
+
+        now = datetime.now(timezone.utc)
+        record.status = "voicemail_skipped"
+        record.updated_at = now
+        self._db.commit()
+
+        _decrement_job_counter(self._db, record.batch_job_id, "active_count")
+        _increment_job_counter(self._db, record.batch_job_id, "completed_count")
+        _increment_job_counter(self._db, record.batch_job_id, "voicemail_skipped_count")
+        self._db.commit()
+        await _maybe_complete_job(self._db, record.batch_job_id)
+
+    async def mark_voicemail_message_left(self, record_id: uuid.UUID) -> None:
+        """AMD detected the beep and the configured voicemail message was played."""
+        record = self._db.get(BatchCallRecord, record_id)
+        if record is None or record.status != "active":
+            return
+
+        now = datetime.now(timezone.utc)
+        record.status = "voicemail_message_left"
+        record.updated_at = now
+        self._db.commit()
+
+        if record.call_id is not None:
+            try:
+                await _bill_connected_call(record, self._db)
+            except Exception as exc:
+                logger.warning("Billing failed for batch record %s: %s", record.id, exc)
+
+        _decrement_job_counter(self._db, record.batch_job_id, "active_count")
+        _increment_job_counter(self._db, record.batch_job_id, "completed_count")
+        _increment_job_counter(self._db, record.batch_job_id, "voicemail_message_left_count")
         self._db.commit()
         await _maybe_complete_job(self._db, record.batch_job_id)
 

--- a/app/services/twilio_service.py
+++ b/app/services/twilio_service.py
@@ -9,6 +9,26 @@ from app.core.config import settings
 from typing import List, Dict, Optional, Any
 from app.core.logger import logger
 
+def _build_amd_kwargs(
+    machine_detection: Optional[str] = None,
+    machine_detection_timeout: Optional[int] = None,
+    async_amd: Optional[str] = None,
+    async_amd_status_callback: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the subset of AMD kwargs to pass to client.calls.create — only includes
+    params that were explicitly set, so omitting them all preserves the "no AMD" default."""
+    kwargs: Dict[str, Any] = {}
+    if machine_detection is not None:
+        kwargs["machine_detection"] = machine_detection
+    if machine_detection_timeout is not None:
+        kwargs["machine_detection_timeout"] = machine_detection_timeout
+    if async_amd is not None:
+        kwargs["async_amd"] = async_amd
+    if async_amd_status_callback is not None:
+        kwargs["async_amd_status_callback"] = async_amd_status_callback
+    return kwargs
+
+
 class TwilioService:
     """Service class for handling Twilio operations"""
     
@@ -75,14 +95,33 @@ class TwilioService:
                     f"(actual={actual_status_method})"
                 )
     
-    def make_call(self, to_number, from_number, webhook_url, status_callback_url, record=True):
-        """Make an outbound call with improved reliability and optional recording"""
+    def make_call(
+        self,
+        to_number,
+        from_number,
+        webhook_url,
+        status_callback_url,
+        record=True,
+        machine_detection: Optional[str] = None,
+        machine_detection_timeout: Optional[int] = None,
+        async_amd: Optional[str] = None,
+        async_amd_status_callback: Optional[str] = None,
+    ):
+        """Make an outbound call with improved reliability and optional recording.
+
+        AMD (Answering Machine Detection) is opt-in via machine_detection — leaving it
+        None preserves the existing "no AMD" behaviour (instant TwiML, no announcements).
+        """
         client = self.get_client()
-        
+
         # Set up recording status callback URL (use settings for correct base URL)
         from app.core.config import settings
         recording_status_callback_url = f"{settings.WEBHOOK_BASE_URL}/api/v1/voice/webhook/recording-status"
-        
+
+        amd_kwargs = _build_amd_kwargs(
+            machine_detection, machine_detection_timeout, async_amd, async_amd_status_callback
+        )
+
         call = client.calls.create(
             to=to_number,
             from_=from_number,
@@ -94,29 +133,35 @@ class TwilioService:
             recording_channels='dual',  # Record both channels
             recording_status_callback=recording_status_callback_url,  # Get recording status updates
             timeout=30,  # Answer timeout (30 seconds)
-            
-            # NO AMD - Fast webhook response prevents Twilio announcements naturally!
-            # Instant TwiML (< 10ms) + Auto-greeting = No "Please hold" messages
+            **amd_kwargs,
         )
-        
+
         return call
-    
+
     def make_call_with_credentials(
-        self, 
-        to_number: str, 
-        from_number: str, 
-        webhook_url: str, 
+        self,
+        to_number: str,
+        from_number: str,
+        webhook_url: str,
         status_callback_url: str,
         account_sid: str,
         auth_token: str,
-        record: bool = True
+        record: bool = True,
+        machine_detection: Optional[str] = None,
+        machine_detection_timeout: Optional[int] = None,
+        async_amd: Optional[str] = None,
+        async_amd_status_callback: Optional[str] = None,
     ):
         """Make call with custom Twilio credentials"""
         client = self.get_client_with_credentials(account_sid, auth_token)
-        
+
         from app.core.config import settings
         recording_status_callback_url = f"{settings.WEBHOOK_BASE_URL}/api/v1/voice/webhook/recording-status"
-        
+
+        amd_kwargs = _build_amd_kwargs(
+            machine_detection, machine_detection_timeout, async_amd, async_amd_status_callback
+        )
+
         call = client.calls.create(
             to=to_number,
             from_=from_number,
@@ -128,8 +173,9 @@ class TwilioService:
             recording_channels='dual',
             recording_status_callback=recording_status_callback_url,
             timeout=30,
+            **amd_kwargs,
         )
-        
+
         return call
     
     def get_recent_calls(self, limit=10):
@@ -618,6 +664,31 @@ class TwilioService:
             
         except TwilioException as e:
             logger.error(f"❌ Error redirecting call {call_sid}: {str(e)}")
+            return False
+
+    def update_call_twiml(
+        self,
+        call_sid: str,
+        twiml: str,
+        account_sid: Optional[str] = None,
+        auth_token: Optional[str] = None,
+    ) -> bool:
+        """
+        Inject TwiML directly into an in-progress call (no URL fetch round-trip).
+        Used by the AMD callback to play a voicemail message and hang up.
+        """
+        client = (
+            self.get_client_with_credentials(account_sid, auth_token)
+            if account_sid and auth_token
+            else self.get_client()
+        )
+
+        try:
+            client.calls(call_sid).update(twiml=twiml)
+            logger.info(f"✅ Call {call_sid} updated with inline TwiML")
+            return True
+        except TwilioException as e:
+            logger.error(f"❌ Error updating call {call_sid} with TwiML: {str(e)}")
             return False
 
     def redirect_call_with_credentials(

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -462,7 +462,7 @@ async def initiate_call(
             db.refresh(call_session)
 
         # Webhook URLs
-        webhook_url = (
+        streaming_webhook_url = (
             f"{base_url}/api/v1/voice/gather/streaming?"
             f"agentId={agent.id}&userId={user_id_filter}&callSessionId={call_session.id}"
         )
@@ -470,6 +470,22 @@ async def initiate_call(
             f"{base_url}/api/v1/voice/webhook/call-events?"
             f"agentId={agent.id}&userId={user_id_filter}&callSessionId={call_session.id}"
         )
+
+        # Answering Machine Detection (batch calls only) — hold the call on a
+        # pause/redirect loop until the async AMD callback resolves human vs machine.
+        amd_status_callback_url: Optional[str] = None
+        if call_request.enable_amd:
+            batch_record_id_q = call_request.batch_call_record_id or ""
+            amd_status_callback_url = (
+                f"{base_url}/api/v1/webhooks/twilio/amd?"
+                f"callSessionId={call_session.id}&batchCallRecordId={batch_record_id_q}"
+            )
+            webhook_url = (
+                f"{base_url}/api/v1/webhooks/twilio/amd-hold?"
+                f"agentId={agent.id}&userId={user_id_filter}&callSessionId={call_session.id}"
+            )
+        else:
+            webhook_url = streaming_webhook_url
 
         logger.info("Making call with webhook_url: %s", webhook_url)
         logger.info("Making call with status_callback_url: %s", status_callback_url)
@@ -493,6 +509,16 @@ async def initiate_call(
         # ── 10. Initiate Twilio call ──────────────────────────────────────
         _twilio_record = not _livekit_recording_enabled
         try:
+            amd_kwargs = (
+                {
+                    "machine_detection": "Enable",
+                    "machine_detection_timeout": 3,
+                    "async_amd": "true",
+                    "async_amd_status_callback": amd_status_callback_url,
+                }
+                if call_request.enable_amd
+                else {}
+            )
             if use_custom_credentials:
                 call = twilio_service.make_call_with_credentials(
                     to_number=call_request.toNumber,
@@ -502,6 +528,7 @@ async def initiate_call(
                     account_sid=account_sid,
                     auth_token=auth_token,
                     record=_twilio_record,
+                    **amd_kwargs,
                 )
             else:
                 call = twilio_service.make_call(
@@ -510,6 +537,7 @@ async def initiate_call(
                     webhook_url=webhook_url,
                     status_callback_url=status_callback_url,
                     record=_twilio_record,
+                    **amd_kwargs,
                 )
         except Exception as exc:
             logger.error(

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7338,6 +7338,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/webhooks/twilio/amd:
+    post:
+      tags:
+      - AMD Webhook
+      - AMD Webhook
+      summary: Amd Callback
+      description: Twilio async AMD status callback — see module docstring.
+      operationId: amd_callback_api_v1_webhooks_twilio_amd_post
+      parameters:
+      - name: callSessionId
+        in: query
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: batchCallRecordId
+        in: query
+        required: false
+        schema:
+          type: string
+          nullable: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            text/html:
+              schema:
+                type: string
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /health:
     get:
       summary: Health Check
@@ -10160,6 +10194,13 @@ components:
         failed_count:
           type: integer
           title: Failed Count
+        voicemail_action:
+          type: string
+          title: Voicemail Action
+          default: skip
+        voicemail_message:
+          type: string
+          nullable: true
         s3_path:
           type: string
           nullable: true
@@ -10218,6 +10259,14 @@ components:
         percent_complete:
           type: number
           title: Percent Complete
+        voicemail_skipped:
+          type: integer
+          title: Voicemail Skipped
+          default: 0
+        voicemail_message_left:
+          type: integer
+          title: Voicemail Message Left
+          default: 0
       type: object
       required:
       - batch_id
@@ -10306,6 +10355,14 @@ components:
         scheduled_at:
           type: string
           format: date-time
+          nullable: true
+        voicemail_action:
+          type: string
+          title: Voicemail Action
+          description: skip | leave_message | continue
+          default: skip
+        voicemail_message:
+          type: string
           nullable: true
       type: object
       required:
@@ -11278,6 +11335,16 @@ components:
           type: string
           nullable: true
         batch_prompt_override:
+          type: string
+          nullable: true
+        enable_amd:
+          type: boolean
+          title: Enable Amd
+          default: false
+        voicemail_action:
+          type: string
+          nullable: true
+        voicemail_message:
           type: string
           nullable: true
       type: object

--- a/tests/api/v2/test_batch_calls.py
+++ b/tests/api/v2/test_batch_calls.py
@@ -121,7 +121,7 @@ class TestCreateBatchJob:
         svc.create_batch_job.return_value = job_out
         return svc
 
-    def _job_out(self, total: int = 3) -> dict:
+    def _job_out(self, total: int = 3, voicemail_action: str = "skip", voicemail_message=None) -> dict:
         from app.schemas.batch_call import BatchJobOut
         from datetime import datetime, timezone
 
@@ -135,6 +135,8 @@ class TestCreateBatchJob:
             active_count=0,
             completed_count=0,
             failed_count=0,
+            voicemail_action=voicemail_action,
+            voicemail_message=voicemail_message,
             s3_path=f"batch-files/{WORKSPACE_ID}/{uuid.uuid4()}.csv",
             scheduled_at=None,
             started_at=None,
@@ -159,6 +161,60 @@ class TestCreateBatchJob:
         assert body["status"] == "pending"
         assert body["total_count"] == 3
         assert body["workspace_id"] == str(WORKSPACE_ID)
+
+    @patch("app.api.v2.routers.batch_calls._enqueue_batch_job", new_callable=AsyncMock)
+    def test_upload_with_voicemail_leave_message_passes_fields_to_service(self, mock_enqueue):
+        svc = self._svc(self._job_out(3, voicemail_action="leave_message", voicemail_message="Call us back"))
+        client = _build_app(svc)
+
+        resp = client.post(
+            "/batch-calls",
+            data={
+                "agent_id": str(AGENT_ID),
+                "voicemail_action": "leave_message",
+                "voicemail_message": "Call us back",
+            },
+            files={"file": ("test.csv", io.BytesIO(VALID_CSV), "text/csv")},
+            headers=AUTH_HEADERS,
+        )
+
+        assert resp.status_code == 201
+        assert resp.json()["voicemail_action"] == "leave_message"
+        assert resp.json()["voicemail_message"] == "Call us back"
+        _, kwargs = svc.create_batch_job.call_args
+        assert kwargs["voicemail_action"] == "leave_message"
+        assert kwargs["voicemail_message"] == "Call us back"
+
+    @patch("app.api.v2.routers.batch_calls._enqueue_batch_job", new_callable=AsyncMock)
+    def test_upload_defaults_voicemail_action_to_skip(self, mock_enqueue):
+        svc = self._svc(self._job_out(3))
+        client = _build_app(svc)
+
+        resp = client.post(
+            "/batch-calls",
+            data={"agent_id": str(AGENT_ID)},
+            files={"file": ("test.csv", io.BytesIO(VALID_CSV), "text/csv")},
+            headers=AUTH_HEADERS,
+        )
+
+        assert resp.status_code == 201
+        _, kwargs = svc.create_batch_job.call_args
+        assert kwargs["voicemail_action"] == "skip"
+
+    @patch("app.api.v2.routers.batch_calls._enqueue_batch_job", new_callable=AsyncMock)
+    def test_upload_invalid_voicemail_action_returns_422(self, mock_enqueue):
+        svc = self._svc(self._job_out(3))
+        client = _build_app(svc)
+
+        resp = client.post(
+            "/batch-calls",
+            data={"agent_id": str(AGENT_ID), "voicemail_action": "bogus"},
+            files={"file": ("test.csv", io.BytesIO(VALID_CSV), "text/csv")},
+            headers=AUTH_HEADERS,
+        )
+
+        assert resp.status_code == 422
+        svc.create_batch_job.assert_not_called()
 
     @patch("app.api.v2.routers.batch_calls._enqueue_batch_job", new_callable=AsyncMock)
     def test_upload_invalid_csv_missing_phone_col_returns_422(self, mock_enqueue):
@@ -232,6 +288,8 @@ class TestCreateBatchJob:
                     file=mock_file,
                     agent_id=AGENT_ID,
                     scheduled_at=None,
+                    voicemail_action="skip",
+                    voicemail_message=None,
                     workspace=mock_workspace,
                     db=MagicMock(),
                     svc=mock_svc,
@@ -275,6 +333,8 @@ class TestCreateBatchJob:
                     file=mock_file,
                     agent_id=AGENT_ID,
                     scheduled_at=None,
+                    voicemail_action="skip",
+                    voicemail_message=None,
                     workspace=mock_workspace,
                     db=MagicMock(),
                     svc=mock_svc,
@@ -310,6 +370,8 @@ class TestCreateBatchJob:
             active_count=0,
             completed_count=0,
             failed_count=0,
+            voicemail_action="skip",
+            voicemail_message=None,
             s3_path=f"batch-files/{WORKSPACE_ID}/x.csv",
             scheduled_at=None,
             started_at=None,
@@ -334,6 +396,8 @@ class TestCreateBatchJob:
                 file=mock_file,
                 agent_id=AGENT_ID,
                 scheduled_at=None,
+                voicemail_action="skip",
+                voicemail_message=None,
                 workspace=mock_workspace,
                 db=MagicMock(),
                 svc=mock_svc,
@@ -424,6 +488,8 @@ class TestGetBatchJob:
         job_model.active_count = 3
         job_model.completed_count = 0
         job_model.failed_count = 0
+        job_model.voicemail_action = "skip"
+        job_model.voicemail_message = None
         job_model.s3_path = "batch-files/x/y.csv"
         job_model.scheduled_at = None
         job_model.started_at = None
@@ -467,6 +533,8 @@ class TestGetBatchJobProgress:
             failed=0,
             total=10,
             percent_complete=30.0,
+            voicemail_skipped=2,
+            voicemail_message_left=1,
         )
         svc = MagicMock()
         svc.get_batch_job_progress.return_value = progress
@@ -481,6 +549,8 @@ class TestGetBatchJobProgress:
         assert body["completed"] == 3
         assert body["total"] == 10
         assert body["percent_complete"] == 30.0
+        assert body["voicemail_skipped"] == 2
+        assert body["voicemail_message_left"] == 1
 
 
 # ── GET /batch-calls/{id}/calls ───────────────────────────────────────────────

--- a/tests/routers/test_amd_webhook.py
+++ b/tests/routers/test_amd_webhook.py
@@ -1,0 +1,642 @@
+"""
+Unit tests for the Twilio AMD webhook (app/routers/amd_webhook.py).
+
+DB is an in-memory SQLite fixture (same pattern as tests/services/test_batch_call_worker.py).
+Twilio REST calls are mocked at the twilio_service boundary — no network calls.
+Signature validation is bypassed via ALLOW_UNAUTHENTICATED_WEBHOOKS except where
+specifically under test.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+from app.db.base import Base
+
+
+@compiles(JSONB, "sqlite")
+def _jsonb_sqlite(type_, compiler, **kw):
+    return "JSON"
+
+
+@compiles(PG_UUID, "sqlite")
+def _uuid_sqlite(type_, compiler, **kw):
+    return "VARCHAR(36)"
+
+
+_SHARED_CONN = sqlite3.connect(":memory:", check_same_thread=False)
+_engine = create_engine(
+    "sqlite://", creator=lambda: _SHARED_CONN, connect_args={"check_same_thread": False}
+)
+_Session = sessionmaker(bind=_engine)
+
+
+def _setup_db():
+    import app.models.agent  # noqa: F401
+    import app.models.batch_call_record  # noqa: F401
+    import app.models.batch_job  # noqa: F401
+    import app.models.call_session  # noqa: F401
+    import app.models.tenant  # noqa: F401
+    import app.models.user  # noqa: F401
+    import app.models.plan  # noqa: F401
+    import app.models.subscription  # noqa: F401
+    import app.models.usage_record  # noqa: F401
+    import app.models.role  # noqa: F401
+
+    Base.metadata.drop_all(bind=_engine)
+    Base.metadata.create_all(bind=_engine)
+
+
+@pytest.fixture()
+def db():
+    _setup_db()
+    session = _Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_signature_validation():
+    """Most tests exercise business logic, not signature validation — bypass it
+    by default; TestSignatureValidation overrides this explicitly."""
+    with patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", True):
+        yield
+
+
+class _FakeRequest:
+    def __init__(self, form_data: dict):
+        self._form_data = form_data
+        self.headers = {}
+
+    async def form(self):
+        return self._form_data
+
+
+def _make_tenant(db):
+    from app.models.tenant import Tenant
+
+    t = Tenant(name="WS", schema_name="ws_test")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t.id
+
+
+def _make_agent(db, tenant_id):
+    from app.models.agent import Agent
+
+    a = Agent(tenant_id=tenant_id, name="TestAgent", system_prompt="", status="ready")
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a.id
+
+
+def _make_user(db):
+    from app.models.user import User
+
+    u = User(
+        id=uuid.uuid4(),
+        first_name="AMD",
+        last_name="Test",
+        email=f"amd-{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+    )
+    db.add(u)
+    db.flush()
+    return u.id
+
+
+def _make_call_session(db, tenant_id, agent_id, user_id, start_time=None):
+    from app.models.call_session import CallSession
+
+    cs = CallSession(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        start_time=start_time or datetime.now(timezone.utc),
+        status="active",
+        call_type="outbound",
+        twilio_call_sid="CAtest123",
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+    return cs
+
+
+def _make_batch_job(
+    db, workspace_id, agent_id, voicemail_action="skip", voicemail_message=None
+):
+    from app.models.batch_job import BatchJob
+
+    j = BatchJob(
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        status="processing",
+        total_count=1,
+        waiting_count=0,
+        active_count=1,
+        completed_count=0,
+        failed_count=0,
+        voicemail_action=voicemail_action,
+        voicemail_message=voicemail_message,
+    )
+    db.add(j)
+    db.commit()
+    db.refresh(j)
+    return j
+
+
+def _make_record(db, batch_job_id, call_id):
+    from app.models.batch_call_record import BatchCallRecord
+
+    r = BatchCallRecord(
+        batch_job_id=batch_job_id,
+        phone_number="+15550001111",
+        status="active",
+        call_id=call_id,
+        attempts=1,
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+# ── machine_start ──────────────────────────────────────────────────────────────
+
+
+class TestMachineStart:
+    def test_skip_action_hangs_up_and_marks_skipped(self, db):
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        job = _make_batch_job(db, workspace_id, agent_id, voicemail_action="skip")
+        record = _make_record(db, job.id, cs.id)
+
+        request = _FakeRequest({"AnsweredBy": "machine_start", "CallSid": "CAtest123"})
+
+        with patch("app.routers.amd_webhook.twilio_service.end_call") as mock_end:
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=str(record.id),
+                    db=db,
+                )
+            )
+            mock_end.assert_called_once_with("CAtest123")
+
+        db.refresh(record)
+        db.refresh(job)
+        assert record.status == "voicemail_skipped"
+        assert job.voicemail_skipped_count == 1
+        assert job.active_count == 0
+
+    def test_leave_message_action_does_not_hang_up_yet(self, db):
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        job = _make_batch_job(
+            db,
+            workspace_id,
+            agent_id,
+            voicemail_action="leave_message",
+            voicemail_message="We tried to reach you.",
+        )
+        record = _make_record(db, job.id, cs.id)
+
+        request = _FakeRequest({"AnsweredBy": "machine_start", "CallSid": "CAtest123"})
+
+        with patch(
+            "app.routers.amd_webhook.twilio_service.end_call"
+        ) as mock_end, patch(
+            "app.routers.amd_webhook.twilio_service.update_call_twiml"
+        ) as mock_update:
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=str(record.id),
+                    db=db,
+                )
+            )
+            mock_end.assert_not_called()
+            mock_update.assert_not_called()
+
+        db.refresh(record)
+        db.refresh(cs)
+        assert record.status == "active"  # unchanged — waiting for the beep
+        assert cs.call_metadata["amd_result"] == "machine_start"
+
+    def test_continue_action_does_not_hang_up_and_releases_hold(self, db):
+        """voicemail_action='continue' must let the call proceed into the normal
+        flow instead of hanging up or getting stuck (regression guard)."""
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        job = _make_batch_job(db, workspace_id, agent_id, voicemail_action="continue")
+        record = _make_record(db, job.id, cs.id)
+
+        request = _FakeRequest({"AnsweredBy": "machine_start", "CallSid": "CAtest123"})
+
+        with patch("app.routers.amd_webhook.twilio_service.end_call") as mock_end:
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=str(record.id),
+                    db=db,
+                )
+            )
+            mock_end.assert_not_called()
+
+        db.refresh(cs)
+        db.refresh(record)
+        assert cs.call_metadata["amd_result"] == "continue"
+        assert record.status == "active"
+
+    def test_missing_job_defaults_to_continue_not_skip(self, db):
+        """A non-batch call that somehow set enable_amd (no batchCallRecordId
+        resolves) must fail open instead of silently hanging up a real caller."""
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest({"AnsweredBy": "machine_start", "CallSid": "CAtest123"})
+
+        with patch("app.routers.amd_webhook.twilio_service.end_call") as mock_end:
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=None,
+                    db=db,
+                )
+            )
+            mock_end.assert_not_called()
+
+        db.refresh(cs)
+        assert cs.call_metadata["amd_result"] == "continue"
+
+
+# ── machine_end_beep ─────────────────────────────────────────────────────────
+
+
+class TestMachineEndBeep:
+    def test_leave_message_plays_tts_and_marks_message_left(self, db):
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        job = _make_batch_job(
+            db,
+            workspace_id,
+            agent_id,
+            voicemail_action="leave_message",
+            voicemail_message="We tried to reach you.",
+        )
+        record = _make_record(db, job.id, cs.id)
+
+        request = _FakeRequest(
+            {"AnsweredBy": "machine_end_beep", "CallSid": "CAtest123"}
+        )
+
+        with patch(
+            "app.routers.amd_webhook.twilio_service.update_call_twiml"
+        ) as mock_update, patch(
+            "app.services.billing_service.BillingService.record_call_usage"
+        ):
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=str(record.id),
+                    db=db,
+                )
+            )
+            mock_update.assert_called_once()
+            call_sid_arg, twiml_arg = (
+                mock_update.call_args.args[0],
+                mock_update.call_args.args[1],
+            )
+            assert call_sid_arg == "CAtest123"
+            assert "Play" in twiml_arg
+            assert "Hangup" in twiml_arg
+
+        db.refresh(record)
+        db.refresh(job)
+        assert record.status == "voicemail_message_left"
+        assert job.voicemail_message_left_count == 1
+
+    def test_skip_action_ignores_beep(self, db):
+        """If voicemail_action is 'skip' the call was already hung up on machine_start;
+        a stray beep callback must not attempt to play anything."""
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        job = _make_batch_job(db, workspace_id, agent_id, voicemail_action="skip")
+        record = _make_record(db, job.id, cs.id)
+
+        request = _FakeRequest(
+            {"AnsweredBy": "machine_end_beep", "CallSid": "CAtest123"}
+        )
+
+        with patch(
+            "app.routers.amd_webhook.twilio_service.update_call_twiml"
+        ) as mock_update:
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=str(record.id),
+                    db=db,
+                )
+            )
+            mock_update.assert_not_called()
+
+    def test_leave_message_with_no_configured_message_falls_back_to_skip(self, db):
+        """An empty voicemail_message means there's nothing to play — must hang
+        up and count as skipped, not falsely report a message was left."""
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        job = _make_batch_job(
+            db,
+            workspace_id,
+            agent_id,
+            voicemail_action="leave_message",
+            voicemail_message=None,
+        )
+        record = _make_record(db, job.id, cs.id)
+
+        request = _FakeRequest(
+            {"AnsweredBy": "machine_end_beep", "CallSid": "CAtest123"}
+        )
+
+        with patch(
+            "app.routers.amd_webhook.twilio_service.update_call_twiml"
+        ) as mock_update, patch(
+            "app.routers.amd_webhook.twilio_service.end_call"
+        ) as mock_end:
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=str(record.id),
+                    db=db,
+                )
+            )
+            mock_update.assert_not_called()
+            mock_end.assert_called_once_with("CAtest123")
+
+        db.refresh(record)
+        db.refresh(job)
+        assert record.status == "voicemail_skipped"
+        assert job.voicemail_skipped_count == 1
+        assert job.voicemail_message_left_count == 0
+
+
+# ── human / unknown ────────────────────────────────────────────────────────────
+
+
+class TestHumanAnswered:
+    def test_human_persists_amd_result_and_does_not_touch_record(self, db):
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        job = _make_batch_job(db, workspace_id, agent_id, voicemail_action="skip")
+        record = _make_record(db, job.id, cs.id)
+
+        request = _FakeRequest({"AnsweredBy": "human", "CallSid": "CAtest123"})
+
+        with patch("app.routers.amd_webhook.twilio_service.end_call") as mock_end:
+            asyncio.run(
+                amd_callback(
+                    request=request,
+                    callSessionId=str(cs.id),
+                    batchCallRecordId=str(record.id),
+                    db=db,
+                )
+            )
+            mock_end.assert_not_called()
+
+        db.refresh(cs)
+        db.refresh(record)
+        assert cs.call_metadata["amd_result"] == "human"
+        assert record.status == "active"  # normal call flow continues untouched
+
+
+# ── signature validation ──────────────────────────────────────────────────────
+
+
+class TestSignatureValidation:
+    def test_amd_callback_rejects_unsigned_request_when_not_bypassed(self, db):
+        from fastapi import HTTPException
+
+        from app.routers.amd_webhook import amd_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest({"AnsweredBy": "human", "CallSid": "CAtest123"})
+
+        with patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False), patch(
+            "app.routers.amd_webhook.validate_twilio_signature", return_value=False
+        ), patch(
+            "app.routers.amd_webhook.validate_twilio_signature_with_token",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    amd_callback(
+                        request=request,
+                        callSessionId=str(cs.id),
+                        batchCallRecordId=None,
+                        db=db,
+                    )
+                )
+
+        assert exc_info.value.status_code == 403
+
+    def test_amd_hold_rejects_unsigned_request_when_not_bypassed(self, db):
+        from fastapi import HTTPException
+
+        from app.routers.amd_webhook import amd_hold
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        with patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False), patch(
+            "app.routers.amd_webhook.validate_twilio_signature", return_value=False
+        ), patch(
+            "app.routers.amd_webhook.validate_twilio_signature_with_token",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    amd_hold(
+                        request=_FakeRequest({}),
+                        agentId=str(agent_id),
+                        userId=str(user_id),
+                        callSessionId=str(cs.id),
+                        db=db,
+                    )
+                )
+
+        assert exc_info.value.status_code == 403
+
+
+# ── amd-hold ──────────────────────────────────────────────────────────────────
+
+
+class TestAmdHold:
+    def test_redirects_to_streaming_once_human_result_recorded(self, db):
+        from app.routers.amd_webhook import amd_hold
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        cs.call_metadata = {"amd_result": "human"}
+        db.commit()
+
+        resp = asyncio.run(
+            amd_hold(
+                request=_FakeRequest({}),
+                agentId=str(agent_id),
+                userId=str(user_id),
+                callSessionId=str(cs.id),
+                db=db,
+            )
+        )
+
+        assert "gather/streaming" in resp.body.decode()
+        assert "Redirect" in resp.body.decode()
+
+    def test_redirects_to_streaming_when_continue_result_recorded(self, db):
+        from app.routers.amd_webhook import amd_hold
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        cs.call_metadata = {"amd_result": "continue"}
+        db.commit()
+
+        resp = asyncio.run(
+            amd_hold(
+                request=_FakeRequest({}),
+                agentId=str(agent_id),
+                userId=str(user_id),
+                callSessionId=str(cs.id),
+                db=db,
+            )
+        )
+
+        assert "gather/streaming" in resp.body.decode()
+
+    def test_pauses_and_loops_when_amd_result_not_yet_known(self, db):
+        from app.routers.amd_webhook import amd_hold
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        resp = asyncio.run(
+            amd_hold(
+                request=_FakeRequest({}),
+                agentId=str(agent_id),
+                userId=str(user_id),
+                callSessionId=str(cs.id),
+                db=db,
+            )
+        )
+
+        body = resp.body.decode()
+        assert "Pause" in body
+        assert "amd-hold" in body
+
+    def test_releases_hold_after_max_wait_even_without_amd_result(self, db):
+        """Guards against an indefinite hold if the async AMD callback never arrives."""
+        from app.routers.amd_webhook import amd_hold
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        stale_start = datetime.now(timezone.utc) - timedelta(seconds=60)
+        cs = _make_call_session(
+            db, workspace_id, agent_id, user_id, start_time=stale_start
+        )
+
+        resp = asyncio.run(
+            amd_hold(
+                request=_FakeRequest({}),
+                agentId=str(agent_id),
+                userId=str(user_id),
+                callSessionId=str(cs.id),
+                db=db,
+            )
+        )
+
+        body = resp.body.decode()
+        assert "gather/streaming" in body
+        assert "Pause" not in body
+
+    def test_fails_open_to_streaming_when_call_session_not_found(self, db):
+        from app.routers.amd_webhook import amd_hold
+
+        resp = asyncio.run(
+            amd_hold(
+                request=_FakeRequest({}),
+                agentId="agent-x",
+                userId="user-x",
+                callSessionId=str(uuid.uuid4()),
+                db=db,
+            )
+        )
+
+        assert "gather/streaming" in resp.body.decode()

--- a/tests/services/test_batch_call_worker.py
+++ b/tests/services/test_batch_call_worker.py
@@ -109,7 +109,9 @@ def _make_agent(db, tenant_id: uuid.UUID, prompt: str = "") -> uuid.UUID:
     return a.id
 
 
-def _make_batch_job(db, workspace_id, agent_id, total=3) -> "BatchJob":  # noqa: F821
+def _make_batch_job(
+    db, workspace_id, agent_id, total=3, voicemail_action="skip", voicemail_message=None
+) -> "BatchJob":  # noqa: F821
     from app.models.batch_job import BatchJob
 
     j = BatchJob(
@@ -121,6 +123,8 @@ def _make_batch_job(db, workspace_id, agent_id, total=3) -> "BatchJob":  # noqa:
         active_count=0,
         completed_count=0,
         failed_count=0,
+        voicemail_action=voicemail_action,
+        voicemail_message=voicemail_message,
     )
     db.add(j)
     db.commit()
@@ -847,3 +851,163 @@ class TestBillingRecordCallUsage:
             .one()
         )
         assert usage.workspace_id == workspace_id
+
+
+# ── Answering Machine Detection (AMD) ─────────────────────────────────────────
+
+class TestDispatchEnablesAMD:
+    """dispatch_record must thread AMD flags into CallInitiateRequest based on
+    the batch job's voicemail_action."""
+
+    def _dispatch(self, db, job, workspace_id, agent_id):
+        from app.schemas.base import SuccessResponse
+        from app.schemas.twilio import CallInitiateResponse
+        from app.services.batch_call_worker_service import BatchCallWorkerService
+
+        record = _make_record(db, job.id, "+15550009999", status="active")
+        job.active_count = 1
+        db.commit()
+
+        _cid = uuid.uuid4()
+        fake_response = SuccessResponse(
+            data=CallInitiateResponse(
+                callId=str(_cid),
+                twilioCallSid="CAamd",
+                callSessionId=str(_cid),
+                status="initiated",
+            )
+        )
+        with patch(
+            "app.services.voice_call_service.initiate_call",
+            new=AsyncMock(return_value=fake_response),
+        ) as mock_call:
+            svc = BatchCallWorkerService(db)
+            asyncio.run(svc.dispatch_record(record, workspace_id, agent_id, None))
+        return mock_call.call_args.kwargs["call_request"]
+
+    def test_voicemail_action_skip_enables_amd(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        job = _make_batch_job(db, workspace_id, agent_id, total=1, voicemail_action="skip")
+
+        req = self._dispatch(db, job, workspace_id, agent_id)
+
+        assert req.enable_amd is True
+        assert req.voicemail_action == "skip"
+
+    def test_voicemail_action_leave_message_enables_amd(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        job = _make_batch_job(
+            db, workspace_id, agent_id, total=1,
+            voicemail_action="leave_message", voicemail_message="Please call us back.",
+        )
+
+        req = self._dispatch(db, job, workspace_id, agent_id)
+
+        assert req.enable_amd is True
+        assert req.voicemail_action == "leave_message"
+        assert req.voicemail_message == "Please call us back."
+
+    def test_voicemail_action_continue_does_not_enable_amd(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        job = _make_batch_job(db, workspace_id, agent_id, total=1, voicemail_action="continue")
+
+        req = self._dispatch(db, job, workspace_id, agent_id)
+
+        assert req.enable_amd is False
+
+
+class TestVoicemailStateTransitions:
+    def test_mark_voicemail_skipped_updates_record_and_counters(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        job = _make_batch_job(db, workspace_id, agent_id, total=1, voicemail_action="skip")
+        record = _make_record(db, job.id, "+15550001111", status="active")
+        job.active_count = 1
+        job.waiting_count = 0
+        db.commit()
+
+        from app.services.batch_call_worker_service import BatchCallWorkerService
+
+        svc = BatchCallWorkerService(db)
+        asyncio.run(svc.mark_voicemail_skipped(record.id))
+
+        db.refresh(record)
+        db.refresh(job)
+        assert record.status == "voicemail_skipped"
+        assert job.active_count == 0
+        assert job.completed_count == 1
+        assert job.voicemail_skipped_count == 1
+        assert job.status == "completed"  # no records remain waiting/active
+
+    def test_mark_voicemail_skipped_is_noop_for_non_active_record(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        job = _make_batch_job(db, workspace_id, agent_id, total=1, voicemail_action="skip")
+        record = _make_record(db, job.id, "+15550001111", status="completed")
+        db.commit()
+
+        from app.services.batch_call_worker_service import BatchCallWorkerService
+
+        svc = BatchCallWorkerService(db)
+        asyncio.run(svc.mark_voicemail_skipped(record.id))
+
+        db.refresh(record)
+        db.refresh(job)
+        assert record.status == "completed"  # untouched
+        assert job.voicemail_skipped_count == 0
+
+    def test_mark_voicemail_message_left_updates_record_counters_and_bills(self, db):
+        from app.models.call_session import CallSession
+        from app.models.user import User
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user = User(
+            id=uuid.uuid4(),
+            first_name="Batch",
+            last_name="AMD",
+            email="batch-amd@example.com",
+            hashed_password="x",
+        )
+        db.add(user)
+        db.flush()
+        call_id = uuid.uuid4()
+        cs = CallSession(
+            id=call_id,
+            user_id=user.id,
+            agent_id=agent_id,
+            tenant_id=workspace_id,
+            start_time=datetime.now(timezone.utc),
+            status="active",
+            call_type="outbound",
+        )
+        db.add(cs)
+
+        job = _make_batch_job(
+            db, workspace_id, agent_id, total=1,
+            voicemail_action="leave_message", voicemail_message="We called, please call back.",
+        )
+        record = _make_record(db, job.id, "+15550001111", status="active")
+        record.call_id = call_id
+        job.active_count = 1
+        job.waiting_count = 0
+        db.commit()
+
+        from app.services.batch_call_worker_service import BatchCallWorkerService
+
+        with patch(
+            "app.services.billing_service.BillingService.record_call_usage"
+        ) as mock_bill:
+            svc = BatchCallWorkerService(db)
+            asyncio.run(svc.mark_voicemail_message_left(record.id))
+
+        db.refresh(record)
+        db.refresh(job)
+        assert record.status == "voicemail_message_left"
+        assert job.active_count == 0
+        assert job.completed_count == 1
+        assert job.voicemail_message_left_count == 1
+        mock_bill.assert_called_once()


### PR DESCRIPTION
## Summary

Adds Twilio Answering Machine Detection (AMD) to outbound batch call campaigns, so tenants can configure how a batch job handles calls answered by voicemail instead of always running the full agent conversation.

- **`voicemail_action`** per batch job: `skip` (hang up immediately), `leave_message` (play a configured TTS message after the beep, then hang up), or `continue` (let the call proceed into the normal agent flow as if a human answered).
- **New DB fields on `BatchJob`**: `voicemail_action`, `voicemail_message`, `voicemail_skipped_count`, `voicemail_message_left_count` — surfaced in the create/list/progress API responses.
- **New webhook router** (`app/routers/amd_webhook.py`, mounted at `/api/v1/webhooks/twilio`):
  - `POST /amd` — Twilio's async AMD status callback (`AnsweredBy`: human/machine_start/machine_end_beep/unknown/fax), drives the skip/leave-message/continue behavior and updates job counters.
  - `POST /amd-hold` — TwiML the call answers into while AMD is still resolving; pauses/redirects in a loop (bounded to 20s) until the callback resolves, then redirects into the normal streaming flow or is torn down directly via the Twilio REST API.
  - Both routes are exempted from the standard API-key/JWT middleware (Twilio calls them with no such credentials) and instead verified via `X-Twilio-Signature`, matching the pattern used by the existing voice webhooks.
- **Twilio client** (`twilio_service.py`): `make_call`/`make_call_with_credentials` accept optional `machine_detection`/`async_amd*` params — a no-op unless a caller explicitly opts in, so existing non-batch call behavior is unchanged.
- **Batch worker**: `dispatch_record` reads the job's `voicemail_action` and threads AMD enablement + the configured message through call initiation.

### Self-review fixes folded in
An internal multi-angle review caught and fixed several issues before this was opened, most notably:
- the new webhook routes would have 401'd (missing from the auth-middleware skip list) — feature would've been dead on arrival,
- `voicemail_action=continue` left calls stuck in the hold loop forever (unhandled case),
- a race between the AMD "skip" hangup and Twilio's own call-status webhook that could double-bill or lose the skip classification (fixed by committing the DB transition before the REST hangup, plus an idempotency guard on the completion path),
- an unbounded hold loop if the async callback is ever dropped.

### Also included
- Alembic migration `20260716_add_amd_voicemail_fields` (additive columns + check constraint on `voicemail_action`).
- `CLAUDE.md` corrections unrelated to AMD but caught while reviewing this branch: Python version (3.14 → 3.11 per Dockerfile), GCS→S3 storage migration reflected, stale outbound-dispatch mechanism description, missing v2 router inventory entries, undocumented repository pattern.

## Test plan
- [x] `pytest tests/` — 1454 passed, 5 skipped (pre-existing Postgres-integration skips requiring `TEST_DATABASE_URL`), no regressions.
- [x] New coverage: `tests/routers/test_amd_webhook.py` (skip/leave_message/continue paths, signature validation, hold-loop timeout/fail-open), extended `tests/services/test_batch_call_worker.py` and `tests/api/v2/test_batch_calls.py` for the new fields/counters.
- [x] Migration applied and verified against the dev database (columns + check constraint confirmed present).
- [x] `ruff` / `black` clean on all touched files.