### PR TITLE
feat: add outbound number reputation monitoring and auto-rotation

### DIFF
--- a/alembic/versions/0e45008a4e03_add_outbound_number_reputation.py
+++ b/alembic/versions/0e45008a4e03_add_outbound_number_reputation.py
@@ -1,0 +1,48 @@
+"""add_outbound_number_reputation
+
+Revision ID: 0e45008a4e03
+Revises: 20260716_amd_voicemail
+Create Date: 2026-07-16 23:45:57.383860
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '0e45008a4e03'
+down_revision: Union[str, Sequence[str], None] = '20260716_amd_voicemail'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'phonenumberreputation',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('phone_number_id', sa.UUID(), nullable=False),
+        sa.Column('reputation_score', sa.Integer(), server_default='100', nullable=False),
+        sa.Column('spam_flagged', sa.Boolean(), server_default='false', nullable=False),
+        sa.Column('last_checked_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('checked_by', sa.String(), nullable=True),
+        sa.Column('flagged_reason', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['phone_number_id'], ['phonenumber.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_phonenumberreputation_phone_number_id'),
+        'phonenumberreputation',
+        ['phone_number_id'],
+        unique=True,
+    )
+    op.add_column('batchjob', sa.Column('actual_from_number', sa.String(length=20), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('batchjob', 'actual_from_number')
+    op.drop_index(op.f('ix_phonenumberreputation_phone_number_id'), table_name='phonenumberreputation')
+    op.drop_table('phonenumberreputation')

--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -15,6 +15,7 @@ from app.api.v2.routers.hipaa import workspace_router as hipaa_workspace_router
 from app.api.v2.routers.workspace import router as workspace_gdpr_router
 from app.api.v2.routers.calendly_integration import router as calendly_integration_router
 from app.api.v2.routers.calendly_integration import calendar_router as calendly_calendar_router
+from app.api.v2.routers.telephony import router as telephony_router
 
 v2_router = APIRouter()
 v2_router.include_router(health_router)
@@ -32,3 +33,4 @@ v2_router.include_router(hipaa_workspace_router)
 v2_router.include_router(workspace_gdpr_router)
 v2_router.include_router(calendly_integration_router)
 v2_router.include_router(calendly_calendar_router)
+v2_router.include_router(telephony_router)

--- a/app/api/v2/routers/batch_calls.py
+++ b/app/api/v2/routers/batch_calls.py
@@ -22,14 +22,17 @@ from datetime import datetime
 from typing import Optional, Union
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile, status
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, get_workspace, require_tenant
+from app.core.error_responses import build_api_error_payload
 from app.core.logger import logger
 from app.core.request_auth import ApiKeyPrincipal
 from app.core.workspace import Workspace
 from app.models.user import User
 from app.services.audit_service import log_audit_event
+from app.services.batch_call_service import AllNumbersFlaggedError
 from app.schemas.batch_call import (
     BatchJobOut,
     BatchJobProgress,
@@ -142,6 +145,38 @@ async def create_batch_job(
         voicemail_action=voicemail_action,
         voicemail_message=voicemail_message,
     )
+
+    # Rotate the outbound caller ID before dispatch if the agent's bound number
+    # is spam-flagged; 422s out if no clean same-country number is available.
+    try:
+        rotation = await svc.rotate_number_if_flagged(
+            workspace_id=workspace.id,
+            agent_id=agent_id,
+            batch_job_id=job_out.id,
+        )
+    except AllNumbersFlaggedError:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=build_api_error_payload(
+                status.HTTP_422_UNPROCESSABLE_ENTITY,
+                "All outbound numbers are spam-flagged. Please add a new number.",
+                error_code="all_numbers_flagged",
+                request_id=getattr(request.state, "request_id", ""),
+            ),
+        )
+
+    if rotation is not None:
+        old_number, new_number = rotation
+        log_audit_event(
+            db,
+            request=request,
+            tenant_id=workspace.id,
+            action="batch.number_rotated",
+            resource_type="batch_job",
+            resource_id=job_out.id,
+            old_value={"from_number": old_number},
+            new_value={"from_number": new_number, "reason": "spam_flagged"},
+        )
 
     await _enqueue_batch_job(str(job_out.id), scheduled_at)
 

--- a/app/api/v2/routers/telephony.py
+++ b/app/api/v2/routers/telephony.py
@@ -1,0 +1,103 @@
+"""
+v2 Telephony — outbound number reputation monitoring.
+
+Auth: API key + x-workspace-id, or JWT dashboard user (get_workspace + role gate).
+
+POST /api/v2/telephony/check-reputation    — on-demand reputation check for one number
+GET  /api/v2/telephony/reputation-summary  — reputation snapshot for every workspace number
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, get_workspace
+from app.api.deps.rbac import require_config_or_api_key, require_readonly_or_api_key
+from app.core.workspace import Workspace
+from app.models.phone_number import PhoneNumber
+from app.models.phone_number_reputation import PhoneNumberReputation
+from app.services.reputation_service import check_number_reputation
+
+router = APIRouter(prefix="/telephony", tags=["Telephony"])
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+class CheckReputationRequest(BaseModel):
+    phone_number_id: uuid.UUID
+
+
+class ReputationResult(BaseModel):
+    spam_flagged: bool
+    reputation_score: int
+    flagged_reason: Optional[str] = None
+
+
+class ReputationSummaryItem(BaseModel):
+    phone_number: str
+    reputation_score: int
+    spam_flagged: bool
+    last_checked_at: Optional[datetime] = None
+
+
+# ── POST /telephony/check-reputation ────────────────────────────────────────
+
+@router.post("/check-reputation", response_model=ReputationResult)
+async def check_reputation(
+    body: CheckReputationRequest,
+    workspace: Workspace = Depends(get_workspace),
+    db: Session = Depends(get_db),
+    _principal=Depends(require_config_or_api_key),
+) -> ReputationResult:
+    """Run a reputation check for a single workspace phone number and persist the result."""
+    phone_number_obj = (
+        db.query(PhoneNumber)
+        .filter(
+            PhoneNumber.id == body.phone_number_id,
+            PhoneNumber.tenant_id == workspace.id,
+        )
+        .first()
+    )
+    if phone_number_obj is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Phone number not found in this workspace",
+        )
+
+    result = await check_number_reputation(db, phone_number_obj)
+    return ReputationResult(**result)
+
+
+# ── GET /telephony/reputation-summary ───────────────────────────────────────
+
+@router.get("/reputation-summary", response_model=List[ReputationSummaryItem])
+async def reputation_summary(
+    workspace: Workspace = Depends(get_workspace),
+    db: Session = Depends(get_db),
+    _principal=Depends(require_readonly_or_api_key),
+) -> List[ReputationSummaryItem]:
+    """Reputation snapshot for every phone number owned by this workspace."""
+    rows = db.execute(
+        select(PhoneNumber, PhoneNumberReputation)
+        .outerjoin(
+            PhoneNumberReputation,
+            PhoneNumberReputation.phone_number_id == PhoneNumber.id,
+        )
+        .where(PhoneNumber.tenant_id == workspace.id)
+    ).all()
+
+    return [
+        ReputationSummaryItem(
+            phone_number=phone_number.phone_number,
+            reputation_score=reputation.reputation_score if reputation else 100,
+            spam_flagged=reputation.spam_flagged if reputation else False,
+            last_checked_at=reputation.last_checked_at if reputation else None,
+        )
+        for phone_number, reputation in rows
+    ]

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -355,6 +355,9 @@ class Settings(BaseSettings):
 
     # ElevenLabs Configuration
     ELEVENLABS_API_KEY: str = ""
+
+    # Outbound number reputation monitoring (First Orion / Hiya)
+    REPUTATION_API_KEY: str = ""
     # Symmetric encryption key for agent.encrypted_elevenlabs_api_key (pgp_sym_encrypt).
     # In production/staging load from Secret Manager; never commit a real value.
     ELEVENLABS_ENCRYPTION_KEY: str = ""

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -219,6 +219,28 @@ def get_hubspot_oauth_credentials() -> Tuple[str, str]:
     return client_id, client_secret
 
 
+def get_reputation_api_key() -> str:
+    """
+    Return the outbound number reputation API key (First Orion / Hiya) for the
+    current environment.
+
+    - production/staging → GCP Secret Manager (secret: REPUTATION_API_KEY), with
+      env-var fallback so deployments that inject the var directly still work.
+    - development/local  → plain env-var / .env value. Empty string is a valid
+      return here (not raised) — reputation_service treats a missing key as
+      "use the mock provider" rather than a hard startup failure.
+    """
+    env = settings.ENVIRONMENT.lower()
+
+    if env in ("production", "staging"):
+        secret_key = _fetch_from_secret_manager("REPUTATION_API_KEY")
+        if secret_key:
+            return secret_key
+        return (getattr(settings, "REPUTATION_API_KEY", "") or "").strip()
+
+    return (getattr(settings, "REPUTATION_API_KEY", "") or "").strip()
+
+
 def get_sso_encryption_key() -> bytes:
     """Return the Fernet key for encrypting SSO OIDC client secrets."""
     env = settings.ENVIRONMENT.lower()

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -88,3 +88,6 @@ from app.models.sso_config import SsoConfig  # noqa: F401
 
 # In-call Stripe payment records
 from app.models.payment_record import PaymentRecord  # noqa: F401
+
+# Outbound number reputation monitoring / auto-rotation
+from app.models.phone_number_reputation import PhoneNumberReputation  # noqa: F401

--- a/app/models/batch_job.py
+++ b/app/models/batch_job.py
@@ -33,6 +33,10 @@ class BatchJob(Base):
     voicemail_skipped_count = Column(Integer, nullable=False, default=0, server_default="0")
     voicemail_message_left_count = Column(Integer, nullable=False, default=0, server_default="0")
 
+    # Rotated outbound caller-ID number actually used for this batch (set when
+    # the agent's bound number was spam-flagged and a clean replacement was found).
+    actual_from_number = Column(String(20), nullable=True)
+
     s3_path = Column(Text, nullable=True)
     scheduled_at = Column(DateTime(timezone=True), nullable=True)
     started_at = Column(DateTime(timezone=True), nullable=True)

--- a/app/models/phone_number.py
+++ b/app/models/phone_number.py
@@ -56,6 +56,12 @@ class PhoneNumber(Base):
         uselist=False,
         cascade="all, delete-orphan",
     )
+    reputation = relationship(
+        "PhoneNumberReputation",
+        back_populates="phone_number",
+        uselist=False,
+        cascade="all, delete-orphan",
+    )
 
     # Global unique constraint: a phone number can belong to only one tenant.
     __table_args__ = (

--- a/app/models/phone_number_reputation.py
+++ b/app/models/phone_number_reputation.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base_class import Base
+
+
+class PhoneNumberReputation(Base):
+    """Carrier spam/reputation check result for an outbound phone number."""
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    phone_number_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("phonenumber.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+
+    reputation_score = Column(Integer, nullable=False, default=100, server_default="100")
+    spam_flagged = Column(Boolean, nullable=False, default=False, server_default="false")
+    last_checked_at = Column(DateTime(timezone=True), nullable=True)
+    # e.g. 'first_orion', 'hiya', 'mock'
+    checked_by = Column(String, nullable=True)
+    flagged_reason = Column(Text, nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    phone_number = relationship("PhoneNumber", back_populates="reputation")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return (
+            f"<PhoneNumberReputation phone_number_id={self.phone_number_id} "
+            f"score={self.reputation_score} flagged={self.spam_flagged}>"
+        )

--- a/app/services/batch_call_service.py
+++ b/app/services/batch_call_service.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 from typing import List, Optional, Tuple
 
 from fastapi import HTTPException, status
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
@@ -42,6 +42,11 @@ _TERMINAL_STATUSES = frozenset({"completed", "cancelled", "failed"})
 
 # Formatter variable pattern  {variable_name}
 _VAR_PATTERN = re.compile(r"\{(\w+)\}")
+
+
+class AllNumbersFlaggedError(Exception):
+    """Raised when the agent's bound number is spam-flagged and no clean
+    same-country replacement exists in the workspace's phone number pool."""
 
 
 def _extract_prompt_vars(prompt: Optional[str]) -> List[str]:
@@ -382,3 +387,125 @@ class BatchCallService:
             "BatchJob %s cancelled: %d waiting records cancelled", batch_id, cancelled_count
         )
         return BatchJobOut.model_validate(job)
+
+    # ── Outbound number reputation / auto-rotation ────────────────────────────
+
+    async def rotate_number_if_flagged(
+        self,
+        workspace_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        batch_job_id: uuid.UUID,
+    ) -> Optional[Tuple[str, str]]:
+        """
+        Check the reputation of the agent's bound phone number for this batch and,
+        if it's spam-flagged, rotate the batch to a clean number from the
+        workspace's pool (same country code, preferring the same area code).
+
+        Returns (old_number, new_number) if a rotation happened, or None if the
+        bound number is clean (or unbound — nothing to rotate here; call
+        initiation will surface the "agent not ready" error as usual).
+
+        Raises AllNumbersFlaggedError if the bound number is flagged and no
+        clean same-country replacement exists in the pool.
+        """
+        from sqlalchemy import or_
+
+        from app.models.phone_number import PhoneNumber
+        from app.models.phone_number_reputation import PhoneNumberReputation
+        from app.services.reputation_service import check_number_reputation
+        from app.utils.phone_geo import get_area_code, get_country_code
+
+        phone_number_obj = (
+            self._db.query(PhoneNumber)
+            .filter(
+                PhoneNumber.assistant_id == agent_id,
+                PhoneNumber.tenant_id == workspace_id,
+                PhoneNumber.status == "active",
+            )
+            .first()
+        )
+        if phone_number_obj is None:
+            return None
+
+        reputation = (
+            self._db.query(PhoneNumberReputation)
+            .filter(PhoneNumberReputation.phone_number_id == phone_number_obj.id)
+            .first()
+        )
+        if reputation is None:
+            await check_number_reputation(self._db, phone_number_obj)
+            reputation = (
+                self._db.query(PhoneNumberReputation)
+                .filter(PhoneNumberReputation.phone_number_id == phone_number_obj.id)
+                .first()
+            )
+
+        if reputation is None or not reputation.spam_flagged:
+            return None
+
+        country_code = get_country_code(phone_number_obj.phone_number)
+        area_code = get_area_code(phone_number_obj.phone_number)
+
+        candidates = (
+            self._db.query(PhoneNumber)
+            .outerjoin(
+                PhoneNumberReputation,
+                PhoneNumberReputation.phone_number_id == PhoneNumber.id,
+            )
+            .filter(
+                PhoneNumber.tenant_id == workspace_id,
+                PhoneNumber.status == "active",
+                PhoneNumber.id != phone_number_obj.id,
+                PhoneNumber.assistant_id.is_(None),
+                or_(
+                    PhoneNumberReputation.id.is_(None),
+                    PhoneNumberReputation.spam_flagged.is_(False),
+                ),
+            )
+            .all()
+        )
+        same_country = [c for c in candidates if get_country_code(c.phone_number) == country_code]
+
+        replacement: Optional[PhoneNumber] = None
+        if area_code:
+            same_area = [c for c in same_country if get_area_code(c.phone_number) == area_code]
+            if same_area:
+                replacement = same_area[0]
+        if replacement is None and same_country:
+            replacement = same_country[0]
+
+        if replacement is None:
+            logger.warning(
+                "BatchJob %s: bound number %s is spam-flagged and no clean replacement "
+                "exists in workspace %s",
+                batch_job_id,
+                phone_number_obj.phone_number,
+                workspace_id,
+            )
+            job = self._db.get(BatchJob, batch_job_id)
+            if job is not None:
+                self._db.execute(
+                    update(BatchCallRecord)
+                    .where(
+                        BatchCallRecord.batch_job_id == batch_job_id,
+                        BatchCallRecord.status == "waiting",
+                    )
+                    .values(status="cancelled", last_error="all_numbers_flagged")
+                )
+                job.status = "failed"
+                job.waiting_count = 0
+                job.completed_at = datetime.now(timezone.utc)
+                self._db.commit()
+            raise AllNumbersFlaggedError()
+
+        job = self._db.get(BatchJob, batch_job_id)
+        job.actual_from_number = replacement.phone_number
+        self._db.commit()
+
+        logger.info(
+            "BatchJob %s: rotated outbound number %s -> %s (spam_flagged)",
+            batch_job_id,
+            phone_number_obj.phone_number,
+            replacement.phone_number,
+        )
+        return phone_number_obj.phone_number, replacement.phone_number

--- a/app/services/batch_call_worker_service.py
+++ b/app/services/batch_call_worker_service.py
@@ -134,6 +134,40 @@ class BatchCallWorkerService:
         job = self._db.get(BatchJob, record.batch_job_id)
         enable_amd = bool(job and job.voicemail_action in ("skip", "leave_message"))
 
+        # If the outbound number was rotated (spam-flagged bound number), dial
+        # out using the rotated number's phone_number_id instead of the agent's
+        # default bound number.
+        rotated_phone_number_id: Optional[str] = None
+        if job and job.actual_from_number:
+            from app.models.phone_number import PhoneNumber
+
+            rotated_number = (
+                self._db.query(PhoneNumber)
+                .filter(
+                    PhoneNumber.phone_number == job.actual_from_number,
+                    PhoneNumber.tenant_id == workspace_id,
+                    PhoneNumber.status == "active",
+                )
+                .first()
+            )
+            if rotated_number is not None:
+                rotated_phone_number_id = str(rotated_number.id)
+            else:
+                logger.error(
+                    "Batch record %s: rotated number %s for batch job %s is no "
+                    "longer active — refusing to fall back to the original "
+                    "(spam-flagged) bound number",
+                    record.id,
+                    job.actual_from_number,
+                    record.batch_job_id,
+                )
+                await self._mark_failed(
+                    record,
+                    "rotated_number_unavailable",
+                    is_system_error=True,
+                )
+                return
+
         # Build prompt with variable substitution (validated at upload time)
         variables: dict = record.variables or {}
         prompt_override: Optional[str] = None
@@ -160,6 +194,7 @@ class BatchCallWorkerService:
             enable_amd=enable_amd,
             voicemail_action=job.voicemail_action if job else None,
             voicemail_message=job.voicemail_message if job else None,
+            phone_number_id=rotated_phone_number_id,
         )
 
         try:

--- a/app/services/reputation_service.py
+++ b/app/services/reputation_service.py
@@ -1,0 +1,166 @@
+"""
+Outbound number reputation checks (First Orion primary, Hiya fallback).
+
+check_number_reputation() is the single entry point used by:
+  - POST /api/v2/telephony/check-reputation
+  - the daily ARQ cron (app.workers.batch_call_worker.check_all_phone_numbers_reputation)
+  - the batch-call rotation flow (app.services.batch_call_service)
+
+In development/local, or whenever REPUTATION_API_KEY is not configured, a
+deterministic mock check is used instead of calling a real carrier API so the
+feature is exercisable without third-party credentials.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Optional
+
+import httpx
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.core.secret_manager import get_reputation_api_key
+from app.models.phone_number import PhoneNumber
+from app.models.phone_number_reputation import PhoneNumberReputation
+
+FIRST_ORION_URL = "https://api.firstorion.com/v1/reputation/lookup"
+HIYA_URL = "https://api.hiya.com/v1/reputation/lookup"
+
+SPAM_THRESHOLD = 50
+REQUEST_TIMEOUT_SECONDS = 10.0
+
+
+def _use_mock() -> bool:
+    env = settings.ENVIRONMENT.lower()
+    if env not in ("staging", "production"):
+        return True
+    return not get_reputation_api_key()
+
+
+def _mock_check(phone_number: str) -> tuple[int, str]:
+    """
+    Deterministic stub: derive a stable 0-100 score from the phone number so
+    repeated checks against the same number are consistent within a test run.
+    """
+    digest = hashlib.sha256(phone_number.encode("utf-8")).hexdigest()
+    score = int(digest[:8], 16) % 101
+    checked_by = "mock"
+    return score, checked_by
+
+
+async def _call_first_orion(api_key: str, phone_number: str) -> tuple[int, str]:
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
+        response = await client.get(
+            FIRST_ORION_URL,
+            params={"number": phone_number},
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        response.raise_for_status()
+        data = response.json()
+        return int(data["reputation_score"]), "first_orion"
+
+
+async def _call_hiya(api_key: str, phone_number: str) -> tuple[int, str]:
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT_SECONDS) as client:
+        response = await client.get(
+            HIYA_URL,
+            params={"number": phone_number},
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+        response.raise_for_status()
+        data = response.json()
+        return int(data["reputation_score"]), "hiya"
+
+
+async def _fetch_score(phone_number: str) -> tuple[int, str]:
+    """Return (reputation_score, checked_by). Falls back to Hiya, then the mock."""
+    if _use_mock():
+        return _mock_check(phone_number)
+
+    api_key = get_reputation_api_key()
+    try:
+        return await _call_first_orion(api_key, phone_number)
+    except Exception as exc:
+        logger.warning(
+            "First Orion reputation lookup failed for %s: %s — falling back to Hiya",
+            phone_number,
+            exc,
+        )
+
+    try:
+        return await _call_hiya(api_key, phone_number)
+    except Exception as exc:
+        logger.error(
+            "Hiya reputation lookup also failed for %s: %s — falling back to mock",
+            phone_number,
+            exc,
+        )
+        return _mock_check(phone_number)
+
+
+async def check_number_reputation(db: Session, phone_number_obj: PhoneNumber) -> dict:
+    """
+    Query the reputation provider for phone_number_obj, upsert the
+    PhoneNumberReputation row, and return the result.
+
+    Returns {spam_flagged: bool, reputation_score: int, flagged_reason: Optional[str]}.
+    """
+    score, checked_by = await _fetch_score(phone_number_obj.phone_number)
+    score = max(0, min(100, score))
+    spam_flagged = score < SPAM_THRESHOLD
+    flagged_reason: Optional[str] = (
+        f"Reputation score {score} below threshold {SPAM_THRESHOLD} ({checked_by})"
+        if spam_flagged
+        else None
+    )
+    now = datetime.now(timezone.utc)
+
+    row = (
+        db.query(PhoneNumberReputation)
+        .filter(PhoneNumberReputation.phone_number_id == phone_number_obj.id)
+        .first()
+    )
+    if row is None:
+        row = PhoneNumberReputation(phone_number_id=phone_number_obj.id)
+        db.add(row)
+
+    row.reputation_score = score
+    row.spam_flagged = spam_flagged
+    row.last_checked_at = now
+    row.checked_by = checked_by
+    row.flagged_reason = flagged_reason
+
+    try:
+        db.commit()
+    except IntegrityError:
+        # Concurrent caller (cron + rotation check, or two rotation checks)
+        # inserted the row first — fall back to updating the existing one.
+        db.rollback()
+        row = (
+            db.query(PhoneNumberReputation)
+            .filter(PhoneNumberReputation.phone_number_id == phone_number_obj.id)
+            .first()
+        )
+        row.reputation_score = score
+        row.spam_flagged = spam_flagged
+        row.last_checked_at = now
+        row.checked_by = checked_by
+        row.flagged_reason = flagged_reason
+        db.commit()
+
+    logger.info(
+        "Reputation check for %s: score=%d flagged=%s checked_by=%s",
+        phone_number_obj.phone_number,
+        score,
+        spam_flagged,
+        checked_by,
+    )
+
+    return {
+        "spam_flagged": spam_flagged,
+        "reputation_score": score,
+        "flagged_reason": flagged_reason,
+    }

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -132,13 +132,36 @@ async def initiate_call(
                     detail=f"Invalid phone_number_id format: {str(e)}",
                 )
             if requested_id != phone_number_obj.id:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=(
-                        "phone_number_id must be the phone number bound to this agent "
-                        f"(bound id: {phone_number_obj.id})."
-                    ),
-                )
+                # System/batch calls may dial out on a rotated number (the agent's
+                # bound number was spam-flagged) rather than the bound number —
+                # bypass the strict agent-binding restriction as long as the
+                # requested number belongs to this tenant and is active.
+                rotated_number_obj = None
+                if is_system_call:
+                    from sqlalchemy import or_ as _or_
+
+                    rotated_number_obj = (
+                        db.query(PhoneNumber)
+                        .filter(
+                            PhoneNumber.id == requested_id,
+                            PhoneNumber.tenant_id == tenant_id_filter,
+                            PhoneNumber.status == "active",
+                            _or_(
+                                PhoneNumber.assistant_id.is_(None),
+                                PhoneNumber.assistant_id == agent.id,
+                            ),
+                        )
+                        .first()
+                    )
+                if rotated_number_obj is None:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=(
+                            "phone_number_id must be the phone number bound to this agent "
+                            f"(bound id: {phone_number_obj.id})."
+                        ),
+                    )
+                phone_number_obj = rotated_number_obj
 
         # ── 5. Validate fromNumber body param (GAP 1) ────────────────────
         from_number = phone_number_obj.phone_number

--- a/app/utils/phone_geo.py
+++ b/app/utils/phone_geo.py
@@ -1,0 +1,64 @@
+"""
+Lightweight E.164 phone number geo parsing — no third-party dependency.
+
+Used by the outbound number rotation flow (app.services.batch_call_service) to
+find a same-country / same-area-code replacement number from the tenant's pool.
+This is a best-effort heuristic, not a full libphonenumber-equivalent parser:
+the "area code" is simply the 3 digits immediately following the country
+calling code, which is correct for NANP (+1) and a reasonable approximation
+for most other national numbering plans.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+# ITU-T E.164 country calling codes (digits only, no leading '+'), grouped by length
+# so the longest matching prefix is tried first.
+_COUNTRY_CALLING_CODES: frozenset[str] = frozenset(
+    {
+        # 1-digit
+        "1", "7",
+        # 2-digit
+        "20", "27", "30", "31", "32", "33", "34", "36", "39", "40", "41", "43",
+        "44", "45", "46", "47", "48", "49", "51", "52", "53", "54", "55", "56",
+        "57", "58", "60", "61", "62", "63", "64", "65", "66", "81", "82", "84",
+        "86", "90", "91", "92", "93", "94", "95", "98",
+        # 3-digit
+        "211", "212", "213", "216", "218", "220", "221", "222", "223", "224",
+        "225", "226", "227", "228", "229", "230", "231", "232", "233", "234",
+        "235", "236", "237", "238", "239", "240", "241", "242", "243", "244",
+        "245", "246", "248", "249", "250", "251", "252", "253", "254", "255",
+        "256", "257", "258", "260", "261", "262", "263", "264", "265", "266",
+        "267", "268", "269", "290", "291", "297", "298", "299", "350", "351",
+        "352", "353", "354", "355", "356", "357", "358", "359", "370", "371",
+        "372", "373", "374", "375", "376", "377", "378", "379", "380", "381",
+        "382", "383", "385", "386", "387", "389", "420", "421", "423", "500",
+        "501", "502", "503", "504", "505", "506", "507", "508", "509", "590",
+        "591", "592", "593", "594", "595", "596", "597", "598", "599", "670",
+        "672", "673", "674", "675", "676", "677", "678", "679", "680", "681",
+        "682", "683", "685", "686", "687", "688", "689", "690", "691", "692",
+        "850", "852", "853", "855", "856", "880", "886", "960", "961", "962",
+        "963", "964", "965", "966", "967", "968", "970", "971", "972", "973",
+        "974", "975", "976", "977", "992", "993", "994", "995", "996", "998",
+    }
+)
+
+
+def get_country_code(e164_number: str) -> Optional[str]:
+    """Return the calling code (e.g. '1', '61') for an E.164 number, or None."""
+    digits = e164_number.lstrip("+")
+    for length in (3, 2, 1):
+        prefix = digits[:length]
+        if prefix in _COUNTRY_CALLING_CODES:
+            return prefix
+    return None
+
+
+def get_area_code(e164_number: str) -> Optional[str]:
+    """Best-effort area code: the 3 digits following the country calling code."""
+    country_code = get_country_code(e164_number)
+    if country_code is None:
+        return None
+    digits = e164_number.lstrip("+")
+    rest = digits[len(country_code):]
+    return rest[:3] if len(rest) >= 3 else None

--- a/app/workers/batch_call_worker.py
+++ b/app/workers/batch_call_worker.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from app.core.config import settings
@@ -479,6 +479,60 @@ async def startup_recover_callbacks(ctx: dict) -> None:
         db.close()
 
 
+# ── Outbound number reputation monitoring ───────────────────────────────────
+
+async def check_all_phone_numbers_reputation(ctx: dict) -> None:
+    """
+    Daily cron: refresh the reputation record for every active phone number
+    whose last check is missing or older than 24 hours.
+    """
+    from sqlalchemy import or_, select
+
+    from app.db.session import SessionLocal
+    from app.models.phone_number import PhoneNumber
+    from app.models.phone_number_reputation import PhoneNumberReputation
+    from app.services.reputation_service import check_number_reputation
+
+    db = SessionLocal()
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+
+        rows = db.execute(
+            select(PhoneNumber)
+            .outerjoin(
+                PhoneNumberReputation,
+                PhoneNumberReputation.phone_number_id == PhoneNumber.id,
+            )
+            .where(
+                PhoneNumber.status == "active",
+                or_(
+                    PhoneNumberReputation.last_checked_at.is_(None),
+                    PhoneNumberReputation.last_checked_at < cutoff,
+                ),
+            )
+        ).scalars().all()
+
+        logger.info("check_all_phone_numbers_reputation: %d number(s) due for a check", len(rows))
+
+        checked = 0
+        for phone_number_obj in rows:
+            try:
+                await check_number_reputation(db, phone_number_obj)
+                checked += 1
+            except Exception as exc:
+                logger.error(
+                    "check_all_phone_numbers_reputation: check failed for %s: %s",
+                    phone_number_obj.id,
+                    exc,
+                    exc_info=True,
+                )
+                db.rollback()
+
+        logger.info("check_all_phone_numbers_reputation: checked %d/%d number(s)", checked, len(rows))
+    finally:
+        db.close()
+
+
 # ── WorkerSettings ────────────────────────────────────────────────────────────
 
 async def purge_old_audit_logs(ctx: dict) -> None:
@@ -532,6 +586,7 @@ class WorkerSettings:
         run_data_export_job,
         # poll_pending_callbacks kept for manual/admin invocation; not in cron_jobs
         poll_pending_callbacks,
+        check_all_phone_numbers_reputation,
     ]
 
     # Replaced at module-load time by the try/except block below
@@ -573,6 +628,8 @@ try:
         _arq.cron(poll_pending_batch_jobs, second={0}, run_at_startup=True),
         # Audit log 90-day retention: runs once per day at 03:00 UTC
         _arq.cron(purge_old_audit_logs, hour={3}, minute={0}, second={0}),
+        # Outbound number reputation refresh: runs once per day at 02:00 UTC
+        _arq.cron(check_all_phone_numbers_reputation, hour={2}, minute={0}, second={0}),
         # Callback recovery is handled by WorkerSettings.on_startup (startup_recover_callbacks),
         # not a periodic cron — no polling loop needed for correctness.
     ]

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9022,6 +9022,55 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - HTTPBearer: []
+  /api/v2/telephony/check-reputation:
+    post:
+      tags:
+      - Telephony
+      summary: Check Reputation
+      description: Run a reputation check for a single workspace phone number and
+        persist the result.
+      operationId: check_reputation_api_v2_telephony_check_reputation_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CheckReputationRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReputationResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
+  /api/v2/telephony/reputation-summary:
+    get:
+      tags:
+      - Telephony
+      summary: Reputation Summary
+      description: Reputation snapshot for every phone number owned by this workspace.
+      operationId: reputation_summary_api_v2_telephony_reputation_summary_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/ReputationSummaryItem'
+                type: array
+                title: Response Reputation Summary Api V2 Telephony Reputation Summary
+                  Get
+      security:
+      - HTTPBearer: []
   /auth/saml/{workspace_slug}/metadata:
     get:
       tags:
@@ -11995,6 +12044,16 @@ components:
       - partially qualified
       - rejected
       title: CandidateStatusEnum
+    CheckReputationRequest:
+      properties:
+        phone_number_id:
+          type: string
+          format: uuid
+          title: Phone Number Id
+      type: object
+      required:
+      - phone_number_id
+      title: CheckReputationRequest
     CreatePaymentSessionRequest:
       properties:
         call_id:
@@ -14737,6 +14796,43 @@ components:
       title: RegisterExternalNumberResponse
       description: External number registration result — sip_password is write-only
         and never returned.
+    ReputationResult:
+      properties:
+        spam_flagged:
+          type: boolean
+          title: Spam Flagged
+        reputation_score:
+          type: integer
+          title: Reputation Score
+        flagged_reason:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - spam_flagged
+      - reputation_score
+      title: ReputationResult
+    ReputationSummaryItem:
+      properties:
+        phone_number:
+          type: string
+          title: Phone Number
+        reputation_score:
+          type: integer
+          title: Reputation Score
+        spam_flagged:
+          type: boolean
+          title: Spam Flagged
+        last_checked_at:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - phone_number
+      - reputation_score
+      - spam_flagged
+      title: ReputationSummaryItem
     ResetPasswordRequest:
       properties:
         token:

--- a/tests/api/v2/test_batch_calls.py
+++ b/tests/api/v2/test_batch_calls.py
@@ -119,6 +119,7 @@ class TestCreateBatchJob:
     def _svc(self, job_out):
         svc = MagicMock()
         svc.create_batch_job.return_value = job_out
+        svc.rotate_number_if_flagged = AsyncMock(return_value=None)
         return svc
 
     def _job_out(self, total: int = 3, voicemail_action: str = "skip", voicemail_message=None) -> dict:
@@ -389,6 +390,7 @@ class TestCreateBatchJob:
 
         mock_svc = MagicMock()
         mock_svc.create_batch_job.return_value = job
+        mock_svc.rotate_number_if_flagged = AsyncMock(return_value=None)
 
         result = asyncio.run(
             create_batch_job(

--- a/tests/api/v2/test_reputation_rotation.py
+++ b/tests/api/v2/test_reputation_rotation.py
@@ -1,0 +1,499 @@
+"""
+Tests for outbound number reputation monitoring / auto-rotation.
+
+Coverage:
+  - BatchCallService.rotate_number_if_flagged: area-code preference, same-country
+    fallback, AllNumbersFlaggedError when no clean number exists, no-op when clean.
+  - POST /batch-calls: 422 all_numbers_flagged payload + batch.number_rotated audit log.
+  - ARQ cron check_all_phone_numbers_reputation: only checks numbers missing/stale (>24h).
+
+DB is an in-memory SQLite fixture (mirrors tests/services/test_batch_call_worker.py).
+The reputation provider call is mocked — no real HTTP calls.
+"""
+from __future__ import annotations
+
+import io
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+
+
+@compiles(JSONB, "sqlite")
+def _jsonb_sqlite(type_, compiler, **kw):
+    return "JSON"
+
+
+@compiles(PG_UUID, "sqlite")
+def _uuid_sqlite(type_, compiler, **kw):
+    return "VARCHAR(36)"
+
+
+_SHARED_CONN = sqlite3.connect(":memory:", check_same_thread=False)
+_engine = create_engine(
+    "sqlite://",
+    creator=lambda: _SHARED_CONN,
+    connect_args={"check_same_thread": False},
+)
+_Session = sessionmaker(bind=_engine)
+
+
+def _setup_db():
+    import app.models.agent  # noqa: F401
+    import app.models.batch_call_record  # noqa: F401
+    import app.models.batch_job  # noqa: F401
+    import app.models.phone_number  # noqa: F401
+    import app.models.phone_number_reputation  # noqa: F401
+    import app.models.tenant  # noqa: F401
+    import app.models.user  # noqa: F401
+    import app.models.plan  # noqa: F401
+    import app.models.subscription  # noqa: F401
+    import app.models.usage_record  # noqa: F401
+    import app.models.role  # noqa: F401
+
+    Base.metadata.drop_all(bind=_engine)
+    Base.metadata.create_all(bind=_engine)
+
+
+@pytest.fixture()
+def db():
+    _setup_db()
+    session = _Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+# ── Helper builders ───────────────────────────────────────────────────────────
+
+def _make_tenant(db) -> uuid.UUID:
+    from app.models.tenant import Tenant
+
+    t = Tenant(name="WS", schema_name="ws_test")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t.id
+
+
+def _make_agent(db, tenant_id: uuid.UUID) -> uuid.UUID:
+    from app.models.agent import Agent
+
+    a = Agent(tenant_id=tenant_id, name="TestAgent", status="ready")
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a.id
+
+
+def _make_phone_number(db, tenant_id, agent_id, number: str):
+    from app.models.phone_number import PhoneNumber
+
+    p = PhoneNumber(
+        tenant_id=tenant_id,
+        phone_number=number,
+        status="active",
+        provider="twilio",
+        assistant_id=agent_id,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+def _make_extra_number(db, tenant_id, number: str):
+    """A pool number not bound to any agent."""
+    return _make_phone_number(db, tenant_id, None, number)
+
+
+def _make_reputation(db, phone_number_id, *, spam_flagged: bool, score: int = 30, checked_at=None):
+    from app.models.phone_number_reputation import PhoneNumberReputation
+
+    r = PhoneNumberReputation(
+        phone_number_id=phone_number_id,
+        reputation_score=score,
+        spam_flagged=spam_flagged,
+        last_checked_at=checked_at or datetime.now(timezone.utc),
+        checked_by="mock",
+    )
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _make_batch_job(db, workspace_id, agent_id, total=2) -> "BatchJob":  # noqa: F821
+    from app.models.batch_job import BatchJob
+
+    j = BatchJob(
+        workspace_id=workspace_id,
+        agent_id=agent_id,
+        status="pending",
+        total_count=total,
+        waiting_count=total,
+        active_count=0,
+        completed_count=0,
+        failed_count=0,
+        voicemail_action="skip",
+    )
+    db.add(j)
+    db.commit()
+    db.refresh(j)
+    return j
+
+
+def _make_record(db, batch_job_id, phone="+61412345678", status="waiting"):
+    from app.models.batch_call_record import BatchCallRecord
+
+    r = BatchCallRecord(batch_job_id=batch_job_id, phone_number=phone, status=status, attempts=0)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+# ── BatchCallService.rotate_number_if_flagged ───────────────────────────────
+
+class TestRotateNumberIfFlagged:
+    def test_clean_bound_number_does_not_rotate(self, db):
+        from app.services.batch_call_service import BatchCallService
+
+        tenant_id = _make_tenant(db)
+        agent_id = _make_agent(db, tenant_id)
+        bound = _make_phone_number(db, tenant_id, agent_id, "+61412345678")
+        _make_reputation(db, bound.id, spam_flagged=False, score=90)
+        job = _make_batch_job(db, tenant_id, agent_id)
+
+        svc = BatchCallService(db)
+        result = asyncio_run(svc.rotate_number_if_flagged(tenant_id, agent_id, job.id))
+
+        assert result is None
+        db.refresh(job)
+        assert job.actual_from_number is None
+
+    def test_rotates_to_clean_number_with_same_area_code(self, db):
+        from app.services.batch_call_service import BatchCallService
+
+        tenant_id = _make_tenant(db)
+        agent_id = _make_agent(db, tenant_id)
+        bound = _make_phone_number(db, tenant_id, agent_id, "+61412345678")  # AU, area 412
+        _make_reputation(db, bound.id, spam_flagged=True, score=10)
+
+        same_area = _make_extra_number(db, tenant_id, "+61412999888")  # same area 412
+        _make_extra_number(db, tenant_id, "+61355566677")  # same country, area 355
+
+        job = _make_batch_job(db, tenant_id, agent_id)
+
+        svc = BatchCallService(db)
+        result = asyncio_run(svc.rotate_number_if_flagged(tenant_id, agent_id, job.id))
+
+        assert result == ("+61412345678", "+61412999888")
+        db.refresh(job)
+        assert job.actual_from_number == "+61412999888"
+
+    def test_falls_back_to_same_country_when_no_area_code_match(self, db):
+        from app.services.batch_call_service import BatchCallService
+
+        tenant_id = _make_tenant(db)
+        agent_id = _make_agent(db, tenant_id)
+        bound = _make_phone_number(db, tenant_id, agent_id, "+61412345678")
+        _make_reputation(db, bound.id, spam_flagged=True, score=10)
+
+        _make_extra_number(db, tenant_id, "+61355566677")
+
+        job = _make_batch_job(db, tenant_id, agent_id)
+
+        svc = BatchCallService(db)
+        result = asyncio_run(svc.rotate_number_if_flagged(tenant_id, agent_id, job.id))
+
+        assert result == ("+61412345678", "+61355566677")
+
+    def test_never_rotates_onto_a_number_bound_to_another_agent(self, db):
+        """A number already assigned to a different agent must never be picked
+        as a replacement — doing so would hijack that agent's caller ID and
+        misroute its inbound callbacks/voicemail replies."""
+        from app.services.batch_call_service import AllNumbersFlaggedError, BatchCallService
+
+        tenant_id = _make_tenant(db)
+        agent_id = _make_agent(db, tenant_id)
+        # A second agent in the same tenant — only its id is needed to bind
+        # the "other" phone number, so avoid the single-agent-per-tenant
+        # uniqueness quirk in the SQLite test schema by not persisting it.
+        other_agent_id = uuid.uuid4()
+        bound = _make_phone_number(db, tenant_id, agent_id, "+61412345678")
+        _make_reputation(db, bound.id, spam_flagged=True, score=10)
+
+        # Only candidate in the pool is bound to a different agent.
+        _make_phone_number(db, tenant_id, other_agent_id, "+61412999888")
+
+        job = _make_batch_job(db, tenant_id, agent_id)
+
+        svc = BatchCallService(db)
+        with pytest.raises(AllNumbersFlaggedError):
+            asyncio_run(svc.rotate_number_if_flagged(tenant_id, agent_id, job.id))
+
+    def test_raises_and_fails_job_when_no_clean_number_available(self, db):
+        from app.services.batch_call_service import AllNumbersFlaggedError, BatchCallService
+
+        tenant_id = _make_tenant(db)
+        agent_id = _make_agent(db, tenant_id)
+        bound = _make_phone_number(db, tenant_id, agent_id, "+61412345678")
+        _make_reputation(db, bound.id, spam_flagged=True, score=10)
+
+        # Another number exists but is also flagged — not usable.
+        other = _make_extra_number(db, tenant_id, "+61412999888")
+        _make_reputation(db, other.id, spam_flagged=True, score=5)
+
+        job = _make_batch_job(db, tenant_id, agent_id)
+        rec = _make_record(db, job.id)
+
+        svc = BatchCallService(db)
+        with pytest.raises(AllNumbersFlaggedError):
+            asyncio_run(svc.rotate_number_if_flagged(tenant_id, agent_id, job.id))
+
+        db.refresh(job)
+        db.refresh(rec)
+        assert job.status == "failed"
+        assert job.actual_from_number is None
+        assert rec.status == "cancelled"
+
+    def test_checks_reputation_when_no_record_exists_yet(self, db):
+        """No PhoneNumberReputation row yet — a check is performed to populate it."""
+        from app.services.batch_call_service import BatchCallService
+
+        tenant_id = _make_tenant(db)
+        agent_id = _make_agent(db, tenant_id)
+        bound = _make_phone_number(db, tenant_id, agent_id, "+61412345678")
+        job = _make_batch_job(db, tenant_id, agent_id)
+
+        async def _fake_check(db_, phone_number_obj):
+            from app.models.phone_number_reputation import PhoneNumberReputation
+
+            row = PhoneNumberReputation(
+                phone_number_id=phone_number_obj.id,
+                reputation_score=20,
+                spam_flagged=True,
+                last_checked_at=datetime.now(timezone.utc),
+                checked_by="mock",
+            )
+            db_.add(row)
+            db_.commit()
+            return {"spam_flagged": True, "reputation_score": 20, "flagged_reason": "low score"}
+
+        clean = _make_extra_number(db, tenant_id, "+61412999888")
+
+        svc = BatchCallService(db)
+        with patch(
+            "app.services.reputation_service.check_number_reputation",
+            new=AsyncMock(side_effect=_fake_check),
+        ):
+            result = asyncio_run(svc.rotate_number_if_flagged(tenant_id, agent_id, job.id))
+
+        assert result == ("+61412345678", "+61412999888")
+
+
+# ── POST /batch-calls rotation integration (router level, mocked service) ──
+
+WORKSPACE_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+RAW_KEY = f"tgs-{uuid.uuid4().hex}"
+AUTH_HEADERS = {"x-api-key": RAW_KEY, "x-workspace-id": str(WORKSPACE_ID)}
+
+
+def _mock_workspace():
+    from app.core.workspace import Workspace
+
+    ws = MagicMock(spec=Workspace)
+    ws.id = WORKSPACE_ID
+    ws.status = "active"
+    ws.is_active = True
+    return ws
+
+
+def _mock_principal():
+    from app.core.request_auth import ApiKeyPrincipal
+
+    return ApiKeyPrincipal(current_tenant_id=WORKSPACE_ID, api_key_id=uuid.uuid4())
+
+
+def _job_out(total: int = 2):
+    from app.schemas.batch_call import BatchJobOut
+
+    return BatchJobOut(
+        id=uuid.uuid4(),
+        workspace_id=WORKSPACE_ID,
+        agent_id=AGENT_ID,
+        status="pending",
+        total_count=total,
+        waiting_count=total,
+        active_count=0,
+        completed_count=0,
+        failed_count=0,
+        voicemail_action="skip",
+        voicemail_message=None,
+        s3_path="batch-files/x/y.csv",
+        scheduled_at=None,
+        started_at=None,
+        completed_at=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _build_app(svc_mock) -> TestClient:
+    from app.api.deps import get_workspace, require_tenant
+    from app.api.v2.routers import batch_calls as bc_module
+    from app.core.exception_handlers import register_exception_handlers
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(bc_module.router)
+
+    mini.dependency_overrides[require_tenant] = _mock_principal
+    mini.dependency_overrides[get_workspace] = _mock_workspace
+
+    def _svc_override():
+        yield svc_mock
+
+    mini.dependency_overrides[bc_module._batch_service] = _svc_override
+    mini.dependency_overrides[bc_module._batch_service_write] = _svc_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+_VALID_CSV = b"phone_number\n+15551111001\n+15551111002"
+
+
+class TestBatchCallsRotationEndpoint:
+    @patch("app.api.v2.routers.batch_calls._enqueue_batch_job", new_callable=AsyncMock)
+    def test_all_numbers_flagged_returns_422(self, mock_enqueue):
+        from app.services.batch_call_service import AllNumbersFlaggedError
+
+        svc = MagicMock()
+        svc.create_batch_job.return_value = _job_out()
+        svc.rotate_number_if_flagged = AsyncMock(side_effect=AllNumbersFlaggedError())
+
+        client = _build_app(svc)
+        resp = client.post(
+            "/batch-calls",
+            data={"agent_id": str(AGENT_ID)},
+            files={"file": ("t.csv", io.BytesIO(_VALID_CSV), "text/csv")},
+            headers=AUTH_HEADERS,
+        )
+
+        assert resp.status_code == 422
+        body = resp.json()
+        assert body["error"]["code"] == "all_numbers_flagged"
+        assert "spam-flagged" in body["error"]["message"]
+        mock_enqueue.assert_not_called()
+
+    @patch("app.api.v2.routers.batch_calls._enqueue_batch_job", new_callable=AsyncMock)
+    @patch("app.api.v2.routers.batch_calls.log_audit_event")
+    def test_rotation_logs_audit_event_and_still_enqueues(self, mock_audit, mock_enqueue):
+        job = _job_out()
+        svc = MagicMock()
+        svc.create_batch_job.return_value = job
+        svc.rotate_number_if_flagged = AsyncMock(return_value=("+15550001111", "+15550002222"))
+
+        client = _build_app(svc)
+        resp = client.post(
+            "/batch-calls",
+            data={"agent_id": str(AGENT_ID)},
+            files={"file": ("t.csv", io.BytesIO(_VALID_CSV), "text/csv")},
+            headers=AUTH_HEADERS,
+        )
+
+        assert resp.status_code == 201
+        mock_enqueue.assert_called_once()
+
+        rotation_calls = [
+            c for c in mock_audit.call_args_list if c.kwargs.get("action") == "batch.number_rotated"
+        ]
+        assert len(rotation_calls) == 1
+        call = rotation_calls[0]
+        assert call.kwargs["old_value"] == {"from_number": "+15550001111"}
+        assert call.kwargs["new_value"] == {"from_number": "+15550002222", "reason": "spam_flagged"}
+
+    @patch("app.api.v2.routers.batch_calls._enqueue_batch_job", new_callable=AsyncMock)
+    @patch("app.api.v2.routers.batch_calls.log_audit_event")
+    def test_no_rotation_when_bound_number_clean(self, mock_audit, mock_enqueue):
+        job = _job_out()
+        svc = MagicMock()
+        svc.create_batch_job.return_value = job
+        svc.rotate_number_if_flagged = AsyncMock(return_value=None)
+
+        client = _build_app(svc)
+        resp = client.post(
+            "/batch-calls",
+            data={"agent_id": str(AGENT_ID)},
+            files={"file": ("t.csv", io.BytesIO(_VALID_CSV), "text/csv")},
+            headers=AUTH_HEADERS,
+        )
+
+        assert resp.status_code == 201
+        rotation_calls = [
+            c for c in mock_audit.call_args_list if c.kwargs.get("action") == "batch.number_rotated"
+        ]
+        assert len(rotation_calls) == 0
+
+
+# ── ARQ cron: check_all_phone_numbers_reputation ────────────────────────────
+
+class TestReputationCronTask:
+    @patch("app.services.reputation_service.check_number_reputation", new_callable=AsyncMock)
+    def test_checks_only_missing_or_stale_numbers(self, mock_check, db, monkeypatch):
+        from app.workers.batch_call_worker import check_all_phone_numbers_reputation
+
+        tenant_id = _make_tenant(db)
+        agent_id = _make_agent(db, tenant_id)
+
+        never_checked = _make_phone_number(db, tenant_id, agent_id, "+61412000001")
+
+        stale = _make_extra_number(db, tenant_id, "+61412000002")
+        _make_reputation(
+            db, stale.id, spam_flagged=False, score=95,
+            checked_at=datetime.now(timezone.utc) - timedelta(hours=25),
+        )
+
+        fresh = _make_extra_number(db, tenant_id, "+61412000003")
+        _make_reputation(
+            db, fresh.id, spam_flagged=False, score=95,
+            checked_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+
+        inactive = _make_extra_number(db, tenant_id, "+61412000004")
+        inactive.status = "inactive"
+        db.commit()
+
+        monkeypatch.setattr("app.db.session.SessionLocal", lambda: db)
+        # db.close() is called by the task; make it a no-op so the fixture's
+        # session stays open for post-assertions.
+        monkeypatch.setattr(db, "close", lambda: None)
+
+        asyncio_run(check_all_phone_numbers_reputation({}))
+
+        checked_ids = {call.args[1].id for call in mock_check.call_args_list}
+        assert never_checked.id in checked_ids
+        assert stale.id in checked_ids
+        assert fresh.id not in checked_ids
+        assert inactive.id not in checked_ids
+        assert mock_check.call_count == 2
+
+
+# ── asyncio helper ────────────────────────────────────────────────────────────
+
+def asyncio_run(coro):
+    import asyncio
+
+    return asyncio.run(coro)

--- a/tests/integration/test_livekit_integration.py
+++ b/tests/integration/test_livekit_integration.py
@@ -1,7 +1,15 @@
 """
 Integration tests for LiveKit — require a live server.
 
-Run only when LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET are set.
+Run only when RUN_LIVEKIT_INTEGRATION=1 and LIVEKIT_URL, LIVEKIT_API_KEY,
+LIVEKIT_API_SECRET are set. The explicit opt-in flag (mirroring
+RUN_GOOGLE_STT_INTEGRATION in test_google_stt_live.py) is required in
+addition to the credential vars because those vars are also present in the
+shared .env file and get loaded into os.environ as a side effect of
+collecting unrelated test modules (e.g. test_google_stt_live.py calls
+load_dotenv() at import time) — without the flag this module would
+silently attempt a real connection whenever it happens to be collected
+alongside such a module, instead of skipping as intended.
 
 These tests confirm both HTTP/API-plane and WebSocket/RTC connectivity from
 the API server to the LiveKit server, covering the full room lifecycle:
@@ -17,6 +25,7 @@ LOCAL DEV — start a throwaway LiveKit server with Docker:
 
     Then run:
 
+    RUN_LIVEKIT_INTEGRATION=1 \\
     LIVEKIT_URL=http://localhost:7880 \\
     LIVEKIT_API_KEY=devkey \\
     LIVEKIT_API_SECRET=secret \\
@@ -32,9 +41,14 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
-# Skip entire module if LiveKit env vars are absent
+# Skip entire module unless explicitly opted in with LiveKit env vars set
 # ---------------------------------------------------------------------------
 
+_RUN_LIVEKIT_INTEGRATION = os.environ.get("RUN_LIVEKIT_INTEGRATION", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
 _LIVEKIT_URL = os.environ.get("LIVEKIT_URL", "")
 _LIVEKIT_API_KEY = os.environ.get("LIVEKIT_API_KEY", "")
 _LIVEKIT_API_SECRET = os.environ.get("LIVEKIT_API_SECRET", "")
@@ -42,8 +56,11 @@ _LIVEKIT_API_SECRET = os.environ.get("LIVEKIT_API_SECRET", "")
 pytestmark = pytest.mark.integration
 
 _skip_unless_livekit = pytest.mark.skipif(
-    not (_LIVEKIT_URL and _LIVEKIT_API_KEY and _LIVEKIT_API_SECRET),
-    reason="LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET not set — skipping integration tests",
+    not (_RUN_LIVEKIT_INTEGRATION and _LIVEKIT_URL and _LIVEKIT_API_KEY and _LIVEKIT_API_SECRET),
+    reason=(
+        "Set RUN_LIVEKIT_INTEGRATION=1 and LIVEKIT_URL, LIVEKIT_API_KEY, "
+        "LIVEKIT_API_SECRET to run live LiveKit integration tests"
+    ),
 )
 
 # Skip RTC tests if the native livekit package cannot be imported


### PR DESCRIPTION
## Summary
- Adds outbound caller-ID reputation checks (First Orion, Hiya fallback) with a daily ARQ cron to refresh scores and a `telephony` API for on-demand checks / per-workspace summary.
- Auto-rotates batch outbound calls off a spam-flagged bound number onto a clean same-country/area-code number from the tenant's pool, with an `AllNumbersFlaggedError` path that cancels the batch when no clean number exists.

## Review fixes included
- Excluded phone numbers already bound to another agent from rotation candidates (was a caller-ID hijack/collision risk).
- Tightened the `is_system_call` `phone_number_id` bypass in `voice_call_service.initiate_call` to only pool numbers or the agent's own number, not any active tenant number.
- `dispatch_record` now fails the batch record instead of silently falling back to dial on the original (still spam-flagged) number when a rotated number becomes unavailable.
- Fixed a concurrent-insert race on `PhoneNumberReputation`'s unique index (`IntegrityError` handling in `check_number_reputation`).
- Fixed a pre-existing, unrelated test-isolation bug: `tests/integration/test_livekit_integration.py` now requires an explicit `RUN_LIVEKIT_INTEGRATION=1` opt-in (matching `RUN_GOOGLE_STT_INTEGRATION`), since `.env` credential leakage from `test_google_stt_live.py`'s `load_dotenv()` was un-skipping it and crashing on `conftest.py`'s mocked `google` module.

## Test plan
- [x] Full suite: `pytest tests/ -v` → 1464 passed, 65 skipped, 0 failed
- [x] New regression test covering cross-agent number exclusion (`test_never_rotates_onto_a_number_bound_to_another_agent`)
- [x] `tests/api/v2/test_reputation_rotation.py` (10/10) and `tests/api/v2/test_batch_calls.py` (17/17) pass