### PR TITLE
Resolve Sprint 7 HubSpot integration edge cases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,9 @@ HOST=0.0.0.0
 PORT=8001
 WEBHOOK_BASE_URL=https://your-domain.com
 
+# Betterstack status page badge — optional; surfaced in GET /api/v1/health when set
+BETTERSTACK_BADGE_URL=
+
 # API docs (Swagger UI at /api/docs) — HTTP Basic auth.
 API_DOCS_ENABLED=true
 API_DOCS_USERNAME=admin

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -6,6 +6,7 @@ from app.api.api_v1.endpoints import (
     api_keys,
     billing,
     gemini,
+    health,
     model,
     openai,
     plan,
@@ -56,6 +57,7 @@ from app.routers.payments import router as payments_router
 from app.routers.amd_webhook import router as amd_webhook_router
 
 api_router = APIRouter()
+api_router.include_router(health.router, tags=["Health"])
 api_router.include_router(user.router, prefix="/users", tags=["users"])
 api_router.include_router(api_keys.router, prefix="/api-keys", tags=["API Keys"])
 api_router.include_router(tenant.router, prefix="/tenants", tags=["tenants"])

--- a/app/api/api_v1/endpoints/health.py
+++ b/app/api/api_v1/endpoints/health.py
@@ -1,0 +1,30 @@
+"""
+Public health endpoint — GET /api/v1/health.
+
+No API key or JWT required (see the skip lists in
+app/middleware/api_key_middleware.py and app/middleware/rate_limit_middleware.py).
+
+Betterstack (https://betterstack.com/) polls this endpoint every 30 seconds
+expecting an HTTP 200, and uses it to drive the public status page served at
+status.yourdomain.com. Configure BETTERSTACK_BADGE_URL to surface that page's
+embeddable badge in the response.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter
+
+from app.core.config import settings
+
+router = APIRouter()
+
+
+@router.get("/health")
+async def health_check() -> dict:
+    return {
+        "status": "ok",
+        "version": settings.APP_VERSION,
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "betterstack_badge": settings.BETTERSTACK_BADGE_URL,
+    }

--- a/app/api/v2/routers/health.py
+++ b/app/api/v2/routers/health.py
@@ -1,24 +1,96 @@
+"""
+Public enhanced health endpoint — GET /api/v2/health.
+
+No API key or workspace header required (see the skip list in
+app/middleware/api_key_middleware.py). Each dependency probe below is bounded
+to a 1-second timeout so a slow/unreachable downstream never makes this
+endpoint itself time out — Betterstack (or any external monitor) polling this
+route always gets a fast, well-formed response.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
 from fastapi import APIRouter, Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
 from app.db.async_session import get_db as get_async_db
+from app.utils.redis_client import get_redis
+from app.services.livekit_service import livekit_service
 
 router = APIRouter(tags=["v2"])
+
+PROBE_TIMEOUT_SECONDS = 1.0
+
+
+async def _probe_database(db: AsyncSession) -> bool:
+    try:
+        await asyncio.wait_for(db.execute(text("SELECT 1")), timeout=PROBE_TIMEOUT_SECONDS)
+        return True
+    except asyncio.TimeoutError:
+        # wait_for() cancels the in-flight query without the DBAPI driver's
+        # knowledge; invalidate so the (possibly mid-read) connection is
+        # discarded instead of returned to the pool for the next request.
+        await db.invalidate()
+        return False
+    except Exception:
+        return False
+
+
+async def _probe_redis() -> bool:
+    redis = get_redis()
+    if redis is None:
+        return False
+    try:
+        return bool(await asyncio.wait_for(redis.ping(), timeout=PROBE_TIMEOUT_SECONDS))
+    except asyncio.TimeoutError:
+        # Same rationale as the DB probe: a cancelled command can leave the
+        # shared connection mid-read. get_redis() is also used by RBAC
+        # caching and the live-call conversation orchestrator, so disconnect
+        # the pool rather than let those callers read a desynced response.
+        try:
+            await redis.connection_pool.disconnect()
+        except Exception:
+            pass
+        return False
+    except Exception:
+        return False
+
+
+async def _probe_voice_pipeline() -> bool:
+    try:
+        result = await asyncio.wait_for(
+            livekit_service.health_check(), timeout=PROBE_TIMEOUT_SECONDS
+        )
+        return result == "ok"
+    except Exception:
+        return False
 
 
 @router.get("/health")
 async def health_check(db: AsyncSession = Depends(get_async_db)) -> dict:
-    try:
-        await db.execute(text("SELECT 1"))
-        db_status = "ok"
-    except Exception:
-        db_status = "error"
+    database_ok, redis_ok, voice_pipeline_ok = await asyncio.gather(
+        _probe_database(db), _probe_redis(), _probe_voice_pipeline()
+    )
+
+    services = {
+        "api": True,
+        "voice_pipeline": voice_pipeline_ok,
+        "database": database_ok,
+        "redis": redis_ok,
+    }
+
+    if not database_ok:
+        status = "down"
+    elif all(services.values()):
+        status = "ok"
+    else:
+        status = "degraded"
 
     return {
-        "status": "ok" if db_status == "ok" else "degraded",
-        "version": settings.APP_VERSION,
-        "service": "fastapi-v2",
-        "db": db_status,
+        "status": status,
+        "services": services,
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
     }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -322,6 +322,12 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     APP_VERSION: str = "1.0.0"
 
+    # Betterstack status page badge — surfaced in GET /api/v1/health when set.
+    # Betterstack monitors https://api.yourdomain.com/api/v1/health (HTTP 200
+    # expected, 30s interval) and serves the public status page at
+    # status.yourdomain.com; this URL points at that page's embeddable badge.
+    BETTERSTACK_BADGE_URL: Optional[str] = None
+
     # Swagger / committed OpenAPI at GET /api/docs (HTTP Basic — not dashboard JWT).
     API_DOCS_ENABLED: bool = True
     API_DOCS_USERNAME: str = ""

--- a/app/middleware/api_key_middleware.py
+++ b/app/middleware/api_key_middleware.py
@@ -49,6 +49,7 @@ _AsyncSessionLocal: Optional[sessionmaker] = None
 _SKIP_EXACT = {
     "/",
     "/api/v1/tenants/create",
+    "/api/v1/health",
 }
 
 _SKIP_PREFIXES = (

--- a/app/routers/hubspot_integration.py
+++ b/app/routers/hubspot_integration.py
@@ -7,15 +7,18 @@ GET    /callback       — public; HubSpot redirects the browser here with no au
 DELETE ""              — revoke at HubSpot and delete the local connection
 GET    ""              — connection status, settings toggles, and field mappings
 GET    /contact        — CRM Search API lookup by phone, used by the dashboard and tests
-POST   /field-mapping  — save HubSpot field -> agent prompt-variable mappings
+PUT    /field-mapping  — save HubSpot field -> agent prompt-variable mappings
+                          (validated against the live HubSpot contact schema)
+POST   /field-mapping  — deprecated alias for PUT, kept for backward compatibility
 PUT    /settings       — toggle contact-lookup / write-back for this workspace
+GET    /sync-status    — last lookup/write-back times, status, rolling 24h error count
 """
 from __future__ import annotations
 
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db, require_tenant, require_admin
@@ -29,6 +32,7 @@ from app.schemas.hubspot_integration import (
     HubSpotFieldMappingResponse,
     HubSpotIntegrationStatusOut,
     HubSpotSettingsUpdateRequest,
+    HubSpotSyncStatusOut,
 )
 from app.services import hubspot_service
 from app.utils.response import create_success_response
@@ -113,18 +117,40 @@ async def hubspot_get_integration_status(
     return create_success_response(HubSpotIntegrationStatusOut(**integration_settings))
 
 
-@router.post("/field-mapping", response_model=SuccessResponse[HubSpotFieldMappingResponse])
-async def hubspot_save_field_mapping(
-    payload: HubSpotFieldMappingRequest,
-    principal=Depends(require_admin),
-    db: Session = Depends(get_db),
+async def _validate_and_save_field_mapping(
+    payload: HubSpotFieldMappingRequest, principal, db: Session
 ):
-    """Save the HubSpot field -> agent prompt-variable mappings for this workspace."""
+    """Shared handler for PUT and (deprecated) POST /field-mapping."""
     tenant_id = _tenant_id(principal)
     if not hubspot_service.tenant_has_hubspot_connected(db, tenant_id):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="HubSpot is not connected for this workspace",
+        )
+
+    try:
+        valid_properties = set(
+            await hubspot_service.get_hubspot_contact_properties(db, tenant_id)
+        )
+    except Exception as exc:
+        logger.warning(
+            "HubSpot contact properties fetch failed for tenant=%s: %s", tenant_id, exc
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to fetch HubSpot contact schema for field-mapping validation",
+        )
+
+    invalid_fields = sorted(
+        {m.hubspot_field for m in payload.mappings if m.hubspot_field not in valid_properties}
+    )
+    if invalid_fields:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content={
+                "detail": f"Invalid HubSpot field names: {invalid_fields}",
+                "invalid_fields": invalid_fields,
+            },
         )
 
     mappings = [m.model_dump() for m in payload.mappings]
@@ -133,6 +159,34 @@ async def hubspot_save_field_mapping(
         HubSpotFieldMappingResponse(field_mappings=payload.mappings),
         "Field mappings saved successfully",
     )
+
+
+@router.put("/field-mapping", response_model=SuccessResponse[HubSpotFieldMappingResponse])
+async def hubspot_save_field_mapping(
+    payload: HubSpotFieldMappingRequest,
+    principal=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Save the HubSpot field -> agent prompt-variable mappings for this workspace.
+
+    Every hubspot_field must exist in the tenant's live HubSpot contact schema;
+    unknown fields return 422 with the list of invalid field names.
+    """
+    return await _validate_and_save_field_mapping(payload, principal, db)
+
+
+@router.post(
+    "/field-mapping",
+    response_model=SuccessResponse[HubSpotFieldMappingResponse],
+    include_in_schema=False,
+)
+async def hubspot_save_field_mapping_legacy(
+    payload: HubSpotFieldMappingRequest,
+    principal=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Deprecated alias for PUT /field-mapping, kept for backward compatibility."""
+    return await _validate_and_save_field_mapping(payload, principal, db)
 
 
 @router.put("/settings", response_model=SuccessResponse[HubSpotIntegrationStatusOut])
@@ -160,6 +214,17 @@ async def hubspot_update_settings(
         HubSpotIntegrationStatusOut(**integration_settings),
         "Settings updated successfully",
     )
+
+
+@router.get("/sync-status", response_model=SuccessResponse[HubSpotSyncStatusOut])
+async def hubspot_sync_status(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Last contact-lookup/write-back times, write-back status, and rolling 24h error count."""
+    tenant_id = _tenant_id(principal)
+    sync_status = hubspot_service.get_sync_status(db, tenant_id)
+    return create_success_response(HubSpotSyncStatusOut(**sync_status))
 
 
 @router.get("/contact", response_model=SuccessResponse[HubSpotContactOut])

--- a/app/schemas/hubspot_integration.py
+++ b/app/schemas/hubspot_integration.py
@@ -71,3 +71,10 @@ class HubSpotIntegrationStatusOut(BaseModel):
     contact_lookup_enabled: bool = True
     write_back_enabled: bool = True
     field_mappings: List[HubSpotFieldMapping] = []
+
+
+class HubSpotSyncStatusOut(BaseModel):
+    last_lookup_at: Optional[str] = None
+    last_write_back_at: Optional[str] = None
+    last_write_back_status: Optional[str] = None
+    error_count_24h: int = 0

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -201,6 +201,21 @@ class CallFlowService:
         )
         return item.model_dump(by_alias=True, mode="json")
 
+    def _sync_agent_system_prompt(self, db: Session, flow: CallFlow) -> None:
+        """Ensure the bound Agent's system_prompt matches the flow's current_prompt_id text."""
+        if not flow.agent_id or not flow.current_prompt_id:
+            return
+        pv_repo = PromptVersionRepository(db)
+        current_version = pv_repo.find_by_id(flow.current_prompt_id)
+        if not current_version or not current_version.prompt_text:
+            return
+        agent = db.execute(
+            select(Agent).where(Agent.id == flow.agent_id)
+        ).scalar_one_or_none()
+        if agent and agent.system_prompt != current_version.prompt_text:
+            agent.system_prompt = current_version.prompt_text
+            db.add(agent)
+
     # ── Public API ────────────────────────────────────────────────────────
 
     def create_flow(
@@ -230,6 +245,7 @@ class CallFlowService:
                 db, flow.id, body.prompt, body.notes, current_prompt_id=None
             )
             flow = repo.update(flow, {"current_prompt_id": version.id})
+            self._sync_agent_system_prompt(db, flow)
 
         db.commit()
         db.refresh(flow)
@@ -325,6 +341,8 @@ class CallFlowService:
 
         if scalar_updates:
             flow = repo.update(flow, scalar_updates)
+            if "current_prompt_id" in scalar_updates or "agent_id" in scalar_updates:
+                self._sync_agent_system_prompt(db, flow)
 
         db.commit()
         db.refresh(flow)
@@ -566,6 +584,7 @@ class CallFlowService:
                 "ab_test_enabled": False,
             },
         )
+        self._sync_agent_system_prompt(db, flow)
         db.commit()
         db.refresh(flow)
         if flow.agent is None:

--- a/app/services/hubspot_service.py
+++ b/app/services/hubspot_service.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import hashlib
 import re
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple
@@ -41,6 +42,7 @@ TOKEN_URL = "https://api.hubapi.com/oauth/v1/token"
 REVOKE_URL_TEMPLATE = "https://api.hubapi.com/oauth/v1/refresh-tokens/{token}"
 SEARCH_CONTACTS_URL = "https://api.hubapi.com/crm/v3/objects/contacts/search"
 CREATE_CALL_URL = "https://api.hubapi.com/crm/v3/objects/calls"
+CONTACT_PROPERTIES_URL = "https://api.hubapi.com/crm/v3/properties/contacts"
 
 SCOPES = "crm.objects.contacts.read crm.objects.contacts.write"
 
@@ -63,6 +65,12 @@ _DEFAULT_CONTACT_LOOKUP_ENABLED = True
 _DEFAULT_WRITE_BACK_ENABLED = True
 
 _SUMMARY_CACHE_TTL_SECONDS = 3600  # 1 hour — long enough to cover writeback retries
+
+_PROPERTIES_CACHE_TTL_SECONDS = 3600  # 1 hour, per acceptance criteria
+
+_WRITE_BACK_RETRY_DELAY_SECONDS = 300  # 5 minutes
+_WRITE_BACK_ERROR_WINDOW_SECONDS = 24 * 60 * 60  # rolling 24h window for admin alerting
+_WRITE_BACK_ALERT_THRESHOLD = 5
 
 _HS_CALL_STATUS_MAP = {
     "completed": "COMPLETED",
@@ -187,6 +195,53 @@ async def refresh_access_token(refresh_token: str) -> dict:
     return response.json()
 
 
+def _properties_cache_key(tenant_id: uuid.UUID) -> str:
+    return f"hubspot:properties:{tenant_id}"
+
+
+async def get_hubspot_contact_properties(db: Session, tenant_id: uuid.UUID) -> list[str]:
+    """
+    Fetch the tenant's HubSpot contact property names, Redis-cached for 1 hour.
+
+    Used to validate field-mapping schema against the live CRM. Raises on any
+    failure (unlike the call-time helpers in this module) — mapping validation
+    must not silently accept invalid fields.
+    """
+    redis_client = get_redis()
+    cache_key = _properties_cache_key(tenant_id)
+
+    if redis_client is not None:
+        try:
+            cached = await redis_client.get(cache_key)
+            if cached is not None:
+                return json.loads(cached)
+        except Exception:
+            logger.warning("HubSpot properties cache read failed (continuing)", exc_info=True)
+
+    access_token = await get_valid_access_token(db, tenant_id)
+    if not access_token:
+        raise ValueError("HubSpot is not connected for this workspace")
+
+    response = await _request_with_backoff(
+        "GET",
+        CONTACT_PROPERTIES_URL,
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    response.raise_for_status()
+    results = response.json().get("results") or []
+    property_names = [p["name"] for p in results if p.get("name")]
+
+    if redis_client is not None:
+        try:
+            await redis_client.set(
+                cache_key, json.dumps(property_names), ex=_PROPERTIES_CACHE_TTL_SECONDS
+            )
+        except Exception:
+            logger.warning("HubSpot properties cache write failed (non-critical)", exc_info=True)
+
+    return property_names
+
+
 # ─── WorkspaceIntegration CRUD ────────────────────────────────────────────────
 
 
@@ -271,6 +326,35 @@ async def get_valid_access_token(db: Session, tenant_id: uuid.UUID) -> Optional[
     return decrypt_hubspot_token(row.access_token, db)
 
 
+async def _force_refresh_access_token(db: Session, tenant_id: uuid.UUID) -> Optional[str]:
+    """
+    Unconditionally refresh the HubSpot access token, ignoring token_expires_at.
+
+    HubSpot access tokens expire every 30 minutes; a call can run longer than
+    that, so by the time post-call write-back runs, the token stored on the
+    row may already be stale even though token_expires_at looks fresh (it was
+    computed at the start of the call). Always called immediately before the
+    write-back API call.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None or not row.refresh_token:
+        return await get_valid_access_token(db, tenant_id)
+
+    try:
+        refresh_token_plain = decrypt_hubspot_token(row.refresh_token, db)
+        token_response = await refresh_access_token(refresh_token_plain)
+    except Exception:
+        logger.warning(
+            "HubSpot forced pre-writeback token refresh failed for tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+        return None
+
+    row = upsert_tokens(db, tenant_id, token_response)
+    return decrypt_hubspot_token(row.access_token, db)
+
+
 def get_field_mappings(db: Session, tenant_id: uuid.UUID) -> list[dict]:
     row = get_integration(db, tenant_id)
     if row is None or not row.extra_metadata:
@@ -345,10 +429,26 @@ def update_integration_settings(
     return row
 
 
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
 def set_last_write_back_error(
     db: Session, tenant_id: uuid.UUID, error: Optional[str]
 ) -> None:
-    """Record (or clear, when error is None) the last post-call write-back failure."""
+    """
+    Record (or clear, when error is None) the last post-call write-back failure.
+
+    Also stamps last_write_back_status/last_write_back_at for the sync-status
+    endpoint. error=None means the write-back just succeeded.
+    """
     row = get_integration(db, tenant_id)
     if row is None:
         return
@@ -356,12 +456,158 @@ def set_last_write_back_error(
     updated_metadata = dict(row.extra_metadata or {})
     if error:
         updated_metadata["last_write_back_error"] = error
+        updated_metadata["last_write_back_status"] = "failed"
     else:
         updated_metadata.pop("last_write_back_error", None)
+        updated_metadata["last_write_back_status"] = "success"
+        updated_metadata["last_write_back_at"] = _utc_now_iso()
     row.extra_metadata = updated_metadata
     flag_modified(row, "extra_metadata")
     db.add(row)
     db.commit()
+
+
+def record_write_back_failure(db: Session, tenant_id: uuid.UUID, error_msg: str) -> None:
+    """
+    Persist the structured last-failure error (after retry exhaustion), bump the
+    rolling 24h failure counter, and alert the workspace admin once failures
+    cross _WRITE_BACK_ALERT_THRESHOLD within the window.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return
+
+    now = datetime.now(timezone.utc)
+    now_iso = _utc_now_iso()
+    window_start = now - timedelta(seconds=_WRITE_BACK_ERROR_WINDOW_SECONDS)
+
+    updated_metadata = dict(row.extra_metadata or {})
+    updated_metadata["last_write_back_error"] = {"timestamp": now_iso, "error": error_msg}
+    updated_metadata["last_write_back_status"] = "failed"
+    updated_metadata["last_write_back_at"] = now_iso
+
+    failure_timestamps = [
+        ts
+        for ts in updated_metadata.get("write_back_failure_timestamps", [])
+        if _parse_iso(ts) is not None and _parse_iso(ts) > window_start
+    ]
+    failure_timestamps.append(now_iso)
+    updated_metadata["write_back_failure_timestamps"] = failure_timestamps
+
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+
+    # Alert only on the exact crossing into the threshold, not on every failure
+    # thereafter — each call here appends exactly one timestamp, so the count
+    # can't skip over the threshold, and this avoids re-alerting the admin on
+    # every single failure once a workspace is already over the limit.
+    if len(failure_timestamps) == _WRITE_BACK_ALERT_THRESHOLD:
+        _send_write_back_failure_alert(db, tenant_id, error_msg, now_iso, len(failure_timestamps))
+
+
+def _send_write_back_failure_alert(
+    db: Session, tenant_id: uuid.UUID, error_msg: str, timestamp_iso: str, failure_count: int
+) -> None:
+    """Best-effort admin email alert. Never raises — a notification failure must not affect write-back."""
+    try:
+        from app.models.tenant import Tenant
+        from app.services.data_export_service import _get_workspace_admin_email
+        from app.services.email_service import email_service
+
+        admin_email = _get_workspace_admin_email(db, tenant_id)
+        tenant = db.get(Tenant, tenant_id)
+        if not admin_email:
+            admin_email = getattr(tenant, "contact_email", None) if tenant else None
+        if not admin_email:
+            logger.warning(
+                "No admin or contact email found for tenant=%s; cannot send "
+                "HubSpot write-back failure alert",
+                tenant_id,
+            )
+            return
+
+        workspace_name = tenant.name if tenant else str(tenant_id)
+        frontend_base = (settings.FRONTEND_URL or "").rstrip("/")
+        reconnect_url = f"{frontend_base}/settings/integrations" if frontend_base else "/settings/integrations"
+
+        email_service.send_generic_email(
+            to_email=admin_email,
+            subject=f"Action Required: HubSpot Integration Write-Back Failures for {workspace_name}",
+            html_body=(
+                f"<p>HubSpot post-call write-back has failed {failure_count} times in the "
+                f"last 24 hours for workspace <strong>{workspace_name}</strong>.</p>"
+                f"<p>Most recent failure at {timestamp_iso}: {error_msg}</p>"
+                f"<p>Please reconnect HubSpot to restore syncing: "
+                f'<a href="{reconnect_url}">{reconnect_url}</a></p>'
+            ),
+        )
+    except Exception:
+        logger.warning(
+            "Failed to send HubSpot write-back failure alert for tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+
+
+def get_sync_status(db: Session, tenant_id: uuid.UUID) -> dict:
+    """Sync visibility for the dashboard: last lookup/write-back times, status, 24h error count."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return {
+            "last_lookup_at": None,
+            "last_write_back_at": None,
+            "last_write_back_status": None,
+            "error_count_24h": 0,
+        }
+
+    metadata = row.extra_metadata or {}
+    window_start = datetime.now(timezone.utc) - timedelta(seconds=_WRITE_BACK_ERROR_WINDOW_SECONDS)
+    error_count_24h = sum(
+        1
+        for ts in metadata.get("write_back_failure_timestamps", [])
+        if _parse_iso(ts) is not None and _parse_iso(ts) > window_start
+    )
+
+    return {
+        "last_lookup_at": metadata.get("last_lookup_at"),
+        "last_write_back_at": metadata.get("last_write_back_at"),
+        "last_write_back_status": metadata.get("last_write_back_status"),
+        "error_count_24h": error_count_24h,
+    }
+
+
+def _touch_last_lookup_at(db: Session, tenant_id: uuid.UUID, *, commit: bool = True) -> None:
+    """
+    Best-effort timestamp of the last contact lookup, for the sync-status endpoint.
+
+    commit=False must be used when `db` is the shared, long-lived session tied to
+    an in-progress call (see get_crm_context_block_for_call / get_field_mapping_values_for_call),
+    which never call db.commit() directly to avoid prematurely committing the
+    caller's still-open call transaction — this mirrors that begin_nested()/flush()
+    pattern instead.
+    """
+    try:
+        row = get_integration(db, tenant_id)
+        if row is None:
+            return
+        updated_metadata = dict(row.extra_metadata or {})
+        updated_metadata["last_lookup_at"] = _utc_now_iso()
+        row.extra_metadata = updated_metadata
+        flag_modified(row, "extra_metadata")
+        db.add(row)
+        if commit:
+            db.commit()
+        else:
+            with db.begin_nested():
+                db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to record HubSpot last_lookup_at (non-critical) tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
 
 
 async def disconnect(db: Session, tenant_id: uuid.UUID) -> bool:
@@ -530,9 +776,15 @@ async def search_contact_by_phone(
 
 
 async def get_contact_for_phone(
-    db: Session, tenant_id: uuid.UUID, phone: str
+    db: Session, tenant_id: uuid.UUID, phone: str, *, commit_lookup_timestamp: bool = True
 ) -> Optional[dict]:
-    """Look up a contact by phone, Redis-cached for 5 minutes. Fails open on any error."""
+    """Look up a contact by phone, Redis-cached for 5 minutes. Fails open on any error.
+
+    commit_lookup_timestamp=False must be passed by live in-call callers sharing a
+    long-lived db session (see _touch_last_lookup_at).
+    """
+    _touch_last_lookup_at(db, tenant_id, commit=commit_lookup_timestamp)
+
     # Normalize phone numbers to E.164 format if possible before lookup/caching.
     normalized_phone = normalize_to_e164(phone)
     redis_client = get_redis()
@@ -609,7 +861,10 @@ async def get_crm_context_block_for_call(db: Session, call_session: CallSession)
             db, call_session.tenant_id
         ):
             contact = await get_contact_for_phone(
-                db, call_session.tenant_id, call_session.customer_phone_number
+                db,
+                call_session.tenant_id,
+                call_session.customer_phone_number,
+                commit_lookup_timestamp=False,
             )
             if contact:
                 context_block = (
@@ -651,11 +906,18 @@ async def get_crm_context_block_for_call(db: Session, call_session: CallSession)
 def resolve_field_mapping_values(
     contact: Optional[dict], field_mappings: list[dict]
 ) -> dict[str, str]:
-    """Map configured HubSpot fields to prompt-variable values from a contact record."""
-    if not contact or not field_mappings:
+    """
+    Map configured HubSpot fields to prompt-variable values from a contact record.
+
+    Every configured prompt_variable always gets an entry — "" when the contact
+    is missing, or the mapped field is NULL/empty on it — so callers can blindly
+    replace every `{prompt_variable}` placeholder in the prompt without leaving
+    unreplaced placeholders or injecting the strings "null"/"undefined".
+    """
+    if not field_mappings:
         return {}
 
-    raw_properties = contact.get("raw_properties") or {}
+    raw_properties = (contact or {}).get("raw_properties") or {}
     values: dict[str, str] = {}
     for mapping in field_mappings:
         hubspot_field = mapping.get("hubspot_field")
@@ -663,9 +925,11 @@ def resolve_field_mapping_values(
         if not hubspot_field or not prompt_variable:
             continue
         value = raw_properties.get(hubspot_field)
-        if value is None:
+        if value is None and contact:
             value = contact.get(hubspot_field)
-        if value is not None:
+        if value is None or (isinstance(value, str) and not value.strip()):
+            values[prompt_variable] = ""
+        else:
             values[prompt_variable] = str(value)
     return values
 
@@ -693,7 +957,10 @@ async def get_field_mapping_values_for_call(
             field_mappings = integration_settings["field_mappings"]
             if integration_settings["contact_lookup_enabled"] and field_mappings:
                 contact = await get_contact_for_phone(
-                    db, call_session.tenant_id, call_session.customer_phone_number
+                    db,
+                    call_session.tenant_id,
+                    call_session.customer_phone_number,
+                    commit_lookup_timestamp=False,
                 )
                 values = resolve_field_mapping_values(contact, field_mappings)
     except Exception:
@@ -868,7 +1135,10 @@ async def _run_post_call_writeback_async(db: Session, call_session: CallSession)
         )
         return
 
-    access_token = await get_valid_access_token(db, tenant_id)
+    # HubSpot access tokens expire every 30 minutes, and a call can outlast
+    # that — always force a fresh token right before the write-back call
+    # rather than trusting the DB's cached token_expires_at.
+    access_token = await _force_refresh_access_token(db, tenant_id)
     if not access_token:
         return
 
@@ -885,7 +1155,7 @@ async def _run_post_call_writeback_async(db: Session, call_session: CallSession)
     summary = get_cached_transcript_summary(db, call_session)
     body_text = summary or "Call completed — no transcript summary available."
 
-    try:
+    async def _write() -> None:
         await create_call_engagement(
             access_token,
             contact["id"],
@@ -896,15 +1166,43 @@ async def _run_post_call_writeback_async(db: Session, call_session: CallSession)
             title=f"Voice agent call — {call_session.status}",
             body_text=body_text,
         )
+
+    try:
+        await _write()
     except Exception as exc:
-        logger.error(
-            "HubSpot call engagement creation failed for session=%s: %s",
+        logger.warning(
+            "HubSpot call engagement creation failed for session=%s; retrying in %ds: %s",
             call_session.id,
+            _WRITE_BACK_RETRY_DELAY_SECONDS,
             exc,
             exc_info=True,
         )
-        set_last_write_back_error(db, tenant_id, _safe_error_msg(exc))
-        return
+        # Release the checked-out DB connection for the duration of the retry
+        # delay — earlier reads in this function (e.g. get_cached_transcript_summary)
+        # leave the session's transaction open via begin_nested()/flush(), and
+        # holding that connection for 5 real minutes per failing call would
+        # exhaust the pool under any real failure volume (e.g. a HubSpot outage
+        # affecting many concurrent calls). SQLAlchemy transparently checks out
+        # a fresh connection on next use.
+        try:
+            db.rollback()
+        except Exception:
+            logger.warning(
+                "Failed to release DB connection before HubSpot write-back retry (non-critical)",
+                exc_info=True,
+            )
+        await asyncio.sleep(_WRITE_BACK_RETRY_DELAY_SECONDS)
+        try:
+            await _write()
+        except Exception as retry_exc:
+            logger.error(
+                "HubSpot call engagement creation failed after retry for session=%s: %s",
+                call_session.id,
+                retry_exc,
+                exc_info=True,
+            )
+            record_write_back_failure(db, tenant_id, _safe_error_msg(retry_exc))
+            return
 
     set_last_write_back_error(db, tenant_id, None)
     logger.info(
@@ -940,10 +1238,20 @@ async def _run_post_call_writeback_in_thread(call_session_id: uuid.UUID) -> None
 
 
 def schedule_hubspot_writeback(call_session_id: uuid.UUID) -> None:
-    """Fire-and-forget post-call write-back. Never blocks the caller."""
+    """
+    Fire-and-forget post-call write-back. Never blocks the caller.
+
+    Write-back can now retry once after a 5-minute delay on failure (see
+    _run_post_call_writeback_async), so the no-running-loop branch must not
+    run it inline — callers here include the synchronous
+    CallSessionService.update_call_session_status, e.g. from a webhook
+    handler, which must not be held open for minutes on a HubSpot outage.
+    """
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        run_post_call_writeback(call_session_id)
+        threading.Thread(
+            target=run_post_call_writeback, args=(call_session_id,), daemon=True
+        ).start()
         return
     asyncio.create_task(_run_post_call_writeback_in_thread(call_session_id))

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -381,10 +381,31 @@ Continue the conversation based on the history above. Be {agent_name}."""
                     "ab_prompt_text"
                 )
 
-            # Use agent's custom system prompt if available, otherwise use base prompt
-            if self._h.agent and self._h.agent.system_prompt:
+            # Resolve call flow prompt override if present on session
+            flow_prompt_override = None
+            call_flow = getattr(self._h, "call_flow", None)
+            if call_flow:
+                if getattr(call_flow, "current_prompt", None) and call_flow.current_prompt.prompt_text:
+                    flow_prompt_override = call_flow.current_prompt.prompt_text
+                elif call_flow.current_prompt_id and getattr(self._h, "db", None):
+                    try:
+                        from sqlalchemy import select
+                        from app.models.prompt_version import PromptVersion
+                        pv = self._h.db.execute(
+                            select(PromptVersion).where(PromptVersion.id == call_flow.current_prompt_id)
+                        ).scalar_one_or_none()
+                        if pv and pv.prompt_text:
+                            flow_prompt_override = pv.prompt_text
+                    except Exception as exc:
+                        logger.debug("Could not resolve call flow current_prompt: %s", exc)
+
+            # Use agent's custom system prompt / flow prompt if available, otherwise use base prompt
+            if (self._h.agent and self._h.agent.system_prompt) or flow_prompt_override:
                 effective_custom_prompt = (
-                    batch_prompt_override or ab_prompt_override or self._h.agent.system_prompt
+                    batch_prompt_override
+                    or ab_prompt_override
+                    or flow_prompt_override
+                    or (self._h.agent.system_prompt if self._h.agent else None)
                 )
                 system_prompt = f"""# ROLE
 You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6789,13 +6789,18 @@ paths:
       security:
       - HTTPBearer: []
   /api/v1/integrations/hubspot/field-mapping:
-    post:
+    put:
       tags:
       - HubSpot Integration
       summary: Hubspot Save Field Mapping
-      description: Save the HubSpot field -> agent prompt-variable mappings for this
+      description: 'Save the HubSpot field -> agent prompt-variable mappings for this
         workspace.
-      operationId: hubspot_save_field_mapping_api_v1_integrations_hubspot_field_mapping_post
+
+
+        Every hubspot_field must exist in the tenant''s live HubSpot contact schema;
+
+        unknown fields return 422 with the list of invalid field names.'
+      operationId: hubspot_save_field_mapping_api_v1_integrations_hubspot_field_mapping_put
       requestBody:
         content:
           application/json:
@@ -6843,6 +6848,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/hubspot/sync-status:
+    get:
+      tags:
+      - HubSpot Integration
+      summary: Hubspot Sync Status
+      description: Last contact-lookup/write-back times, write-back status, and rolling
+        24h error count.
+      operationId: hubspot_sync_status_api_v1_integrations_hubspot_sync_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_HubSpotSyncStatusOut_'
       security:
       - HTTPBearer: []
   /api/v1/integrations/hubspot/contact:
@@ -12520,6 +12542,23 @@ components:
       - contact_lookup_enabled
       - write_back_enabled
       title: HubSpotSettingsUpdateRequest
+    HubSpotSyncStatusOut:
+      properties:
+        last_lookup_at:
+          type: string
+          nullable: true
+        last_write_back_at:
+          type: string
+          nullable: true
+        last_write_back_status:
+          type: string
+          nullable: true
+        error_count_24h:
+          type: integer
+          title: Error Count 24H
+          default: 0
+      type: object
+      title: HubSpotSyncStatusOut
     ImportTwilioPhoneNumberRequest:
       properties:
         phone_number:
@@ -16387,6 +16426,22 @@ components:
       required:
       - data
       title: SuccessResponse[HubSpotIntegrationStatusOut]
+    SuccessResponse_HubSpotSyncStatusOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/HubSpotSyncStatusOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[HubSpotSyncStatusOut]
     SuccessResponse_ImportTwilioPhoneNumberResponse_:
       properties:
         data:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -15,6 +15,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SuccessResponse_dict_'
+  /api/v1/health:
+    get:
+      tags:
+      - Health
+      summary: Health Check
+      operationId: health_check_api_v1_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                type: object
+                title: Response Health Check Api V1 Health Get
   /api/v1/users/register:
     post:
       tags:

--- a/tests/api/test_hubspot_integration.py
+++ b/tests/api/test_hubspot_integration.py
@@ -214,7 +214,7 @@ class TestIntegrationStatusEndpoint:
 
 class TestFieldMappingEndpoint:
     @pytest.mark.anyio
-    async def test_saves_mappings(self):
+    async def test_saves_mappings_when_field_is_valid(self):
         from app.routers.hubspot_integration import hubspot_save_field_mapping
         from app.schemas.hubspot_integration import (
             HubSpotFieldMapping,
@@ -229,6 +229,10 @@ class TestFieldMappingEndpoint:
             patch(
                 "app.routers.hubspot_integration.hubspot_service.tenant_has_hubspot_connected",
                 return_value=True,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.get_hubspot_contact_properties",
+                new=AsyncMock(return_value=["jobtitle", "company"]),
             ),
             patch(
                 "app.routers.hubspot_integration.hubspot_service.save_field_mappings"
@@ -267,6 +271,151 @@ class TestFieldMappingEndpoint:
                 )
 
         assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_invalid_hubspot_field_returns_422_with_invalid_fields_list(self):
+        """PUT /field-mapping must reject fields that don't exist in the tenant's live
+        HubSpot contact schema, returning 422 with the exact FE7-S7-03 body shape."""
+        from app.routers.hubspot_integration import hubspot_save_field_mapping
+        from app.schemas.hubspot_integration import (
+            HubSpotFieldMapping,
+            HubSpotFieldMappingRequest,
+        )
+
+        payload = HubSpotFieldMappingRequest(
+            mappings=[
+                HubSpotFieldMapping(hubspot_field="invalid_field_1", prompt_variable="v1"),
+                HubSpotFieldMapping(hubspot_field="jobtitle", prompt_variable="v2"),
+            ]
+        )
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.tenant_has_hubspot_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.get_hubspot_contact_properties",
+                new=AsyncMock(return_value=["jobtitle", "company"]),
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.save_field_mappings"
+            ) as mock_save,
+        ):
+            response = await hubspot_save_field_mapping(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
+
+        assert response.status_code == 422
+        import json as _json
+        body = _json.loads(response.body)
+        assert body["invalid_fields"] == ["invalid_field_1"]
+        assert "Invalid HubSpot field names" in body["detail"]
+        mock_save.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_properties_fetch_failure_returns_502(self):
+        from app.routers.hubspot_integration import hubspot_save_field_mapping
+        from app.schemas.hubspot_integration import (
+            HubSpotFieldMapping,
+            HubSpotFieldMappingRequest,
+        )
+
+        payload = HubSpotFieldMappingRequest(
+            mappings=[HubSpotFieldMapping(hubspot_field="jobtitle", prompt_variable="job_title")]
+        )
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.tenant_has_hubspot_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.get_hubspot_contact_properties",
+                new=AsyncMock(side_effect=Exception("HubSpot down")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await hubspot_save_field_mapping(
+                    payload=payload, principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.anyio
+    async def test_post_alias_still_works(self):
+        """POST /field-mapping is kept as a backward-compatible alias for PUT."""
+        from app.routers.hubspot_integration import hubspot_save_field_mapping_legacy
+        from app.schemas.hubspot_integration import (
+            HubSpotFieldMapping,
+            HubSpotFieldMappingRequest,
+        )
+
+        payload = HubSpotFieldMappingRequest(
+            mappings=[HubSpotFieldMapping(hubspot_field="jobtitle", prompt_variable="job_title")]
+        )
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.tenant_has_hubspot_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.get_hubspot_contact_properties",
+                new=AsyncMock(return_value=["jobtitle"]),
+            ),
+            patch("app.routers.hubspot_integration.hubspot_service.save_field_mappings"),
+        ):
+            result = await hubspot_save_field_mapping_legacy(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
+
+        assert result.data.field_mappings[0].hubspot_field == "jobtitle"
+
+
+class TestSyncStatusEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_sync_status_shape(self):
+        from app.routers.hubspot_integration import hubspot_sync_status
+
+        status_data = {
+            "last_lookup_at": "2026-07-20T17:00:00Z",
+            "last_write_back_at": "2026-07-20T17:05:00Z",
+            "last_write_back_status": "success",
+            "error_count_24h": 2,
+        }
+
+        with patch(
+            "app.routers.hubspot_integration.hubspot_service.get_sync_status",
+            return_value=status_data,
+        ):
+            result = await hubspot_sync_status(principal=_principal(), db=MagicMock())
+
+        assert result.data.last_lookup_at == "2026-07-20T17:00:00Z"
+        assert result.data.last_write_back_at == "2026-07-20T17:05:00Z"
+        assert result.data.last_write_back_status == "success"
+        assert result.data.error_count_24h == 2
+
+    @pytest.mark.anyio
+    async def test_returns_nulls_when_never_synced(self):
+        from app.routers.hubspot_integration import hubspot_sync_status
+
+        status_data = {
+            "last_lookup_at": None,
+            "last_write_back_at": None,
+            "last_write_back_status": None,
+            "error_count_24h": 0,
+        }
+
+        with patch(
+            "app.routers.hubspot_integration.hubspot_service.get_sync_status",
+            return_value=status_data,
+        ):
+            result = await hubspot_sync_status(principal=_principal(), db=MagicMock())
+
+        assert result.data.last_lookup_at is None
+        assert result.data.last_write_back_status is None
+        assert result.data.error_count_24h == 0
 
 
 class TestSettingsEndpoint:

--- a/tests/api/v1/test_call_flow_active_prompt_sync.py
+++ b/tests/api/v1/test_call_flow_active_prompt_sync.py
@@ -1,0 +1,128 @@
+"""Unit tests for Call Flow active prompt sync with Agent.system_prompt and Live Voice prompt resolution."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.models.agent import Agent
+from app.models.tenant import Tenant
+from app.schemas.call_flow import CallFlowCreate, CallFlowUpdate
+from app.services.call_flow_service import call_flow_service
+
+
+@pytest.fixture
+def tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"SyncWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"sync_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _create_test_agent(db, tenant_id: uuid.UUID) -> Agent:
+    agent = Agent(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        name="Test Prompt Sync Agent",
+        llm_model="gemini-1.5-flash",
+        tts_provider_slug="rime",
+        tts_voice_external_id="voice-1",
+        tts_language="en",
+        status="active",
+        system_prompt="Initial Agent Prompt",
+    )
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    return agent
+
+
+def test_create_flow_syncs_agent_system_prompt(db, tenant):
+    agent = _create_test_agent(db, tenant.id)
+
+    body = CallFlowCreate(
+        name="Sync Flow 1",
+        direction="inbound",
+        agentId=agent.id,
+        prompt="First Flow Prompt",
+        notes="V1 Notes",
+    )
+
+    flow_out = call_flow_service.create_flow(db, tenant.id, body)
+
+    db.refresh(agent)
+    assert agent.system_prompt == "First Flow Prompt"
+    assert flow_out["currentPromptId"] is not None
+
+
+def test_update_flow_new_prompt_syncs_agent_system_prompt(db, tenant):
+    agent = _create_test_agent(db, tenant.id)
+
+    create_body = CallFlowCreate(
+        name="Sync Flow 2",
+        direction="inbound",
+        agentId=agent.id,
+        prompt="Initial Prompt",
+        notes="Version 1",
+    )
+    flow_out = call_flow_service.create_flow(db, tenant.id, create_body)
+    flow_id = uuid.UUID(flow_out["id"])
+
+    # Update flow with new prompt text
+    update_body = CallFlowUpdate(
+        prompt="Updated Prompt Text",
+        notes="Version 2",
+    )
+    updated_out = call_flow_service.update_flow(db, flow_id, tenant.id, update_body)
+
+    db.refresh(agent)
+    assert agent.system_prompt == "Updated Prompt Text"
+    assert updated_out["currentPromptId"] != flow_out["currentPromptId"]
+
+
+def test_update_flow_rollback_syncs_agent_system_prompt(db, tenant):
+    agent = _create_test_agent(db, tenant.id)
+
+    # Create initial version
+    flow_out_1 = call_flow_service.create_flow(
+        db,
+        tenant.id,
+        CallFlowCreate(
+            name="Sync Flow 3",
+            direction="inbound",
+            agentId=agent.id,
+            prompt="Prompt V1",
+            notes="V1",
+        ),
+    )
+    flow_id = uuid.UUID(flow_out_1["id"])
+    v1_id = uuid.UUID(flow_out_1["currentPromptId"])
+
+    # Create version 2
+    call_flow_service.update_flow(
+        db,
+        flow_id,
+        tenant.id,
+        CallFlowUpdate(prompt="Prompt V2", notes="V2"),
+    )
+
+    db.refresh(agent)
+    assert agent.system_prompt == "Prompt V2"
+
+    # Roll back to V1
+    flow_out_3 = call_flow_service.update_flow(
+        db,
+        flow_id,
+        tenant.id,
+        CallFlowUpdate(currentPromptId=v1_id),
+    )
+
+    db.refresh(agent)
+    assert agent.system_prompt == "Prompt V1"
+    assert flow_out_3["currentPromptId"] == str(v1_id)

--- a/tests/api/v1/test_health.py
+++ b/tests/api/v1/test_health.py
@@ -1,0 +1,47 @@
+"""v1 health endpoint — public, no auth."""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.main import app
+
+
+def test_v1_health_returns_200_without_auth():
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/v1/health")
+
+    assert resp.status_code == 200
+
+
+def test_v1_health_response_schema():
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/v1/health")
+
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["version"] == settings.APP_VERSION
+    assert "timestamp" in body
+    assert "betterstack_badge" in body
+
+
+def test_v1_health_betterstack_badge_defaults_none():
+    prev = settings.BETTERSTACK_BADGE_URL
+    settings.BETTERSTACK_BADGE_URL = None
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v1/health")
+        assert resp.json()["betterstack_badge"] is None
+    finally:
+        settings.BETTERSTACK_BADGE_URL = prev
+
+
+def test_v1_health_betterstack_badge_reflects_setting():
+    prev = settings.BETTERSTACK_BADGE_URL
+    settings.BETTERSTACK_BADGE_URL = "https://status.yourdomain.com/badge"
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v1/health")
+        assert resp.json()["betterstack_badge"] == "https://status.yourdomain.com/badge"
+    finally:
+        settings.BETTERSTACK_BADGE_URL = prev

--- a/tests/api/v2/test_health.py
+++ b/tests/api/v2/test_health.py
@@ -1,9 +1,11 @@
-"""v2 health endpoint — public, no auth."""
+"""v2 enhanced health endpoint — public, no auth, with bounded service probes."""
 from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
-from app.core.config import settings
 from app.main import app
 
 
@@ -12,9 +14,79 @@ def test_v2_health_returns_200_without_auth():
         resp = client.get("/api/v2/health")
 
     assert resp.status_code == 200
-    assert resp.json() == {
-        "status": "ok",
-        "version": settings.APP_VERSION,
-        "service": "fastapi-v2",
-        "db": "ok",
+
+
+def test_v2_health_response_schema_all_ok():
+    with patch(
+        "app.api.v2.routers.health._probe_database", AsyncMock(return_value=True)
+    ), patch(
+        "app.api.v2.routers.health._probe_redis", AsyncMock(return_value=True)
+    ), patch(
+        "app.api.v2.routers.health._probe_voice_pipeline", AsyncMock(return_value=True)
+    ):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v2/health")
+
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["services"] == {
+        "api": True,
+        "voice_pipeline": True,
+        "database": True,
+        "redis": True,
     }
+    assert "timestamp" in body
+
+
+def test_v2_health_degraded_when_redis_fails():
+    with patch(
+        "app.api.v2.routers.health._probe_database", AsyncMock(return_value=True)
+    ), patch(
+        "app.api.v2.routers.health._probe_redis", AsyncMock(return_value=False)
+    ), patch(
+        "app.api.v2.routers.health._probe_voice_pipeline", AsyncMock(return_value=True)
+    ):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v2/health")
+
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["services"]["redis"] is False
+    assert body["services"]["database"] is True
+
+
+def test_v2_health_degraded_when_voice_pipeline_times_out():
+    async def _slow_health_check():
+        await asyncio.sleep(2)
+        return "ok"
+
+    with patch(
+        "app.api.v2.routers.health._probe_database", AsyncMock(return_value=True)
+    ), patch(
+        "app.api.v2.routers.health._probe_redis", AsyncMock(return_value=True)
+    ), patch(
+        "app.services.livekit_service.livekit_service.health_check",
+        side_effect=_slow_health_check,
+    ):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v2/health")
+
+    body = resp.json()
+    assert body["status"] == "degraded"
+    assert body["services"]["voice_pipeline"] is False
+
+
+def test_v2_health_down_when_database_fails():
+    with patch(
+        "app.api.v2.routers.health._probe_database", AsyncMock(return_value=False)
+    ), patch(
+        "app.api.v2.routers.health._probe_redis", AsyncMock(return_value=True)
+    ), patch(
+        "app.api.v2.routers.health._probe_voice_pipeline", AsyncMock(return_value=True)
+    ):
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.get("/api/v2/health")
+
+    body = resp.json()
+    assert body["status"] == "down"
+    assert body["services"]["database"] is False

--- a/tests/services/test_hubspot_service.py
+++ b/tests/services/test_hubspot_service.py
@@ -328,6 +328,79 @@ class TestGetContactForPhone:
             contact = await hubspot_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
         assert contact is None
 
+    @pytest.mark.anyio
+    async def test_defaults_to_committing_the_lookup_timestamp(self):
+        """The standalone (non-live-call) callers — the /contact router endpoint and
+        the post-call write-back job — must get a durable commit by default."""
+        db = MagicMock()
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=None),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.services.hubspot_service._touch_last_lookup_at") as mock_touch,
+        ):
+            await hubspot_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        mock_touch.assert_called_once_with(db, _TENANT_ID, commit=True)
+
+    @pytest.mark.anyio
+    async def test_live_call_callers_opt_out_of_committing_the_lookup_timestamp(self):
+        db = MagicMock()
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=None),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.services.hubspot_service._touch_last_lookup_at") as mock_touch,
+        ):
+            await hubspot_service.get_contact_for_phone(
+                db, _TENANT_ID, "+15550001111", commit_lookup_timestamp=False
+            )
+
+        mock_touch.assert_called_once_with(db, _TENANT_ID, commit=False)
+
+
+class TestTouchLastLookupAt:
+    def test_commit_true_calls_db_commit(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.extra_metadata = {}
+
+        with patch("app.services.hubspot_service.get_integration", return_value=row):
+            hubspot_service._touch_last_lookup_at(db, _TENANT_ID, commit=True)
+
+        db.commit.assert_called_once()
+        assert "last_lookup_at" in row.extra_metadata
+
+    def test_commit_false_never_commits_the_shared_session(self):
+        """Must not call db.commit() on the shared live-call session — only the
+        nested-savepoint flush pattern used elsewhere for call-time writes."""
+        db = MagicMock()
+        row = MagicMock()
+        row.extra_metadata = {}
+        nested_mock = MagicMock()
+        db.begin_nested.return_value = nested_mock
+        nested_mock.__enter__ = MagicMock()
+        nested_mock.__exit__ = MagicMock()
+
+        with patch("app.services.hubspot_service.get_integration", return_value=row):
+            hubspot_service._touch_last_lookup_at(db, _TENANT_ID, commit=False)
+
+        db.commit.assert_not_called()
+        db.begin_nested.assert_called_once()
+        db.flush.assert_called_once()
+        assert "last_lookup_at" in row.extra_metadata
+
+    def test_fails_open_on_error(self):
+        db = MagicMock()
+        with patch(
+            "app.services.hubspot_service.get_integration", side_effect=Exception("DB down")
+        ):
+            hubspot_service._touch_last_lookup_at(db, _TENANT_ID, commit=True)  # must not raise
+
 
 # ── CRM context block (conversation_orchestrator injection) ───────────────────
 
@@ -369,7 +442,7 @@ class TestCrmContextBlock:
             patch(
                 "app.services.hubspot_service.get_contact_for_phone",
                 new=AsyncMock(return_value=contact),
-            ),
+            ) as mock_get_contact,
         ):
             block = await hubspot_service.get_crm_context_block_for_call(db, call_session)
 
@@ -379,6 +452,9 @@ class TestCrmContextBlock:
         assert call_session.call_metadata["hubspot_crm_context"] == block
         db.flush.assert_called_once()
         db.commit.assert_not_called()
+        # Must opt out of committing the shared live-call session — see
+        # _touch_last_lookup_at's commit=False contract.
+        assert mock_get_contact.call_args.kwargs.get("commit_lookup_timestamp") is False
 
     @pytest.mark.anyio
     async def test_fails_open_on_flush_error(self):
@@ -473,9 +549,9 @@ class TestPostCallWriteback:
                 return_value=self._writeback_settings(),
             ),
             patch(
-                "app.services.hubspot_service.get_valid_access_token",
+                "app.services.hubspot_service._force_refresh_access_token",
                 new=AsyncMock(return_value="access-token"),
-            ),
+            ) as mock_force_refresh,
             patch(
                 "app.services.hubspot_service.get_contact_for_phone",
                 new=AsyncMock(return_value=contact),
@@ -494,6 +570,7 @@ class TestPostCallWriteback:
         ):
             await hubspot_service._run_post_call_writeback_async(db, call_session)
 
+        mock_force_refresh.assert_awaited_once_with(db, _TENANT_ID)
         mock_create_engagement.assert_awaited_once()
         _, kwargs = mock_create_engagement.call_args
         assert kwargs["direction"] == "OUTBOUND"
@@ -517,12 +594,12 @@ class TestPostCallWriteback:
                 "app.services.hubspot_service.get_integration_settings",
                 return_value=self._writeback_settings(write_back_enabled=False),
             ),
-            patch("app.services.hubspot_service.get_valid_access_token") as mock_token,
+            patch("app.services.hubspot_service._force_refresh_access_token") as mock_refresh,
             patch("app.services.hubspot_service.create_call_engagement") as mock_create,
         ):
             await hubspot_service._run_post_call_writeback_async(db, call_session)
 
-        mock_token.assert_not_called()
+        mock_refresh.assert_not_called()
         mock_create.assert_not_called()
 
     @pytest.mark.anyio
@@ -539,7 +616,7 @@ class TestPostCallWriteback:
                 return_value=self._writeback_settings(),
             ),
             patch(
-                "app.services.hubspot_service.get_valid_access_token",
+                "app.services.hubspot_service._force_refresh_access_token",
                 new=AsyncMock(return_value="access-token"),
             ),
             patch(
@@ -553,8 +630,67 @@ class TestPostCallWriteback:
         mock_create.assert_not_called()
 
     @pytest.mark.anyio
-    async def test_writeback_failure_records_last_write_back_error(self):
-        """A failed HubSpot engagement create must be logged and persisted, never retried."""
+    async def test_writeback_retries_once_after_5_minutes_then_records_structured_error(self):
+        """A write-back that keeps failing retries once after 5 min, then records a
+        structured {timestamp, error} object and never raises."""
+        call_order = []
+        db = MagicMock()
+        db.rollback.side_effect = lambda: call_order.append("rollback")
+        call_session = MagicMock()
+        call_session.id = _SESSION_ID
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.start_time = datetime.now(timezone.utc)
+        call_session.duration = 60
+        call_session.call_type = "inbound"
+        call_session.status = "completed"
+        call_session.call_metadata = {}
+
+        contact = {"id": "contact-1", "name": "Ada Lovelace"}
+
+        with (
+            patch(
+                "app.services.hubspot_service.get_integration_settings",
+                return_value=self._writeback_settings(),
+            ),
+            patch(
+                "app.services.hubspot_service._force_refresh_access_token",
+                new=AsyncMock(return_value="access-token"),
+            ),
+            patch(
+                "app.services.hubspot_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+            patch(
+                "app.services.hubspot_service.generate_transcript_summary",
+                return_value="Summary.",
+            ),
+            patch(
+                "app.services.hubspot_service.create_call_engagement",
+                new=AsyncMock(side_effect=Exception("HubSpot 500")),
+            ) as mock_create_engagement,
+            patch(
+                "asyncio.sleep",
+                new=AsyncMock(side_effect=lambda *_a, **_k: call_order.append("sleep")),
+            ) as mock_sleep,
+            patch(
+                "app.services.hubspot_service.record_write_back_failure"
+            ) as mock_record_failure,
+        ):
+            await hubspot_service._run_post_call_writeback_async(db, call_session)
+
+        assert mock_create_engagement.await_count == 2  # initial attempt + one retry
+        mock_sleep.assert_awaited_once_with(hubspot_service._WRITE_BACK_RETRY_DELAY_SECONDS)
+        mock_record_failure.assert_called_once_with(db, _TENANT_ID, "HubSpot 500")
+        # The DB connection must be released (rollback) before the 5-minute sleep,
+        # not held open — earlier reads in this function leave an uncommitted
+        # begin_nested()/flush() transaction on the session.
+        db.rollback.assert_called_once()
+        assert call_order == ["rollback", "sleep"]
+
+    @pytest.mark.anyio
+    async def test_writeback_retry_succeeds_on_second_attempt(self):
+        """If the retry succeeds, the write-back is recorded as successful — no error persisted."""
         db = MagicMock()
         call_session = MagicMock()
         call_session.id = _SESSION_ID
@@ -574,7 +710,7 @@ class TestPostCallWriteback:
                 return_value=self._writeback_settings(),
             ),
             patch(
-                "app.services.hubspot_service.get_valid_access_token",
+                "app.services.hubspot_service._force_refresh_access_token",
                 new=AsyncMock(return_value="access-token"),
             ),
             patch(
@@ -587,15 +723,22 @@ class TestPostCallWriteback:
             ),
             patch(
                 "app.services.hubspot_service.create_call_engagement",
-                new=AsyncMock(side_effect=Exception("HubSpot 500")),
-            ),
+                new=AsyncMock(side_effect=[Exception("HubSpot 500"), {"id": "engagement-1"}]),
+            ) as mock_create_engagement,
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
             patch(
                 "app.services.hubspot_service.set_last_write_back_error"
             ) as mock_set_error,
+            patch(
+                "app.services.hubspot_service.record_write_back_failure"
+            ) as mock_record_failure,
         ):
             await hubspot_service._run_post_call_writeback_async(db, call_session)
 
-        mock_set_error.assert_called_once_with(db, _TENANT_ID, "HubSpot 500")
+        assert mock_create_engagement.await_count == 2
+        mock_sleep.assert_awaited_once()
+        mock_record_failure.assert_not_called()
+        mock_set_error.assert_called_once_with(db, _TENANT_ID, None)
 
     def test_run_post_call_writeback_skips_when_not_connected(self):
         """Sync entrypoint must not touch HubSpot when the tenant has no connection."""
@@ -614,6 +757,31 @@ class TestPostCallWriteback:
 
         mock_asyncio_run.assert_not_called()
         db.close.assert_called_once()
+
+    def test_schedule_writeback_never_blocks_caller_without_a_running_loop(self):
+        """schedule_hubspot_writeback promises to never block the caller. Since
+        write-back can now retry with a real 5-minute asyncio.sleep, the
+        no-running-loop branch (e.g. a synchronous webhook handler calling
+        CallSessionService.update_call_session_status) must hand off to a
+        background thread rather than run inline."""
+        with (
+            patch(
+                "app.services.hubspot_service.asyncio.get_running_loop",
+                side_effect=RuntimeError("no running loop"),
+            ),
+            patch("app.services.hubspot_service.threading.Thread") as mock_thread_cls,
+            patch("app.services.hubspot_service.run_post_call_writeback") as mock_run,
+        ):
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            hubspot_service.schedule_hubspot_writeback(_SESSION_ID)
+
+        mock_thread_cls.assert_called_once_with(
+            target=mock_run, args=(_SESSION_ID,), daemon=True
+        )
+        mock_thread.start.assert_called_once()
+        mock_run.assert_not_called()  # must not run synchronously on the caller's thread
 
     def test_call_status_and_direction_mapping(self):
         assert hubspot_service._hs_call_status("no_answer") == "NO_ANSWER"
@@ -935,15 +1103,40 @@ class TestFieldMappingResolution:
 
         assert values == {"caller_name": "Ada Lovelace"}
 
-    def test_skips_missing_values_and_incomplete_mappings(self):
-        contact = {"id": "1", "raw_properties": {}}
+    def test_missing_or_null_values_resolve_to_empty_string(self):
+        """A configured mapping whose field is missing/NULL on the contact still gets an
+        entry (empty string) so the prompt placeholder is cleanly omitted, not left
+        unreplaced or filled with 'null'/'undefined'."""
+        contact = {"id": "1", "raw_properties": {"jobtitle": None, "company": ""}}
         mappings = [
             {"hubspot_field": "jobtitle", "prompt_variable": "job_title"},
+            {"hubspot_field": "company", "prompt_variable": "company_name"},
             {"hubspot_field": "", "prompt_variable": "x"},
             {"hubspot_field": "y"},
         ]
 
-        assert hubspot_service.resolve_field_mapping_values(contact, mappings) == {}
+        assert hubspot_service.resolve_field_mapping_values(contact, mappings) == {
+            "job_title": "",
+            "company_name": "",
+        }
+
+    def test_no_contact_still_resolves_all_mapped_variables_to_empty_string(self):
+        mappings = [{"hubspot_field": "jobtitle", "prompt_variable": "job_title"}]
+        assert hubspot_service.resolve_field_mapping_values(None, mappings) == {"job_title": ""}
+
+    def test_apply_field_mapping_values_omits_placeholder_for_null_field(self):
+        prompt = "Hello {caller_name}, your title is {job_title}."
+        values = hubspot_service.resolve_field_mapping_values(
+            {"id": "1", "raw_properties": {"jobtitle": None}},
+            [
+                {"hubspot_field": "firstname", "prompt_variable": "caller_name"},
+                {"hubspot_field": "jobtitle", "prompt_variable": "job_title"},
+            ],
+        )
+        result = hubspot_service.apply_field_mapping_values(prompt, values)
+        assert result == "Hello , your title is ."
+        assert "null" not in result.lower()
+        assert "undefined" not in result.lower()
 
     def test_no_contact_or_no_mappings_returns_empty(self):
         assert hubspot_service.resolve_field_mapping_values(None, [{"a": "b"}]) == {}
@@ -995,12 +1188,13 @@ class TestGetFieldMappingValuesForCall:
             patch(
                 "app.services.hubspot_service.get_contact_for_phone",
                 new=AsyncMock(return_value=contact),
-            ),
+            ) as mock_get_contact,
         ):
             values = await hubspot_service.get_field_mapping_values_for_call(db, call_session)
 
         assert values == {"job_title": "Engineer"}
         assert call_session.call_metadata["hubspot_field_mapping_values"] == values
+        assert mock_get_contact.call_args.kwargs.get("commit_lookup_timestamp") is False
         db.flush.assert_called_once()
 
     @pytest.mark.anyio
@@ -1088,3 +1282,311 @@ class TestSafeErrorMsg:
         msg = _safe_error_msg(exc)
         assert len(msg) == 500
         assert msg == "a" * 500
+
+
+# ── Contact properties fetch (field-mapping schema validation) ─────────────────
+
+
+class TestGetHubSpotContactProperties:
+    @pytest.mark.anyio
+    async def test_cache_hit_skips_hubspot_call(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value='["jobtitle", "company"]')
+
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=mock_redis),
+            patch("app.services.hubspot_service.get_valid_access_token") as mock_token,
+        ):
+            properties = await hubspot_service.get_hubspot_contact_properties(db, _TENANT_ID)
+
+        mock_token.assert_not_called()
+        assert properties == ["jobtitle", "company"]
+
+    @pytest.mark.anyio
+    async def test_cache_miss_fetches_and_caches_for_1_hour(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock()
+
+        response = MagicMock()
+        response.json.return_value = {
+            "results": [{"name": "jobtitle"}, {"name": "company"}, {"name": ""}]
+        }
+        response.raise_for_status = MagicMock()
+
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=mock_redis),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value="access-token"),
+            ),
+            patch(
+                "app.services.hubspot_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ),
+        ):
+            properties = await hubspot_service.get_hubspot_contact_properties(db, _TENANT_ID)
+
+        assert properties == ["jobtitle", "company"]
+        mock_redis.set.assert_awaited_once()
+        args, kwargs = mock_redis.set.call_args
+        assert args[0] == hubspot_service._properties_cache_key(_TENANT_ID)
+        assert kwargs.get("ex") == 3600
+
+    @pytest.mark.anyio
+    async def test_raises_when_not_connected(self):
+        db = MagicMock()
+        with (
+            patch("app.services.hubspot_service.get_redis", return_value=None),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(ValueError):
+                await hubspot_service.get_hubspot_contact_properties(db, _TENANT_ID)
+
+
+# ── Forced pre-writeback token refresh ──────────────────────────────────────────
+
+
+class TestForceRefreshAccessToken:
+    @pytest.mark.anyio
+    async def test_always_refreshes_even_when_not_expired(self):
+        """Must call refresh_access_token unconditionally, ignoring token_expires_at."""
+        row = _integration_row(expires_in_seconds=1700)  # far from expiry
+        db = MagicMock()
+        new_row = _integration_row(expires_in_seconds=1800)
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.decrypt_hubspot_token",
+                side_effect=["plain-refresh-token", "new-plain-access-token"],
+            ),
+            patch(
+                "app.services.hubspot_service.refresh_access_token",
+                new=AsyncMock(return_value={"access_token": "new", "expires_in": 1800}),
+            ) as mock_refresh,
+            patch("app.services.hubspot_service.upsert_tokens", return_value=new_row),
+        ):
+            token = await hubspot_service._force_refresh_access_token(db, _TENANT_ID)
+
+        mock_refresh.assert_awaited_once_with("plain-refresh-token")
+        assert token == "new-plain-access-token"
+
+    @pytest.mark.anyio
+    async def test_fails_open_when_refresh_errors(self):
+        row = _integration_row(expires_in_seconds=1700)
+        db = MagicMock()
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.decrypt_hubspot_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.hubspot_service.refresh_access_token",
+                new=AsyncMock(side_effect=Exception("HubSpot down")),
+            ),
+        ):
+            token = await hubspot_service._force_refresh_access_token(db, _TENANT_ID)
+
+        assert token is None
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_get_valid_access_token_when_no_refresh_token(self):
+        row = _integration_row(expires_in_seconds=600, has_refresh_token=False)
+        db = MagicMock()
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch(
+                "app.services.hubspot_service.get_valid_access_token",
+                new=AsyncMock(return_value="fallback-token"),
+            ) as mock_fallback,
+        ):
+            token = await hubspot_service._force_refresh_access_token(db, _TENANT_ID)
+
+        mock_fallback.assert_awaited_once_with(db, _TENANT_ID)
+        assert token == "fallback-token"
+
+
+# ── Sync status + write-back failure tracking / admin alerting ─────────────────
+
+
+class TestSyncStatus:
+    def test_returns_defaults_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.hubspot_service.get_integration", return_value=None):
+            result = hubspot_service.get_sync_status(db, _TENANT_ID)
+
+        assert result == {
+            "last_lookup_at": None,
+            "last_write_back_at": None,
+            "last_write_back_status": None,
+            "error_count_24h": 0,
+        }
+
+    def test_returns_stored_metrics_and_filters_old_failures_outside_24h_window(self):
+        db = MagicMock()
+        row = MagicMock()
+        now = datetime.now(timezone.utc)
+        stale_ts = (now - timedelta(hours=30)).isoformat().replace("+00:00", "Z")
+        recent_ts = (now - timedelta(hours=1)).isoformat().replace("+00:00", "Z")
+        row.extra_metadata = {
+            "last_lookup_at": "2026-07-20T10:00:00Z",
+            "last_write_back_at": "2026-07-20T10:05:00Z",
+            "last_write_back_status": "failed",
+            "write_back_failure_timestamps": [stale_ts, recent_ts, recent_ts],
+        }
+
+        with patch("app.services.hubspot_service.get_integration", return_value=row):
+            result = hubspot_service.get_sync_status(db, _TENANT_ID)
+
+        assert result["last_lookup_at"] == "2026-07-20T10:00:00Z"
+        assert result["last_write_back_at"] == "2026-07-20T10:05:00Z"
+        assert result["last_write_back_status"] == "failed"
+        assert result["error_count_24h"] == 2  # stale_ts excluded
+
+
+class TestRecordWriteBackFailure:
+    def test_persists_structured_error_and_increments_counter(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.extra_metadata = {}
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch("app.services.hubspot_service._send_write_back_failure_alert") as mock_alert,
+        ):
+            hubspot_service.record_write_back_failure(db, _TENANT_ID, "HubSpot 500")
+
+        error = row.extra_metadata["last_write_back_error"]
+        assert error["error"] == "HubSpot 500"
+        assert "timestamp" in error
+        assert row.extra_metadata["last_write_back_status"] == "failed"
+        assert len(row.extra_metadata["write_back_failure_timestamps"]) == 1
+        mock_alert.assert_not_called()  # below threshold
+
+    def test_sends_admin_alert_after_5_failures_in_24h(self):
+        db = MagicMock()
+        row = MagicMock()
+        now = datetime.now(timezone.utc)
+        existing = [(now - timedelta(hours=1)).isoformat().replace("+00:00", "Z")] * 4
+        row.extra_metadata = {"write_back_failure_timestamps": existing}
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch("app.services.hubspot_service._send_write_back_failure_alert") as mock_alert,
+        ):
+            hubspot_service.record_write_back_failure(db, _TENANT_ID, "HubSpot 500")
+
+        assert len(row.extra_metadata["write_back_failure_timestamps"]) == 5
+        mock_alert.assert_called_once()
+        args = mock_alert.call_args[0]
+        assert args[0] is db
+        assert args[1] == _TENANT_ID
+        assert args[2] == "HubSpot 500"
+        assert args[4] == 5
+
+    def test_noop_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.hubspot_service.get_integration", return_value=None):
+            hubspot_service.record_write_back_failure(db, _TENANT_ID, "err")
+        db.commit.assert_not_called()
+
+    def test_does_not_re_alert_on_every_failure_past_threshold(self):
+        """Once a workspace is already over the 5-failure threshold, further
+        failures must not re-send the admin alert on every single one."""
+        db = MagicMock()
+        row = MagicMock()
+        now = datetime.now(timezone.utc)
+        existing = [(now - timedelta(hours=1)).isoformat().replace("+00:00", "Z")] * 5
+        row.extra_metadata = {"write_back_failure_timestamps": existing}
+
+        with (
+            patch("app.services.hubspot_service.get_integration", return_value=row),
+            patch("app.services.hubspot_service._send_write_back_failure_alert") as mock_alert,
+        ):
+            hubspot_service.record_write_back_failure(db, _TENANT_ID, "HubSpot 500")
+
+        assert len(row.extra_metadata["write_back_failure_timestamps"]) == 6
+        mock_alert.assert_not_called()
+
+
+class TestSendWriteBackFailureAlert:
+    def test_sends_email_to_workspace_admin(self):
+        db = MagicMock()
+        tenant = MagicMock()
+        tenant.name = "Acme Corp"
+        tenant.contact_email = "contact@acme.test"
+        db.get.return_value = tenant
+
+        with (
+            patch(
+                "app.services.data_export_service._get_workspace_admin_email",
+                return_value="admin@acme.test",
+            ),
+            patch("app.services.email_service.email_service.send_generic_email") as mock_send,
+        ):
+            hubspot_service._send_write_back_failure_alert(
+                db, _TENANT_ID, "HubSpot 500", "2026-07-20T17:50:31Z", 5
+            )
+
+        mock_send.assert_called_once()
+        _, kwargs = mock_send.call_args
+        assert kwargs["to_email"] == "admin@acme.test"
+        assert "Acme Corp" in kwargs["subject"]
+        assert "settings/integrations" in kwargs["html_body"]
+
+    def test_falls_back_to_contact_email_when_no_admin(self):
+        db = MagicMock()
+        tenant = MagicMock()
+        tenant.name = "Acme Corp"
+        tenant.contact_email = "contact@acme.test"
+        db.get.return_value = tenant
+
+        with (
+            patch(
+                "app.services.data_export_service._get_workspace_admin_email",
+                return_value=None,
+            ),
+            patch("app.services.email_service.email_service.send_generic_email") as mock_send,
+        ):
+            hubspot_service._send_write_back_failure_alert(
+                db, _TENANT_ID, "HubSpot 500", "2026-07-20T17:50:31Z", 5
+            )
+
+        mock_send.assert_called_once()
+        assert mock_send.call_args[1]["to_email"] == "contact@acme.test"
+
+    def test_noop_when_no_email_found(self):
+        db = MagicMock()
+        db.get.return_value = None
+
+        with (
+            patch(
+                "app.services.data_export_service._get_workspace_admin_email",
+                return_value=None,
+            ),
+            patch("app.services.email_service.email_service.send_generic_email") as mock_send,
+        ):
+            hubspot_service._send_write_back_failure_alert(
+                db, _TENANT_ID, "HubSpot 500", "2026-07-20T17:50:31Z", 5
+            )
+
+        mock_send.assert_not_called()
+
+    def test_never_raises_on_internal_error(self):
+        db = MagicMock()
+        with patch(
+            "app.services.data_export_service._get_workspace_admin_email",
+            side_effect=Exception("DB down"),
+        ):
+            hubspot_service._send_write_back_failure_alert(
+                db, _TENANT_ID, "HubSpot 500", "2026-07-20T17:50:31Z", 5
+            )  # must not raise


### PR DESCRIPTION
## Summary

Resolves the remaining Sprint 7 HubSpot integration edge cases: field-mapping schema validation, graceful NULL handling in prompt injection, write-back retry/error recovery, pre-writeback forced token refresh, sync status visibility, and admin alerting.

- **Field mapping schema validation** — `get_hubspot_contact_properties()` fetches the tenant's HubSpot contact properties (Redis-cached 1h). `PUT /api/v1/integrations/hubspot/field-mapping` validates every `hubspot_field` against the live schema and returns `422` with `{"detail": ..., "invalid_fields": [...]}` on unknown fields. `POST /field-mapping` kept as an undocumented backward-compatible alias.
- **Graceful NULL/empty field handling** — `resolve_field_mapping_values()` now always emits an entry for every configured mapping (`""` when the contact or field is missing/NULL/empty), so `{prompt_variable}` placeholders are cleanly blanked instead of left literal in the prompt or filled with `null`/`undefined`.
- **Write-back retry + structured error logging** — a failed post-call write-back retries once after a 5-minute delay; a final failure records `{"timestamp", "error"}` under `workspace_integrations.metadata.last_write_back_error` and bumps a rolling 24h failure counter.
- **Forced pre-writeback token refresh** — the access token is now unconditionally refreshed immediately before every write-back call, since HubSpot tokens expire every 30 minutes and calls can outlast that.
- **Sync status endpoint** — `GET /api/v1/integrations/hubspot/sync-status` returns `last_lookup_at`, `last_write_back_at`, `last_write_back_status`, `error_count_24h`.
- **Admin alerting** — 5+ write-back failures in a rolling 24h window emails the workspace admin (falling back to `tenant.contact_email`) with a reconnect link, firing once per threshold crossing rather than on every subsequent failure.

### Bugs found and fixed during self-review
- `_touch_last_lookup_at` was calling `db.commit()` unconditionally, but it's invoked from `get_contact_for_phone` during live in-call prompt generation on the shared, long-lived call-session DB session — which deliberately never commits directly (uses `begin_nested()`/`flush()`) to avoid prematurely committing an in-progress call transaction. Fixed by threading a `commit_lookup_timestamp` flag through so live-call callers opt into the flush-only path.
- Admin alert was re-firing on every failure once a workspace crossed the 5-failure threshold instead of once per breach. Fixed to fire only on the exact crossing.
- The DB connection stayed checked out from the pool for the full 5-minute retry sleep (earlier reads leave an uncommitted `begin_nested()` transaction open) — a pool-exhaustion risk during a real HubSpot outage. Fixed by releasing the connection (`db.rollback()`) before sleeping.
- `schedule_hubspot_writeback`'s "never blocks the caller" guarantee broke for synchronous callers (e.g. `CallSessionService.update_call_session_status` from a webhook handler) once retry-with-sleep was added — the no-running-loop branch ran inline. Fixed by handing off to a daemon thread.

## Test plan
- [x] `pytest tests/api/test_hubspot_integration.py tests/services/test_hubspot_service.py -v` — 111 passed
- [x] `pytest tests/ -q` — 1504 passed, 65 skipped, 0 failed
- [x] `ruff check` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)