### PR TITLE
fix: allow updating prompt version notes independently of prompt text

### DIFF
--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -145,6 +145,18 @@ class CallFlowService:
             return True
         return current.prompt_text != new_prompt
 
+    def _update_current_version_notes(
+        self, db: Session, flow: CallFlow, notes: Optional[str]
+    ) -> None:
+        """Patch notes on the flow's currently active prompt version, if any."""
+        if notes is None or flow.current_prompt_id is None:
+            return
+        pv_repo = PromptVersionRepository(db)
+        current_ver = pv_repo.find_by_id(flow.current_prompt_id)
+        if current_ver:
+            current_ver.notes = notes
+            db.add(current_ver)
+
     # ── Serialization helpers ─────────────────────────────────────────────
 
     def _version_to_out(self, v: PromptVersion) -> PromptVersionOut:
@@ -328,8 +340,10 @@ class CallFlowService:
                     current_prompt_id=flow.current_prompt_id,
                 )
                 scalar_updates["current_prompt_id"] = version.id
+            else:
+                self._update_current_version_notes(db, flow, body.notes)
         elif body.current_prompt_id is not None:
-            # Explicit rollback — no prompt text provided
+            # Explicit rollback / version select — no prompt text provided
             pv_repo = PromptVersionRepository(db)
             target = pv_repo.find_by_id(body.current_prompt_id)
             if target is None or target.flow_id != flow.id:
@@ -337,7 +351,12 @@ class CallFlowService:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="currentPromptId does not belong to this flow",
                 )
+            if body.notes is not None:
+                target.notes = body.notes
+                db.add(target)
             scalar_updates["current_prompt_id"] = body.current_prompt_id
+        else:
+            self._update_current_version_notes(db, flow, body.notes)
 
         if scalar_updates:
             flow = repo.update(flow, scalar_updates)

--- a/tests/api/test_call_flows.py
+++ b/tests/api/test_call_flows.py
@@ -299,6 +299,25 @@ class TestUpdateCallFlow:
         # Still 2 versions (no new version created)
         assert len(body["promptVersions"]) == 2
 
+    def test_update_notes_via_current_prompt_id(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        created = self._create_flow(authed_client, auth_tenant, test_agent)
+        v1_id = created["currentPromptId"]
+
+        resp = authed_client.put(
+            f"/api/v1/call-flows/{created['id']}",
+            json={"currentPromptId": v1_id, "notes": "updated notes for v1"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["currentPromptId"] == v1_id
+        matching_ver = next(
+            v for v in body["promptVersions"] if v["id"] == v1_id
+        )
+        assert matching_ver["notes"] == "updated notes for v1"
+
     def test_rollback_with_wrong_flow_version_returns_400(
         self, authed_client, auth_tenant, test_agent, db
     ):


### PR DESCRIPTION
## Summary
- `PUT /api/v1/call-flows/{id}` now lets `notes` be patched onto the active prompt version even when `prompt` is unchanged (or omitted), and when combined with `currentPromptId` for a rollback/version-select.
- Deduplicated the repeated find-and-patch-notes logic into a single `_update_current_version_notes` helper.

## Test plan
- [x] `pytest tests/api/test_call_flows.py -v` — 30 passed, including new `test_update_notes_via_current_prompt_id`