### PR TITLE
feat: soft-delete prompt versions on call flows

### DIFF
--- a/alembic/versions/20260721_add_soft_delete_to_promptversion.py
+++ b/alembic/versions/20260721_add_soft_delete_to_promptversion.py
@@ -1,0 +1,28 @@
+"""add is_deleted to promptversion
+
+Revision ID: 20260721_prompt_soft_del
+Revises: 20260716_amd_voicemail
+Create Date: 2026-07-21
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "20260721_prompt_soft_del"
+down_revision: Union[str, Sequence[str], None] = "0e45008a4e03"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "promptversion",
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("promptversion", "is_deleted")

--- a/app/models/prompt_version.py
+++ b/app/models/prompt_version.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Text, DateTime, ForeignKey, Index
+from sqlalchemy import Column, Text, DateTime, ForeignKey, Index, Boolean
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -18,6 +18,7 @@ class PromptVersion(Base):
     # DB-only: sanitized copy for Gemini — never returned in API responses
     gemini_prompt = Column(Text, nullable=True)
     notes = Column(Text, nullable=True)
+    is_deleted = Column(Boolean, default=False, nullable=False, server_default="false")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     call_flow = relationship(

--- a/app/repositories/prompt_version_repository.py
+++ b/app/repositories/prompt_version_repository.py
@@ -22,7 +22,10 @@ class PromptVersionRepository:
         return version
 
     def find_by_id(self, version_id: uuid.UUID) -> Optional[PromptVersion]:
-        stmt = select(PromptVersion).where(PromptVersion.id == version_id)
+        stmt = select(PromptVersion).where(
+            PromptVersion.id == version_id,
+            PromptVersion.is_deleted == False,  # noqa: E712
+        )
         return self.db.execute(stmt).scalar_one_or_none()
 
     def find_by_flow(
@@ -31,20 +34,29 @@ class PromptVersionRepository:
         *,
         order_desc: bool = True,
     ) -> list[PromptVersion]:
-        stmt = select(PromptVersion).where(PromptVersion.flow_id == flow_id)
+        stmt = select(PromptVersion).where(
+            PromptVersion.flow_id == flow_id,
+            PromptVersion.is_deleted == False,  # noqa: E712
+        )
         stmt = stmt.order_by(
             PromptVersion.created_at.desc() if order_desc else PromptVersion.created_at.asc()
         )
         return list(self.db.execute(stmt).scalars().all())
 
     def count_by_flow(self, flow_id: uuid.UUID) -> int:
-        stmt = select(func.count(PromptVersion.id)).where(PromptVersion.flow_id == flow_id)
+        stmt = select(func.count(PromptVersion.id)).where(
+            PromptVersion.flow_id == flow_id,
+            PromptVersion.is_deleted == False,  # noqa: E712
+        )
         return int(self.db.execute(stmt).scalar_one())
 
     def find_oldest_by_flow(self, flow_id: uuid.UUID) -> Optional[PromptVersion]:
         stmt = (
             select(PromptVersion)
-            .where(PromptVersion.flow_id == flow_id)
+            .where(
+                PromptVersion.flow_id == flow_id,
+                PromptVersion.is_deleted == False,  # noqa: E712
+            )
             .order_by(PromptVersion.created_at.asc())
             .limit(1)
         )
@@ -56,11 +68,19 @@ class PromptVersionRepository:
         exclude_version_id: Optional[uuid.UUID],
     ) -> Optional[PromptVersion]:
         """Oldest version by created_at that is NOT the current active version."""
-        stmt = select(PromptVersion).where(PromptVersion.flow_id == flow_id)
+        stmt = select(PromptVersion).where(
+            PromptVersion.flow_id == flow_id,
+            PromptVersion.is_deleted == False,  # noqa: E712
+        )
         if exclude_version_id is not None:
             stmt = stmt.where(PromptVersion.id != exclude_version_id)
         stmt = stmt.order_by(PromptVersion.created_at.asc()).limit(1)
         return self.db.execute(stmt).scalar_one_or_none()
+
+    def soft_delete(self, version: PromptVersion) -> None:
+        version.is_deleted = True
+        self.db.add(version)
+        self.db.flush()
 
     def delete(self, version: PromptVersion) -> None:
         self.db.delete(version)

--- a/app/routers/call_flows.py
+++ b/app/routers/call_flows.py
@@ -94,6 +94,32 @@ def get_prompt_versions(
     return call_flow_service.get_prompt_versions(db, flow_id, _workspace_id(principal))
 
 
+@router.delete(
+    "/{flow_id}/prompt-versions/{version_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_prompt_version(
+    flow_id: uuid.UUID,
+    version_id: uuid.UUID,
+    request: Request,
+    principal: Union[User, ApiKeyPrincipal] = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+):
+    tid = _workspace_id(principal)
+    call_flow_service.delete_prompt_version(db, flow_id, version_id, tid)
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tid,
+        action="call_flow.prompt_version_deleted",
+        resource_type="prompt_version",
+        resource_id=version_id,
+        actor_user_id=principal.id if isinstance(principal, User) else None,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
 @router.get("/{flow_id}")
 def get_call_flow(
     flow_id: uuid.UUID,

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -423,6 +423,49 @@ class CallFlowService:
             for v in versions
         ]
 
+    def delete_prompt_version(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        version_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> None:
+        """Delete a single prompt version from a call flow.
+
+        Guards:
+        - Flow must exist and belong to tenant
+        - Version must exist and belong to flow
+        - Cannot delete the currently active version (flow.current_prompt_id)
+        - Cannot delete a version currently assigned as an A/B test variant
+        - Cannot delete the only remaining version of a flow
+        """
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        pv_repo = PromptVersionRepository(db)
+        version = pv_repo.find_by_id(version_id)
+        if version is None or version.flow_id != flow.id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Prompt version {version_id} not found in call flow {flow_id}",
+            )
+        if flow.current_prompt_id == version.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot delete the currently active prompt version. Please switch to another version first.",
+            )
+        if version.id in (flow.ab_prompt_a_id, flow.ab_prompt_b_id):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot delete a prompt version assigned to an active A/B test. Please update the A/B test first.",
+            )
+        count = pv_repo.count_by_flow(flow.id)
+        if count <= 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot delete the only prompt version of a call flow.",
+            )
+        pv_repo.soft_delete(version)
+        db.commit()
+
     # ── A/B prompt testing ──────────────────────────────────────────────────
 
     def update_ab_test(

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1424,6 +1424,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/call-flows/{flow_id}/prompt-versions/{version_id}:
+    delete:
+      tags:
+      - Call Flows
+      summary: Delete Prompt Version
+      operationId: delete_prompt_version_api_v1_call_flows__flow_id__prompt_versions__version_id__delete
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      - name: version_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Version Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/call-flows/{flow_id}:
     get:
       tags:

--- a/tests/api/test_call_flows.py
+++ b/tests/api/test_call_flows.py
@@ -351,6 +351,103 @@ class TestUpdateCallFlow:
         assert body["name"] == "Renamed Flow"
         assert body["direction"] == "outbound"
 
+    def test_delete_prompt_version_success(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        created = self._create_flow(authed_client, auth_tenant, test_agent)
+        v1_id = created["currentPromptId"]
+
+        # Create v2 so v1 is no longer active
+        authed_client.put(
+            f"/api/v1/call-flows/{created['id']}",
+            json={"prompt": "v2 prompt"},
+            headers=_headers(auth_tenant),
+        )
+
+        # Delete non-active version v1
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/{created['id']}/prompt-versions/{v1_id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 204
+
+        # Confirm v1 is gone from prompt-versions API response
+        versions = authed_client.get(
+            f"/api/v1/call-flows/{created['id']}/prompt-versions",
+            headers=_headers(auth_tenant),
+        ).json()
+        assert len(versions) == 1
+        assert versions[0]["id"] != v1_id
+
+        # Verify soft delete flag is_deleted == True in database
+        soft_deleted_v1 = db.query(PromptVersion).filter(PromptVersion.id == uuid.UUID(v1_id)).first()
+        assert soft_deleted_v1 is not None
+        assert soft_deleted_v1.is_deleted is True
+
+    def test_delete_active_prompt_version_returns_400(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        created = self._create_flow(authed_client, auth_tenant, test_agent)
+        v1_id = created["currentPromptId"]
+
+        # Try deleting active version v1
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/{created['id']}/prompt-versions/{v1_id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+
+    def test_delete_only_prompt_version_returns_400(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        created = self._create_flow(authed_client, auth_tenant, test_agent)
+        v1_id = created["currentPromptId"]
+
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/{created['id']}/prompt-versions/{v1_id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+
+    def test_delete_nonexistent_prompt_version_returns_404(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        created = self._create_flow(authed_client, auth_tenant, test_agent)
+        dummy_id = str(uuid.uuid4())
+
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/{created['id']}/prompt-versions/{dummy_id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_delete_ab_test_variant_prompt_version_returns_400(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        created = self._create_flow(authed_client, auth_tenant, test_agent)
+        v1_id = created["currentPromptId"]
+
+        # Create v2 so v1 is no longer active
+        authed_client.put(
+            f"/api/v1/call-flows/{created['id']}",
+            json={"prompt": "v2 prompt"},
+            headers=_headers(auth_tenant),
+        )
+
+        # Assign v1 as the A/B test's variant A
+        flow = db.query(CallFlow).filter(CallFlow.id == uuid.UUID(created["id"])).first()
+        flow.ab_test_enabled = True
+        flow.ab_prompt_a_id = uuid.UUID(v1_id)
+        flow.ab_prompt_b_id = uuid.UUID(v1_id)
+        db.add(flow)
+        db.commit()
+
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/{created['id']}/prompt-versions/{v1_id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+
 
 @pytest.mark.usefixtures("db")
 class TestGetCallFlow:


### PR DESCRIPTION
## Summary
- Add `DELETE /api/v1/call-flows/{flow_id}/prompt-versions/{version_id}` to soft-delete a single prompt version (`is_deleted` flag, no hard delete).
- Guards: version must belong to the flow; cannot delete the currently active version (`current_prompt_id`); cannot delete a version assigned to an active A/B test (`ab_prompt_a_id`/`ab_prompt_b_id`); cannot delete the last remaining version of a flow.
- `PromptVersionRepository` read paths (`find_by_id`, `find_by_flow`, `count_by_flow`, `find_oldest_by_flow`, `find_oldest_excluding_active`) now filter out soft-deleted rows.
- Migration adds `promptversion.is_deleted` (boolean, default false).
- Audit log entry (`call_flow.prompt_version_deleted`) emitted on delete.

## Test plan
- [x] `pytest tests/api/test_call_flows.py -v` — 35 passed, including new tests for: successful soft delete, deleting the active version (400), deleting the only version (400), deleting a nonexistent version (404), and deleting a version assigned as an A/B test variant (400).
- [x] `pytest tests/ -q --ignore=tests/integration` — 1521 passed, 5 skipped, no regressions.
- [x] Verified `alembic heads` resolves to a single head after the new migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)