### PR TITLE
feat: replace SendGrid with AWS SES for transactional email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -137,8 +137,8 @@ GCP_PROJECT_ID=
 PINECONE_API_KEY=
 PINECONE_INDEX_NAME=voiceagent-kb
 
-# SendGrid
-SENDGRID_API_KEY=
+# AWS SES (email) — delivery uses AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_REGION_NAME below.
+AWS_SES_SENDER_EMAIL=
 
 # Redis — in Docker Compose, host "redis" is the named service.
 REDIS_URL=redis://redis:6379

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Multi-tenant SaaS Voice Agent Backend. Tenants configure AI voice agents that ha
 **DB**: PostgreSQL via SQLAlchemy 2.x (sync) + asyncpg (async) + Alembic  
 **Background jobs**: ARQ (Redis-backed) for batch calls; APScheduler (PostgreSQL job store) for smart callbacks  
 **Vector store**: Pinecone + pgvector for RAG  
-**Infra**: S3 for recordings/KB files/data exports (migrated off GCS — `GCS_*` env vars are legacy/unused), Stripe for billing, SendGrid for email, Redis for rate-limiting, Calendly for voice-agent booking (replaced the local appointment/slot-reservation DB flow)
+**Infra**: S3 for recordings/KB files/data exports (migrated off GCS — `GCS_*` env vars are legacy/unused), Stripe for billing, AWS SES for email, Redis for rate-limiting, Calendly for voice-agent booking (replaced the local appointment/slot-reservation DB flow)
 
 ---
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -167,9 +167,8 @@ class CrmSettings(BaseModel):
     # Trello
     trello_api_key: str = Field(default="", validation_alias="TRELLO_PLATFORM_API_KEY")
     trello_api_token: str = Field(default="", validation_alias="TRELLO_PLATFORM_API_TOKEN")
-    # SendGrid
-    sendgrid_api_key: str = Field(default="", validation_alias="SENDGRID_API_KEY")
-    sendgrid_sender_email: str = Field(default="", validation_alias="SENDGRID_SENDER_EMAIL")
+    # AWS SES
+    aws_ses_sender_email: str = Field(default="", validation_alias="AWS_SES_SENDER_EMAIL")
     # Stripe
     stripe_publishable_key: str = Field(default="", validation_alias="STRIPE_PUBLISHABLE_KEY")
     stripe_secret_key: str = Field(default="", validation_alias="STRIPE_SECRET_KEY")
@@ -341,9 +340,9 @@ class Settings(BaseSettings):
     WEBHOOK_BASE_URL: str = "https://tgs-agent-be.onrender.com"
     N8N_WEBHOOK_URL: str = ""  # n8n webhook URL for scheduled calls
     N8N_WEBHOOK_SECRET: str = ""  # Secret for verifying n8n webhook requests
-    # Email settings (SendGrid)
-    SENDGRID_API_KEY: str = ""
-    SENDGRID_SENDER_EMAIL: str = ""
+    # Email settings (AWS SES) — sender identity; delivery uses AWS_ACCESS_KEY_ID /
+    # AWS_SECRET_ACCESS_KEY / AWS_REGION_NAME (shared with S3, declared below).
+    AWS_SES_SENDER_EMAIL: str = ""
 
     # Password reset settings
     PASSWORD_RESET_TOKEN_EXPIRE_MINUTES: int = 30
@@ -844,8 +843,7 @@ class Settings(BaseSettings):
             monday_workspace_id=self.MONDAY_WORKSPACE_ID,
             trello_api_key=self.TRELLO_PLATFORM_API_KEY,
             trello_api_token=self.TRELLO_PLATFORM_API_TOKEN,
-            sendgrid_api_key=self.SENDGRID_API_KEY,
-            sendgrid_sender_email=self.SENDGRID_SENDER_EMAIL,
+            aws_ses_sender_email=self.AWS_SES_SENDER_EMAIL,
             stripe_publishable_key=self.STRIPE_PUBLISHABLE_KEY,
             stripe_secret_key=self.STRIPE_SECRET_KEY,
             stripe_webhook_secret=self.STRIPE_WEBHOOK_SECRET,

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -1,17 +1,28 @@
 import logging
+import re
 from typing import List, Optional
 
-from sendgrid import SendGridAPIClient
-from sendgrid.helpers.mail import Mail
+from botocore.exceptions import ClientError
+
 from app.core.config import settings
+from app.services.s3_service import get_ses_client
 
 logger = logging.getLogger(__name__)
+
+# SES error codes that indicate a sandbox/verification restriction rather
+# than a transient failure — logged distinctly so they're easy to spot.
+_SANDBOX_ERROR_CODES = {
+    "MessageRejected",
+    "MailFromDomainNotVerifiedException",
+    "AccountSendingPausedException",
+    "LimitExceededException",
+}
 
 
 def build_invite_email_content(
     invite_token: str, inviter_name: str, tenant_name: str
 ) -> tuple[str, str]:
-    """Subject + HTML body for workspace invite (log now, SendGrid later)."""
+    """Subject + HTML body for workspace invite."""
     subject = f"You're invited to join {tenant_name} on Voice Agent Platform"
     invite_link = f"{settings.FRONTEND_URL}/accept-invite?token={invite_token}"
     html_body = f"""
@@ -33,20 +44,28 @@ def build_invite_email_content(
     return subject, html_body
 
 
+def _html_to_text(html_body: str) -> str:
+    """Best-effort plain-text fallback derived from an HTML body."""
+    text = re.sub(r"<[^>]+>", "", html_body)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n\s*\n+", "\n\n", text)
+    return text.strip()
+
+
 class EmailService:
     def __init__(self):
-        self.sg_client = SendGridAPIClient(settings.SENDGRID_API_KEY) if settings.SENDGRID_API_KEY else None
-        self.sender_email = settings.SENDGRID_SENDER_EMAIL
-    
+        self.sender_email = settings.AWS_SES_SENDER_EMAIL
+        self.ses_client = get_ses_client()
+
     def send_password_reset_email(self, email: str, reset_token: str, user_name: str) -> bool:
         """
         Send password reset email to user
-        
+
         Args:
             email: User's email address
             reset_token: Password reset token
             user_name: User's name for personalization
-            
+
         Returns:
             bool: True if email sent successfully, False otherwise
         """
@@ -73,16 +92,17 @@ class EmailService:
         except Exception as e:
             logger.error(f"Error sending password reset email to {email}: {str(e)}")
             return False
-    
+
     def _send_email(
         self,
         to_email: str,
         subject: str,
         html_body: str,
         cc_emails: Optional[List[str]] = None,
+        text_body: Optional[str] = None,
     ) -> bool:
         """
-        Send an email using SendGrid API.
+        Send an email using AWS SES.
 
         In staging, emails are logged to the console instead of actually
         sent — avoids real mail going out from a non-production environment.
@@ -93,41 +113,68 @@ class EmailService:
                 to_email, cc_emails or [], subject, html_body,
             )
             return True
+
+        if not self.sender_email:
+            logger.error("AWS SES sender is not configured. Missing AWS_SES_SENDER_EMAIL.")
+            return False
+
+        if not text_body:
+            text_body = _html_to_text(html_body)
+
+        destination = {"ToAddresses": [to_email]}
+        if cc_emails:
+            valid_ccs = [cc for cc in cc_emails if cc and cc.strip()]
+            if valid_ccs:
+                destination["CcAddresses"] = valid_ccs
+
+        body_dict = {
+            "Html": {"Data": html_body, "Charset": "UTF-8"},
+            "Text": {"Data": text_body, "Charset": "UTF-8"},
+        }
+
         try:
-            if not self.sg_client:
-                logger.error("SendGrid client is not configured. Missing SENDGRID_API_KEY.")
-                return False
-            message = Mail(
-                from_email=self.sender_email,
-                to_emails=to_email,
-                subject=subject,
-                html_content=html_body,
+            response = self.ses_client.send_email(
+                Source=self.sender_email,
+                Destination=destination,
+                Message={
+                    "Subject": {"Data": subject, "Charset": "UTF-8"},
+                    "Body": body_dict,
+                },
             )
-            # Optionally add CC recipients
-            if cc_emails:
-                for cc in cc_emails:
-                    if cc:
-                        message.add_cc(cc)
-            response = self.sg_client.send(message)
-            if 200 <= response.status_code < 300:
+            status_code = response.get("ResponseMetadata", {}).get("HTTPStatusCode", 200)
+            if 200 <= status_code < 300:
                 logger.info(f"Email sent successfully to {to_email}")
                 return True
-            logger.error(f"Failed to send email to {to_email}. Status: {response.status_code}")
+            logger.error(f"Failed to send email to {to_email}. Status: {status_code}")
+            return False
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "Unknown")
+            error_message = e.response.get("Error", {}).get("Message", str(e))
+            if error_code in _SANDBOX_ERROR_CODES:
+                logger.error(
+                    "AWS SES sandbox/restriction error [%s] sending email to %s: %s",
+                    error_code, to_email, error_message,
+                )
+            else:
+                logger.error(
+                    "AWS SES ClientError [%s] sending email to %s: %s",
+                    error_code, to_email, error_message,
+                )
             return False
         except Exception as e:
-            logger.error(f"Error sending email via SendGrid: {str(e)}")
+            logger.error(f"Unexpected error sending email via SES to {to_email}: {str(e)}")
             return False
-    
+
     def send_invite_email(self, email: str, invite_token: str, inviter_name: str, tenant_name: str) -> bool:
         """
-        Send team invitation email via Gmail
-        
+        Send team invitation email
+
         Args:
             email: Invitee's email address
             invite_token: Invitation token
             inviter_name: Name of person sending invite
             tenant_name: Name of the team/tenant
-            
+
         Returns:
             bool: True if email sent successfully, False otherwise
         """

--- a/app/services/s3_service.py
+++ b/app/services/s3_service.py
@@ -1,11 +1,12 @@
 """
-Shared S3 client factory.
+Shared AWS client factory.
 
-Every service that talks to Amazon S3 must obtain its client via
-get_s3_client() rather than instantiating boto3 directly, so credentials
-and region configuration stay centralized in one place.
+Every service that talks to an AWS API must obtain its client via one of
+the get_*_client() helpers below rather than instantiating boto3 directly,
+so credentials and region configuration stay centralized in one place.
 
 Docs: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html
+      https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ses.html
 """
 from __future__ import annotations
 
@@ -30,3 +31,8 @@ def get_s3_client():
 def get_kms_client():
     """Return a boto3 KMS client configured from application settings."""
     return boto3.client("kms", **_client_kwargs())
+
+
+def get_ses_client():
+    """Return a boto3 SES client configured from application settings."""
+    return boto3.client("ses", **_client_kwargs())

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,6 @@ google-auth-oauthlib==1.4.0
 deepgram-sdk==6.1.1
 google-cloud-texttospeech==2.36.0
 google-cloud-speech==2.40.0
-sendgrid==6.12.5
 geopy==2.4.1
 timezonefinder==8.2.4
 tzdata==2026.2

--- a/tests/services/test_email_service.py
+++ b/tests/services/test_email_service.py
@@ -1,0 +1,231 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from botocore.exceptions import ClientError
+
+from app.services.email_service import EmailService, _html_to_text
+
+
+@pytest.fixture
+def email_service_instance():
+    with patch("app.services.email_service.get_ses_client") as mock_get_ses_client:
+        mock_ses = MagicMock()
+        mock_get_ses_client.return_value = mock_ses
+        service = EmailService()
+        service.sender_email = "sender@example.com"
+        yield service, mock_ses
+
+
+def _success_response():
+    return {"MessageId": "abc123", "ResponseMetadata": {"HTTPStatusCode": 200}}
+
+
+def _client_error(code="MessageRejected", message="Email address is not verified."):
+    return ClientError(
+        error_response={"Error": {"Code": code, "Message": message}},
+        operation_name="SendEmail",
+    )
+
+
+class TestHtmlToText:
+    def test_strips_tags(self):
+        html = "<html><body><h2>Hi</h2><p>Hello <strong>World</strong></p></body></html>"
+        text = _html_to_text(html)
+        assert "<" not in text
+        assert "Hello" in text and "World" in text
+
+
+class TestSendEmailSuccess:
+    def test_sends_html_email(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        result = service._send_email(
+            to_email="user@example.com",
+            subject="Test Subject",
+            html_body="<p>Hello</p>",
+        )
+
+        assert result is True
+        mock_ses.send_email.assert_called_once()
+        kwargs = mock_ses.send_email.call_args.kwargs
+        assert kwargs["Source"] == "sender@example.com"
+        assert kwargs["Destination"] == {"ToAddresses": ["user@example.com"]}
+        assert kwargs["Message"]["Subject"]["Data"] == "Test Subject"
+        assert kwargs["Message"]["Body"]["Html"]["Data"] == "<p>Hello</p>"
+
+    def test_generates_plain_text_fallback_when_missing(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        service._send_email(
+            to_email="user@example.com",
+            subject="Test",
+            html_body="<p>Hello <strong>World</strong></p>",
+        )
+
+        body = mock_ses.send_email.call_args.kwargs["Message"]["Body"]
+        assert "Text" in body
+        assert "Hello" in body["Text"]["Data"]
+        assert "<" not in body["Text"]["Data"]
+
+    def test_uses_provided_text_body(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        service._send_email(
+            to_email="user@example.com",
+            subject="Test",
+            html_body="<p>Hello</p>",
+            text_body="Plain text version",
+        )
+
+        body = mock_ses.send_email.call_args.kwargs["Message"]["Body"]
+        assert body["Text"]["Data"] == "Plain text version"
+
+
+class TestSendEmailCc:
+    def test_includes_valid_cc_recipients(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        service._send_email(
+            to_email="user@example.com",
+            subject="Test",
+            html_body="<p>Hello</p>",
+            cc_emails=["cc1@example.com", "cc2@example.com"],
+        )
+
+        destination = mock_ses.send_email.call_args.kwargs["Destination"]
+        assert destination["CcAddresses"] == ["cc1@example.com", "cc2@example.com"]
+
+    def test_filters_out_empty_cc_entries(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        service._send_email(
+            to_email="user@example.com",
+            subject="Test",
+            html_body="<p>Hello</p>",
+            cc_emails=["", None, "  ", "valid@example.com"],
+        )
+
+        destination = mock_ses.send_email.call_args.kwargs["Destination"]
+        assert destination["CcAddresses"] == ["valid@example.com"]
+
+    def test_no_cc_key_when_no_cc_emails(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        service._send_email(
+            to_email="user@example.com",
+            subject="Test",
+            html_body="<p>Hello</p>",
+        )
+
+        destination = mock_ses.send_email.call_args.kwargs["Destination"]
+        assert "CcAddresses" not in destination
+
+
+class TestSendEmailErrors:
+    def test_missing_sender_email_returns_false(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        service.sender_email = ""
+
+        result = service._send_email(
+            to_email="user@example.com", subject="Test", html_body="<p>Hi</p>"
+        )
+
+        assert result is False
+        mock_ses.send_email.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "error_code",
+        [
+            "MessageRejected",
+            "MailFromDomainNotVerifiedException",
+            "AccountSendingPausedException",
+            "LimitExceededException",
+        ],
+    )
+    def test_client_error_returns_false(self, email_service_instance, error_code):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.side_effect = _client_error(code=error_code)
+
+        result = service._send_email(
+            to_email="user@example.com", subject="Test", html_body="<p>Hi</p>"
+        )
+
+        assert result is False
+
+    def test_unexpected_exception_returns_false(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.side_effect = RuntimeError("boom")
+
+        result = service._send_email(
+            to_email="user@example.com", subject="Test", html_body="<p>Hi</p>"
+        )
+
+        assert result is False
+
+
+class TestStagingMode:
+    def test_staging_short_circuits_without_calling_ses(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        with patch("app.services.email_service.settings.ENVIRONMENT", "staging"):
+            result = service._send_email(
+                to_email="user@example.com", subject="Test", html_body="<p>Hi</p>"
+            )
+
+        assert result is True
+        mock_ses.send_email.assert_not_called()
+
+
+class TestPublicMethods:
+    def test_send_invite_email(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        result = service.send_invite_email(
+            "invitee@example.com", "token123", "Alice", "Acme Corp"
+        )
+
+        assert result is True
+        mock_ses.send_email.assert_called_once()
+
+    def test_send_password_reset_email(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        result = service.send_password_reset_email(
+            "user@example.com", "reset-token", "Bob"
+        )
+
+        assert result is True
+        mock_ses.send_email.assert_called_once()
+
+    def test_send_data_export_ready_email(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        result = service.send_data_export_ready_email(
+            "admin@example.com", "https://example.com/export.zip", "Acme Corp"
+        )
+
+        assert result is True
+        mock_ses.send_email.assert_called_once()
+
+    def test_send_generic_email_with_cc(self, email_service_instance):
+        service, mock_ses = email_service_instance
+        mock_ses.send_email.return_value = _success_response()
+
+        result = service.send_generic_email(
+            "user@example.com",
+            "Subject",
+            "<p>Body</p>",
+            cc_emails=["cc@example.com"],
+        )
+
+        assert result is True
+        destination = mock_ses.send_email.call_args.kwargs["Destination"]
+        assert destination["CcAddresses"] == ["cc@example.com"]


### PR DESCRIPTION
## Summary
- Completely removes SendGrid (package, config fields, env vars) in favor of AWS SES via boto3
- Adds `AWS_SES_SENDER_EMAIL` config, reusing the existing `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION_NAME` settings already used for S3
- `EmailService` now sends via `ses_client.send_email(...)`, with a generated plain-text fallback and CC support, obtained through a new shared `get_ses_client()` factory (alongside the existing `get_s3_client()` / `get_kms_client()` in `app/services/s3_service.py`)
- Robust `ClientError` handling distinguishing SES sandbox/verification/rate-limit error codes (`MessageRejected`, `MailFromDomainNotVerifiedException`, `AccountSendingPausedException`, `LimitExceededException`) from other failures
- Updates `CLAUDE.md`, `.env.example` accordingly

## Test plan
- [x] New `tests/services/test_email_service.py` — 18 tests covering success, CC handling, staging short-circuit, and SES `ClientError` scenarios
- [x] Existing consumers of `email_service` still pass unmodified: `tests/api/test_workspace_invite.py`, `tests/services/test_data_export_service.py`, `tests/services/test_hubspot_service.py`, `tests/api/test_callback_scheduler.py`
- [x] Full suite: `pytest tests/` — 1539 passed, 65 skipped
- [x] Verified no remaining `sendgrid` references anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)