### PR TITLE
feat: add Salesforce CRM integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,22 @@ HUBSPOT_REDIRECT_URI=
 # Preserve compatibility with existing encrypted tokens by keeping the key unchanged.
 HUBSPOT_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
 
+# --- Salesforce CRM integration ------------------------------------------------
+# Connected App credentials from Salesforce Setup > App Manager. In staging/production
+# these are read from Secret Manager (see app/core/secret_manager.py); these env
+# vars are local-dev fallbacks only.
+SALESFORCE_CLIENT_ID=
+SALESFORCE_CLIENT_SECRET=
+# Must exactly match the callback URL configured on the Connected App. Defaults to
+# {WEBHOOK_BASE_URL}/api/v1/integrations/salesforce/callback when unset.
+SALESFORCE_REDIRECT_URI=
+# Symmetric encryption key for workspaceintegration.access_token/refresh_token (AES-256-GCM).
+# MUST be a randomly generated 32-byte secret (represented as a 64-character hex string).
+SALESFORCE_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
+# Fixed OAuth login host. Use https://test.salesforce.com for sandbox orgs.
+SALESFORCE_LOGIN_URL=https://login.salesforce.com
+SALESFORCE_API_VERSION=v59.0
+
 # --- Calendly calendar integration --------------------------------------------
 # OAuth app credentials from https://developer.calendly.com/.
 CALENDLY_CLIENT_ID=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Multi-tenant SaaS Voice Agent Backend. Tenants configure AI voice agents that handle inbound/outbound phone calls via Twilio + LiveKit, transcribe speech (Deepgram / Google STT), generate responses via LLM (OpenAI / Gemini / Groq), and synthesise voice (ElevenLabs / Rime / Google TTS). Post-call data syncs to tenant-configured CRMs.
+Multi-tenant SaaS Voice Agent Backend. Tenants configure AI voice agents that handle inbound/outbound phone calls via Twilio + LiveKit, transcribe speech (Deepgram / Google STT), generate responses via LLM (OpenAI / Gemini / Groq), and synthesise voice (ElevenLabs / Rime / Google TTS). Post-call data syncs to tenant-configured CRMs (see "CRM integrations" below — there are three independent CRM stacks).
 
 **Runtime**: Python 3.11 (Docker) / FastAPI, Uvicorn  
 **DB**: PostgreSQL via SQLAlchemy 2.x (sync) + asyncpg (async) + Alembic  
@@ -57,7 +57,7 @@ ruff check . && black .
 - v2 routers live in `app/api/v2/routers/` and carry their own `prefix=` on the `APIRouter`.
 - **Note**: the v1 agents router is registered at `/agent` (singular), not `/agents`.
 
-**v2 router inventory**: `active_calls`, `audit_events`, `batch_calls`, `callback_scheduler`, `webhooks`, `workspace` (branding, pricing, usage, member roles, sub-accounts, GDPR data export / account deletion), `hipaa` (HIPAA flag per call-flow, CMEK KMS key management), `flows` / `flow_data` (A/B prompt testing on call flows), `calendly_integration` (status, event types, availability, event creation — mounted twice, once under its own prefix and once under `calendar`), `health`.
+**v2 router inventory**: `active_calls`, `audit_events`, `batch_calls`, `callback_scheduler`, `webhooks`, `workspace` (branding, pricing, usage, member roles, sub-accounts, GDPR data export / account deletion), `hipaa` (HIPAA flag per call-flow, CMEK KMS key management), `flows` / `flow_data` (A/B prompt testing on call flows), `calendly_integration` (status, event types, availability, event creation — mounted twice, once under its own prefix and once under `calendar`), `telephony` (outbound number reputation checks), `health`.
 
 **v1 recruiting module**: job descriptions, resumes, resume interviews, and recruitment dashboard are all registered under `/api/v1/recruiting/`.
 
@@ -157,6 +157,14 @@ result = agent_service.get_agent_by_id(db, agent_id, tenant_id)
 Services never import `SessionLocal` — they always receive `db: Session` as a parameter.
 
 A handful of domains (`agent`, `call_flow`, `folder`, `prompt_version`, `workspace`) additionally split raw SQL access into a `Repository` class under `app/repositories/`, with the service holding/constructing the repo per-request (`self._repo(db)`). Most services query models directly instead — check whether a repository already exists for a model before adding new query methods on the service.
+
+### CRM integrations — three unrelated stacks
+
+"CRM" refers to three independent subsystems with no shared tables or code paths. When asked to "add CRM support," pick the right one:
+
+- **Sales-contact write-back** (`app/services/hubspot_service.py`, `app/services/salesforce_service.py`, `app/routers/hubspot_integration.py`, `app/routers/salesforce_integration.py`): OAuth 2.0 tokens stored encrypted in `workspace_integration`. Post-call, `CallSessionService.update_call_session_status()` calls `schedule_hubspot_writeback()` / `schedule_salesforce_writeback()`, which look up the matched Contact and write a HubSpot Call engagement or a Salesforce `Task` sObject. All call-time paths fail open — a CRM outage never blocks a call.
+- **Inbound-call → Trello sync** (`app/services/inbound_call_crm_sync_service.py`): a separate, Trello-only config (`TenantInboundCRMConfig` model), triggered by the same post-call hook but otherwise unrelated to the hubspot/salesforce code.
+- **Task-management board integration** (`app/services/base_crm_service.py`, `crm_service_factory.py`, `crm_config_service.py`, plus `monday_service.py` / `clickup_service.py` / `jira_service.py` / `trello_service.py`): API-key-based, configured per-tenant via `CRMConfig` (`app/models/tenant_crm_config.py`). Invoked from `app/routers/scheduled_calls.py` / `scheduled_call_service.py` and `appointment_follow_up_service.py` to create a task/card/issue per scheduled call or follow-up — not tied to call completion. `CRMConfig.crm_type` is schema-locked to `monday`/`clickup`/`jira`/`trello`; don't repurpose it for HubSpot/Salesforce.
 
 ### Outbound call dispatch
 

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -51,6 +51,7 @@ from app.routers.business_knowledge import router as business_knowledge_router
 from app.routers.recordings import router as recordings_router
 from app.routers.integrations import router as integrations_router
 from app.routers.hubspot_integration import router as hubspot_integration_router
+from app.routers.salesforce_integration import router as salesforce_integration_router
 from app.routers.call_history import router as call_history_router
 from app.routers.call_history import batch_router as batch_call_metrics_router
 from app.routers.payments import router as payments_router
@@ -167,6 +168,11 @@ api_router.include_router(
     hubspot_integration_router,
     prefix="/integrations/hubspot",
     tags=["HubSpot Integration"],
+)
+api_router.include_router(
+    salesforce_integration_router,
+    prefix="/integrations/salesforce",
+    tags=["Salesforce Integration"],
 )
 api_router.include_router(call_history_router, prefix="/calls", tags=["Call History Analytics"])
 api_router.include_router(batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"])

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -151,6 +151,13 @@ class CrmSettings(BaseModel):
     hubspot_token_encryption_key: str = Field(
         default="", validation_alias="HUBSPOT_TOKEN_ENCRYPTION_KEY"
     )
+    # Salesforce
+    salesforce_client_id: str = Field(default="", validation_alias="SALESFORCE_CLIENT_ID")
+    salesforce_client_secret: str = Field(default="", validation_alias="SALESFORCE_CLIENT_SECRET")
+    salesforce_redirect_uri: str = Field(default="", validation_alias="SALESFORCE_REDIRECT_URI")
+    salesforce_token_encryption_key: str = Field(
+        default="", validation_alias="SALESFORCE_TOKEN_ENCRYPTION_KEY"
+    )
     # Calendly
     calendly_client_id: str = Field(default="", validation_alias="CALENDLY_CLIENT_ID")
     calendly_client_secret: str = Field(default="", validation_alias="CALENDLY_CLIENT_SECRET")
@@ -386,6 +393,28 @@ class Settings(BaseSettings):
     # Symmetric encryption key for workspaceintegration.access_token / refresh_token
     # (pgp_sym_encrypt) — same scheme as ELEVENLABS_ENCRYPTION_KEY above.
     HUBSPOT_TOKEN_ENCRYPTION_KEY: str = ""
+
+    # Salesforce CRM OAuth (app/services/salesforce_service.py).
+    # client_id/client_secret kept here as local-dev fallbacks only — in
+    # staging/production they are read from Secret Manager (see
+    # app/core/secret_manager.py::get_salesforce_oauth_credentials).
+    SALESFORCE_CLIENT_ID: str = ""
+    SALESFORCE_CLIENT_SECRET: str = ""
+    SALESFORCE_REDIRECT_URI: str = ""  # defaults to {WEBHOOK_BASE_URL}/api/v1/integrations/salesforce/callback
+    # Symmetric encryption key for workspaceintegration.access_token / refresh_token
+    # (AES-256-GCM) — same scheme as HUBSPOT_TOKEN_ENCRYPTION_KEY above.
+    SALESFORCE_TOKEN_ENCRYPTION_KEY: str = ""
+    # Fixed OAuth login host — https://login.salesforce.com for production orgs,
+    # https://test.salesforce.com for sandboxes. NOT per-tenant: the data-plane
+    # instance_url returned in the token response is what varies per org.
+    SALESFORCE_LOGIN_URL: str = "https://login.salesforce.com"
+    SALESFORCE_API_VERSION: str = "v59.0"
+    # Salesforce token responses (unlike HubSpot's) do not include expires_in —
+    # session length is an org-configurable setting with no fixed default we can
+    # read via the API. We assume a conservative TTL and rely on AC #4's
+    # refresh-60s-early rule to force a refresh well before typical session
+    # timeouts (Salesforce's own default session timeout is 2 hours).
+    SALESFORCE_ACCESS_TOKEN_TTL_SECONDS: int = 1800
 
     # Calendly calendar OAuth (app/services/calendly_service.py).
     CALENDLY_CLIENT_ID: str = ""
@@ -834,6 +863,10 @@ class Settings(BaseSettings):
             hubspot_client_secret=self.HUBSPOT_CLIENT_SECRET,
             hubspot_redirect_uri=self.HUBSPOT_REDIRECT_URI,
             hubspot_token_encryption_key=self.HUBSPOT_TOKEN_ENCRYPTION_KEY,
+            salesforce_client_id=self.SALESFORCE_CLIENT_ID,
+            salesforce_client_secret=self.SALESFORCE_CLIENT_SECRET,
+            salesforce_redirect_uri=self.SALESFORCE_REDIRECT_URI,
+            salesforce_token_encryption_key=self.SALESFORCE_TOKEN_ENCRYPTION_KEY,
             calendly_client_id=self.CALENDLY_CLIENT_ID,
             calendly_client_secret=self.CALENDLY_CLIENT_SECRET,
             calendly_redirect_uri=self.CALENDLY_REDIRECT_URI,

--- a/app/core/db_encryption.py
+++ b/app/core/db_encryption.py
@@ -310,6 +310,63 @@ def decrypt_hubspot_token(ciphertext: str, db: Session) -> str:
         raise ValueError(f"HubSpot token decryption failed: {exc}") from exc
 
 
+# Tags Salesforce OAuth token ciphertext. New integration — no legacy pgcrypto
+# rows exist, so unlike HubSpot's decrypt_hubspot_token there is no fallback path.
+_SALESFORCE_AESGCM_PREFIX = "gcm1:"
+
+
+def _salesforce_aes_key() -> bytes:
+    """Derive a 32-byte AES-256 key from SALESFORCE_TOKEN_ENCRYPTION_KEY.
+
+    SECURITY NOTE:
+      For secure AES-256-GCM encryption, SALESFORCE_TOKEN_ENCRYPTION_KEY must be
+      configured as a randomly generated 32-byte secret (typically represented
+      as a 64-character hex string, e.g. generated via `secrets.token_hex(32)`).
+    """
+    key = settings.SALESFORCE_TOKEN_ENCRYPTION_KEY
+    if not key:
+        raise ValueError(
+            "SALESFORCE_TOKEN_ENCRYPTION_KEY is not configured — "
+            "cannot encrypt/decrypt Salesforce OAuth token."
+        )
+    return hashlib.sha256(key.encode("utf-8")).digest()
+
+
+def encrypt_salesforce_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+    """Encrypt *plaintext* Salesforce OAuth token with AES-256-GCM.
+
+    Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
+    encryption has no GCM mode). ``db`` is accepted only for parity with the other
+    encrypt_* helpers in this module; it is unused here.
+
+    Raises ``ValueError`` if ``SALESFORCE_TOKEN_ENCRYPTION_KEY`` is not configured.
+    """
+    key = _salesforce_aes_key()
+    nonce = os.urandom(12)  # 96-bit nonce, the standard size for AES-GCM
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext.encode("utf-8"), None)
+    return _SALESFORCE_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode("ascii")
+
+
+def decrypt_salesforce_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+    """Decrypt a Salesforce OAuth token written by :func:`encrypt_salesforce_token`.
+
+    Raises ``ValueError`` if ``SALESFORCE_TOKEN_ENCRYPTION_KEY`` is not configured,
+    the ciphertext is missing/corrupt, or was encrypted with a different key.
+    """
+    if not ciphertext:
+        raise ValueError("ciphertext is empty")
+    if not ciphertext.startswith(_SALESFORCE_AESGCM_PREFIX):
+        raise ValueError("Unrecognized Salesforce token ciphertext format")
+
+    key = _salesforce_aes_key()
+    try:
+        raw = base64.b64decode(ciphertext[len(_SALESFORCE_AESGCM_PREFIX):])
+        nonce, body = raw[:12], raw[12:]
+        return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
+    except Exception as exc:
+        raise ValueError(f"Salesforce token decryption failed: {exc}") from exc
+
+
 # Tags new-format ciphertext unambiguously for the Calendly OAuth token columns.
 _CALENDLY_AESGCM_PREFIX = "gcm1:"
 

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -219,6 +219,46 @@ def get_hubspot_oauth_credentials() -> Tuple[str, str]:
     return client_id, client_secret
 
 
+@lru_cache(maxsize=1)
+def _load_salesforce_production_credentials() -> Tuple[str, str]:
+    """Fetch Salesforce Connected App credentials from Secret Manager (cached after first call)."""
+    client_id = _fetch_from_secret_manager("SALESFORCE_CLIENT_ID") or settings.SALESFORCE_CLIENT_ID
+    client_secret = (
+        _fetch_from_secret_manager("SALESFORCE_CLIENT_SECRET") or settings.SALESFORCE_CLIENT_SECRET
+    )
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "Salesforce OAuth credentials unavailable. Set GCP_PROJECT_ID and Secret Manager "
+            "secrets (SALESFORCE_CLIENT_ID, SALESFORCE_CLIENT_SECRET) or the equivalent env vars."
+        )
+    return client_id, client_secret
+
+
+def get_salesforce_oauth_credentials() -> Tuple[str, str]:
+    """
+    Return (client_id, client_secret) appropriate for the current environment.
+
+    - production/staging → GCP Secret Manager with env-var fallback
+    - development         → env-var / .env values
+
+    Raises RuntimeError in staging/production when credentials are absent,
+    ValueError in development.
+    """
+    env = settings.ENVIRONMENT.lower()
+
+    if env in ("production", "staging"):
+        return _load_salesforce_production_credentials()
+
+    client_id = settings.SALESFORCE_CLIENT_ID
+    client_secret = settings.SALESFORCE_CLIENT_SECRET
+    if not client_id or not client_secret:
+        raise ValueError(
+            "Salesforce OAuth credentials not configured. Set SALESFORCE_CLIENT_ID and "
+            "SALESFORCE_CLIENT_SECRET in your .env file for local development."
+        )
+    return client_id, client_secret
+
+
 def get_reputation_api_key() -> str:
     """
     Return the outbound number reputation API key (First Orion / Hiya) for the

--- a/app/routers/integrations.py
+++ b/app/routers/integrations.py
@@ -267,9 +267,12 @@ async def list_integrations(
     make_secret = get_make_secret(tenant)
     n8n_secret = get_n8n_secret(tenant)
 
-    from app.services import hubspot_service
+    from app.services import hubspot_service, salesforce_service
 
     hubspot_connected, hubspot_connected_at = hubspot_service.get_connection_status(db, tenant.id)
+    salesforce_connected, salesforce_connected_at = salesforce_service.get_connection_status(
+        db, tenant.id
+    )
 
     integrations = [
         IntegrationItem(
@@ -288,6 +291,16 @@ async def list_integrations(
             name="hubspot",
             connected=hubspot_connected,
             connected_at=hubspot_connected_at,
+        ),
+        IntegrationItem(
+            name="salesforce",
+            connected=salesforce_connected,
+            connected_at=salesforce_connected_at,
+            last_sync_at=(
+                salesforce_service.get_sync_status(db, tenant.id).get("last_write_back_at")
+                if salesforce_connected
+                else None
+            ),
         ),
     ]
 

--- a/app/routers/salesforce_integration.py
+++ b/app/routers/salesforce_integration.py
@@ -1,0 +1,172 @@
+"""
+Salesforce CRM OAuth integration endpoints.
+
+GET    /connect        — redirect to Salesforce's OAuth consent page (tenant-authenticated)
+GET    /callback       — public; Salesforce redirects the browser here with no auth headers,
+                          so the connecting tenant is recovered from the signed `state` param
+DELETE ""              — revoke at Salesforce and delete the local connection
+GET    ""              — connection status and write-back toggle
+GET    /contact        — SOQL contact lookup by phone, used by the dashboard and tests
+PUT    /settings        — toggle post-call write-back for this workspace
+GET    /sync-status    — last lookup/write-back times, status, rolling 24h error count
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant, require_admin
+from app.core.config import settings
+from app.core.logger import logger
+from app.schemas.base import SuccessResponse
+from app.schemas.salesforce_integration import (
+    SalesforceContactOut,
+    SalesforceDisconnectResponse,
+    SalesforceIntegrationStatusOut,
+    SalesforceSettingsUpdateRequest,
+    SalesforceSyncStatusOut,
+)
+from app.services import salesforce_service
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+
+def _tenant_id(principal) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+@router.get("/connect", include_in_schema=False)
+async def salesforce_connect(
+    principal=Depends(require_admin),
+):
+    """Redirect to Salesforce's OAuth consent page. Scopes: api, refresh_token."""
+    tenant_id = _tenant_id(principal)
+    state = salesforce_service.build_oauth_state(tenant_id)
+    auth_url = salesforce_service.build_authorization_url(state)
+    return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/callback", include_in_schema=False)
+async def salesforce_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+):
+    """
+    Salesforce OAuth callback. No auth dependency — this is a top-level browser
+    redirect from Salesforce, which cannot carry our JWT/API-key headers. The
+    connecting tenant is recovered from the signed `state` param instead.
+    """
+    try:
+        tenant_id = salesforce_service.verify_oauth_state(state)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    try:
+        token_response = await salesforce_service.exchange_code_for_tokens(code)
+    except Exception as exc:
+        logger.warning("Salesforce OAuth code exchange failed for tenant=%s: %s", tenant_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to exchange authorization code with Salesforce",
+        )
+
+    salesforce_service.upsert_tokens(db, tenant_id, token_response)
+
+    base = (settings.FRONTEND_URL or "").rstrip("/")
+    redirect_to = f"{base}/settings/integrations?salesforce=connected" if base else "/settings/integrations"
+    return RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
+
+
+@router.delete("", response_model=SuccessResponse[SalesforceDisconnectResponse])
+async def salesforce_disconnect(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Revoke the token at Salesforce and delete the workspaceintegration row."""
+    tenant_id = _tenant_id(principal)
+    disconnected = await salesforce_service.disconnect(db, tenant_id)
+    if not disconnected:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Salesforce is not connected for this workspace",
+        )
+    return create_success_response(
+        SalesforceDisconnectResponse(disconnected=True),
+        "Salesforce disconnected successfully",
+    )
+
+
+@router.get("", response_model=SuccessResponse[SalesforceIntegrationStatusOut])
+async def salesforce_get_integration_status(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Connection status and write-back toggle for this workspace."""
+    tenant_id = _tenant_id(principal)
+    integration_settings = salesforce_service.get_integration_settings(db, tenant_id)
+    return create_success_response(SalesforceIntegrationStatusOut(**integration_settings))
+
+
+@router.put("/settings", response_model=SuccessResponse[SalesforceIntegrationStatusOut])
+async def salesforce_update_settings(
+    payload: SalesforceSettingsUpdateRequest,
+    principal=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Toggle post-call write-back for this workspace."""
+    tenant_id = _tenant_id(principal)
+    if not salesforce_service.tenant_has_salesforce_connected(db, tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Salesforce is not connected for this workspace",
+        )
+
+    salesforce_service.update_integration_settings(
+        db, tenant_id, write_back_enabled=payload.write_back_enabled
+    )
+    integration_settings = salesforce_service.get_integration_settings(db, tenant_id)
+    return create_success_response(
+        SalesforceIntegrationStatusOut(**integration_settings),
+        "Settings updated successfully",
+    )
+
+
+@router.get("/sync-status", response_model=SuccessResponse[SalesforceSyncStatusOut])
+async def salesforce_sync_status(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Last contact-lookup/write-back times, write-back status, and rolling 24h error count."""
+    tenant_id = _tenant_id(principal)
+    sync_status = salesforce_service.get_sync_status(db, tenant_id)
+    return create_success_response(SalesforceSyncStatusOut(**sync_status))
+
+
+@router.get("/contact", response_model=SuccessResponse[SalesforceContactOut])
+async def salesforce_get_contact(
+    phone: str = Query(..., description="Phone number to search for (E.164 or local format)"),
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """SOQL contact lookup by phone. Redis-cached for 5 minutes per phone number."""
+    tenant_id = _tenant_id(principal)
+
+    if not salesforce_service.tenant_has_salesforce_connected(db, tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Salesforce is not connected for this workspace",
+        )
+
+    contact = await salesforce_service.get_contact_for_phone(db, tenant_id, phone)
+    if not contact:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No Salesforce contact found for this phone number",
+        )
+
+    return create_success_response(SalesforceContactOut(**contact))

--- a/app/schemas/integration.py
+++ b/app/schemas/integration.py
@@ -28,6 +28,7 @@ class IntegrationItem(BaseModel):
     webhook_url: Optional[str] = None
     last_triggered_at: Optional[datetime] = None
     connected_at: Optional[datetime] = None
+    last_sync_at: Optional[str] = None
 
 
 class IntegrationListResponse(BaseModel):

--- a/app/schemas/salesforce_integration.py
+++ b/app/schemas/salesforce_integration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class SalesforceAuthorizeResponse(BaseModel):
+    authorization_url: str
+
+
+class SalesforceContactOut(BaseModel):
+    id: str
+    name: Optional[str] = None
+    account: Optional[str] = None
+    email: Optional[str] = None
+
+
+class SalesforceDisconnectResponse(BaseModel):
+    disconnected: bool
+    provider: str = "salesforce"
+
+
+class SalesforceSettingsUpdateRequest(BaseModel):
+    write_back_enabled: bool
+
+
+class SalesforceIntegrationStatusOut(BaseModel):
+    connected: bool
+    connected_at: Optional[datetime] = None
+    last_sync_at: Optional[str] = None
+    write_back_enabled: bool = True
+
+
+class SalesforceSyncStatusOut(BaseModel):
+    last_lookup_at: Optional[str] = None
+    last_write_back_at: Optional[str] = None
+    last_write_back_status: Optional[str] = None
+    error_count_24h: int = 0

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -294,6 +294,24 @@ class CallSessionService:
                             "HubSpot write-back schedule failed (non-critical): %s", hubspot_exc
                         )
 
+                # Salesforce post-call write-back: create a Task (Activity) with the
+                # transcript summary once the call has actually completed. Fire-and-forget
+                # (fail open) — see app/services/salesforce_service.py::schedule_salesforce_writeback.
+                if status == "completed":
+                    try:
+                        from app.services.salesforce_service import (
+                            schedule_salesforce_writeback,
+                            tenant_has_salesforce_connected,
+                        )
+
+                        if tenant_has_salesforce_connected(db, call_session.tenant_id):
+                            schedule_salesforce_writeback(call_session.id)
+                    except Exception as salesforce_exc:  # pragma: no cover
+                        logger.warning(
+                            "Salesforce write-back schedule failed (non-critical): %s",
+                            salesforce_exc,
+                        )
+
                 # Smart Callback: schedule a retry for missed outbound calls.
                 # maybe_schedule_callback writes the CallbackSchedule row (sync).
                 # _fire_callback_enqueue then submits the ARQ job on the current

--- a/app/services/salesforce_service.py
+++ b/app/services/salesforce_service.py
@@ -1,0 +1,1004 @@
+"""
+Salesforce CRM integration — OAuth 2.0 Web Server Flow, contact lookup, and
+post-call write-back to the Task (Activity) object.
+
+External HTTP calls: Salesforce OAuth (``{SALESFORCE_LOGIN_URL}/services/oauth2/*``,
+always the fixed login host, never the org's instance) and the org's REST Data API
+(``{instance_url}/services/data/v{version}/*`` — instance_url varies per org and is
+only known after the OAuth token exchange, unlike HubSpot's fixed api.hubapi.com host).
+
+Every public entrypoint used at call time (contact lookup, CRM context injection,
+post-call write-back) fails open: Salesforce being down or rate-limited logs a
+warning and returns None/"" rather than raising, so a call is never blocked.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import hashlib
+import re
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+from urllib.parse import urlencode
+
+import httpx
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.core.config import settings
+from app.core.db_encryption import decrypt_salesforce_token, encrypt_salesforce_token
+from app.core.logger import logger
+from app.core.secret_manager import get_salesforce_oauth_credentials
+from app.db.session import SessionLocal
+from app.models.call_session import CallSession
+from app.models.workspace_integration import WorkspaceIntegration
+from app.utils.redis_client import get_redis
+
+PROVIDER = "salesforce"
+
+SCOPES = "api refresh_token"
+
+_MAX_RETRIES = 5
+_BASE_BACKOFF_SECONDS = 1.0
+
+_STATE_PURPOSE = "salesforce_oauth_state"
+_STATE_TTL_MINUTES = 10
+
+_CONTACT_CACHE_TTL_SECONDS = 300  # 5 minutes, per acceptance criteria
+_CONTACT_NOT_FOUND_SENTINEL = "__not_found__"
+
+_DEFAULT_WRITE_BACK_ENABLED = True
+
+_WRITE_BACK_RETRY_DELAY_SECONDS = 300  # 5 minutes
+_WRITE_BACK_ERROR_WINDOW_SECONDS = 24 * 60 * 60  # rolling 24h window for admin alerting
+_WRITE_BACK_ALERT_THRESHOLD = 5
+
+
+def _login_url() -> str:
+    return settings.SALESFORCE_LOGIN_URL.rstrip("/")
+
+
+def _api_version() -> str:
+    return settings.SALESFORCE_API_VERSION
+
+
+# ─── HTTP with backoff ────────────────────────────────────────────────────────
+
+
+async def _request_with_backoff(method: str, url: str, **kwargs) -> httpx.Response:
+    """Call Salesforce with exponential backoff on 429 (1s, 2s, 4s, 8s, 16s)."""
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        attempt = 0
+        while True:
+            response = await client.request(method, url, **kwargs)
+            if response.status_code != 429 or attempt >= _MAX_RETRIES:
+                return response
+
+            retry_after_header = response.headers.get("Retry-After")
+            wait_seconds = (
+                float(retry_after_header)
+                if retry_after_header
+                else _BASE_BACKOFF_SECONDS * (2 ** attempt)
+            )
+            logger.warning(
+                "Salesforce 429 on %s %s; retrying in %.1fs (attempt %d/%d)",
+                method,
+                url,
+                wait_seconds,
+                attempt + 1,
+                _MAX_RETRIES,
+            )
+            await asyncio.sleep(wait_seconds)
+            attempt += 1
+
+
+# ─── OAuth state (signed, carries tenant_id through the redirect round-trip) ──
+
+
+def build_oauth_state(tenant_id: uuid.UUID) -> str:
+    payload = {
+        "tenant_id": str(tenant_id),
+        "purpose": _STATE_PURPOSE,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=_STATE_TTL_MINUTES),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def verify_oauth_state(state: str) -> uuid.UUID:
+    """Raises ValueError if state is missing, expired, tampered, or malformed."""
+    try:
+        payload = jwt.decode(state, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+    except JWTError as exc:
+        raise ValueError("Invalid or expired OAuth state") from exc
+
+    if payload.get("purpose") != _STATE_PURPOSE:
+        raise ValueError("Invalid OAuth state purpose")
+
+    tenant_id_str = payload.get("tenant_id")
+    if not tenant_id_str:
+        raise ValueError("OAuth state missing tenant_id")
+
+    try:
+        return uuid.UUID(tenant_id_str)
+    except ValueError as exc:
+        raise ValueError("OAuth state has malformed tenant_id") from exc
+
+
+def get_redirect_uri() -> str:
+    return settings.SALESFORCE_REDIRECT_URI or (
+        f"{settings.WEBHOOK_BASE_URL.rstrip('/')}/api/v1/integrations/salesforce/callback"
+    )
+
+
+def build_authorization_url(state: str) -> str:
+    client_id, _ = get_salesforce_oauth_credentials()
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": get_redirect_uri(),
+        "scope": SCOPES,
+        "state": state,
+    }
+    return f"{_login_url()}/services/oauth2/authorize?{urlencode(params)}"
+
+
+# ─── Token exchange / refresh ─────────────────────────────────────────────────
+
+
+async def exchange_code_for_tokens(code: str) -> dict:
+    client_id, client_secret = get_salesforce_oauth_credentials()
+    response = await _request_with_backoff(
+        "POST",
+        f"{_login_url()}/services/oauth2/token",
+        data={
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": get_redirect_uri(),
+            "code": code,
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def refresh_access_token(refresh_token: str) -> dict:
+    client_id, client_secret = get_salesforce_oauth_credentials()
+    response = await _request_with_backoff(
+        "POST",
+        f"{_login_url()}/services/oauth2/token",
+        data={
+            "grant_type": "refresh_token",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "refresh_token": refresh_token,
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# ─── WorkspaceIntegration CRUD ────────────────────────────────────────────────
+
+
+def get_integration(db: Session, tenant_id: uuid.UUID) -> Optional[WorkspaceIntegration]:
+    return (
+        db.query(WorkspaceIntegration)
+        .filter(
+            WorkspaceIntegration.workspace_id == tenant_id,
+            WorkspaceIntegration.provider == PROVIDER,
+        )
+        .first()
+    )
+
+
+def tenant_has_salesforce_connected(db: Session, tenant_id: uuid.UUID) -> bool:
+    return get_integration(db, tenant_id) is not None
+
+
+def get_connection_status(
+    db: Session, tenant_id: uuid.UUID
+) -> Tuple[bool, Optional[datetime]]:
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return False, None
+    return True, row.created_at
+
+
+def upsert_tokens(
+    db: Session, tenant_id: uuid.UUID, token_response: dict
+) -> WorkspaceIntegration:
+    access_token = token_response["access_token"]
+    refresh_token = token_response.get("refresh_token")
+    instance_url = token_response.get("instance_url")
+    expires_at = datetime.now(timezone.utc) + timedelta(
+        seconds=settings.SALESFORCE_ACCESS_TOKEN_TTL_SECONDS
+    )
+
+    row = get_integration(db, tenant_id)
+    if row is None:
+        row = WorkspaceIntegration(workspace_id=tenant_id, provider=PROVIDER)
+
+    row.access_token = encrypt_salesforce_token(access_token, db)
+    if refresh_token:
+        row.refresh_token = encrypt_salesforce_token(refresh_token, db)
+    row.token_expires_at = expires_at
+
+    if instance_url:
+        updated_metadata = dict(row.extra_metadata or {})
+        updated_metadata["instance_url"] = instance_url
+        row.extra_metadata = updated_metadata
+        flag_modified(row, "extra_metadata")
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+async def get_valid_access_token(
+    db: Session, tenant_id: uuid.UUID
+) -> Optional[Tuple[str, str]]:
+    """Return (access_token, instance_url), refreshing the token first if it's near-expiry."""
+    row = get_integration(db, tenant_id)
+    if row is None or not row.access_token:
+        return None
+
+    instance_url = (row.extra_metadata or {}).get("instance_url")
+    if not instance_url:
+        logger.warning(
+            "Salesforce integration for tenant=%s has no stored instance_url", tenant_id
+        )
+        return None
+
+    expires_at = row.token_expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    now = datetime.now(timezone.utc)
+    if expires_at is not None and expires_at > now + timedelta(seconds=60):
+        return decrypt_salesforce_token(row.access_token, db), instance_url
+
+    if not row.refresh_token:
+        logger.warning(
+            "Salesforce access token expired for tenant=%s but no refresh_token stored",
+            tenant_id,
+        )
+        return None
+
+    try:
+        refresh_token_plain = decrypt_salesforce_token(row.refresh_token, db)
+        token_response = await refresh_access_token(refresh_token_plain)
+    except Exception:
+        logger.warning(
+            "Salesforce token refresh failed for tenant=%s", tenant_id, exc_info=True
+        )
+        return None
+
+    row = upsert_tokens(db, tenant_id, token_response)
+    instance_url = (row.extra_metadata or {}).get("instance_url") or instance_url
+    return decrypt_salesforce_token(row.access_token, db), instance_url
+
+
+async def _force_refresh_access_token(
+    db: Session, tenant_id: uuid.UUID
+) -> Optional[Tuple[str, str]]:
+    """
+    Unconditionally refresh the Salesforce access token, ignoring token_expires_at.
+
+    A call can run longer than our assumed token TTL; always called immediately
+    before the write-back API call, mirroring HubSpot's forced pre-writeback refresh.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None or not row.refresh_token:
+        return await get_valid_access_token(db, tenant_id)
+
+    try:
+        refresh_token_plain = decrypt_salesforce_token(row.refresh_token, db)
+        token_response = await refresh_access_token(refresh_token_plain)
+    except Exception:
+        logger.warning(
+            "Salesforce forced pre-writeback token refresh failed for tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+        return None
+
+    row = upsert_tokens(db, tenant_id, token_response)
+    instance_url = (row.extra_metadata or {}).get("instance_url")
+    if not instance_url:
+        return None
+    return decrypt_salesforce_token(row.access_token, db), instance_url
+
+
+def get_integration_settings(db: Session, tenant_id: uuid.UUID) -> dict:
+    """Return the tenant's Salesforce connection status and write-back toggle, with defaults applied."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return {
+            "connected": False,
+            "connected_at": None,
+            "last_sync_at": None,
+            "write_back_enabled": _DEFAULT_WRITE_BACK_ENABLED,
+        }
+
+    metadata = row.extra_metadata or {}
+    last_sync_at = metadata.get("last_write_back_at") or metadata.get("last_lookup_at")
+    return {
+        "connected": True,
+        "connected_at": row.created_at,
+        "last_sync_at": last_sync_at,
+        "write_back_enabled": metadata.get("write_back_enabled", _DEFAULT_WRITE_BACK_ENABLED),
+    }
+
+
+def update_integration_settings(
+    db: Session, tenant_id: uuid.UUID, *, write_back_enabled: bool
+) -> WorkspaceIntegration:
+    """Persist the write-back toggle. Raises ValueError if not connected."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        raise ValueError("Salesforce is not connected for this workspace")
+
+    updated_metadata = dict(row.extra_metadata or {})
+    updated_metadata["write_back_enabled"] = write_back_enabled
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def set_last_write_back_error(
+    db: Session, tenant_id: uuid.UUID, error: Optional[str]
+) -> None:
+    """
+    Record (or clear, when error is None) the last post-call write-back failure.
+
+    Also stamps last_write_back_status/last_write_back_at for the sync-status
+    endpoint. error=None means the write-back just succeeded.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return
+
+    updated_metadata = dict(row.extra_metadata or {})
+    if error:
+        updated_metadata["last_write_back_error"] = error
+        updated_metadata["last_write_back_status"] = "failed"
+    else:
+        updated_metadata.pop("last_write_back_error", None)
+        updated_metadata["last_write_back_status"] = "success"
+        updated_metadata["last_write_back_at"] = _utc_now_iso()
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+
+
+def record_write_back_failure(db: Session, tenant_id: uuid.UUID, error_msg: str) -> None:
+    """
+    Persist the structured last-failure error (after retry exhaustion), bump the
+    rolling 24h failure counter, and alert the workspace admin once failures
+    cross _WRITE_BACK_ALERT_THRESHOLD within the window.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return
+
+    now = datetime.now(timezone.utc)
+    now_iso = _utc_now_iso()
+    window_start = now - timedelta(seconds=_WRITE_BACK_ERROR_WINDOW_SECONDS)
+
+    updated_metadata = dict(row.extra_metadata or {})
+    updated_metadata["last_write_back_error"] = {"timestamp": now_iso, "error": error_msg}
+    updated_metadata["last_write_back_status"] = "failed"
+    updated_metadata["last_write_back_at"] = now_iso
+
+    failure_timestamps = [
+        ts
+        for ts in updated_metadata.get("write_back_failure_timestamps", [])
+        if _parse_iso(ts) is not None and _parse_iso(ts) > window_start
+    ]
+    failure_timestamps.append(now_iso)
+    updated_metadata["write_back_failure_timestamps"] = failure_timestamps
+
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+
+    # Alert only on the exact crossing into the threshold, not on every failure
+    # thereafter — each call here appends exactly one timestamp, so the count
+    # can't skip over the threshold, and this avoids re-alerting the admin on
+    # every single failure once a workspace is already over the limit.
+    if len(failure_timestamps) == _WRITE_BACK_ALERT_THRESHOLD:
+        _send_write_back_failure_alert(db, tenant_id, error_msg, now_iso, len(failure_timestamps))
+
+
+def _send_write_back_failure_alert(
+    db: Session, tenant_id: uuid.UUID, error_msg: str, timestamp_iso: str, failure_count: int
+) -> None:
+    """Best-effort admin email alert. Never raises — a notification failure must not affect write-back."""
+    try:
+        from app.models.tenant import Tenant
+        from app.services.data_export_service import _get_workspace_admin_email
+        from app.services.email_service import email_service
+
+        admin_email = _get_workspace_admin_email(db, tenant_id)
+        tenant = db.get(Tenant, tenant_id)
+        if not admin_email:
+            admin_email = getattr(tenant, "contact_email", None) if tenant else None
+        if not admin_email:
+            logger.warning(
+                "No admin or contact email found for tenant=%s; cannot send "
+                "Salesforce write-back failure alert",
+                tenant_id,
+            )
+            return
+
+        workspace_name = tenant.name if tenant else str(tenant_id)
+        frontend_base = (settings.FRONTEND_URL or "").rstrip("/")
+        reconnect_url = f"{frontend_base}/settings/integrations" if frontend_base else "/settings/integrations"
+
+        email_service.send_generic_email(
+            to_email=admin_email,
+            subject=f"Action Required: Salesforce Integration Write-Back Failures for {workspace_name}",
+            html_body=(
+                f"<p>Salesforce post-call write-back has failed {failure_count} times in the "
+                f"last 24 hours for workspace <strong>{workspace_name}</strong>.</p>"
+                f"<p>Most recent failure at {timestamp_iso}: {error_msg}</p>"
+                f"<p>Please reconnect Salesforce to restore syncing: "
+                f'<a href="{reconnect_url}">{reconnect_url}</a></p>'
+            ),
+        )
+    except Exception:
+        logger.warning(
+            "Failed to send Salesforce write-back failure alert for tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+
+
+def get_sync_status(db: Session, tenant_id: uuid.UUID) -> dict:
+    """Sync visibility for the dashboard: last lookup/write-back times, status, 24h error count."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return {
+            "last_lookup_at": None,
+            "last_write_back_at": None,
+            "last_write_back_status": None,
+            "error_count_24h": 0,
+        }
+
+    metadata = row.extra_metadata or {}
+    window_start = datetime.now(timezone.utc) - timedelta(seconds=_WRITE_BACK_ERROR_WINDOW_SECONDS)
+    error_count_24h = sum(
+        1
+        for ts in metadata.get("write_back_failure_timestamps", [])
+        if _parse_iso(ts) is not None and _parse_iso(ts) > window_start
+    )
+
+    return {
+        "last_lookup_at": metadata.get("last_lookup_at"),
+        "last_write_back_at": metadata.get("last_write_back_at"),
+        "last_write_back_status": metadata.get("last_write_back_status"),
+        "error_count_24h": error_count_24h,
+    }
+
+
+def _touch_last_lookup_at(db: Session, tenant_id: uuid.UUID, *, commit: bool = True) -> None:
+    """
+    Best-effort timestamp of the last contact lookup, for the sync-status endpoint.
+
+    commit=False must be used when `db` is the shared, long-lived session tied to
+    an in-progress call (see get_crm_context_block_for_call), which never calls
+    db.commit() directly to avoid prematurely committing the caller's still-open
+    call transaction — this mirrors that begin_nested()/flush() pattern instead.
+    """
+    try:
+        row = get_integration(db, tenant_id)
+        if row is None:
+            return
+        updated_metadata = dict(row.extra_metadata or {})
+        updated_metadata["last_lookup_at"] = _utc_now_iso()
+        row.extra_metadata = updated_metadata
+        flag_modified(row, "extra_metadata")
+        db.add(row)
+        if commit:
+            db.commit()
+        else:
+            with db.begin_nested():
+                db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to record Salesforce last_lookup_at (non-critical) tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+
+
+async def disconnect(db: Session, tenant_id: uuid.UUID) -> bool:
+    """Revoke the refresh token at Salesforce (best-effort) and delete the local row."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return False
+
+    if row.refresh_token:
+        try:
+            refresh_token_plain = decrypt_salesforce_token(row.refresh_token, db)
+            await _request_with_backoff(
+                "POST",
+                f"{_login_url()}/services/oauth2/revoke",
+                data={"token": refresh_token_plain},
+            )
+        except Exception:
+            logger.warning(
+                "Salesforce token revoke failed (continuing with local disconnect) tenant=%s",
+                tenant_id,
+                exc_info=True,
+            )
+
+    db.delete(row)
+    db.commit()
+    return True
+
+
+# ─── Contact lookup (SOQL query, Redis-cached) ─────────────────────────────────
+
+
+def normalize_to_e164(phone: str) -> str:
+    """Normalize phone number to E.164 format if possible.
+    E.164 format: +[country_code][subscriber_number] up to 15 digits total.
+    """
+    if not phone:
+        return ""
+    phone = phone.strip()
+    has_plus = phone.startswith("+")
+    digits = "".join(c for c in phone if c.isdigit())
+
+    if not digits:
+        return phone
+
+    if has_plus:
+        return f"+{digits}"
+
+    if len(digits) == 10:
+        return f"+1{digits}"
+    elif len(digits) == 11 and digits.startswith("1"):
+        return f"+{digits}"
+    else:
+        return f"+{digits}"
+
+
+def _get_phone_search_values(phone: str) -> list[str]:
+    """Generate a list of unique exact-match phone number variations for lookup."""
+    values = set()
+    digits = "".join(c for c in phone if c.isdigit())
+
+    normalized = normalize_to_e164(phone)
+    if normalized:
+        values.add(normalized)
+
+    stripped = phone.strip()
+    if stripped:
+        values.add(stripped)
+
+    if digits:
+        values.add(digits)
+        if len(digits) == 11 and digits.startswith("1"):
+            values.add(digits[1:])
+        elif len(digits) == 10:
+            values.add(f"1{digits}")
+
+    return sorted(list(values))
+
+
+def _contact_cache_key(tenant_id: uuid.UUID, phone: str) -> str:
+    # Hash the phone number to avoid storing PII in plaintext in Redis keys.
+    phone_hash = hashlib.sha256(phone.encode("utf-8")).hexdigest()
+    return f"salesforce:contact:{tenant_id}:{phone_hash}"
+
+
+def _soql_escape(value: str) -> str:
+    """Escape single quotes and backslashes for safe interpolation into a SOQL string literal."""
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _contact_dict_from_salesforce(raw: dict) -> dict:
+    account = raw.get("Account") or {}
+    return {
+        "id": raw.get("Id"),
+        "name": raw.get("Name"),
+        "email": raw.get("Email"),
+        "account": account.get("Name") if isinstance(account, dict) else None,
+    }
+
+
+async def search_contact_by_phone(
+    access_token: str, instance_url: str, phone: str
+) -> Optional[dict]:
+    search_vals = _get_phone_search_values(phone)
+    if not search_vals:
+        return None
+
+    phone_clause = " OR ".join(f"Phone='{_soql_escape(v)}'" for v in search_vals)
+    soql = f"SELECT Id, Name, Email, Account.Name FROM Contact WHERE {phone_clause} LIMIT 1"
+
+    url = f"{instance_url.rstrip('/')}/services/data/{_api_version()}/query"
+    response = await _request_with_backoff(
+        "GET",
+        url,
+        headers={"Authorization": f"Bearer {access_token}"},
+        params={"q": soql},
+    )
+    response.raise_for_status()
+    records = response.json().get("records") or []
+    return records[0] if records else None
+
+
+async def get_contact_for_phone(
+    db: Session, tenant_id: uuid.UUID, phone: str, *, commit_lookup_timestamp: bool = True
+) -> Optional[dict]:
+    """Look up a contact by phone, Redis-cached for 5 minutes. Fails open on any error.
+
+    commit_lookup_timestamp=False must be passed by live in-call callers sharing a
+    long-lived db session (see _touch_last_lookup_at).
+    """
+    _touch_last_lookup_at(db, tenant_id, commit=commit_lookup_timestamp)
+
+    normalized_phone = normalize_to_e164(phone)
+    redis_client = get_redis()
+    cache_key = _contact_cache_key(tenant_id, normalized_phone)
+
+    if redis_client is not None:
+        try:
+            cached = await redis_client.get(cache_key)
+            if cached is not None:
+                return None if cached == _CONTACT_NOT_FOUND_SENTINEL else json.loads(cached)
+        except Exception:
+            logger.warning("Salesforce contact cache read failed (continuing)", exc_info=True)
+
+    try:
+        token_info = await get_valid_access_token(db, tenant_id)
+        if not token_info:
+            return None
+        access_token, instance_url = token_info
+        raw_contact = await search_contact_by_phone(access_token, instance_url, normalized_phone)
+    except Exception:
+        logger.warning(
+            "Salesforce contact search failed for tenant=%s (failing open)",
+            tenant_id,
+            exc_info=True,
+        )
+        return None
+
+    contact = _contact_dict_from_salesforce(raw_contact) if raw_contact else None
+
+    if redis_client is not None:
+        try:
+            payload = (
+                _CONTACT_NOT_FOUND_SENTINEL if contact is None else json.dumps(contact)
+            )
+            await redis_client.set(cache_key, payload, ex=_CONTACT_CACHE_TTL_SECONDS)
+        except Exception:
+            logger.warning("Salesforce contact cache write failed (non-critical)", exc_info=True)
+
+    return contact
+
+
+# ─── CRM context injection (conversation_orchestrator) ────────────────────────
+
+
+async def get_crm_context_block_for_call(db: Session, call_session: CallSession) -> str:
+    """
+    Fetch the CRM context block for a call's system prompt, once per call.
+
+    Cached in call_session.call_metadata["salesforce_crm_context"] so subsequent
+    turns (the prompt is rebuilt every turn) reuse the cached string instead of
+    re-querying Salesforce/Redis. Fails open — returns "" on any error so a CRM
+    outage never blocks the call.
+    """
+    metadata = call_session.call_metadata or {}
+    if "salesforce_crm_context" in metadata:
+        return metadata.get("salesforce_crm_context") or ""
+
+    context_block = ""
+    try:
+        if call_session.customer_phone_number and tenant_has_salesforce_connected(
+            db, call_session.tenant_id
+        ):
+            contact = await get_contact_for_phone(
+                db,
+                call_session.tenant_id,
+                call_session.customer_phone_number,
+                commit_lookup_timestamp=False,
+            )
+            if contact:
+                context_block = (
+                    f"CRM CONTEXT (Salesforce): Name: {contact.get('name') or 'Unknown'}, "
+                    f"Account: {contact.get('account') or 'Unknown'}, "
+                    f"Email: {contact.get('email') or 'Unknown'}"
+                )
+    except Exception:
+        logger.warning(
+            "Salesforce CRM context lookup failed (continuing without CRM context)",
+            exc_info=True,
+        )
+        context_block = ""
+
+    try:
+        # Use a nested transaction savepoint to isolate database flushing.
+        # This keeps the helper fail-open and avoids committing the main transaction
+        # during prompt generation.
+        with db.begin_nested():
+            updated_metadata = dict(call_session.call_metadata or {})
+            updated_metadata["salesforce_crm_context"] = context_block
+            call_session.call_metadata = updated_metadata
+            flag_modified(call_session, "call_metadata")
+            db.add(call_session)
+            db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to cache Salesforce CRM context on call_session (non-critical)",
+            exc_info=True,
+        )
+
+    return context_block
+
+
+# ─── Post-call write-back (Task/Activity + Gemini summary) ────────────────────
+
+
+def _transcript_text(db: Session, call_session: CallSession) -> str:
+    from app.services.transcript_service import transcript_service
+
+    messages = transcript_service.get_messages_by_session(db, call_session.id)
+    lines = [f"{m.role}: {m.message}" for m in messages if m.message]
+    return "\n".join(lines)
+
+
+def generate_transcript_summary(db: Session, call_session: CallSession) -> str:
+    """2-sentence Gemini summary of the call transcript. Fails open — returns ''."""
+    transcript_text = _transcript_text(db, call_session)
+    if not transcript_text.strip():
+        return ""
+
+    from app.services.gemini_service import gemini_service
+
+    try:
+        result = gemini_service.generate_text(
+            prompt=(
+                "Summarize this phone call transcript in exactly 2 sentences, "
+                "focused on the caller's request and the outcome:\n\n" + transcript_text
+            ),
+            model_name="gemini-2.0-flash",
+            temperature=0.2,
+            max_tokens=120,
+        )
+        return (result.get("content") or "").strip()
+    except Exception:
+        logger.warning(
+            "Salesforce post-call summary generation failed (continuing without summary)",
+            exc_info=True,
+        )
+        return ""
+
+
+def get_cached_transcript_summary(db: Session, call_session: CallSession) -> str:
+    """
+    2-sentence Gemini summary of the call transcript, cached on
+    call_session.call_metadata["salesforce_call_summary"] so a retried write-back
+    never calls Gemini twice for the same call.
+    """
+    metadata = call_session.call_metadata or {}
+    if "salesforce_call_summary" in metadata:
+        return metadata.get("salesforce_call_summary") or ""
+
+    summary = generate_transcript_summary(db, call_session)
+
+    try:
+        with db.begin_nested():
+            updated_metadata = dict(call_session.call_metadata or {})
+            updated_metadata["salesforce_call_summary"] = summary
+            call_session.call_metadata = updated_metadata
+            flag_modified(call_session, "call_metadata")
+            db.add(call_session)
+            db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to cache Salesforce call summary on call_session (non-critical)",
+            exc_info=True,
+        )
+
+    return summary
+
+
+def _sf_call_type(call_type: Optional[str]) -> str:
+    return "Inbound" if (call_type or "").lower() == "inbound" else "Outbound"
+
+
+async def create_call_task(
+    access_token: str,
+    instance_url: str,
+    contact_id: str,
+    *,
+    occurred_at: datetime,
+    duration_seconds: int,
+    description: str,
+    call_type: Optional[str] = None,
+) -> dict:
+    payload = {
+        "WhoId": contact_id,
+        "Subject": "AI Voice Call",
+        "Status": "Completed",
+        "Description": description,
+        "ActivityDate": occurred_at.date().isoformat(),
+        "TaskSubtype": "Call",
+        "CallDurationInSeconds": max(int(duration_seconds), 0),
+        "CallType": _sf_call_type(call_type),
+    }
+    url = f"{instance_url.rstrip('/')}/services/data/{_api_version()}/sobjects/Task"
+    response = await _request_with_backoff(
+        "POST",
+        url,
+        headers={"Authorization": f"Bearer {access_token}"},
+        json=payload,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+_MAX_ERROR_LEN = 500
+
+
+def _safe_error_msg(exc: Exception) -> str:
+    """Extract a brief, safe error summary for tenant-visible storage."""
+    msg = str(exc)
+    # Redact anything that looks like a bearer token
+    msg = re.sub(r'Bearer [A-Za-z0-9\-._~+/]+=*', 'Bearer [redacted]', msg)
+    return msg[:_MAX_ERROR_LEN]
+
+
+async def _run_post_call_writeback_async(db: Session, call_session: CallSession) -> None:
+    tenant_id = call_session.tenant_id
+
+    integration_settings = get_integration_settings(db, tenant_id)
+    if not integration_settings["write_back_enabled"]:
+        logger.info(
+            "Salesforce write-back skipped — disabled in settings for tenant=%s",
+            tenant_id,
+        )
+        return
+
+    # A call can outlast our assumed access-token TTL — always force a fresh
+    # token right before the write-back call rather than trusting the DB's
+    # cached token_expires_at.
+    token_info = await _force_refresh_access_token(db, tenant_id)
+    if not token_info:
+        return
+    access_token, instance_url = token_info
+
+    contact = await get_contact_for_phone(
+        db, tenant_id, call_session.customer_phone_number
+    )
+    if not contact or not contact.get("id"):
+        logger.info(
+            "Salesforce write-back skipped — no matching contact for session=%s",
+            call_session.id,
+        )
+        return
+
+    summary = get_cached_transcript_summary(db, call_session)
+    body_text = summary or "Call completed — no transcript summary available."
+
+    async def _write() -> None:
+        await create_call_task(
+            access_token,
+            instance_url,
+            contact["id"],
+            occurred_at=call_session.start_time or datetime.now(timezone.utc),
+            duration_seconds=call_session.duration or 0,
+            description=body_text,
+            call_type=call_session.call_type,
+        )
+
+    try:
+        await _write()
+    except Exception as exc:
+        logger.warning(
+            "Salesforce Task creation failed for session=%s; retrying in %ds: %s",
+            call_session.id,
+            _WRITE_BACK_RETRY_DELAY_SECONDS,
+            exc,
+            exc_info=True,
+        )
+        # Release the checked-out DB connection for the duration of the retry
+        # delay — see hubspot_service._run_post_call_writeback_async for the
+        # rationale (avoids exhausting the pool during a CRM outage).
+        try:
+            db.rollback()
+        except Exception:
+            logger.warning(
+                "Failed to release DB connection before Salesforce write-back retry (non-critical)",
+                exc_info=True,
+            )
+        await asyncio.sleep(_WRITE_BACK_RETRY_DELAY_SECONDS)
+        try:
+            await _write()
+        except Exception as retry_exc:
+            logger.error(
+                "Salesforce Task creation failed after retry for session=%s: %s",
+                call_session.id,
+                retry_exc,
+                exc_info=True,
+            )
+            record_write_back_failure(db, tenant_id, _safe_error_msg(retry_exc))
+            return
+
+    set_last_write_back_error(db, tenant_id, None)
+    logger.info(
+        "Salesforce Task created for session=%s contact=%s",
+        call_session.id,
+        contact["id"],
+    )
+
+
+def run_post_call_writeback(call_session_id: uuid.UUID) -> None:
+    """Sync entrypoint — opens its own session, mirrors hubspot_service.run_post_call_writeback."""
+    db: Session = SessionLocal()
+    try:
+        call_session = db.query(CallSession).filter(CallSession.id == call_session_id).first()
+        if not call_session or not call_session.customer_phone_number:
+            return
+        if not tenant_has_salesforce_connected(db, call_session.tenant_id):
+            return
+
+        asyncio.run(_run_post_call_writeback_async(db, call_session))
+    except Exception:
+        logger.warning(
+            "Salesforce post-call write-back failed (non-critical) session=%s",
+            call_session_id,
+            exc_info=True,
+        )
+    finally:
+        db.close()
+
+
+async def _run_post_call_writeback_in_thread(call_session_id: uuid.UUID) -> None:
+    await asyncio.to_thread(run_post_call_writeback, call_session_id)
+
+
+def schedule_salesforce_writeback(call_session_id: uuid.UUID) -> None:
+    """
+    Fire-and-forget post-call write-back. Never blocks the caller.
+
+    Write-back can retry once after a 5-minute delay on failure (see
+    _run_post_call_writeback_async), so the no-running-loop branch must not
+    run it inline — callers here include the synchronous
+    CallSessionService.update_call_session_status, which must not be held
+    open for minutes on a Salesforce outage.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        threading.Thread(
+            target=run_post_call_writeback, args=(call_session_id,), daemon=True
+        ).start()
+        return
+    asyncio.create_task(_run_post_call_writeback_in_thread(call_session_id))

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -564,6 +564,37 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 else:
                     system_prompt = system_prompt + "\n\n" + crm_context_block
 
+            # Salesforce CRM context injection: same fail-open, once-per-call,
+            # call_metadata-cached pattern as the HubSpot block above.
+            salesforce_context_block = ""
+            if self._h.call_session and self._h.db:
+                try:
+                    from app.services import salesforce_service
+
+                    salesforce_context_block = await asyncio.wait_for(
+                        salesforce_service.get_crm_context_block_for_call(
+                            self._h.db, self._h.call_session
+                        ),
+                        timeout=0.6,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "Salesforce CRM context lookup timed out; proceeding without CRM context"
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "Salesforce CRM context lookup failed; proceeding without context: %s", exc
+                    )
+
+            if salesforce_context_block:
+                anchor = "# CONVERSATION STATE"
+                if anchor in system_prompt:
+                    system_prompt = system_prompt.replace(
+                        anchor, salesforce_context_block + "\n\n" + anchor, 1
+                    )
+                else:
+                    system_prompt = system_prompt + "\n\n" + salesforce_context_block
+
             # Cross-session caller memory: fetched once at call start (DB lookup,
             # 100ms timeout budget, fail-open) and cached on call_session.call_metadata
             # so every later turn is a cheap in-memory dict read. Injected right after

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -6946,6 +6946,115 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/integrations/salesforce:
+    get:
+      tags:
+      - Salesforce Integration
+      summary: Salesforce Get Integration Status
+      description: Connection status and write-back toggle for this workspace.
+      operationId: salesforce_get_integration_status_api_v1_integrations_salesforce_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SalesforceIntegrationStatusOut_'
+      security:
+      - HTTPBearer: []
+    delete:
+      tags:
+      - Salesforce Integration
+      summary: Salesforce Disconnect
+      description: Revoke the token at Salesforce and delete the workspaceintegration
+        row.
+      operationId: salesforce_disconnect_api_v1_integrations_salesforce_delete
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SalesforceDisconnectResponse_'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/salesforce/settings:
+    put:
+      tags:
+      - Salesforce Integration
+      summary: Salesforce Update Settings
+      description: Toggle post-call write-back for this workspace.
+      operationId: salesforce_update_settings_api_v1_integrations_salesforce_settings_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SalesforceSettingsUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SalesforceIntegrationStatusOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/salesforce/sync-status:
+    get:
+      tags:
+      - Salesforce Integration
+      summary: Salesforce Sync Status
+      description: Last contact-lookup/write-back times, write-back status, and rolling
+        24h error count.
+      operationId: salesforce_sync_status_api_v1_integrations_salesforce_sync_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SalesforceSyncStatusOut_'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/salesforce/contact:
+    get:
+      tags:
+      - Salesforce Integration
+      summary: Salesforce Get Contact
+      description: SOQL contact lookup by phone. Redis-cached for 5 minutes per phone
+        number.
+      operationId: salesforce_get_contact_api_v1_integrations_salesforce_contact_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: phone
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Phone number to search for (E.164 or local format)
+          title: Phone
+        description: Phone number to search for (E.164 or local format)
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SalesforceContactOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/calls/history:
     get:
       tags:
@@ -12695,6 +12804,9 @@ components:
           type: string
           format: date-time
           nullable: true
+        last_sync_at:
+          type: string
+          nullable: true
       type: object
       required:
       - name
@@ -15631,6 +15743,83 @@ components:
       - is_active
       - supports_streaming
       title: STTProviderOut
+    SalesforceContactOut:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          nullable: true
+        account:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - id
+      title: SalesforceContactOut
+    SalesforceDisconnectResponse:
+      properties:
+        disconnected:
+          type: boolean
+          title: Disconnected
+        provider:
+          type: string
+          title: Provider
+          default: salesforce
+      type: object
+      required:
+      - disconnected
+      title: SalesforceDisconnectResponse
+    SalesforceIntegrationStatusOut:
+      properties:
+        connected:
+          type: boolean
+          title: Connected
+        connected_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_sync_at:
+          type: string
+          nullable: true
+        write_back_enabled:
+          type: boolean
+          title: Write Back Enabled
+          default: true
+      type: object
+      required:
+      - connected
+      title: SalesforceIntegrationStatusOut
+    SalesforceSettingsUpdateRequest:
+      properties:
+        write_back_enabled:
+          type: boolean
+          title: Write Back Enabled
+      type: object
+      required:
+      - write_back_enabled
+      title: SalesforceSettingsUpdateRequest
+    SalesforceSyncStatusOut:
+      properties:
+        last_lookup_at:
+          type: string
+          nullable: true
+        last_write_back_at:
+          type: string
+          nullable: true
+        last_write_back_status:
+          type: string
+          nullable: true
+        error_count_24h:
+          type: integer
+          title: Error Count 24H
+          default: 0
+      type: object
+      title: SalesforceSyncStatusOut
     ScheduleEntry:
       properties:
         day:
@@ -17240,6 +17429,70 @@ components:
       required:
       - data
       title: SuccessResponse[ResumeInterviewTrelloCallMediaResponse]
+    SuccessResponse_SalesforceContactOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/SalesforceContactOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[SalesforceContactOut]
+    SuccessResponse_SalesforceDisconnectResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/SalesforceDisconnectResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[SalesforceDisconnectResponse]
+    SuccessResponse_SalesforceIntegrationStatusOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/SalesforceIntegrationStatusOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[SalesforceIntegrationStatusOut]
+    SuccessResponse_SalesforceSyncStatusOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/SalesforceSyncStatusOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[SalesforceSyncStatusOut]
     SuccessResponse_SingleCallResponse_:
       properties:
         data:

--- a/tests/api/test_hubspot_integration.py
+++ b/tests/api/test_hubspot_integration.py
@@ -534,6 +534,10 @@ class TestIntegrationListIncludesHubSpot:
                 "app.services.hubspot_service.get_connection_status",
                 return_value=(True, connected_at),
             ),
+            patch(
+                "app.services.salesforce_service.get_connection_status",
+                return_value=(False, None),
+            ),
         ):
             result = await list_integrations(request=request, user=_principal(), db=db)
 

--- a/tests/api/test_salesforce_integration.py
+++ b/tests/api/test_salesforce_integration.py
@@ -1,0 +1,371 @@
+"""
+Tests for Salesforce OAuth integration router endpoints.
+
+Router functions are called directly (mirroring tests/api/test_hubspot_integration.py),
+with `db` mocked and external Salesforce calls patched at the service boundary.
+
+Coverage:
+  1.  GET /connect — redirects to Salesforce's OAuth consent page
+  2.  GET /callback — exchanges mock code for tokens, stores them, redirects
+  3.  GET /callback — invalid state -> 400; token exchange failure -> 502
+  4.  GET /contact — correct response shape; not connected -> 400; not found -> 404
+  5.  DELETE "" — disconnects; 404 when not connected
+  6.  GET /api/v1/integrations — includes a salesforce entry with connected/connected_at
+  7.  GET "" / PUT /settings / GET /sync-status — status and toggle round trip
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_TENANT_ID = uuid.UUID("aa200000-0000-0000-0000-000000000001")
+
+
+def _principal():
+    p = MagicMock()
+    p.current_tenant_id = _TENANT_ID
+    return p
+
+
+class TestConnect:
+    @pytest.mark.anyio
+    async def test_redirects_to_salesforce(self):
+        from app.routers.salesforce_integration import salesforce_connect
+
+        with (
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.build_oauth_state",
+                return_value="signed-state",
+            ),
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.build_authorization_url",
+                return_value="https://login.salesforce.com/services/oauth2/authorize?client_id=abc&state=signed-state",
+            ),
+        ):
+            response = await salesforce_connect(principal=_principal())
+
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://login.salesforce.com/services/oauth2/authorize?client_id=abc&state=signed-state"
+        )
+
+
+class TestCallback:
+    @pytest.mark.anyio
+    async def test_exchanges_code_and_stores_tokens(self):
+        from app.routers.salesforce_integration import salesforce_callback
+
+        db = MagicMock()
+        token_response = {
+            "access_token": "a",
+            "refresh_token": "r",
+            "instance_url": "https://acme.my.salesforce.com",
+        }
+
+        with (
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.exchange_code_for_tokens",
+                new=AsyncMock(return_value=token_response),
+            ) as mock_exchange,
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.upsert_tokens"
+            ) as mock_upsert,
+        ):
+            response = await salesforce_callback(
+                code="mock-auth-code", state="signed-state", db=db
+            )
+
+        mock_exchange.assert_awaited_once_with("mock-auth-code")
+        mock_upsert.assert_called_once_with(db, _TENANT_ID, token_response)
+        assert response.status_code == 302
+        assert "salesforce=connected" in response.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_invalid_state_returns_400(self):
+        from app.routers.salesforce_integration import salesforce_callback
+
+        with patch(
+            "app.routers.salesforce_integration.salesforce_service.verify_oauth_state",
+            side_effect=ValueError("Invalid or expired OAuth state"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await salesforce_callback(
+                    code="mock-auth-code", state="bad-state", db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_token_exchange_failure_returns_502(self):
+        from app.routers.salesforce_integration import salesforce_callback
+
+        with (
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.exchange_code_for_tokens",
+                new=AsyncMock(side_effect=Exception("Salesforce 400")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await salesforce_callback(
+                    code="mock-auth-code", state="signed-state", db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 502
+
+
+class TestContactEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_correct_shape(self):
+        from app.routers.salesforce_integration import salesforce_get_contact
+
+        contact = {
+            "id": "003xx000004TmiQAAS",
+            "name": "Ada Lovelace",
+            "account": "Acme Corp",
+            "email": "ada@example.com",
+        }
+
+        with (
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.tenant_has_salesforce_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+        ):
+            result = await salesforce_get_contact(
+                phone="+15550001111", principal=_principal(), db=MagicMock()
+            )
+
+        assert result.data.id == "003xx000004TmiQAAS"
+        assert result.data.name == "Ada Lovelace"
+        assert result.data.account == "Acme Corp"
+        assert result.data.email == "ada@example.com"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_400(self):
+        from app.routers.salesforce_integration import salesforce_get_contact
+
+        with patch(
+            "app.routers.salesforce_integration.salesforce_service.tenant_has_salesforce_connected",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await salesforce_get_contact(
+                    phone="+15550001111", principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_no_match_returns_404(self):
+        from app.routers.salesforce_integration import salesforce_get_contact
+
+        with (
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.tenant_has_salesforce_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.get_contact_for_phone",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await salesforce_get_contact(
+                    phone="+15550001111", principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 404
+
+
+class TestIntegrationStatusEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_status_shape(self):
+        from app.routers.salesforce_integration import salesforce_get_integration_status
+
+        connected_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        settings = {
+            "connected": True,
+            "connected_at": connected_at,
+            "last_sync_at": "2026-06-02T00:00:00Z",
+            "write_back_enabled": False,
+        }
+
+        with patch(
+            "app.routers.salesforce_integration.salesforce_service.get_integration_settings",
+            return_value=settings,
+        ):
+            result = await salesforce_get_integration_status(
+                principal=_principal(), db=MagicMock()
+            )
+
+        assert result.data.connected is True
+        assert result.data.connected_at == connected_at
+        assert result.data.last_sync_at == "2026-06-02T00:00:00Z"
+        assert result.data.write_back_enabled is False
+
+
+class TestSettingsEndpoint:
+    @pytest.mark.anyio
+    async def test_updates_settings(self):
+        from app.routers.salesforce_integration import salesforce_update_settings
+        from app.schemas.salesforce_integration import SalesforceSettingsUpdateRequest
+
+        payload = SalesforceSettingsUpdateRequest(write_back_enabled=False)
+
+        with (
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.tenant_has_salesforce_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.update_integration_settings"
+            ) as mock_update,
+            patch(
+                "app.routers.salesforce_integration.salesforce_service.get_integration_settings",
+                return_value={
+                    "connected": True,
+                    "connected_at": datetime.now(timezone.utc),
+                    "last_sync_at": None,
+                    "write_back_enabled": False,
+                },
+            ),
+        ):
+            result = await salesforce_update_settings(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
+
+        mock_update.assert_called_once_with(
+            mock_update.call_args[0][0], _TENANT_ID, write_back_enabled=False
+        )
+        assert result.data.write_back_enabled is False
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_400(self):
+        from app.routers.salesforce_integration import salesforce_update_settings
+        from app.schemas.salesforce_integration import SalesforceSettingsUpdateRequest
+
+        payload = SalesforceSettingsUpdateRequest(write_back_enabled=False)
+
+        with patch(
+            "app.routers.salesforce_integration.salesforce_service.tenant_has_salesforce_connected",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await salesforce_update_settings(
+                    payload=payload, principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 400
+
+
+class TestSyncStatusEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_sync_status_shape(self):
+        from app.routers.salesforce_integration import salesforce_sync_status
+
+        sync_status = {
+            "last_lookup_at": "2026-06-01T00:00:00Z",
+            "last_write_back_at": "2026-06-01T00:05:00Z",
+            "last_write_back_status": "success",
+            "error_count_24h": 0,
+        }
+
+        with patch(
+            "app.routers.salesforce_integration.salesforce_service.get_sync_status",
+            return_value=sync_status,
+        ):
+            result = await salesforce_sync_status(principal=_principal(), db=MagicMock())
+
+        assert result.data.last_lookup_at == "2026-06-01T00:00:00Z"
+        assert result.data.last_write_back_status == "success"
+        assert result.data.error_count_24h == 0
+
+
+class TestDisconnectEndpoint:
+    @pytest.mark.anyio
+    async def test_disconnects_successfully(self):
+        from app.routers.salesforce_integration import salesforce_disconnect
+
+        with patch(
+            "app.routers.salesforce_integration.salesforce_service.disconnect",
+            new=AsyncMock(return_value=True),
+        ):
+            result = await salesforce_disconnect(principal=_principal(), db=MagicMock())
+
+        assert result.data.disconnected is True
+        assert result.data.provider == "salesforce"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_404(self):
+        from app.routers.salesforce_integration import salesforce_disconnect
+
+        with patch(
+            "app.routers.salesforce_integration.salesforce_service.disconnect",
+            new=AsyncMock(return_value=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await salesforce_disconnect(principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 404
+
+
+class TestIntegrationListIncludesSalesforce:
+    @pytest.mark.anyio
+    async def test_list_integrations_includes_salesforce_status(self):
+        from app.routers.integrations import list_integrations
+
+        request = MagicMock()
+        tenant = MagicMock()
+        tenant.id = _TENANT_ID
+        tenant.workspace_settings = {}
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = tenant
+
+        connected_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        with (
+            patch(
+                "app.core.request_auth.get_workspace_from_request",
+                return_value=MagicMock(id=_TENANT_ID),
+            ),
+            patch(
+                "app.services.hubspot_service.get_connection_status",
+                return_value=(False, None),
+            ),
+            patch(
+                "app.services.salesforce_service.get_connection_status",
+                return_value=(True, connected_at),
+            ),
+            patch(
+                "app.services.salesforce_service.get_sync_status",
+                return_value={
+                    "last_lookup_at": None,
+                    "last_write_back_at": "2026-06-02T00:00:00Z",
+                    "last_write_back_status": "success",
+                    "error_count_24h": 0,
+                },
+            ),
+        ):
+            result = await list_integrations(request=request, user=_principal(), db=db)
+
+        salesforce_item = next(i for i in result.integrations if i.name == "salesforce")
+        assert salesforce_item.connected is True
+        assert salesforce_item.connected_at == connected_at
+        assert salesforce_item.last_sync_at == "2026-06-02T00:00:00Z"

--- a/tests/services/test_salesforce_service.py
+++ b/tests/services/test_salesforce_service.py
@@ -1,0 +1,878 @@
+"""
+Tests for Salesforce CRM integration service.
+
+External HTTP calls (OAuth token endpoint, SOQL query API, sobjects/Task API) are
+mocked at the boundary (`_request_with_backoff`) per CLAUDE.md convention.
+
+Coverage:
+  1.  OAuth state: sign/verify round trip, tamper rejection, wrong purpose rejection
+  2.  Authorization URL: client_id/scope/state present
+  3.  Token refresh: returns cached (token, instance_url) when fresh; refreshes when
+      expired; persists instance_url; returns None when no refresh_token; fails open
+  4.  Contact lookup: correct {id, name, account, email} shape; Redis cache
+      hit/miss/store; fails open on Salesforce error
+  5.  CRM context block: exact "CRM CONTEXT (Salesforce): ..." format, cached on
+      call_metadata after first fetch; fails open
+  6.  Post-call write-back: creates a Task with the Gemini summary and
+      CallDurationInSeconds; skips when write-back disabled; records/clears
+      last_write_back_error; retries once after 5 minutes
+  7.  Disconnect: revokes + deletes; returns False when not connected
+  8.  429 backoff: retries with exponential delay, honors Retry-After
+  9.  Phone normalization / search value variations
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import salesforce_service
+
+
+_TENANT_ID = uuid.UUID("aa200000-0000-0000-0000-000000000001")
+_SESSION_ID = uuid.UUID("bb200000-0000-0000-0000-000000000002")
+
+
+# ── OAuth state ────────────────────────────────────────────────────────────────
+
+
+class TestOAuthState:
+    def test_roundtrip(self):
+        state = salesforce_service.build_oauth_state(_TENANT_ID)
+        assert salesforce_service.verify_oauth_state(state) == _TENANT_ID
+
+    def test_tampered_state_rejected(self):
+        state = salesforce_service.build_oauth_state(_TENANT_ID)
+        with pytest.raises(ValueError):
+            salesforce_service.verify_oauth_state(state + "x")
+
+    def test_wrong_purpose_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        bad_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "something_else",
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            salesforce_service.verify_oauth_state(bad_state)
+
+    def test_expired_state_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        expired_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "salesforce_oauth_state",
+                "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            salesforce_service.verify_oauth_state(expired_state)
+
+
+class TestAuthorizationUrl:
+    def test_contains_client_id_scope_and_state(self):
+        with patch(
+            "app.services.salesforce_service.get_salesforce_oauth_credentials",
+            return_value=("client-123", "secret-456"),
+        ):
+            state = salesforce_service.build_oauth_state(_TENANT_ID)
+            url = salesforce_service.build_authorization_url(state)
+
+        assert url.startswith("https://login.salesforce.com/services/oauth2/authorize")
+        assert "client_id=client-123" in url
+        assert "scope=api" in url or "scope=api+refresh_token" in url
+        assert f"state={state}" in url
+
+
+# ── Token refresh ──────────────────────────────────────────────────────────────
+
+
+def _integration_row(*, expires_in_seconds: float, has_refresh_token: bool = True, instance_url="https://acme.my.salesforce.com"):
+    row = MagicMock()
+    row.access_token = "encrypted-access-token"
+    row.refresh_token = "encrypted-refresh-token" if has_refresh_token else None
+    row.token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
+    row.extra_metadata = {"instance_url": instance_url} if instance_url else {}
+    return row
+
+
+class TestTokenRefresh:
+    @pytest.mark.anyio
+    async def test_returns_existing_token_when_not_expired(self):
+        row = _integration_row(expires_in_seconds=600)
+        db = MagicMock()
+
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                return_value="plain-access-token",
+            ) as mock_decrypt,
+        ):
+            result = await salesforce_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert result == ("plain-access-token", "https://acme.my.salesforce.com")
+        mock_decrypt.assert_called_once_with(row.access_token, db)
+
+    @pytest.mark.anyio
+    async def test_refreshes_when_expired(self):
+        row = _integration_row(expires_in_seconds=-60)
+        db = MagicMock()
+        new_row = _integration_row(expires_in_seconds=1800, instance_url="https://acme.my.salesforce.com")
+
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                side_effect=["plain-refresh-token", "new-plain-access-token"],
+            ),
+            patch(
+                "app.services.salesforce_service.refresh_access_token",
+                new=AsyncMock(
+                    return_value={
+                        "access_token": "new",
+                        "instance_url": "https://acme.my.salesforce.com",
+                    }
+                ),
+            ) as mock_refresh,
+            patch("app.services.salesforce_service.upsert_tokens", return_value=new_row) as mock_upsert,
+        ):
+            result = await salesforce_service.get_valid_access_token(db, _TENANT_ID)
+
+        mock_refresh.assert_awaited_once_with("plain-refresh-token")
+        mock_upsert.assert_called_once()
+        assert result == ("new-plain-access-token", "https://acme.my.salesforce.com")
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_expired_and_no_refresh_token(self):
+        row = _integration_row(expires_in_seconds=-60, has_refresh_token=False)
+        db = MagicMock()
+
+        with patch("app.services.salesforce_service.get_integration", return_value=row):
+            result = await salesforce_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_no_integration(self):
+        db = MagicMock()
+        with patch("app.services.salesforce_service.get_integration", return_value=None):
+            result = await salesforce_service.get_valid_access_token(db, _TENANT_ID)
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_no_instance_url_stored(self):
+        row = _integration_row(expires_in_seconds=600, instance_url=None)
+        db = MagicMock()
+        with patch("app.services.salesforce_service.get_integration", return_value=row):
+            result = await salesforce_service.get_valid_access_token(db, _TENANT_ID)
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_refresh_failure_fails_open(self):
+        row = _integration_row(expires_in_seconds=-60)
+        db = MagicMock()
+
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.salesforce_service.refresh_access_token",
+                new=AsyncMock(side_effect=Exception("Salesforce down")),
+            ),
+        ):
+            result = await salesforce_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert result is None
+
+
+class TestForceRefreshAccessToken:
+    @pytest.mark.anyio
+    async def test_always_refreshes_even_when_not_expired(self):
+        row = _integration_row(expires_in_seconds=600)
+        db = MagicMock()
+        new_row = _integration_row(expires_in_seconds=1800)
+
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                side_effect=["plain-refresh-token", "new-token"],
+            ),
+            patch(
+                "app.services.salesforce_service.refresh_access_token",
+                new=AsyncMock(return_value={"access_token": "new", "instance_url": "https://acme.my.salesforce.com"}),
+            ) as mock_refresh,
+            patch("app.services.salesforce_service.upsert_tokens", return_value=new_row),
+        ):
+            result = await salesforce_service._force_refresh_access_token(db, _TENANT_ID)
+
+        mock_refresh.assert_awaited_once()
+        assert result == ("new-token", "https://acme.my.salesforce.com")
+
+    @pytest.mark.anyio
+    async def test_fails_open_when_refresh_errors(self):
+        row = _integration_row(expires_in_seconds=600)
+        db = MagicMock()
+
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.salesforce_service.refresh_access_token",
+                new=AsyncMock(side_effect=Exception("down")),
+            ),
+        ):
+            result = await salesforce_service._force_refresh_access_token(db, _TENANT_ID)
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_get_valid_access_token_when_no_refresh_token(self):
+        row = _integration_row(expires_in_seconds=600, has_refresh_token=False)
+        db = MagicMock()
+
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                return_value="plain-access-token",
+            ),
+        ):
+            result = await salesforce_service._force_refresh_access_token(db, _TENANT_ID)
+
+        assert result == ("plain-access-token", "https://acme.my.salesforce.com")
+
+
+# ── Contact lookup ──────────────────────────────────────────────────────────────
+
+
+_RAW_CONTACT = {
+    "Id": "003xx000004TmiQAAS",
+    "Name": "Ada Lovelace",
+    "Email": "ada@example.com",
+    "Account": {"Name": "Acme Corp"},
+}
+
+
+class TestContactShape:
+    def test_contact_dict_from_salesforce_shape(self):
+        contact = salesforce_service._contact_dict_from_salesforce(_RAW_CONTACT)
+        assert contact == {
+            "id": "003xx000004TmiQAAS",
+            "name": "Ada Lovelace",
+            "email": "ada@example.com",
+            "account": "Acme Corp",
+        }
+
+    def test_missing_account_resolves_to_none(self):
+        raw = {"Id": "1", "Name": "A B", "Email": "a@b.com"}
+        contact = salesforce_service._contact_dict_from_salesforce(raw)
+        assert contact["account"] is None
+
+
+class TestGetContactForPhone:
+    @pytest.mark.anyio
+    async def test_cache_hit_skips_salesforce_call(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(
+            return_value='{"id": "1", "name": "Cached Person", "email": null, "account": null}'
+        )
+
+        with (
+            patch("app.services.salesforce_service.get_redis", return_value=mock_redis),
+            patch("app.services.salesforce_service.get_valid_access_token") as mock_token,
+        ):
+            contact = await salesforce_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        mock_token.assert_not_called()
+        assert contact["name"] == "Cached Person"
+
+    @pytest.mark.anyio
+    async def test_cache_miss_fetches_and_stores(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock()
+
+        with (
+            patch("app.services.salesforce_service.get_redis", return_value=mock_redis),
+            patch(
+                "app.services.salesforce_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "https://acme.my.salesforce.com")),
+            ),
+            patch(
+                "app.services.salesforce_service.search_contact_by_phone",
+                new=AsyncMock(return_value=_RAW_CONTACT),
+            ),
+        ):
+            contact = await salesforce_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact["id"] == "003xx000004TmiQAAS"
+        assert contact["name"] == "Ada Lovelace"
+        mock_redis.set.assert_awaited_once()
+        _, kwargs = mock_redis.set.call_args
+        assert kwargs.get("ex") == 300
+
+    @pytest.mark.anyio
+    async def test_no_match_caches_not_found_sentinel(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock()
+
+        with (
+            patch("app.services.salesforce_service.get_redis", return_value=mock_redis),
+            patch(
+                "app.services.salesforce_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "https://acme.my.salesforce.com")),
+            ),
+            patch(
+                "app.services.salesforce_service.search_contact_by_phone",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            contact = await salesforce_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+        mock_redis.set.assert_awaited_once_with(
+            salesforce_service._contact_cache_key(_TENANT_ID, "+15550001111"),
+            salesforce_service._CONTACT_NOT_FOUND_SENTINEL,
+            ex=300,
+        )
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_salesforce_error(self):
+        """A Salesforce outage during contact search must never raise — call proceeds without CRM data."""
+        db = MagicMock()
+
+        with (
+            patch("app.services.salesforce_service.get_redis", return_value=None),
+            patch(
+                "app.services.salesforce_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "https://acme.my.salesforce.com")),
+            ),
+            patch(
+                "app.services.salesforce_service.search_contact_by_phone",
+                new=AsyncMock(side_effect=Exception("Salesforce 500")),
+            ),
+        ):
+            contact = await salesforce_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+
+    @pytest.mark.anyio
+    async def test_no_access_token_returns_none(self):
+        db = MagicMock()
+
+        with (
+            patch("app.services.salesforce_service.get_redis", return_value=None),
+            patch(
+                "app.services.salesforce_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            contact = await salesforce_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+
+
+# ── CRM context block ────────────────────────────────────────────────────────────
+
+
+def _call_session(*, phone="+15550001111", metadata=None):
+    cs = MagicMock()
+    cs.id = _SESSION_ID
+    cs.tenant_id = _TENANT_ID
+    cs.customer_phone_number = phone
+    cs.call_metadata = metadata
+    return cs
+
+
+class TestCrmContextBlock:
+    @pytest.mark.anyio
+    async def test_returns_cached_value_without_refetching(self):
+        db = MagicMock()
+        call_session = _call_session(
+            metadata={"salesforce_crm_context": "CRM CONTEXT (Salesforce): cached"}
+        )
+
+        with patch(
+            "app.services.salesforce_service.tenant_has_salesforce_connected"
+        ) as mock_connected:
+            block = await salesforce_service.get_crm_context_block_for_call(db, call_session)
+
+        mock_connected.assert_not_called()
+        assert block == "CRM CONTEXT (Salesforce): cached"
+
+    @pytest.mark.anyio
+    async def test_fetches_and_caches_on_first_call(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+        contact = {"id": "1", "name": "Ada Lovelace", "account": "Acme Corp", "email": "ada@example.com"}
+
+        with (
+            patch(
+                "app.services.salesforce_service.tenant_has_salesforce_connected", return_value=True
+            ),
+            patch(
+                "app.services.salesforce_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ) as mock_get_contact,
+        ):
+            block = await salesforce_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == (
+            "CRM CONTEXT (Salesforce): Name: Ada Lovelace, "
+            "Account: Acme Corp, Email: ada@example.com"
+        )
+        assert call_session.call_metadata["salesforce_crm_context"] == block
+        db.flush.assert_called_once()
+        db.commit.assert_not_called()
+        assert mock_get_contact.call_args.kwargs.get("commit_lookup_timestamp") is False
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_empty_block(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch(
+            "app.services.salesforce_service.tenant_has_salesforce_connected", return_value=False
+        ):
+            block = await salesforce_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == ""
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_exception(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch(
+            "app.services.salesforce_service.tenant_has_salesforce_connected",
+            side_effect=Exception("DB down"),
+        ):
+            block = await salesforce_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == ""
+
+
+# ── Post-call write-back ───────────────────────────────────────────────────────
+
+
+class TestPostCallWriteback:
+    @staticmethod
+    def _writeback_settings(**overrides):
+        settings = {
+            "connected": True,
+            "connected_at": datetime.now(timezone.utc),
+            "last_sync_at": None,
+            "write_back_enabled": True,
+        }
+        settings.update(overrides)
+        return settings
+
+    @pytest.mark.anyio
+    async def test_creates_task_with_summary(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.id = _SESSION_ID
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.start_time = datetime.now(timezone.utc)
+        call_session.duration = 120
+        call_session.call_type = "outbound"
+        call_session.status = "completed"
+        call_session.call_metadata = {}
+
+        contact = {"id": "contact-1", "name": "Ada Lovelace"}
+
+        with (
+            patch(
+                "app.services.salesforce_service.get_integration_settings",
+                return_value=self._writeback_settings(),
+            ),
+            patch(
+                "app.services.salesforce_service._force_refresh_access_token",
+                new=AsyncMock(return_value=("access-token", "https://acme.my.salesforce.com")),
+            ) as mock_force_refresh,
+            patch(
+                "app.services.salesforce_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+            patch(
+                "app.services.salesforce_service.generate_transcript_summary",
+                return_value="Caller asked about pricing. Agent booked a follow-up demo.",
+            ),
+            patch(
+                "app.services.salesforce_service.create_call_task",
+                new=AsyncMock(return_value={"id": "task-1"}),
+            ) as mock_create_task,
+            patch("app.services.salesforce_service.set_last_write_back_error") as mock_set_error,
+        ):
+            await salesforce_service._run_post_call_writeback_async(db, call_session)
+
+        mock_force_refresh.assert_awaited_once_with(db, _TENANT_ID)
+        mock_create_task.assert_awaited_once()
+        args, kwargs = mock_create_task.call_args
+        assert args[0] == "access-token"
+        assert args[1] == "https://acme.my.salesforce.com"
+        assert args[2] == "contact-1"
+        assert kwargs["duration_seconds"] == 120
+        assert "pricing" in kwargs["description"]
+        assert kwargs["call_type"] == "outbound"
+        mock_set_error.assert_called_once_with(db, _TENANT_ID, None)
+
+    @pytest.mark.anyio
+    async def test_skips_when_write_back_disabled(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.id = _SESSION_ID
+
+        with (
+            patch(
+                "app.services.salesforce_service.get_integration_settings",
+                return_value=self._writeback_settings(write_back_enabled=False),
+            ),
+            patch("app.services.salesforce_service._force_refresh_access_token") as mock_refresh,
+            patch("app.services.salesforce_service.create_call_task") as mock_create,
+        ):
+            await salesforce_service._run_post_call_writeback_async(db, call_session)
+
+        mock_refresh.assert_not_called()
+        mock_create.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_skips_when_no_matching_contact(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.id = _SESSION_ID
+
+        with (
+            patch(
+                "app.services.salesforce_service.get_integration_settings",
+                return_value=self._writeback_settings(),
+            ),
+            patch(
+                "app.services.salesforce_service._force_refresh_access_token",
+                new=AsyncMock(return_value=("access-token", "https://acme.my.salesforce.com")),
+            ),
+            patch(
+                "app.services.salesforce_service.get_contact_for_phone",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.services.salesforce_service.create_call_task") as mock_create,
+        ):
+            await salesforce_service._run_post_call_writeback_async(db, call_session)
+
+        mock_create.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_writeback_retries_once_after_5_minutes_then_records_structured_error(self):
+        call_order = []
+        db = MagicMock()
+        db.rollback.side_effect = lambda: call_order.append("rollback")
+        call_session = MagicMock()
+        call_session.id = _SESSION_ID
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.start_time = datetime.now(timezone.utc)
+        call_session.duration = 60
+        call_session.call_type = "inbound"
+        call_session.status = "completed"
+        call_session.call_metadata = {}
+
+        contact = {"id": "contact-1", "name": "Ada Lovelace"}
+
+        with (
+            patch(
+                "app.services.salesforce_service.get_integration_settings",
+                return_value=self._writeback_settings(),
+            ),
+            patch(
+                "app.services.salesforce_service._force_refresh_access_token",
+                new=AsyncMock(return_value=("access-token", "https://acme.my.salesforce.com")),
+            ),
+            patch(
+                "app.services.salesforce_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+            patch(
+                "app.services.salesforce_service.generate_transcript_summary",
+                return_value="Summary.",
+            ),
+            patch(
+                "app.services.salesforce_service.create_call_task",
+                new=AsyncMock(side_effect=Exception("Salesforce 500")),
+            ) as mock_create_task,
+            patch(
+                "asyncio.sleep",
+                new=AsyncMock(side_effect=lambda *_a, **_k: call_order.append("sleep")),
+            ) as mock_sleep,
+            patch("app.services.salesforce_service.record_write_back_failure") as mock_record_failure,
+        ):
+            await salesforce_service._run_post_call_writeback_async(db, call_session)
+
+        assert mock_create_task.await_count == 2
+        mock_sleep.assert_awaited_once_with(salesforce_service._WRITE_BACK_RETRY_DELAY_SECONDS)
+        mock_record_failure.assert_called_once_with(db, _TENANT_ID, "Salesforce 500")
+        db.rollback.assert_called_once()
+        assert call_order == ["rollback", "sleep"]
+
+    def test_run_post_call_writeback_skips_when_not_connected(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        db.query.return_value.filter.return_value.first.return_value = call_session
+
+        with (
+            patch("app.services.salesforce_service.SessionLocal", return_value=db),
+            patch(
+                "app.services.salesforce_service.tenant_has_salesforce_connected",
+                return_value=False,
+            ),
+            patch("asyncio.run") as mock_asyncio_run,
+        ):
+            salesforce_service.run_post_call_writeback(_SESSION_ID)
+
+        mock_asyncio_run.assert_not_called()
+        db.close.assert_called_once()
+
+    def test_schedule_writeback_never_blocks_caller_without_a_running_loop(self):
+        with (
+            patch(
+                "app.services.salesforce_service.asyncio.get_running_loop",
+                side_effect=RuntimeError("no running loop"),
+            ),
+            patch("app.services.salesforce_service.threading.Thread") as mock_thread_cls,
+            patch("app.services.salesforce_service.run_post_call_writeback") as mock_run,
+        ):
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            salesforce_service.schedule_salesforce_writeback(_SESSION_ID)
+
+        mock_thread_cls.assert_called_once_with(
+            target=mock_run, args=(_SESSION_ID,), daemon=True
+        )
+        mock_thread.start.assert_called_once()
+        mock_run.assert_not_called()
+
+
+# ── Disconnect ──────────────────────────────────────────────────────────────────
+
+
+class TestDisconnect:
+    @pytest.mark.anyio
+    async def test_revokes_and_deletes_row(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.refresh_token = "encrypted-refresh-token"
+
+        mock_response = MagicMock()
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.salesforce_service._request_with_backoff",
+                new=AsyncMock(return_value=mock_response),
+            ) as mock_request,
+        ):
+            result = await salesforce_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        db.delete.assert_called_once_with(row)
+        db.commit.assert_called_once()
+        mock_request.assert_awaited_once()
+        assert mock_request.call_args[0][0] == "POST"
+        assert "revoke" in mock_request.call_args[0][1]
+
+    @pytest.mark.anyio
+    async def test_returns_false_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.salesforce_service.get_integration", return_value=None):
+            result = await salesforce_service.disconnect(db, _TENANT_ID)
+        assert result is False
+        db.delete.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_revoke_failure_still_deletes_local_row(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.refresh_token = "encrypted-refresh-token"
+
+        with (
+            patch("app.services.salesforce_service.get_integration", return_value=row),
+            patch(
+                "app.services.salesforce_service.decrypt_salesforce_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.salesforce_service._request_with_backoff",
+                new=AsyncMock(side_effect=Exception("Salesforce down")),
+            ),
+        ):
+            result = await salesforce_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        db.delete.assert_called_once_with(row)
+        db.commit.assert_called_once()
+
+
+# ── Backoff ──────────────────────────────────────────────────────────────────────
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def request(self, method, url, **kwargs):
+        return self._responses.pop(0)
+
+
+class TestBackoff:
+    @pytest.mark.anyio
+    async def test_retries_on_429_then_succeeds(self):
+        rate_limited = MagicMock(status_code=429, headers={})
+        ok = MagicMock(status_code=200, headers={})
+
+        with (
+            patch(
+                "app.services.salesforce_service.httpx.AsyncClient",
+                return_value=_FakeAsyncClient([rate_limited, ok]),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            response = await salesforce_service._request_with_backoff("GET", "https://x")
+
+        assert response.status_code == 200
+        mock_sleep.assert_awaited_once_with(1.0)
+
+    @pytest.mark.anyio
+    async def test_honors_retry_after_header(self):
+        rate_limited = MagicMock(status_code=429, headers={"Retry-After": "3"})
+        ok = MagicMock(status_code=200, headers={})
+
+        with (
+            patch(
+                "app.services.salesforce_service.httpx.AsyncClient",
+                return_value=_FakeAsyncClient([rate_limited, ok]),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await salesforce_service._request_with_backoff("GET", "https://x")
+
+        mock_sleep.assert_awaited_once_with(3.0)
+
+    @pytest.mark.anyio
+    async def test_gives_up_after_max_retries(self):
+        responses = [MagicMock(status_code=429, headers={}) for _ in range(6)]
+
+        with (
+            patch(
+                "app.services.salesforce_service.httpx.AsyncClient",
+                return_value=_FakeAsyncClient(responses),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            response = await salesforce_service._request_with_backoff("GET", "https://x")
+
+        assert response.status_code == 429
+
+
+# ── Phone normalization ───────────────────────────────────────────────────────────
+
+
+class TestCallTypeMapping:
+    def test_maps_inbound_and_outbound(self):
+        assert salesforce_service._sf_call_type("inbound") == "Inbound"
+        assert salesforce_service._sf_call_type("Inbound") == "Inbound"
+        assert salesforce_service._sf_call_type("outbound") == "Outbound"
+        assert salesforce_service._sf_call_type(None) == "Outbound"
+        assert salesforce_service._sf_call_type("") == "Outbound"
+
+
+class TestPhoneNormalization:
+    def test_normalize_to_e164(self):
+        assert salesforce_service.normalize_to_e164("5550001111") == "+15550001111"
+        assert salesforce_service.normalize_to_e164("15550001111") == "+15550001111"
+        assert salesforce_service.normalize_to_e164("+15550001111") == "+15550001111"
+        assert salesforce_service.normalize_to_e164("") == ""
+
+    def test_get_phone_search_values(self):
+        values = salesforce_service._get_phone_search_values("+15550001111")
+        assert "+15550001111" in values
+        assert "5550001111" in values
+        assert "15550001111" in values
+
+
+# ── Sync status / settings ─────────────────────────────────────────────────────
+
+
+class TestIntegrationSettings:
+    def test_not_connected_returns_disconnected_defaults(self):
+        db = MagicMock()
+        with patch("app.services.salesforce_service.get_integration", return_value=None):
+            result = salesforce_service.get_integration_settings(db, _TENANT_ID)
+        assert result["connected"] is False
+        assert result["write_back_enabled"] is True
+
+    def test_update_settings_raises_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.salesforce_service.get_integration", return_value=None):
+            with pytest.raises(ValueError):
+                salesforce_service.update_integration_settings(db, _TENANT_ID, write_back_enabled=False)
+
+
+class TestSyncStatus:
+    def test_returns_defaults_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.salesforce_service.get_integration", return_value=None):
+            result = salesforce_service.get_sync_status(db, _TENANT_ID)
+        assert result == {
+            "last_lookup_at": None,
+            "last_write_back_at": None,
+            "last_write_back_status": None,
+            "error_count_24h": 0,
+        }
+
+
+class TestSafeErrorMsg:
+    def test_redacts_bearer_token(self):
+        exc = Exception("failed with Bearer abc123.def456==")
+        msg = salesforce_service._safe_error_msg(exc)
+        assert "abc123" not in msg
+        assert "Bearer [redacted]" in msg


### PR DESCRIPTION
## Summary
- Adds Salesforce CRM integration mirroring the existing HubSpot pattern: OAuth 2.0 Web Server Flow via a Connected App, SOQL contact lookup (Redis-cached 5 min) with CRM context injected into the LLM system prompt at call start, and post-call write-back to the Salesforce `Task` object.
- Tokens stored AES-256-GCM encrypted in the existing `workspace_integrations` table under provider `"salesforce"`. New `SALESFORCE_TOKEN_ENCRYPTION_KEY`, `SALESFORCE_CLIENT_ID/SECRET`, `SALESFORCE_LOGIN_URL`, `SALESFORCE_API_VERSION` config, with local-dev `.env` fallbacks and Secret Manager support in staging/production.
- All call-time paths (contact lookup, prompt injection, write-back) fail open — a Salesforce outage never blocks or fails a call, matching HubSpot's behavior.
- New endpoints under `/api/v1/integrations/salesforce`: `connect`, `callback`, `GET ""`, `DELETE ""`, `GET /contact`, `PUT /settings`, `GET /sync-status`. Also added to the aggregate `GET /api/v1/integrations` status list.

## Test plan
- [x] `pytest tests/services/test_salesforce_service.py tests/api/test_salesforce_integration.py -v` — all pass
- [x] `pytest tests/services/test_hubspot_service.py tests/api/test_hubspot_integration.py -v` — no regressions
- [x] Full suite: `pytest tests/ -q` — 1597 passed, 65 skipped, 0 failed
- [x] App imports cleanly and all 7 Salesforce routes register correctly (verified via route introspection)
- [ ] Manual OAuth round-trip against a real Salesforce Developer Edition org (needs `SALESFORCE_CLIENT_ID`/`SECRET` configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)