### PR TITLE
feat: add GoHighLevel (GHL) CRM integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,19 @@ SALESFORCE_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print
 SALESFORCE_LOGIN_URL=https://login.salesforce.com
 SALESFORCE_API_VERSION=v59.0
 
+# --- GoHighLevel (GHL) CRM integration -----------------------------------------
+# Marketplace app credentials from https://marketplace.gohighlevel.com/. In
+# staging/production these are read from Secret Manager (see
+# app/core/secret_manager.py); these env vars are local-dev fallbacks only.
+GHL_CLIENT_ID=
+GHL_CLIENT_SECRET=
+# Must exactly match the redirect URI configured on the GHL marketplace app.
+# Defaults to {WEBHOOK_BASE_URL}/api/v1/integrations/leadconnector/callback when unset.
+GHL_REDIRECT_URI=
+# Symmetric encryption key for workspaceintegration.access_token/refresh_token (AES-256-GCM).
+# MUST be a randomly generated 32-byte secret (represented as a 64-character hex string).
+GHL_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
+
 # --- Calendly calendar integration --------------------------------------------
 # OAuth app credentials from https://developer.calendly.com/.
 CALENDLY_CLIENT_ID=

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -52,6 +52,7 @@ from app.routers.recordings import router as recordings_router
 from app.routers.integrations import router as integrations_router
 from app.routers.hubspot_integration import router as hubspot_integration_router
 from app.routers.salesforce_integration import router as salesforce_integration_router
+from app.routers.ghl_integration import router as ghl_integration_router
 from app.routers.call_history import router as call_history_router
 from app.routers.call_history import batch_router as batch_call_metrics_router
 from app.routers.payments import router as payments_router
@@ -173,6 +174,11 @@ api_router.include_router(
     salesforce_integration_router,
     prefix="/integrations/salesforce",
     tags=["Salesforce Integration"],
+)
+api_router.include_router(
+    ghl_integration_router,
+    prefix="/integrations/leadconnector",
+    tags=["GoHighLevel Integration"],
 )
 api_router.include_router(call_history_router, prefix="/calls", tags=["Call History Analytics"])
 api_router.include_router(batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"])

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -158,6 +158,13 @@ class CrmSettings(BaseModel):
     salesforce_token_encryption_key: str = Field(
         default="", validation_alias="SALESFORCE_TOKEN_ENCRYPTION_KEY"
     )
+    # GoHighLevel (GHL)
+    ghl_client_id: str = Field(default="", validation_alias="GHL_CLIENT_ID")
+    ghl_client_secret: str = Field(default="", validation_alias="GHL_CLIENT_SECRET")
+    ghl_redirect_uri: str = Field(default="", validation_alias="GHL_REDIRECT_URI")
+    ghl_token_encryption_key: str = Field(
+        default="", validation_alias="GHL_TOKEN_ENCRYPTION_KEY"
+    )
     # Calendly
     calendly_client_id: str = Field(default="", validation_alias="CALENDLY_CLIENT_ID")
     calendly_client_secret: str = Field(default="", validation_alias="CALENDLY_CLIENT_SECRET")
@@ -415,6 +422,19 @@ class Settings(BaseSettings):
     # refresh-60s-early rule to force a refresh well before typical session
     # timeouts (Salesforce's own default session timeout is 2 hours).
     SALESFORCE_ACCESS_TOKEN_TTL_SECONDS: int = 1800
+
+    # GoHighLevel (GHL) CRM OAuth (app/services/ghl_service.py).
+    # client_id/client_secret kept here as local-dev fallbacks only — in
+    # staging/production they are read from Secret Manager (see
+    # app/core/secret_manager.py::get_ghl_oauth_credentials).
+    GHL_CLIENT_ID: str = ""
+    GHL_CLIENT_SECRET: str = ""
+    GHL_REDIRECT_URI: str = ""  # defaults to {WEBHOOK_BASE_URL}/api/v1/integrations/leadconnector/callback
+    # Symmetric encryption key for workspaceintegration.access_token / refresh_token
+    # (AES-256-GCM) — same scheme as HUBSPOT_TOKEN_ENCRYPTION_KEY above.
+    GHL_TOKEN_ENCRYPTION_KEY: str = ""
+    GHL_API_BASE_URL: str = "https://services.leadconnectorhq.com"
+    GHL_API_VERSION: str = "2021-07-28"
 
     # Calendly calendar OAuth (app/services/calendly_service.py).
     CALENDLY_CLIENT_ID: str = ""
@@ -867,6 +887,10 @@ class Settings(BaseSettings):
             salesforce_client_secret=self.SALESFORCE_CLIENT_SECRET,
             salesforce_redirect_uri=self.SALESFORCE_REDIRECT_URI,
             salesforce_token_encryption_key=self.SALESFORCE_TOKEN_ENCRYPTION_KEY,
+            ghl_client_id=self.GHL_CLIENT_ID,
+            ghl_client_secret=self.GHL_CLIENT_SECRET,
+            ghl_redirect_uri=self.GHL_REDIRECT_URI,
+            ghl_token_encryption_key=self.GHL_TOKEN_ENCRYPTION_KEY,
             calendly_client_id=self.CALENDLY_CLIENT_ID,
             calendly_client_secret=self.CALENDLY_CLIENT_SECRET,
             calendly_redirect_uri=self.CALENDLY_REDIRECT_URI,

--- a/app/core/db_encryption.py
+++ b/app/core/db_encryption.py
@@ -428,6 +428,64 @@ def decrypt_calendly_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001
         raise ValueError(f"Calendly token decryption failed: {exc}") from exc
 
 
+# Tags GoHighLevel (GHL) OAuth token ciphertext. New integration — no legacy
+# pgcrypto rows exist, so unlike HubSpot's decrypt_hubspot_token there is no
+# fallback path.
+_GHL_AESGCM_PREFIX = "gcm1:"
+
+
+def _ghl_aes_key() -> bytes:
+    """Derive a 32-byte AES-256 key from GHL_TOKEN_ENCRYPTION_KEY.
+
+    SECURITY NOTE:
+      For secure AES-256-GCM encryption, GHL_TOKEN_ENCRYPTION_KEY must be
+      configured as a randomly generated 32-byte secret (typically represented
+      as a 64-character hex string, e.g. generated via `secrets.token_hex(32)`).
+    """
+    key = settings.GHL_TOKEN_ENCRYPTION_KEY
+    if not key:
+        raise ValueError(
+            "GHL_TOKEN_ENCRYPTION_KEY is not configured — "
+            "cannot encrypt/decrypt GoHighLevel OAuth token."
+        )
+    return hashlib.sha256(key.encode("utf-8")).digest()
+
+
+def encrypt_ghl_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+    """Encrypt *plaintext* GoHighLevel OAuth token with AES-256-GCM.
+
+    Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
+    encryption has no GCM mode). ``db`` is accepted only for parity with the other
+    encrypt_* helpers in this module; it is unused here.
+
+    Raises ``ValueError`` if ``GHL_TOKEN_ENCRYPTION_KEY`` is not configured.
+    """
+    key = _ghl_aes_key()
+    nonce = os.urandom(12)  # 96-bit nonce, the standard size for AES-GCM
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext.encode("utf-8"), None)
+    return _GHL_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode("ascii")
+
+
+def decrypt_ghl_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+    """Decrypt a GoHighLevel OAuth token written by :func:`encrypt_ghl_token`.
+
+    Raises ``ValueError`` if ``GHL_TOKEN_ENCRYPTION_KEY`` is not configured,
+    the ciphertext is missing/corrupt, or was encrypted with a different key.
+    """
+    if not ciphertext:
+        raise ValueError("ciphertext is empty")
+    if not ciphertext.startswith(_GHL_AESGCM_PREFIX):
+        raise ValueError("Unrecognized GoHighLevel token ciphertext format")
+
+    key = _ghl_aes_key()
+    try:
+        raw = base64.b64decode(ciphertext[len(_GHL_AESGCM_PREFIX):])
+        nonce, body = raw[:12], raw[12:]
+        return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
+    except Exception as exc:
+        raise ValueError(f"GoHighLevel token decryption failed: {exc}") from exc
+
+
 def decrypt_stored_elevenlabs_key(
     ciphertext: str,
     *,

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -259,6 +259,44 @@ def get_salesforce_oauth_credentials() -> Tuple[str, str]:
     return client_id, client_secret
 
 
+@lru_cache(maxsize=1)
+def _load_ghl_production_credentials() -> Tuple[str, str]:
+    """Fetch GoHighLevel OAuth app credentials from Secret Manager (cached after first call)."""
+    client_id = _fetch_from_secret_manager("GHL_CLIENT_ID") or settings.GHL_CLIENT_ID
+    client_secret = _fetch_from_secret_manager("GHL_CLIENT_SECRET") or settings.GHL_CLIENT_SECRET
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "GoHighLevel OAuth credentials unavailable. Set GCP_PROJECT_ID and Secret Manager "
+            "secrets (GHL_CLIENT_ID, GHL_CLIENT_SECRET) or the equivalent env vars."
+        )
+    return client_id, client_secret
+
+
+def get_ghl_oauth_credentials() -> Tuple[str, str]:
+    """
+    Return (client_id, client_secret) appropriate for the current environment.
+
+    - production/staging → GCP Secret Manager with env-var fallback
+    - development         → env-var / .env values
+
+    Raises RuntimeError in staging/production when credentials are absent,
+    ValueError in development.
+    """
+    env = settings.ENVIRONMENT.lower()
+
+    if env in ("production", "staging"):
+        return _load_ghl_production_credentials()
+
+    client_id = settings.GHL_CLIENT_ID
+    client_secret = settings.GHL_CLIENT_SECRET
+    if not client_id or not client_secret:
+        raise ValueError(
+            "GoHighLevel OAuth credentials not configured. Set GHL_CLIENT_ID and "
+            "GHL_CLIENT_SECRET in your .env file for local development."
+        )
+    return client_id, client_secret
+
+
 def get_reputation_api_key() -> str:
     """
     Return the outbound number reputation API key (First Orion / Hiya) for the

--- a/app/routers/ghl_integration.py
+++ b/app/routers/ghl_integration.py
@@ -1,0 +1,227 @@
+"""
+GoHighLevel (GHL) CRM OAuth integration endpoints.
+
+GET    /connect        — redirect to GHL's OAuth consent page (tenant-authenticated)
+GET    /callback       — public; GHL redirects the browser here with no auth headers,
+                          so the connecting tenant is recovered from the signed `state` param
+DELETE ""              — revoke local credentials and delete the connection
+GET    ""              — connection status and write-back toggle
+GET    /contact        — Contacts API lookup by phone, used by the dashboard and tests
+POST   /note           — create a note directly against a GHL contact
+PUT    /settings        — toggle post-call write-back for this workspace
+GET    /sync-status    — last lookup/write-back times, status, rolling 24h error count
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant, require_admin, require_manager
+from app.core.config import settings
+from app.core.logger import logger
+from app.schemas.base import SuccessResponse
+from app.schemas.ghl_integration import (
+    GhlContactOut,
+    GhlDisconnectResponse,
+    GhlIntegrationStatusOut,
+    GhlNoteCreateRequest,
+    GhlNoteCreateResponse,
+    GhlSettingsUpdateRequest,
+    GhlSyncStatusOut,
+)
+from app.services import ghl_service
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+
+def _tenant_id(principal) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+@router.get("/connect", include_in_schema=False)
+async def ghl_connect(
+    principal=Depends(require_admin),
+):
+    """Redirect to GHL's OAuth consent page. Scopes: contacts.readonly, contacts.write."""
+    tenant_id = _tenant_id(principal)
+    state = ghl_service.build_oauth_state(tenant_id)
+    auth_url = ghl_service.build_authorization_url(state)
+    return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/callback", include_in_schema=False)
+async def ghl_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+):
+    """
+    GHL OAuth callback. No auth dependency — this is a top-level browser
+    redirect from GHL, which cannot carry our JWT/API-key headers. The
+    connecting tenant is recovered from the signed `state` param instead.
+    """
+    try:
+        tenant_id = ghl_service.verify_oauth_state(state)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    try:
+        token_response = await ghl_service.exchange_code_for_tokens(code)
+    except Exception as exc:
+        logger.warning("GHL OAuth code exchange failed for tenant=%s: %s", tenant_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to exchange authorization code with GoHighLevel",
+        )
+
+    ghl_service.upsert_tokens(db, tenant_id, token_response)
+
+    base = (settings.FRONTEND_URL or "").rstrip("/")
+    redirect_to = f"{base}/settings/integrations?ghl=connected" if base else "/settings/integrations"
+    return RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
+
+
+@router.delete("", response_model=SuccessResponse[GhlDisconnectResponse])
+async def ghl_disconnect(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Revoke local GHL OAuth credentials and delete the workspaceintegration row."""
+    tenant_id = _tenant_id(principal)
+    disconnected = await ghl_service.disconnect(db, tenant_id)
+    if not disconnected:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="GoHighLevel is not connected for this workspace",
+        )
+    return create_success_response(
+        GhlDisconnectResponse(disconnected=True),
+        "GoHighLevel disconnected successfully",
+    )
+
+
+@router.get("", response_model=SuccessResponse[GhlIntegrationStatusOut])
+async def ghl_get_integration_status(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Connection status and write-back toggle for this workspace."""
+    tenant_id = _tenant_id(principal)
+    integration_settings = ghl_service.get_integration_settings(db, tenant_id)
+    return create_success_response(GhlIntegrationStatusOut(**integration_settings))
+
+
+@router.put("/settings", response_model=SuccessResponse[GhlIntegrationStatusOut])
+async def ghl_update_settings(
+    payload: GhlSettingsUpdateRequest,
+    principal=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Toggle post-call write-back for this workspace."""
+    tenant_id = _tenant_id(principal)
+    if not ghl_service.tenant_has_ghl_connected(db, tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="GoHighLevel is not connected for this workspace",
+        )
+
+    ghl_service.update_integration_settings(
+        db, tenant_id, write_back_enabled=payload.write_back_enabled
+    )
+    integration_settings = ghl_service.get_integration_settings(db, tenant_id)
+    return create_success_response(
+        GhlIntegrationStatusOut(**integration_settings),
+        "Settings updated successfully",
+    )
+
+
+@router.get("/sync-status", response_model=SuccessResponse[GhlSyncStatusOut])
+async def ghl_sync_status(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Last contact-lookup/write-back times, write-back status, and rolling 24h error count."""
+    tenant_id = _tenant_id(principal)
+    sync_status = ghl_service.get_sync_status(db, tenant_id)
+    return create_success_response(GhlSyncStatusOut(**sync_status))
+
+
+@router.get("/contact", response_model=SuccessResponse[GhlContactOut])
+async def ghl_get_contact(
+    phone: str = Query(..., description="Phone number to search for (E.164 or local format)"),
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Contacts API lookup by phone. Redis-cached for 5 minutes per phone number."""
+    tenant_id = _tenant_id(principal)
+
+    if not ghl_service.tenant_has_ghl_connected(db, tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="GoHighLevel is not connected for this workspace",
+        )
+
+    contact = await ghl_service.get_contact_for_phone(db, tenant_id, phone)
+    if not contact:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No GoHighLevel contact found for this phone number",
+        )
+
+    return create_success_response(GhlContactOut(**contact))
+
+
+@router.post("/note", response_model=SuccessResponse[GhlNoteCreateResponse])
+async def ghl_create_note(
+    payload: GhlNoteCreateRequest,
+    principal=Depends(require_manager),
+    db: Session = Depends(get_db),
+):
+    """Create a note directly against a GHL contact. Writes to the tenant's live
+    CRM, so (like /settings) this requires manager+ rather than any authenticated
+    member — a read_only member must not be able to write into GoHighLevel."""
+    tenant_id = _tenant_id(principal)
+
+    if not ghl_service.tenant_has_ghl_connected(db, tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="GoHighLevel is not connected for this workspace",
+        )
+
+    token_info = await ghl_service.get_valid_access_token(db, tenant_id)
+    if not token_info:
+        # Connected, but the stored token is unusable (refresh failed/expired
+        # refresh token) — distinct from "never connected" so the client
+        # doesn't wrongly prompt the user to redo the OAuth flow for what may
+        # be a transient GHL outage.
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to obtain a valid GoHighLevel access token",
+        )
+    access_token, _location_id = token_info
+
+    try:
+        note_response = await ghl_service.create_note(
+            access_token, payload.contact_id, payload.content, tenant_id
+        )
+    except Exception as exc:
+        logger.warning(
+            "GHL note creation failed for tenant=%s contact=%s: %s",
+            tenant_id,
+            payload.contact_id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to create note in GoHighLevel",
+        )
+
+    note_id = note_response.get("id") or (note_response.get("note") or {}).get("id")
+    return create_success_response(
+        GhlNoteCreateResponse(id=note_id, contact_id=payload.contact_id),
+        "Note created successfully",
+    )

--- a/app/routers/integrations.py
+++ b/app/routers/integrations.py
@@ -267,12 +267,13 @@ async def list_integrations(
     make_secret = get_make_secret(tenant)
     n8n_secret = get_n8n_secret(tenant)
 
-    from app.services import hubspot_service, salesforce_service
+    from app.services import ghl_service, hubspot_service, salesforce_service
 
     hubspot_connected, hubspot_connected_at = hubspot_service.get_connection_status(db, tenant.id)
     salesforce_connected, salesforce_connected_at = salesforce_service.get_connection_status(
         db, tenant.id
     )
+    ghl_connected, ghl_connected_at = ghl_service.get_connection_status(db, tenant.id)
 
     integrations = [
         IntegrationItem(
@@ -299,6 +300,16 @@ async def list_integrations(
             last_sync_at=(
                 salesforce_service.get_sync_status(db, tenant.id).get("last_write_back_at")
                 if salesforce_connected
+                else None
+            ),
+        ),
+        IntegrationItem(
+            name="GoHighLevel",
+            connected=ghl_connected,
+            connected_at=ghl_connected_at,
+            last_sync_at=(
+                ghl_service.get_sync_status(db, tenant.id).get("last_write_back_at")
+                if ghl_connected
                 else None
             ),
         ),

--- a/app/schemas/ghl_integration.py
+++ b/app/schemas/ghl_integration.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class GhlAuthorizeResponse(BaseModel):
+    authorization_url: str
+
+
+class GhlContactOut(BaseModel):
+    id: str
+    name: Optional[str] = None
+    email: Optional[str] = None
+    tags: List[str] = []
+    pipeline_stage: Optional[str] = None
+    last_activity_date: Optional[str] = None
+
+
+class GhlNoteCreateRequest(BaseModel):
+    contact_id: str
+    content: str
+
+
+class GhlNoteCreateResponse(BaseModel):
+    id: Optional[str] = None
+    contact_id: str
+
+
+class GhlDisconnectResponse(BaseModel):
+    disconnected: bool
+    provider: str = "gohighlevel"
+
+
+class GhlSettingsUpdateRequest(BaseModel):
+    write_back_enabled: bool
+
+
+class GhlIntegrationStatusOut(BaseModel):
+    connected: bool
+    connected_at: Optional[datetime] = None
+    last_sync_at: Optional[str] = None
+    write_back_enabled: bool = True
+
+
+class GhlSyncStatusOut(BaseModel):
+    last_lookup_at: Optional[str] = None
+    last_write_back_at: Optional[str] = None
+    last_write_back_status: Optional[str] = None
+    last_ghl_error: Optional[str] = None
+    error_count_24h: int = 0

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -312,6 +312,24 @@ class CallSessionService:
                             salesforce_exc,
                         )
 
+                # GoHighLevel (GHL) post-call write-back: create a note with the
+                # transcript summary once the call has actually completed. Enqueued
+                # as an ARQ background job (fail open) — see
+                # app/services/ghl_service.py::schedule_ghl_writeback.
+                if status == "completed":
+                    try:
+                        from app.services.ghl_service import (
+                            schedule_ghl_writeback,
+                            tenant_has_ghl_connected,
+                        )
+
+                        if tenant_has_ghl_connected(db, call_session.tenant_id):
+                            schedule_ghl_writeback(call_session.id)
+                    except Exception as ghl_exc:  # pragma: no cover
+                        logger.warning(
+                            "GHL write-back schedule failed (non-critical): %s", ghl_exc
+                        )
+
                 # Smart Callback: schedule a retry for missed outbound calls.
                 # maybe_schedule_callback writes the CallbackSchedule row (sync).
                 # _fire_callback_enqueue then submits the ARQ job on the current

--- a/app/services/ghl_service.py
+++ b/app/services/ghl_service.py
@@ -1,0 +1,1037 @@
+"""
+GoHighLevel (GHL) CRM integration — OAuth 2.0, contact lookup, and post-call
+note write-back.
+
+External HTTP calls: GHL OAuth (``https://services.leadconnectorhq.com/oauth/token``)
+and the API v2 Contacts/Notes API (``https://services.leadconnectorhq.com/contacts/*``).
+Every API v2 request must carry the ``Version: 2021-07-28`` header.
+
+Rate limit: GHL allows 100 requests/10s per authorization. ``check_rate_limit``
+enforces this with a Redis fixed-window counter, keyed per tenant, before every
+outbound API v2 call (not the OAuth token endpoint).
+
+Every public entrypoint used at call time (contact lookup, CRM context injection,
+post-call write-back) fails open: GHL being down or rate-limited logs a warning
+and returns None/"" rather than raising, so a call is never blocked.
+
+Unlike HubSpot/Salesforce (which fire-and-forget via a thread/asyncio task),
+post-call write-back here is enqueued as an ARQ background job (see
+app/workers/batch_call_worker.py::ghl_post_call_writeback) per the GHL
+acceptance criteria, and retries at most once before recording the failure on
+workspace_integration.metadata.last_ghl_error.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import hashlib
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+from urllib.parse import urlencode
+
+import httpx
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.core.config import settings
+from app.core.db_encryption import decrypt_ghl_token, encrypt_ghl_token
+from app.core.logger import logger
+from app.core.secret_manager import get_ghl_oauth_credentials
+from app.db.session import SessionLocal
+from app.models.call_session import CallSession
+from app.models.workspace_integration import WorkspaceIntegration
+from app.utils.arq_pool import get_arq_pool
+from app.utils.redis_client import get_redis
+
+PROVIDER = "gohighlevel"
+
+AUTHORIZE_URL = "https://marketplace.gohighlevel.com/oauth/chooselocation"
+
+SCOPES = "contacts.readonly contacts.write"
+
+_MAX_RETRIES = 5
+_BASE_BACKOFF_SECONDS = 1.0
+
+_STATE_PURPOSE = "ghl_oauth_state"
+_STATE_TTL_MINUTES = 10
+
+_CONTACT_CACHE_TTL_SECONDS = 300  # 5 minutes, per acceptance criteria
+_CONTACT_NOT_FOUND_SENTINEL = "__not_found__"
+
+_DEFAULT_WRITE_BACK_ENABLED = True
+
+_WRITE_BACK_RETRY_DELAY_SECONDS = 300  # 5 minutes
+_WRITE_BACK_ERROR_WINDOW_SECONDS = 24 * 60 * 60  # rolling 24h window
+_WRITE_BACK_ALERT_THRESHOLD = 5
+
+# Redis-backed fixed-window rate limiter (100 requests / 10 seconds).
+_RATE_LIMIT_MAX_REQUESTS = 100
+_RATE_LIMIT_WINDOW_SECONDS = 10
+
+# Calling codes with a well-known "local"/trunk-prefixed national format,
+# used as the fallback lookup when the E.164 search returns no match.
+# AU: +61412345678 -> 0412345678 (per acceptance criteria example).
+_TRUNK_ZERO_COUNTRY_CODES = ("61", "44", "64")
+
+
+def _api_base_url() -> str:
+    return settings.GHL_API_BASE_URL.rstrip("/")
+
+
+def _api_version() -> str:
+    return settings.GHL_API_VERSION
+
+
+def _token_url() -> str:
+    return f"{_api_base_url()}/oauth/token"
+
+
+# ─── Redis-backed rate limiter (100 req / 10s) ─────────────────────────────────
+
+
+async def check_rate_limit(tenant_id: uuid.UUID) -> None:
+    """
+    Enforce GHL's 100 requests/10s limit with a Redis fixed-window counter.
+
+    No-ops (does not block) if Redis is unavailable — a missing rate limiter
+    must never itself become a reason to fail a CRM call.
+    """
+    redis_client = get_redis()
+    if redis_client is None:
+        return
+
+    key = f"ghl:rate_limit:{tenant_id}"
+    try:
+        count = await redis_client.incr(key)
+        if count == 1:
+            await redis_client.expire(key, _RATE_LIMIT_WINDOW_SECONDS)
+        if count > _RATE_LIMIT_MAX_REQUESTS:
+            ttl = await redis_client.ttl(key)
+            wait_seconds = ttl if ttl and ttl > 0 else _RATE_LIMIT_WINDOW_SECONDS
+            logger.warning(
+                "GHL rate limit exceeded for tenant=%s; waiting %.1fs", tenant_id, wait_seconds
+            )
+            await asyncio.sleep(wait_seconds)
+    except Exception:
+        logger.warning("GHL rate limiter check failed (continuing)", exc_info=True)
+
+
+# ─── HTTP with backoff ────────────────────────────────────────────────────────
+
+
+async def _request_with_backoff(method: str, url: str, **kwargs) -> httpx.Response:
+    """Call GHL with exponential backoff on 429 (1s, 2s, 4s, 8s, 16s)."""
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        attempt = 0
+        while True:
+            response = await client.request(method, url, **kwargs)
+            if response.status_code != 429 or attempt >= _MAX_RETRIES:
+                return response
+
+            retry_after_header = response.headers.get("Retry-After")
+            wait_seconds = (
+                float(retry_after_header)
+                if retry_after_header
+                else _BASE_BACKOFF_SECONDS * (2 ** attempt)
+            )
+            logger.warning(
+                "GHL 429 on %s %s; retrying in %.1fs (attempt %d/%d)",
+                method,
+                url,
+                wait_seconds,
+                attempt + 1,
+                _MAX_RETRIES,
+            )
+            await asyncio.sleep(wait_seconds)
+            attempt += 1
+
+
+def _api_headers(access_token: str) -> dict:
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Version": _api_version(),
+    }
+
+
+# ─── OAuth state (signed, carries tenant_id through the redirect round-trip) ──
+
+
+def build_oauth_state(tenant_id: uuid.UUID) -> str:
+    payload = {
+        "tenant_id": str(tenant_id),
+        "purpose": _STATE_PURPOSE,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=_STATE_TTL_MINUTES),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def verify_oauth_state(state: str) -> uuid.UUID:
+    """Raises ValueError if state is missing, expired, tampered, or malformed."""
+    try:
+        payload = jwt.decode(state, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+    except JWTError as exc:
+        raise ValueError("Invalid or expired OAuth state") from exc
+
+    if payload.get("purpose") != _STATE_PURPOSE:
+        raise ValueError("Invalid OAuth state purpose")
+
+    tenant_id_str = payload.get("tenant_id")
+    if not tenant_id_str:
+        raise ValueError("OAuth state missing tenant_id")
+
+    try:
+        return uuid.UUID(tenant_id_str)
+    except ValueError as exc:
+        raise ValueError("OAuth state has malformed tenant_id") from exc
+
+
+def get_redirect_uri() -> str:
+    return settings.GHL_REDIRECT_URI or (
+        f"{settings.WEBHOOK_BASE_URL.rstrip('/')}/api/v1/integrations/leadconnector/callback"
+    )
+
+
+def build_authorization_url(state: str) -> str:
+    client_id, _ = get_ghl_oauth_credentials()
+    params = {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": get_redirect_uri(),
+        "scope": SCOPES,
+        "state": state,
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+
+# ─── Token exchange / refresh ─────────────────────────────────────────────────
+
+
+async def exchange_code_for_tokens(code: str) -> dict:
+    client_id, client_secret = get_ghl_oauth_credentials()
+    response = await _request_with_backoff(
+        "POST",
+        _token_url(),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": get_redirect_uri(),
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+async def refresh_access_token(refresh_token: str) -> dict:
+    client_id, client_secret = get_ghl_oauth_credentials()
+    response = await _request_with_backoff(
+        "POST",
+        _token_url(),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+# ─── WorkspaceIntegration CRUD ────────────────────────────────────────────────
+
+
+def get_integration(db: Session, tenant_id: uuid.UUID) -> Optional[WorkspaceIntegration]:
+    return (
+        db.query(WorkspaceIntegration)
+        .filter(
+            WorkspaceIntegration.workspace_id == tenant_id,
+            WorkspaceIntegration.provider == PROVIDER,
+        )
+        .first()
+    )
+
+
+def tenant_has_ghl_connected(db: Session, tenant_id: uuid.UUID) -> bool:
+    return get_integration(db, tenant_id) is not None
+
+
+def get_connection_status(
+    db: Session, tenant_id: uuid.UUID
+) -> Tuple[bool, Optional[datetime]]:
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return False, None
+    return True, row.created_at
+
+
+def upsert_tokens(
+    db: Session, tenant_id: uuid.UUID, token_response: dict
+) -> WorkspaceIntegration:
+    access_token = token_response["access_token"]
+    refresh_token = token_response.get("refresh_token")
+    expires_in = int(token_response.get("expires_in", 3600))
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    location_id = token_response.get("locationId")
+
+    row = get_integration(db, tenant_id)
+    if row is None:
+        row = WorkspaceIntegration(workspace_id=tenant_id, provider=PROVIDER)
+
+    row.access_token = encrypt_ghl_token(access_token, db)
+    if refresh_token:
+        row.refresh_token = encrypt_ghl_token(refresh_token, db)
+    row.token_expires_at = expires_at
+
+    if location_id:
+        updated_metadata = dict(row.extra_metadata or {})
+        updated_metadata["location_id"] = location_id
+        row.extra_metadata = updated_metadata
+        flag_modified(row, "extra_metadata")
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+async def get_valid_access_token(
+    db: Session, tenant_id: uuid.UUID
+) -> Optional[Tuple[str, str]]:
+    """Return (access_token, location_id), refreshing the token first if within 5 min of expiry."""
+    row = get_integration(db, tenant_id)
+    if row is None or not row.access_token:
+        return None
+
+    location_id = (row.extra_metadata or {}).get("location_id")
+    if not location_id:
+        logger.warning(
+            "GHL integration for tenant=%s has no stored location_id", tenant_id
+        )
+        return None
+
+    expires_at = row.token_expires_at
+    if expires_at is not None and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+
+    now = datetime.now(timezone.utc)
+    if expires_at is not None and expires_at > now + timedelta(minutes=5):
+        return decrypt_ghl_token(row.access_token, db), location_id
+
+    if not row.refresh_token:
+        logger.warning(
+            "GHL access token expired for tenant=%s but no refresh_token stored", tenant_id
+        )
+        return None
+
+    try:
+        refresh_token_plain = decrypt_ghl_token(row.refresh_token, db)
+        token_response = await refresh_access_token(refresh_token_plain)
+    except Exception:
+        logger.warning("GHL token refresh failed for tenant=%s", tenant_id, exc_info=True)
+        return None
+
+    row = upsert_tokens(db, tenant_id, token_response)
+    location_id = (row.extra_metadata or {}).get("location_id") or location_id
+    return decrypt_ghl_token(row.access_token, db), location_id
+
+
+async def _force_refresh_access_token(
+    db: Session, tenant_id: uuid.UUID
+) -> Optional[Tuple[str, str]]:
+    """
+    Unconditionally refresh the GHL access token, ignoring token_expires_at.
+
+    A call can run longer than our assumed token TTL; always called immediately
+    before the write-back API call, mirroring HubSpot/Salesforce's forced
+    pre-writeback refresh.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None or not row.refresh_token:
+        return await get_valid_access_token(db, tenant_id)
+
+    try:
+        refresh_token_plain = decrypt_ghl_token(row.refresh_token, db)
+        token_response = await refresh_access_token(refresh_token_plain)
+    except Exception:
+        logger.warning(
+            "GHL forced pre-writeback token refresh failed for tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+        return None
+
+    row = upsert_tokens(db, tenant_id, token_response)
+    location_id = (row.extra_metadata or {}).get("location_id")
+    if not location_id:
+        return None
+    return decrypt_ghl_token(row.access_token, db), location_id
+
+
+def get_integration_settings(db: Session, tenant_id: uuid.UUID) -> dict:
+    """Return the tenant's GHL connection status and write-back toggle, with defaults applied."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return {
+            "connected": False,
+            "connected_at": None,
+            "last_sync_at": None,
+            "write_back_enabled": _DEFAULT_WRITE_BACK_ENABLED,
+        }
+
+    metadata = row.extra_metadata or {}
+    last_sync_at = metadata.get("last_write_back_at") or metadata.get("last_lookup_at")
+    return {
+        "connected": True,
+        "connected_at": row.created_at,
+        "last_sync_at": last_sync_at,
+        "write_back_enabled": metadata.get("write_back_enabled", _DEFAULT_WRITE_BACK_ENABLED),
+    }
+
+
+def update_integration_settings(
+    db: Session, tenant_id: uuid.UUID, *, write_back_enabled: bool
+) -> WorkspaceIntegration:
+    """Persist the write-back toggle. Raises ValueError if not connected."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        raise ValueError("GoHighLevel is not connected for this workspace")
+
+    updated_metadata = dict(row.extra_metadata or {})
+    updated_metadata["write_back_enabled"] = write_back_enabled
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def set_last_ghl_error(db: Session, tenant_id: uuid.UUID, error: Optional[str]) -> None:
+    """
+    Record (or clear, when error is None) the last post-call write-back failure
+    on ``workspace_integration.metadata.last_ghl_error``.
+
+    Also stamps last_write_back_status/last_write_back_at for the sync-status
+    endpoint. error=None means the write-back just succeeded.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return
+
+    updated_metadata = dict(row.extra_metadata or {})
+    if error:
+        updated_metadata["last_ghl_error"] = error
+        updated_metadata["last_write_back_status"] = "failed"
+    else:
+        updated_metadata.pop("last_ghl_error", None)
+        updated_metadata["last_write_back_status"] = "success"
+        updated_metadata["last_write_back_at"] = _utc_now_iso()
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+
+
+def record_write_back_failure(db: Session, tenant_id: uuid.UUID, error_msg: str) -> None:
+    """
+    Persist the structured last-failure error (after the single retry is
+    exhausted), bump the rolling 24h failure counter, and alert the workspace
+    admin once failures cross _WRITE_BACK_ALERT_THRESHOLD within the window.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return
+
+    now = datetime.now(timezone.utc)
+    now_iso = _utc_now_iso()
+    window_start = now - timedelta(seconds=_WRITE_BACK_ERROR_WINDOW_SECONDS)
+
+    updated_metadata = dict(row.extra_metadata or {})
+    updated_metadata["last_ghl_error"] = error_msg
+    updated_metadata["last_write_back_status"] = "failed"
+    updated_metadata["last_write_back_at"] = now_iso
+
+    failure_timestamps = [
+        ts
+        for ts in updated_metadata.get("write_back_failure_timestamps", [])
+        if _parse_iso(ts) is not None and _parse_iso(ts) > window_start
+    ]
+    failure_timestamps.append(now_iso)
+    updated_metadata["write_back_failure_timestamps"] = failure_timestamps
+
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+
+    if len(failure_timestamps) == _WRITE_BACK_ALERT_THRESHOLD:
+        _send_write_back_failure_alert(db, tenant_id, error_msg, now_iso, len(failure_timestamps))
+
+
+def _send_write_back_failure_alert(
+    db: Session, tenant_id: uuid.UUID, error_msg: str, timestamp_iso: str, failure_count: int
+) -> None:
+    """Best-effort admin email alert. Never raises — a notification failure must not affect write-back."""
+    try:
+        from app.models.tenant import Tenant
+        from app.services.data_export_service import _get_workspace_admin_email
+        from app.services.email_service import email_service
+
+        admin_email = _get_workspace_admin_email(db, tenant_id)
+        tenant = db.get(Tenant, tenant_id)
+        if not admin_email:
+            admin_email = getattr(tenant, "contact_email", None) if tenant else None
+        if not admin_email:
+            logger.warning(
+                "No admin or contact email found for tenant=%s; cannot send "
+                "GoHighLevel write-back failure alert",
+                tenant_id,
+            )
+            return
+
+        workspace_name = tenant.name if tenant else str(tenant_id)
+        frontend_base = (settings.FRONTEND_URL or "").rstrip("/")
+        reconnect_url = f"{frontend_base}/settings/integrations" if frontend_base else "/settings/integrations"
+
+        email_service.send_generic_email(
+            to_email=admin_email,
+            subject=f"Action Required: GoHighLevel Integration Write-Back Failures for {workspace_name}",
+            html_body=(
+                f"<p>GoHighLevel post-call write-back has failed {failure_count} times in the "
+                f"last 24 hours for workspace <strong>{workspace_name}</strong>.</p>"
+                f"<p>Most recent failure at {timestamp_iso}: {error_msg}</p>"
+                f"<p>Please reconnect GoHighLevel to restore syncing: "
+                f'<a href="{reconnect_url}">{reconnect_url}</a></p>'
+            ),
+        )
+    except Exception:
+        logger.warning(
+            "Failed to send GoHighLevel write-back failure alert for tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+
+
+def get_sync_status(db: Session, tenant_id: uuid.UUID) -> dict:
+    """Sync visibility for the dashboard: last lookup/write-back times, status, 24h error count."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return {
+            "last_lookup_at": None,
+            "last_write_back_at": None,
+            "last_write_back_status": None,
+            "last_ghl_error": None,
+            "error_count_24h": 0,
+        }
+
+    metadata = row.extra_metadata or {}
+    window_start = datetime.now(timezone.utc) - timedelta(seconds=_WRITE_BACK_ERROR_WINDOW_SECONDS)
+    error_count_24h = sum(
+        1
+        for ts in metadata.get("write_back_failure_timestamps", [])
+        if _parse_iso(ts) is not None and _parse_iso(ts) > window_start
+    )
+
+    return {
+        "last_lookup_at": metadata.get("last_lookup_at"),
+        "last_write_back_at": metadata.get("last_write_back_at"),
+        "last_write_back_status": metadata.get("last_write_back_status"),
+        "last_ghl_error": metadata.get("last_ghl_error"),
+        "error_count_24h": error_count_24h,
+    }
+
+
+def _touch_last_lookup_at(db: Session, tenant_id: uuid.UUID, *, commit: bool = True) -> None:
+    """
+    Best-effort timestamp of the last contact lookup, for the sync-status endpoint.
+
+    commit=False must be used when `db` is the shared, long-lived session tied to
+    an in-progress call (see get_crm_context_block_for_call), which never calls
+    db.commit() directly to avoid prematurely committing the caller's still-open
+    call transaction.
+    """
+    try:
+        row = get_integration(db, tenant_id)
+        if row is None:
+            return
+        updated_metadata = dict(row.extra_metadata or {})
+        updated_metadata["last_lookup_at"] = _utc_now_iso()
+        row.extra_metadata = updated_metadata
+        flag_modified(row, "extra_metadata")
+        db.add(row)
+        if commit:
+            db.commit()
+        else:
+            with db.begin_nested():
+                db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to record GHL last_lookup_at (non-critical) tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+
+
+async def disconnect(db: Session, tenant_id: uuid.UUID) -> bool:
+    """
+    Revoke local GHL OAuth credentials and delete the workspace_integration row.
+
+    GHL's API v2 does not document a token-revocation endpoint, so — unlike
+    HubSpot/Salesforce disconnect — there is no external revoke call here;
+    deleting the encrypted tokens locally is the full revocation surface we
+    control.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return False
+
+    db.delete(row)
+    db.commit()
+    return True
+
+
+# ─── Contact lookup (Contacts API, Redis-cached) ───────────────────────────────
+
+
+def normalize_to_e164(phone: str) -> str:
+    """Normalize phone number to E.164 format if possible.
+    E.164 format: +[country_code][subscriber_number] up to 15 digits total.
+    """
+    if not phone:
+        return ""
+    phone = phone.strip()
+    has_plus = phone.startswith("+")
+    digits = "".join(c for c in phone if c.isdigit())
+
+    if not digits:
+        return phone
+
+    if has_plus:
+        return f"+{digits}"
+
+    if len(digits) == 10:
+        return f"+1{digits}"
+    elif len(digits) == 11 and digits.startswith("1"):
+        return f"+{digits}"
+    else:
+        return f"+{digits}"
+
+
+def local_format_fallback(e164_phone: str) -> Optional[str]:
+    """
+    Best-effort "local" format fallback used when the E.164 lookup finds no
+    contact: strip the country calling code and prepend a trunk 0, mirroring
+    AU (+61412345678 -> 0412345678) and similar 0-trunk numbering plans.
+
+    Returns None when the number doesn't start with a known trunk-0 calling
+    code (e.g. NANP +1 numbers have no equivalent local form to try).
+    """
+    if not e164_phone or not e164_phone.startswith("+"):
+        return None
+    digits = e164_phone[1:]
+    for code in sorted(_TRUNK_ZERO_COUNTRY_CODES, key=len, reverse=True):
+        if digits.startswith(code):
+            subscriber = digits[len(code):]
+            if subscriber:
+                return f"0{subscriber}"
+    return None
+
+
+def _contact_cache_key(tenant_id: uuid.UUID, phone: str) -> str:
+    # Hash the phone number to avoid storing PII in plaintext in Redis keys.
+    phone_hash = hashlib.sha256(phone.encode("utf-8")).hexdigest()
+    return f"ghl:contact:{tenant_id}:{phone_hash}"
+
+
+def _contact_dict_from_ghl(raw: dict) -> dict:
+    first = (raw.get("firstName") or "").strip()
+    last = (raw.get("lastName") or "").strip()
+    name = raw.get("contactName") or f"{first} {last}".strip() or None
+    return {
+        "id": raw.get("id"),
+        "name": name,
+        "email": raw.get("email"),
+        "tags": raw.get("tags") or [],
+        "pipeline_stage": raw.get("pipelineStage") or raw.get("pipeline_stage"),
+        "last_activity_date": raw.get("lastActivity") or raw.get("dateUpdated"),
+    }
+
+
+async def search_contact_by_phone(
+    access_token: str, location_id: str, phone: str, tenant_id: uuid.UUID
+) -> Optional[dict]:
+    """
+    Search GHL contacts by phone. Tries E.164 first; if no match, falls back
+    to the local/trunk-0 format (see local_format_fallback) before giving up.
+    """
+    url = f"{_api_base_url()}/contacts/"
+    headers = _api_headers(access_token)
+
+    e164_phone = normalize_to_e164(phone)
+    candidates = [e164_phone] if e164_phone else []
+    local_phone = local_format_fallback(e164_phone) if e164_phone else None
+    if local_phone:
+        candidates.append(local_phone)
+
+    for candidate in candidates:
+        await check_rate_limit(tenant_id)
+        response = await _request_with_backoff(
+            "GET",
+            url,
+            headers=headers,
+            params={"locationId": location_id, "phone": candidate},
+        )
+        response.raise_for_status()
+        contacts = response.json().get("contacts") or []
+        if contacts:
+            return contacts[0]
+
+    return None
+
+
+async def get_contact_for_phone(
+    db: Session, tenant_id: uuid.UUID, phone: str, *, commit_lookup_timestamp: bool = True
+) -> Optional[dict]:
+    """Look up a contact by phone, Redis-cached for 5 minutes. Fails open on any error.
+
+    commit_lookup_timestamp=False must be passed by live in-call callers sharing a
+    long-lived db session (see _touch_last_lookup_at).
+    """
+    _touch_last_lookup_at(db, tenant_id, commit=commit_lookup_timestamp)
+
+    normalized_phone = normalize_to_e164(phone)
+    redis_client = get_redis()
+    cache_key = _contact_cache_key(tenant_id, normalized_phone)
+
+    if redis_client is not None:
+        try:
+            cached = await redis_client.get(cache_key)
+            if cached is not None:
+                return None if cached == _CONTACT_NOT_FOUND_SENTINEL else json.loads(cached)
+        except Exception:
+            logger.warning("GHL contact cache read failed (continuing)", exc_info=True)
+
+    try:
+        token_info = await get_valid_access_token(db, tenant_id)
+        if not token_info:
+            return None
+        access_token, location_id = token_info
+        raw_contact = await search_contact_by_phone(
+            access_token, location_id, normalized_phone, tenant_id
+        )
+    except Exception:
+        logger.warning(
+            "GHL contact search failed for tenant=%s (failing open)", tenant_id, exc_info=True
+        )
+        return None
+
+    contact = _contact_dict_from_ghl(raw_contact) if raw_contact else None
+
+    if redis_client is not None:
+        try:
+            payload = _CONTACT_NOT_FOUND_SENTINEL if contact is None else json.dumps(contact)
+            await redis_client.set(cache_key, payload, ex=_CONTACT_CACHE_TTL_SECONDS)
+        except Exception:
+            logger.warning("GHL contact cache write failed (non-critical)", exc_info=True)
+
+    return contact
+
+
+# ─── CRM context injection (conversation_orchestrator) ────────────────────────
+
+
+async def get_crm_context_block_for_call(db: Session, call_session: CallSession) -> str:
+    """
+    Fetch the CRM context block for a call's system prompt, once per call.
+
+    Cached in call_session.call_metadata["ghl_crm_context"] so subsequent turns
+    (the prompt is rebuilt every turn) reuse the cached string instead of
+    re-querying GHL/Redis. Fails open — returns "" on any error so a CRM
+    outage never blocks the call.
+    """
+    metadata = call_session.call_metadata or {}
+    if "ghl_crm_context" in metadata:
+        return metadata.get("ghl_crm_context") or ""
+
+    context_block = ""
+    try:
+        if call_session.customer_phone_number and tenant_has_ghl_connected(
+            db, call_session.tenant_id
+        ):
+            contact = await get_contact_for_phone(
+                db,
+                call_session.tenant_id,
+                call_session.customer_phone_number,
+                commit_lookup_timestamp=False,
+            )
+            if contact:
+                tags = contact.get("tags") or []
+                context_block = (
+                    f"CRM CONTEXT (GoHighLevel): Name: {contact.get('name') or 'Unknown'}, "
+                    f"Tags: {', '.join(tags)}, "
+                    f"Pipeline: {contact.get('pipeline_stage') or 'Unknown'}"
+                )
+    except Exception:
+        logger.warning(
+            "GHL CRM context lookup failed (continuing without CRM context)", exc_info=True
+        )
+        context_block = ""
+
+    try:
+        with db.begin_nested():
+            updated_metadata = dict(call_session.call_metadata or {})
+            updated_metadata["ghl_crm_context"] = context_block
+            call_session.call_metadata = updated_metadata
+            flag_modified(call_session, "call_metadata")
+            db.add(call_session)
+            db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to cache GHL CRM context on call_session (non-critical)", exc_info=True
+        )
+
+    return context_block
+
+
+# ─── Note creation (post-call write-back + direct endpoint) ───────────────────
+
+
+def _transcript_text(db: Session, call_session: CallSession) -> str:
+    from app.services.transcript_service import transcript_service
+
+    messages = transcript_service.get_messages_by_session(db, call_session.id)
+    lines = [f"{m.role}: {m.message}" for m in messages if m.message]
+    return "\n".join(lines)
+
+
+def generate_transcript_summary(db: Session, call_session: CallSession) -> str:
+    """2-sentence Gemini summary of the call transcript. Fails open — returns ''."""
+    transcript_text = _transcript_text(db, call_session)
+    if not transcript_text.strip():
+        return ""
+
+    from app.services.gemini_service import gemini_service
+
+    try:
+        result = gemini_service.generate_text(
+            prompt=(
+                "Summarize this phone call transcript in exactly 2 sentences, "
+                "focused on the caller's request and the outcome:\n\n" + transcript_text
+            ),
+            model_name="gemini-2.0-flash",
+            temperature=0.2,
+            max_tokens=120,
+        )
+        return (result.get("content") or "").strip()
+    except Exception:
+        logger.warning(
+            "GHL post-call summary generation failed (continuing without summary)", exc_info=True
+        )
+        return ""
+
+
+def get_cached_transcript_summary(db: Session, call_session: CallSession) -> str:
+    """
+    2-sentence Gemini summary of the call transcript, cached on
+    call_session.call_metadata["ghl_call_summary"] so a retried write-back
+    never calls Gemini twice for the same call.
+    """
+    metadata = call_session.call_metadata or {}
+    if "ghl_call_summary" in metadata:
+        return metadata.get("ghl_call_summary") or ""
+
+    summary = generate_transcript_summary(db, call_session)
+
+    try:
+        with db.begin_nested():
+            updated_metadata = dict(call_session.call_metadata or {})
+            updated_metadata["ghl_call_summary"] = summary
+            call_session.call_metadata = updated_metadata
+            flag_modified(call_session, "call_metadata")
+            db.add(call_session)
+            db.flush()
+    except Exception:
+        logger.warning(
+            "Failed to cache GHL call summary on call_session (non-critical)", exc_info=True
+        )
+
+    return summary
+
+
+def build_note_content(
+    *, duration_seconds: int, outcome: Optional[str], summary: str
+) -> str:
+    """Note body: call duration, outcome, and the 2-sentence Gemini summary."""
+    summary_text = summary or "No summary available."
+    return (
+        f"Call duration: {max(int(duration_seconds), 0)}s. "
+        f"Outcome: {outcome or 'completed'}. "
+        f"Summary: {summary_text}"
+    )
+
+
+async def create_note(
+    access_token: str, contact_id: str, content: str, tenant_id: uuid.UUID
+) -> dict:
+    await check_rate_limit(tenant_id)
+    url = f"{_api_base_url()}/contacts/{contact_id}/notes"
+    response = await _request_with_backoff(
+        "POST",
+        url,
+        headers={**_api_headers(access_token), "Content-Type": "application/json"},
+        json={"body": content},
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+_MAX_ERROR_LEN = 500
+
+
+def _safe_error_msg(exc: Exception) -> str:
+    """Extract a brief, safe error summary for tenant-visible storage."""
+    msg = str(exc)
+    # Redact anything that looks like a bearer token
+    msg = re.sub(r'Bearer [A-Za-z0-9\-._~+/]+=*', 'Bearer [redacted]', msg)
+    return msg[:_MAX_ERROR_LEN]
+
+
+async def _run_post_call_writeback_async(db: Session, call_session: CallSession) -> None:
+    tenant_id = call_session.tenant_id
+
+    integration_settings = get_integration_settings(db, tenant_id)
+    if not integration_settings["write_back_enabled"]:
+        logger.info(
+            "GHL write-back skipped — disabled in settings for tenant=%s", tenant_id
+        )
+        return
+
+    # A call can outlast our assumed access-token TTL — always force a fresh
+    # token right before the write-back call rather than trusting the DB's
+    # cached token_expires_at.
+    token_info = await _force_refresh_access_token(db, tenant_id)
+    if not token_info:
+        return
+    access_token, _location_id = token_info
+
+    contact = await get_contact_for_phone(db, tenant_id, call_session.customer_phone_number)
+    if not contact or not contact.get("id"):
+        logger.info(
+            "GHL write-back skipped — no matching contact for session=%s", call_session.id
+        )
+        return
+
+    summary = get_cached_transcript_summary(db, call_session)
+    note_content = build_note_content(
+        duration_seconds=call_session.duration or 0,
+        outcome=call_session.status,
+        summary=summary,
+    )
+
+    async def _write() -> None:
+        await create_note(access_token, contact["id"], note_content, tenant_id)
+
+    try:
+        await _write()
+    except Exception as exc:
+        logger.warning(
+            "GHL note creation failed for session=%s; retrying in %ds: %s",
+            call_session.id,
+            _WRITE_BACK_RETRY_DELAY_SECONDS,
+            exc,
+            exc_info=True,
+        )
+        try:
+            db.rollback()
+        except Exception:
+            logger.warning(
+                "Failed to release DB connection before GHL write-back retry (non-critical)",
+                exc_info=True,
+            )
+        await asyncio.sleep(_WRITE_BACK_RETRY_DELAY_SECONDS)
+        try:
+            await _write()
+        except Exception as retry_exc:
+            logger.error(
+                "GHL note creation failed after retry for session=%s: %s",
+                call_session.id,
+                retry_exc,
+                exc_info=True,
+            )
+            record_write_back_failure(db, tenant_id, _safe_error_msg(retry_exc))
+            return
+
+    set_last_ghl_error(db, tenant_id, None)
+    logger.info(
+        "GHL note created for session=%s contact=%s", call_session.id, contact["id"]
+    )
+
+
+async def _post_call_writeback_arq_task(ctx: dict, call_session_id: str) -> None:
+    """
+    ARQ job entrypoint — registered as ``ghl_post_call_writeback`` in
+    app/workers/batch_call_worker.py::WorkerSettings.functions.
+    """
+    db: Session = SessionLocal()
+    try:
+        session_uuid = uuid.UUID(call_session_id)
+        call_session = db.query(CallSession).filter(CallSession.id == session_uuid).first()
+        if not call_session or not call_session.customer_phone_number:
+            return
+        if not tenant_has_ghl_connected(db, call_session.tenant_id):
+            return
+
+        await _run_post_call_writeback_async(db, call_session)
+    except Exception:
+        logger.warning(
+            "GHL post-call write-back failed (non-critical) session=%s",
+            call_session_id,
+            exc_info=True,
+        )
+    finally:
+        db.close()
+
+
+def schedule_ghl_writeback(call_session_id: uuid.UUID) -> None:
+    """
+    Enqueue the post-call write-back as an ARQ background job. Fire-and-forget
+    — never blocks the caller. Fails open if the ARQ pool isn't ready: GHL
+    sync is best-effort and must never affect call completion.
+    """
+    pool = get_arq_pool()
+    if pool is None:
+        logger.warning(
+            "ARQ pool not ready; GHL write-back skipped for session=%s", call_session_id
+        )
+        return
+
+    async def _enqueue() -> None:
+        try:
+            await pool.enqueue_job("ghl_post_call_writeback", str(call_session_id))
+        except Exception as exc:
+            logger.warning("Failed to enqueue GHL write-back job: %s", exc)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(_enqueue())
+        return
+    asyncio.create_task(_enqueue())

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -595,6 +595,37 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 else:
                     system_prompt = system_prompt + "\n\n" + salesforce_context_block
 
+            # GoHighLevel (GHL) CRM context injection: same fail-open, once-per-call,
+            # call_metadata-cached pattern as the HubSpot/Salesforce blocks above.
+            ghl_context_block = ""
+            if self._h.call_session and self._h.db:
+                try:
+                    from app.services import ghl_service
+
+                    ghl_context_block = await asyncio.wait_for(
+                        ghl_service.get_crm_context_block_for_call(
+                            self._h.db, self._h.call_session
+                        ),
+                        timeout=0.6,
+                    )
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "GHL CRM context lookup timed out; proceeding without CRM context"
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "GHL CRM context lookup failed; proceeding without context: %s", exc
+                    )
+
+            if ghl_context_block:
+                anchor = "# CONVERSATION STATE"
+                if anchor in system_prompt:
+                    system_prompt = system_prompt.replace(
+                        anchor, ghl_context_block + "\n\n" + anchor, 1
+                    )
+                else:
+                    system_prompt = system_prompt + "\n\n" + ghl_context_block
+
             # Cross-session caller memory: fetched once at call start (DB lookup,
             # 100ms timeout budget, fail-open) and cached on call_session.call_metadata
             # so every later turn is a cheap in-memory dict read. Injected right after

--- a/app/workers/batch_call_worker.py
+++ b/app/workers/batch_call_worker.py
@@ -285,6 +285,19 @@ async def run_data_export_job(ctx: dict, export_job_id: str) -> None:
         db.close()
 
 
+# ── GoHighLevel (GHL) post-call write-back ────────────────────────────────────
+
+
+async def ghl_post_call_writeback(ctx: dict, call_session_id: str) -> None:
+    """
+    ARQ job: create a GHL note summarizing a completed call. Enqueued by
+    app.services.ghl_service.schedule_ghl_writeback on call completion.
+    """
+    from app.services.ghl_service import _post_call_writeback_arq_task
+
+    await _post_call_writeback_arq_task(ctx, call_session_id)
+
+
 # ── Smart Callback tasks (ARQ-based replacement for APScheduler polling) ─────
 
 
@@ -582,6 +595,7 @@ class WorkerSettings:
         retry_webhook_delivery,
         kb_ingestion_task,
         execute_callback,
+        ghl_post_call_writeback,
         purge_old_audit_logs,
         run_data_export_job,
         # poll_pending_callbacks kept for manual/admin invocation; not in cron_jobs

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7055,6 +7055,148 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/integrations/leadconnector:
+    get:
+      tags:
+      - GoHighLevel Integration
+      summary: Ghl Get Integration Status
+      description: Connection status and write-back toggle for this workspace.
+      operationId: ghl_get_integration_status_api_v1_integrations_leadconnector_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_GhlIntegrationStatusOut_'
+      security:
+      - HTTPBearer: []
+    delete:
+      tags:
+      - GoHighLevel Integration
+      summary: Ghl Disconnect
+      description: Revoke local GHL OAuth credentials and delete the workspaceintegration
+        row.
+      operationId: ghl_disconnect_api_v1_integrations_leadconnector_delete
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_GhlDisconnectResponse_'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/leadconnector/settings:
+    put:
+      tags:
+      - GoHighLevel Integration
+      summary: Ghl Update Settings
+      description: Toggle post-call write-back for this workspace.
+      operationId: ghl_update_settings_api_v1_integrations_leadconnector_settings_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GhlSettingsUpdateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_GhlIntegrationStatusOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/leadconnector/sync-status:
+    get:
+      tags:
+      - GoHighLevel Integration
+      summary: Ghl Sync Status
+      description: Last contact-lookup/write-back times, write-back status, and rolling
+        24h error count.
+      operationId: ghl_sync_status_api_v1_integrations_leadconnector_sync_status_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_GhlSyncStatusOut_'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/leadconnector/contact:
+    get:
+      tags:
+      - GoHighLevel Integration
+      summary: Ghl Get Contact
+      description: Contacts API lookup by phone. Redis-cached for 5 minutes per phone
+        number.
+      operationId: ghl_get_contact_api_v1_integrations_leadconnector_contact_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: phone
+        in: query
+        required: true
+        schema:
+          type: string
+          description: Phone number to search for (E.164 or local format)
+          title: Phone
+        description: Phone number to search for (E.164 or local format)
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_GhlContactOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/integrations/leadconnector/note:
+    post:
+      tags:
+      - GoHighLevel Integration
+      summary: Ghl Create Note
+      description: 'Create a note directly against a GHL contact. Writes to the tenant''s
+        live
+
+        CRM, so (like /settings) this requires manager+ rather than any authenticated
+
+        member — a read_only member must not be able to write into GoHighLevel.'
+      operationId: ghl_create_note_api_v1_integrations_leadconnector_note_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GhlNoteCreateRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_GhlNoteCreateResponse_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /api/v1/calls/history:
     get:
       tags:
@@ -12559,6 +12701,120 @@ components:
       type: object
       title: GapInterval
       description: A single time gap between callback attempts.
+    GhlContactOut:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+          default: []
+        pipeline_stage:
+          type: string
+          nullable: true
+        last_activity_date:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - id
+      title: GhlContactOut
+    GhlDisconnectResponse:
+      properties:
+        disconnected:
+          type: boolean
+          title: Disconnected
+        provider:
+          type: string
+          title: Provider
+          default: gohighlevel
+      type: object
+      required:
+      - disconnected
+      title: GhlDisconnectResponse
+    GhlIntegrationStatusOut:
+      properties:
+        connected:
+          type: boolean
+          title: Connected
+        connected_at:
+          type: string
+          format: date-time
+          nullable: true
+        last_sync_at:
+          type: string
+          nullable: true
+        write_back_enabled:
+          type: boolean
+          title: Write Back Enabled
+          default: true
+      type: object
+      required:
+      - connected
+      title: GhlIntegrationStatusOut
+    GhlNoteCreateRequest:
+      properties:
+        contact_id:
+          type: string
+          title: Contact Id
+        content:
+          type: string
+          title: Content
+      type: object
+      required:
+      - contact_id
+      - content
+      title: GhlNoteCreateRequest
+    GhlNoteCreateResponse:
+      properties:
+        id:
+          type: string
+          nullable: true
+        contact_id:
+          type: string
+          title: Contact Id
+      type: object
+      required:
+      - contact_id
+      title: GhlNoteCreateResponse
+    GhlSettingsUpdateRequest:
+      properties:
+        write_back_enabled:
+          type: boolean
+          title: Write Back Enabled
+      type: object
+      required:
+      - write_back_enabled
+      title: GhlSettingsUpdateRequest
+    GhlSyncStatusOut:
+      properties:
+        last_lookup_at:
+          type: string
+          nullable: true
+        last_write_back_at:
+          type: string
+          nullable: true
+        last_write_back_status:
+          type: string
+          nullable: true
+        last_ghl_error:
+          type: string
+          nullable: true
+        error_count_24h:
+          type: integer
+          title: Error Count 24H
+          default: 0
+      type: object
+      title: GhlSyncStatusOut
     GoogleLoginRequest:
       properties:
         google_token:
@@ -16598,6 +16854,86 @@ components:
       required:
       - data
       title: SuccessResponse[ForgotPasswordResponse]
+    SuccessResponse_GhlContactOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/GhlContactOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[GhlContactOut]
+    SuccessResponse_GhlDisconnectResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/GhlDisconnectResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[GhlDisconnectResponse]
+    SuccessResponse_GhlIntegrationStatusOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/GhlIntegrationStatusOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[GhlIntegrationStatusOut]
+    SuccessResponse_GhlNoteCreateResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/GhlNoteCreateResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[GhlNoteCreateResponse]
+    SuccessResponse_GhlSyncStatusOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/GhlSyncStatusOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[GhlSyncStatusOut]
     SuccessResponse_HubSpotContactOut_:
       properties:
         data:

--- a/tests/api/test_ghl_integration.py
+++ b/tests/api/test_ghl_integration.py
@@ -1,0 +1,479 @@
+"""
+Tests for GoHighLevel (GHL) OAuth integration router endpoints.
+
+Router functions are called directly (mirroring tests/api/test_salesforce_integration.py),
+with `db` mocked and external GHL calls patched at the service boundary.
+
+Coverage:
+  1.  GET /connect — redirects to GHL's OAuth consent page
+  2.  GET /callback — exchanges mock code for tokens, stores them, redirects
+  3.  GET /callback — invalid state -> 400; token exchange failure -> 502
+  4.  GET /contact — correct response shape; not connected -> 400; not found -> 404
+  5.  POST /note — creates a note directly; not connected -> 400; upstream failure -> 502
+  6.  DELETE "" — disconnects; 404 when not connected
+  7.  GET /api/v1/integrations — includes a GoHighLevel entry with connected/connected_at
+  8.  GET "" / PUT /settings / GET /sync-status — status and toggle round trip
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_TENANT_ID = uuid.UUID("aa300000-0000-0000-0000-000000000001")
+
+
+def _principal():
+    p = MagicMock()
+    p.current_tenant_id = _TENANT_ID
+    return p
+
+
+class TestConnect:
+    @pytest.mark.anyio
+    async def test_redirects_to_ghl(self):
+        from app.routers.ghl_integration import ghl_connect
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.build_oauth_state",
+                return_value="signed-state",
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.build_authorization_url",
+                return_value="https://marketplace.gohighlevel.com/oauth/chooselocation?client_id=abc&state=signed-state",
+            ),
+        ):
+            response = await ghl_connect(principal=_principal())
+
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://marketplace.gohighlevel.com/oauth/chooselocation?client_id=abc&state=signed-state"
+        )
+
+
+class TestCallback:
+    @pytest.mark.anyio
+    async def test_exchanges_code_and_stores_tokens(self):
+        from app.routers.ghl_integration import ghl_callback
+
+        db = MagicMock()
+        token_response = {
+            "access_token": "a",
+            "refresh_token": "r",
+            "expires_in": 3600,
+            "locationId": "loc-1",
+        }
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.exchange_code_for_tokens",
+                new=AsyncMock(return_value=token_response),
+            ) as mock_exchange,
+            patch(
+                "app.routers.ghl_integration.ghl_service.upsert_tokens"
+            ) as mock_upsert,
+        ):
+            response = await ghl_callback(code="mock-auth-code", state="signed-state", db=db)
+
+        mock_exchange.assert_awaited_once_with("mock-auth-code")
+        mock_upsert.assert_called_once_with(db, _TENANT_ID, token_response)
+        assert response.status_code == 302
+        assert "ghl=connected" in response.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_invalid_state_returns_400(self):
+        from app.routers.ghl_integration import ghl_callback
+
+        with patch(
+            "app.routers.ghl_integration.ghl_service.verify_oauth_state",
+            side_effect=ValueError("Invalid or expired OAuth state"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_callback(code="mock-auth-code", state="bad-state", db=MagicMock())
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_token_exchange_failure_returns_502(self):
+        from app.routers.ghl_integration import ghl_callback
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.exchange_code_for_tokens",
+                new=AsyncMock(side_effect=Exception("GHL 400")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_callback(code="mock-auth-code", state="signed-state", db=MagicMock())
+
+        assert exc_info.value.status_code == 502
+
+
+class TestContactEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_correct_shape(self):
+        from app.routers.ghl_integration import ghl_get_contact
+
+        contact = {
+            "id": "contact-1",
+            "name": "Ada Lovelace",
+            "email": "ada@example.com",
+            "tags": ["vip"],
+            "pipeline_stage": "Negotiation",
+            "last_activity_date": "2026-06-01T00:00:00Z",
+        }
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+        ):
+            result = await ghl_get_contact(
+                phone="+61412345678", principal=_principal(), db=MagicMock()
+            )
+
+        assert result.data.id == "contact-1"
+        assert result.data.name == "Ada Lovelace"
+        assert result.data.tags == ["vip"]
+        assert result.data.pipeline_stage == "Negotiation"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_400(self):
+        from app.routers.ghl_integration import ghl_get_contact
+
+        with patch(
+            "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_get_contact(
+                    phone="+61412345678", principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_no_match_returns_404(self):
+        from app.routers.ghl_integration import ghl_get_contact
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.get_contact_for_phone",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_get_contact(
+                    phone="+61412345678", principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 404
+
+
+class TestNoteEndpoint:
+    @pytest.mark.anyio
+    async def test_creates_note_successfully(self):
+        from app.routers.ghl_integration import ghl_create_note
+        from app.schemas.ghl_integration import GhlNoteCreateRequest
+
+        payload = GhlNoteCreateRequest(contact_id="contact-1", content="Called about billing.")
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.create_note",
+                new=AsyncMock(return_value={"id": "note-1"}),
+            ) as mock_create,
+        ):
+            result = await ghl_create_note(payload=payload, principal=_principal(), db=MagicMock())
+
+        mock_create.assert_awaited_once_with(
+            "access-token", "contact-1", "Called about billing.", _TENANT_ID
+        )
+        assert result.data.contact_id == "contact-1"
+        assert result.data.id == "note-1"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_400(self):
+        from app.routers.ghl_integration import ghl_create_note
+        from app.schemas.ghl_integration import GhlNoteCreateRequest
+
+        payload = GhlNoteCreateRequest(contact_id="contact-1", content="Called about billing.")
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+                return_value=False,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.get_valid_access_token",
+            ) as mock_get_token,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_create_note(payload=payload, principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 400
+        mock_get_token.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_connected_but_token_unavailable_returns_502(self):
+        """
+        Connected, but the token refresh failed (e.g. a transient GHL outage or
+        a revoked refresh token) — must be distinguished from "never connected"
+        so the client isn't told to redo the OAuth flow unnecessarily.
+        """
+        from app.routers.ghl_integration import ghl_create_note
+        from app.schemas.ghl_integration import GhlNoteCreateRequest
+
+        payload = GhlNoteCreateRequest(contact_id="contact-1", content="Called about billing.")
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_create_note(payload=payload, principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.anyio
+    async def test_upstream_failure_returns_502(self):
+        from app.routers.ghl_integration import ghl_create_note
+        from app.schemas.ghl_integration import GhlNoteCreateRequest
+
+        payload = GhlNoteCreateRequest(contact_id="contact-1", content="Called about billing.")
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.create_note",
+                new=AsyncMock(side_effect=Exception("GHL 500")),
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_create_note(payload=payload, principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 502
+
+
+class TestIntegrationStatusEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_status_shape(self):
+        from app.routers.ghl_integration import ghl_get_integration_status
+
+        connected_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        settings = {
+            "connected": True,
+            "connected_at": connected_at,
+            "last_sync_at": "2026-06-02T00:00:00Z",
+            "write_back_enabled": False,
+        }
+
+        with patch(
+            "app.routers.ghl_integration.ghl_service.get_integration_settings",
+            return_value=settings,
+        ):
+            result = await ghl_get_integration_status(principal=_principal(), db=MagicMock())
+
+        assert result.data.connected is True
+        assert result.data.connected_at == connected_at
+        assert result.data.last_sync_at == "2026-06-02T00:00:00Z"
+        assert result.data.write_back_enabled is False
+
+
+class TestSettingsEndpoint:
+    @pytest.mark.anyio
+    async def test_updates_settings(self):
+        from app.routers.ghl_integration import ghl_update_settings
+        from app.schemas.ghl_integration import GhlSettingsUpdateRequest
+
+        payload = GhlSettingsUpdateRequest(write_back_enabled=False)
+
+        with (
+            patch(
+                "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.ghl_integration.ghl_service.update_integration_settings"
+            ) as mock_update,
+            patch(
+                "app.routers.ghl_integration.ghl_service.get_integration_settings",
+                return_value={
+                    "connected": True,
+                    "connected_at": datetime.now(timezone.utc),
+                    "last_sync_at": None,
+                    "write_back_enabled": False,
+                },
+            ),
+        ):
+            result = await ghl_update_settings(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
+
+        mock_update.assert_called_once_with(
+            mock_update.call_args[0][0], _TENANT_ID, write_back_enabled=False
+        )
+        assert result.data.write_back_enabled is False
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_400(self):
+        from app.routers.ghl_integration import ghl_update_settings
+        from app.schemas.ghl_integration import GhlSettingsUpdateRequest
+
+        payload = GhlSettingsUpdateRequest(write_back_enabled=False)
+
+        with patch(
+            "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
+            return_value=False,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_update_settings(
+                    payload=payload, principal=_principal(), db=MagicMock()
+                )
+
+        assert exc_info.value.status_code == 400
+
+
+class TestSyncStatusEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_sync_status_shape(self):
+        from app.routers.ghl_integration import ghl_sync_status
+
+        sync_status = {
+            "last_lookup_at": "2026-06-01T00:00:00Z",
+            "last_write_back_at": "2026-06-01T00:05:00Z",
+            "last_write_back_status": "success",
+            "last_ghl_error": None,
+            "error_count_24h": 0,
+        }
+
+        with patch(
+            "app.routers.ghl_integration.ghl_service.get_sync_status",
+            return_value=sync_status,
+        ):
+            result = await ghl_sync_status(principal=_principal(), db=MagicMock())
+
+        assert result.data.last_lookup_at == "2026-06-01T00:00:00Z"
+        assert result.data.last_write_back_status == "success"
+        assert result.data.error_count_24h == 0
+
+
+class TestDisconnectEndpoint:
+    @pytest.mark.anyio
+    async def test_disconnects_successfully(self):
+        from app.routers.ghl_integration import ghl_disconnect
+
+        with patch(
+            "app.routers.ghl_integration.ghl_service.disconnect",
+            new=AsyncMock(return_value=True),
+        ):
+            result = await ghl_disconnect(principal=_principal(), db=MagicMock())
+
+        assert result.data.disconnected is True
+        assert result.data.provider == "gohighlevel"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_404(self):
+        from app.routers.ghl_integration import ghl_disconnect
+
+        with patch(
+            "app.routers.ghl_integration.ghl_service.disconnect",
+            new=AsyncMock(return_value=False),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await ghl_disconnect(principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 404
+
+
+class TestIntegrationListIncludesGhl:
+    @pytest.mark.anyio
+    async def test_list_integrations_includes_ghl_status(self):
+        from app.routers.integrations import list_integrations
+
+        request = MagicMock()
+        tenant = MagicMock()
+        tenant.id = _TENANT_ID
+        tenant.workspace_settings = {}
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = tenant
+
+        connected_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+        with (
+            patch(
+                "app.core.request_auth.get_workspace_from_request",
+                return_value=MagicMock(id=_TENANT_ID),
+            ),
+            patch(
+                "app.services.hubspot_service.get_connection_status",
+                return_value=(False, None),
+            ),
+            patch(
+                "app.services.salesforce_service.get_connection_status",
+                return_value=(False, None),
+            ),
+            patch(
+                "app.services.ghl_service.get_connection_status",
+                return_value=(True, connected_at),
+            ),
+            patch(
+                "app.services.ghl_service.get_sync_status",
+                return_value={
+                    "last_lookup_at": None,
+                    "last_write_back_at": "2026-06-02T00:00:00Z",
+                    "last_write_back_status": "success",
+                    "last_ghl_error": None,
+                    "error_count_24h": 0,
+                },
+            ),
+        ):
+            result = await list_integrations(request=request, user=_principal(), db=db)
+
+        ghl_item = next(i for i in result.integrations if i.name == "GoHighLevel")
+        assert ghl_item.connected is True
+        assert ghl_item.connected_at == connected_at
+        assert ghl_item.last_sync_at == "2026-06-02T00:00:00Z"

--- a/tests/api/test_hubspot_integration.py
+++ b/tests/api/test_hubspot_integration.py
@@ -538,6 +538,10 @@ class TestIntegrationListIncludesHubSpot:
                 "app.services.salesforce_service.get_connection_status",
                 return_value=(False, None),
             ),
+            patch(
+                "app.services.ghl_service.get_connection_status",
+                return_value=(False, None),
+            ),
         ):
             result = await list_integrations(request=request, user=_principal(), db=db)
 

--- a/tests/api/test_salesforce_integration.py
+++ b/tests/api/test_salesforce_integration.py
@@ -362,6 +362,10 @@ class TestIntegrationListIncludesSalesforce:
                     "error_count_24h": 0,
                 },
             ),
+            patch(
+                "app.services.ghl_service.get_connection_status",
+                return_value=(False, None),
+            ),
         ):
             result = await list_integrations(request=request, user=_principal(), db=db)
 

--- a/tests/services/test_ghl_service.py
+++ b/tests/services/test_ghl_service.py
@@ -1,0 +1,972 @@
+"""
+Tests for GoHighLevel (GHL) CRM integration service.
+
+External HTTP calls (OAuth token endpoint, Contacts API, Notes API) are mocked
+at the boundary (`_request_with_backoff`) per CLAUDE.md convention.
+
+Coverage:
+  1.  OAuth state: sign/verify round trip, tamper rejection, wrong purpose rejection
+  2.  Authorization URL: client_id/scope/state present
+  3.  Token refresh: returns cached (token, location_id) when fresh; refreshes when
+      within 5 min of expiry; persists location_id; returns None when no refresh_token;
+      fails open
+  4.  Contact lookup: correct {id, name, email, tags, pipeline_stage, last_activity_date}
+      shape; E.164-then-local fallback; Redis cache hit/miss/store; fails open on GHL error
+  5.  CRM context block: exact "CRM CONTEXT (GoHighLevel): ..." format, cached on
+      call_metadata after first fetch; fails open
+  6.  Post-call write-back: creates a note with duration/outcome/Gemini summary;
+      skips when write-back disabled; records/clears last_ghl_error; retries once
+  7.  Disconnect: deletes local row; returns False when not connected
+  8.  429 backoff: retries with exponential delay, honors Retry-After
+  9.  Phone normalization / local-format fallback
+  10. Redis-backed rate limiter: no-ops without Redis; waits when over budget
+  11. ARQ enqueue: schedule_ghl_writeback enqueues the job; fails open without a pool
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import ghl_service
+
+
+_TENANT_ID = uuid.UUID("aa300000-0000-0000-0000-000000000001")
+_SESSION_ID = uuid.UUID("bb300000-0000-0000-0000-000000000002")
+
+
+# ── OAuth state ────────────────────────────────────────────────────────────────
+
+
+class TestOAuthState:
+    def test_roundtrip(self):
+        state = ghl_service.build_oauth_state(_TENANT_ID)
+        assert ghl_service.verify_oauth_state(state) == _TENANT_ID
+
+    def test_tampered_state_rejected(self):
+        state = ghl_service.build_oauth_state(_TENANT_ID)
+        with pytest.raises(ValueError):
+            ghl_service.verify_oauth_state(state + "x")
+
+    def test_wrong_purpose_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        bad_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "something_else",
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            ghl_service.verify_oauth_state(bad_state)
+
+    def test_expired_state_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        expired_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "ghl_oauth_state",
+                "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            ghl_service.verify_oauth_state(expired_state)
+
+
+class TestAuthorizationUrl:
+    def test_contains_client_id_scope_and_state(self):
+        with patch(
+            "app.services.ghl_service.get_ghl_oauth_credentials",
+            return_value=("client-123", "secret-456"),
+        ):
+            state = ghl_service.build_oauth_state(_TENANT_ID)
+            url = ghl_service.build_authorization_url(state)
+
+        assert url.startswith("https://marketplace.gohighlevel.com/oauth/chooselocation")
+        assert "client_id=client-123" in url
+        assert "contacts.readonly" in url
+        assert f"state={state}" in url
+
+
+# ── Token refresh ──────────────────────────────────────────────────────────────
+
+
+def _integration_row(*, expires_in_seconds: float, has_refresh_token: bool = True, location_id="loc-1"):
+    row = MagicMock()
+    row.access_token = "encrypted-access-token"
+    row.refresh_token = "encrypted-refresh-token" if has_refresh_token else None
+    row.token_expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
+    row.extra_metadata = {"location_id": location_id} if location_id else {}
+    return row
+
+
+class TestTokenRefresh:
+    @pytest.mark.anyio
+    async def test_returns_existing_token_when_not_near_expiry(self):
+        row = _integration_row(expires_in_seconds=600)
+        db = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.get_integration", return_value=row),
+            patch(
+                "app.services.ghl_service.decrypt_ghl_token",
+                return_value="plain-access-token",
+            ) as mock_decrypt,
+        ):
+            result = await ghl_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert result == ("plain-access-token", "loc-1")
+        mock_decrypt.assert_called_once_with(row.access_token, db)
+
+    @pytest.mark.anyio
+    async def test_refreshes_when_within_5_minutes_of_expiry(self):
+        row = _integration_row(expires_in_seconds=120)
+        db = MagicMock()
+        new_row = _integration_row(expires_in_seconds=3600, location_id="loc-1")
+
+        with (
+            patch("app.services.ghl_service.get_integration", return_value=row),
+            patch(
+                "app.services.ghl_service.decrypt_ghl_token",
+                side_effect=["plain-refresh-token", "new-plain-access-token"],
+            ),
+            patch(
+                "app.services.ghl_service.refresh_access_token",
+                new=AsyncMock(
+                    return_value={
+                        "access_token": "new",
+                        "refresh_token": "new-refresh",
+                        "expires_in": 3600,
+                        "locationId": "loc-1",
+                    }
+                ),
+            ) as mock_refresh,
+            patch("app.services.ghl_service.upsert_tokens", return_value=new_row) as mock_upsert,
+        ):
+            result = await ghl_service.get_valid_access_token(db, _TENANT_ID)
+
+        mock_refresh.assert_awaited_once_with("plain-refresh-token")
+        mock_upsert.assert_called_once()
+        assert result == ("new-plain-access-token", "loc-1")
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_expired_and_no_refresh_token(self):
+        row = _integration_row(expires_in_seconds=-60, has_refresh_token=False)
+        db = MagicMock()
+
+        with patch("app.services.ghl_service.get_integration", return_value=row):
+            result = await ghl_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_no_integration(self):
+        db = MagicMock()
+        with patch("app.services.ghl_service.get_integration", return_value=None):
+            result = await ghl_service.get_valid_access_token(db, _TENANT_ID)
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_no_location_id_stored(self):
+        row = _integration_row(expires_in_seconds=600, location_id=None)
+        db = MagicMock()
+        with patch("app.services.ghl_service.get_integration", return_value=row):
+            result = await ghl_service.get_valid_access_token(db, _TENANT_ID)
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_refresh_failure_fails_open(self):
+        row = _integration_row(expires_in_seconds=120)
+        db = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.get_integration", return_value=row),
+            patch(
+                "app.services.ghl_service.decrypt_ghl_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.ghl_service.refresh_access_token",
+                new=AsyncMock(side_effect=Exception("GHL down")),
+            ),
+        ):
+            result = await ghl_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert result is None
+
+
+class TestForceRefreshAccessToken:
+    @pytest.mark.anyio
+    async def test_always_refreshes_even_when_not_expired(self):
+        row = _integration_row(expires_in_seconds=3600)
+        db = MagicMock()
+        new_row = _integration_row(expires_in_seconds=3600)
+
+        with (
+            patch("app.services.ghl_service.get_integration", return_value=row),
+            patch(
+                "app.services.ghl_service.decrypt_ghl_token",
+                side_effect=["plain-refresh-token", "new-token"],
+            ),
+            patch(
+                "app.services.ghl_service.refresh_access_token",
+                new=AsyncMock(return_value={"access_token": "new", "locationId": "loc-1"}),
+            ) as mock_refresh,
+            patch("app.services.ghl_service.upsert_tokens", return_value=new_row),
+        ):
+            result = await ghl_service._force_refresh_access_token(db, _TENANT_ID)
+
+        mock_refresh.assert_awaited_once()
+        assert result == ("new-token", "loc-1")
+
+    @pytest.mark.anyio
+    async def test_fails_open_when_refresh_errors(self):
+        row = _integration_row(expires_in_seconds=3600)
+        db = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.get_integration", return_value=row),
+            patch(
+                "app.services.ghl_service.decrypt_ghl_token",
+                return_value="plain-refresh-token",
+            ),
+            patch(
+                "app.services.ghl_service.refresh_access_token",
+                new=AsyncMock(side_effect=Exception("down")),
+            ),
+        ):
+            result = await ghl_service._force_refresh_access_token(db, _TENANT_ID)
+
+        assert result is None
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_get_valid_access_token_when_no_refresh_token(self):
+        row = _integration_row(expires_in_seconds=3600, has_refresh_token=False)
+        db = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.get_integration", return_value=row),
+            patch(
+                "app.services.ghl_service.decrypt_ghl_token",
+                return_value="plain-access-token",
+            ),
+        ):
+            result = await ghl_service._force_refresh_access_token(db, _TENANT_ID)
+
+        assert result == ("plain-access-token", "loc-1")
+
+
+# ── Contact lookup ──────────────────────────────────────────────────────────────
+
+
+_RAW_CONTACT = {
+    "id": "contact-1",
+    "firstName": "Ada",
+    "lastName": "Lovelace",
+    "email": "ada@example.com",
+    "tags": ["vip", "lead"],
+    "pipelineStage": "Negotiation",
+    "lastActivity": "2026-06-01T00:00:00Z",
+}
+
+
+class TestContactShape:
+    def test_contact_dict_from_ghl_shape(self):
+        contact = ghl_service._contact_dict_from_ghl(_RAW_CONTACT)
+        assert contact == {
+            "id": "contact-1",
+            "name": "Ada Lovelace",
+            "email": "ada@example.com",
+            "tags": ["vip", "lead"],
+            "pipeline_stage": "Negotiation",
+            "last_activity_date": "2026-06-01T00:00:00Z",
+        }
+
+    def test_missing_name_fields_resolve_to_none(self):
+        raw = {"id": "1", "email": "a@b.com"}
+        contact = ghl_service._contact_dict_from_ghl(raw)
+        assert contact["name"] is None
+        assert contact["tags"] == []
+
+
+class TestLocalFormatFallback:
+    def test_au_number_strips_country_code_and_prepends_zero(self):
+        assert ghl_service.local_format_fallback("+61412345678") == "0412345678"
+
+    def test_uk_number(self):
+        assert ghl_service.local_format_fallback("+447911123456") == "07911123456"
+
+    def test_nanp_number_has_no_local_fallback(self):
+        assert ghl_service.local_format_fallback("+15550001111") is None
+
+    def test_empty_input(self):
+        assert ghl_service.local_format_fallback("") is None
+
+
+class TestSearchContactByPhone:
+    @pytest.mark.anyio
+    async def test_e164_match_found_on_first_try(self):
+        response = MagicMock()
+        response.json.return_value = {"contacts": [_RAW_CONTACT]}
+        response.raise_for_status = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.check_rate_limit", new=AsyncMock()),
+            patch(
+                "app.services.ghl_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ) as mock_request,
+        ):
+            contact = await ghl_service.search_contact_by_phone(
+                "token", "loc-1", "+61412345678", _TENANT_ID
+            )
+
+        assert contact == _RAW_CONTACT
+        assert mock_request.await_count == 1
+        assert mock_request.call_args.kwargs["params"]["phone"] == "+61412345678"
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_local_format_when_e164_has_no_match(self):
+        empty_response = MagicMock()
+        empty_response.json.return_value = {"contacts": []}
+        empty_response.raise_for_status = MagicMock()
+        match_response = MagicMock()
+        match_response.json.return_value = {"contacts": [_RAW_CONTACT]}
+        match_response.raise_for_status = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.check_rate_limit", new=AsyncMock()),
+            patch(
+                "app.services.ghl_service._request_with_backoff",
+                new=AsyncMock(side_effect=[empty_response, match_response]),
+            ) as mock_request,
+        ):
+            contact = await ghl_service.search_contact_by_phone(
+                "token", "loc-1", "+61412345678", _TENANT_ID
+            )
+
+        assert contact == _RAW_CONTACT
+        assert mock_request.await_count == 2
+        assert mock_request.call_args_list[0].kwargs["params"]["phone"] == "+61412345678"
+        assert mock_request.call_args_list[1].kwargs["params"]["phone"] == "0412345678"
+
+    @pytest.mark.anyio
+    async def test_no_match_returns_none(self):
+        empty_response = MagicMock()
+        empty_response.json.return_value = {"contacts": []}
+        empty_response.raise_for_status = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.check_rate_limit", new=AsyncMock()),
+            patch(
+                "app.services.ghl_service._request_with_backoff",
+                new=AsyncMock(return_value=empty_response),
+            ),
+        ):
+            contact = await ghl_service.search_contact_by_phone(
+                "token", "loc-1", "+15550001111", _TENANT_ID
+            )
+
+        assert contact is None
+
+
+class TestGetContactForPhone:
+    @pytest.mark.anyio
+    async def test_cache_hit_skips_ghl_call(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(
+            return_value='{"id": "1", "name": "Cached Person", "email": null, "tags": [], "pipeline_stage": null, "last_activity_date": null}'
+        )
+
+        with (
+            patch("app.services.ghl_service.get_redis", return_value=mock_redis),
+            patch("app.services.ghl_service.get_valid_access_token") as mock_token,
+        ):
+            contact = await ghl_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        mock_token.assert_not_called()
+        assert contact["name"] == "Cached Person"
+
+    @pytest.mark.anyio
+    async def test_cache_miss_fetches_and_stores(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock()
+
+        with (
+            patch("app.services.ghl_service.get_redis", return_value=mock_redis),
+            patch(
+                "app.services.ghl_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ),
+            patch(
+                "app.services.ghl_service.search_contact_by_phone",
+                new=AsyncMock(return_value=_RAW_CONTACT),
+            ),
+        ):
+            contact = await ghl_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact["id"] == "contact-1"
+        assert contact["name"] == "Ada Lovelace"
+        mock_redis.set.assert_awaited_once()
+        _, kwargs = mock_redis.set.call_args
+        assert kwargs.get("ex") == 300
+
+    @pytest.mark.anyio
+    async def test_no_match_caches_not_found_sentinel(self):
+        db = MagicMock()
+        mock_redis = AsyncMock()
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.set = AsyncMock()
+
+        with (
+            patch("app.services.ghl_service.get_redis", return_value=mock_redis),
+            patch(
+                "app.services.ghl_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ),
+            patch(
+                "app.services.ghl_service.search_contact_by_phone",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            contact = await ghl_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+        mock_redis.set.assert_awaited_once_with(
+            ghl_service._contact_cache_key(_TENANT_ID, "+15550001111"),
+            ghl_service._CONTACT_NOT_FOUND_SENTINEL,
+            ex=300,
+        )
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_ghl_error(self):
+        """A GHL outage during contact search must never raise — call proceeds without CRM data."""
+        db = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.get_redis", return_value=None),
+            patch(
+                "app.services.ghl_service.get_valid_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ),
+            patch(
+                "app.services.ghl_service.search_contact_by_phone",
+                new=AsyncMock(side_effect=Exception("GHL 500")),
+            ),
+        ):
+            contact = await ghl_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+
+    @pytest.mark.anyio
+    async def test_no_access_token_returns_none(self):
+        db = MagicMock()
+
+        with (
+            patch("app.services.ghl_service.get_redis", return_value=None),
+            patch(
+                "app.services.ghl_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            contact = await ghl_service.get_contact_for_phone(db, _TENANT_ID, "+15550001111")
+
+        assert contact is None
+
+
+# ── CRM context block ────────────────────────────────────────────────────────────
+
+
+def _call_session(*, phone="+15550001111", metadata=None):
+    cs = MagicMock()
+    cs.id = _SESSION_ID
+    cs.tenant_id = _TENANT_ID
+    cs.customer_phone_number = phone
+    cs.call_metadata = metadata
+    return cs
+
+
+class TestCrmContextBlock:
+    @pytest.mark.anyio
+    async def test_returns_cached_value_without_refetching(self):
+        db = MagicMock()
+        call_session = _call_session(
+            metadata={"ghl_crm_context": "CRM CONTEXT (GoHighLevel): cached"}
+        )
+
+        with patch("app.services.ghl_service.tenant_has_ghl_connected") as mock_connected:
+            block = await ghl_service.get_crm_context_block_for_call(db, call_session)
+
+        mock_connected.assert_not_called()
+        assert block == "CRM CONTEXT (GoHighLevel): cached"
+
+    @pytest.mark.anyio
+    async def test_fetches_and_caches_on_first_call(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+        contact = {
+            "id": "1",
+            "name": "Ada Lovelace",
+            "email": "ada@example.com",
+            "tags": ["vip", "lead"],
+            "pipeline_stage": "Negotiation",
+        }
+
+        with (
+            patch("app.services.ghl_service.tenant_has_ghl_connected", return_value=True),
+            patch(
+                "app.services.ghl_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ) as mock_get_contact,
+        ):
+            block = await ghl_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == (
+            "CRM CONTEXT (GoHighLevel): Name: Ada Lovelace, "
+            "Tags: vip, lead, Pipeline: Negotiation"
+        )
+        assert call_session.call_metadata["ghl_crm_context"] == block
+        db.flush.assert_called_once()
+        db.commit.assert_not_called()
+        assert mock_get_contact.call_args.kwargs.get("commit_lookup_timestamp") is False
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_empty_block(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch("app.services.ghl_service.tenant_has_ghl_connected", return_value=False):
+            block = await ghl_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == ""
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_exception(self):
+        db = MagicMock()
+        call_session = _call_session(metadata={})
+
+        with patch(
+            "app.services.ghl_service.tenant_has_ghl_connected",
+            side_effect=Exception("DB down"),
+        ):
+            block = await ghl_service.get_crm_context_block_for_call(db, call_session)
+
+        assert block == ""
+
+
+# ── Post-call write-back ───────────────────────────────────────────────────────
+
+
+class TestPostCallWriteback:
+    @staticmethod
+    def _writeback_settings(**overrides):
+        settings = {
+            "connected": True,
+            "connected_at": datetime.now(timezone.utc),
+            "last_sync_at": None,
+            "write_back_enabled": True,
+        }
+        settings.update(overrides)
+        return settings
+
+    @pytest.mark.anyio
+    async def test_creates_note_with_duration_outcome_and_summary(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.id = _SESSION_ID
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.duration = 120
+        call_session.status = "completed"
+        call_session.call_metadata = {}
+
+        contact = {"id": "contact-1", "name": "Ada Lovelace"}
+
+        with (
+            patch(
+                "app.services.ghl_service.get_integration_settings",
+                return_value=self._writeback_settings(),
+            ),
+            patch(
+                "app.services.ghl_service._force_refresh_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ) as mock_force_refresh,
+            patch(
+                "app.services.ghl_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+            patch(
+                "app.services.ghl_service.generate_transcript_summary",
+                return_value="Caller asked about pricing. Agent booked a follow-up demo.",
+            ),
+            patch(
+                "app.services.ghl_service.create_note",
+                new=AsyncMock(return_value={"id": "note-1"}),
+            ) as mock_create_note,
+            patch("app.services.ghl_service.set_last_ghl_error") as mock_set_error,
+        ):
+            await ghl_service._run_post_call_writeback_async(db, call_session)
+
+        mock_force_refresh.assert_awaited_once_with(db, _TENANT_ID)
+        mock_create_note.assert_awaited_once()
+        args, _kwargs = mock_create_note.call_args
+        assert args[0] == "access-token"
+        assert args[1] == "contact-1"
+        assert "120s" in args[2]
+        assert "completed" in args[2]
+        assert "pricing" in args[2]
+        assert args[3] == _TENANT_ID
+        mock_set_error.assert_called_once_with(db, _TENANT_ID, None)
+
+    @pytest.mark.anyio
+    async def test_skips_when_write_back_disabled(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.id = _SESSION_ID
+
+        with (
+            patch(
+                "app.services.ghl_service.get_integration_settings",
+                return_value=self._writeback_settings(write_back_enabled=False),
+            ),
+            patch("app.services.ghl_service._force_refresh_access_token") as mock_refresh,
+            patch("app.services.ghl_service.create_note") as mock_create,
+        ):
+            await ghl_service._run_post_call_writeback_async(db, call_session)
+
+        mock_refresh.assert_not_called()
+        mock_create.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_skips_when_no_matching_contact(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.id = _SESSION_ID
+
+        with (
+            patch(
+                "app.services.ghl_service.get_integration_settings",
+                return_value=self._writeback_settings(),
+            ),
+            patch(
+                "app.services.ghl_service._force_refresh_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ),
+            patch(
+                "app.services.ghl_service.get_contact_for_phone",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("app.services.ghl_service.create_note") as mock_create,
+        ):
+            await ghl_service._run_post_call_writeback_async(db, call_session)
+
+        mock_create.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_writeback_retries_once_then_records_last_ghl_error(self):
+        call_order = []
+        db = MagicMock()
+        db.rollback.side_effect = lambda: call_order.append("rollback")
+        call_session = MagicMock()
+        call_session.id = _SESSION_ID
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        call_session.duration = 60
+        call_session.status = "completed"
+        call_session.call_metadata = {}
+
+        contact = {"id": "contact-1", "name": "Ada Lovelace"}
+
+        with (
+            patch(
+                "app.services.ghl_service.get_integration_settings",
+                return_value=self._writeback_settings(),
+            ),
+            patch(
+                "app.services.ghl_service._force_refresh_access_token",
+                new=AsyncMock(return_value=("access-token", "loc-1")),
+            ),
+            patch(
+                "app.services.ghl_service.get_contact_for_phone",
+                new=AsyncMock(return_value=contact),
+            ),
+            patch(
+                "app.services.ghl_service.generate_transcript_summary",
+                return_value="Summary.",
+            ),
+            patch(
+                "app.services.ghl_service.create_note",
+                new=AsyncMock(side_effect=Exception("GHL 500")),
+            ) as mock_create_note,
+            patch(
+                "asyncio.sleep",
+                new=AsyncMock(side_effect=lambda *_a, **_k: call_order.append("sleep")),
+            ) as mock_sleep,
+            patch("app.services.ghl_service.record_write_back_failure") as mock_record_failure,
+        ):
+            await ghl_service._run_post_call_writeback_async(db, call_session)
+
+        assert mock_create_note.await_count == 2
+        mock_sleep.assert_awaited_once_with(ghl_service._WRITE_BACK_RETRY_DELAY_SECONDS)
+        mock_record_failure.assert_called_once_with(db, _TENANT_ID, "GHL 500")
+        db.rollback.assert_called_once()
+        assert call_order == ["rollback", "sleep"]
+
+    @pytest.mark.anyio
+    async def test_arq_task_skips_when_not_connected(self):
+        db = MagicMock()
+        call_session = MagicMock()
+        call_session.tenant_id = _TENANT_ID
+        call_session.customer_phone_number = "+15550001111"
+        db.query.return_value.filter.return_value.first.return_value = call_session
+
+        with (
+            patch("app.services.ghl_service.SessionLocal", return_value=db),
+            patch("app.services.ghl_service.tenant_has_ghl_connected", return_value=False),
+            patch("app.services.ghl_service._run_post_call_writeback_async") as mock_run,
+        ):
+            await ghl_service._post_call_writeback_arq_task({}, str(_SESSION_ID))
+
+        mock_run.assert_not_called()
+        db.close.assert_called_once()
+
+    def test_schedule_writeback_enqueues_arq_job(self):
+        mock_pool = MagicMock()
+        mock_pool.enqueue_job = AsyncMock()
+
+        with (
+            patch("app.services.ghl_service.get_arq_pool", return_value=mock_pool),
+            patch(
+                "app.services.ghl_service.asyncio.get_running_loop",
+                side_effect=RuntimeError("no running loop"),
+            ),
+            patch("app.services.ghl_service.asyncio.run") as mock_run,
+        ):
+            ghl_service.schedule_ghl_writeback(_SESSION_ID)
+
+        mock_run.assert_called_once()
+
+    def test_schedule_writeback_fails_open_without_arq_pool(self):
+        with patch("app.services.ghl_service.get_arq_pool", return_value=None):
+            # Must not raise even though no pool is available.
+            ghl_service.schedule_ghl_writeback(_SESSION_ID)
+
+
+# ── Disconnect ──────────────────────────────────────────────────────────────────
+
+
+class TestDisconnect:
+    @pytest.mark.anyio
+    async def test_deletes_local_row(self):
+        db = MagicMock()
+        row = MagicMock()
+
+        with patch("app.services.ghl_service.get_integration", return_value=row):
+            result = await ghl_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        db.delete.assert_called_once_with(row)
+        db.commit.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_returns_false_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.ghl_service.get_integration", return_value=None):
+            result = await ghl_service.disconnect(db, _TENANT_ID)
+        assert result is False
+        db.delete.assert_not_called()
+
+
+# ── Backoff ──────────────────────────────────────────────────────────────────────
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def request(self, method, url, **kwargs):
+        return self._responses.pop(0)
+
+
+class TestBackoff:
+    @pytest.mark.anyio
+    async def test_retries_on_429_then_succeeds(self):
+        rate_limited = MagicMock(status_code=429, headers={})
+        ok = MagicMock(status_code=200, headers={})
+
+        with (
+            patch(
+                "app.services.ghl_service.httpx.AsyncClient",
+                return_value=_FakeAsyncClient([rate_limited, ok]),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            response = await ghl_service._request_with_backoff("GET", "https://x")
+
+        assert response.status_code == 200
+        mock_sleep.assert_awaited_once_with(1.0)
+
+    @pytest.mark.anyio
+    async def test_honors_retry_after_header(self):
+        rate_limited = MagicMock(status_code=429, headers={"Retry-After": "3"})
+        ok = MagicMock(status_code=200, headers={})
+
+        with (
+            patch(
+                "app.services.ghl_service.httpx.AsyncClient",
+                return_value=_FakeAsyncClient([rate_limited, ok]),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await ghl_service._request_with_backoff("GET", "https://x")
+
+        mock_sleep.assert_awaited_once_with(3.0)
+
+    @pytest.mark.anyio
+    async def test_gives_up_after_max_retries(self):
+        responses = [MagicMock(status_code=429, headers={}) for _ in range(6)]
+
+        with (
+            patch(
+                "app.services.ghl_service.httpx.AsyncClient",
+                return_value=_FakeAsyncClient(responses),
+            ),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            response = await ghl_service._request_with_backoff("GET", "https://x")
+
+        assert response.status_code == 429
+
+
+# ── Rate limiter ──────────────────────────────────────────────────────────────────
+
+
+class TestRateLimiter:
+    @pytest.mark.anyio
+    async def test_noop_without_redis(self):
+        with patch("app.services.ghl_service.get_redis", return_value=None):
+            # Must not raise.
+            await ghl_service.check_rate_limit(_TENANT_ID)
+
+    @pytest.mark.anyio
+    async def test_waits_when_over_budget(self):
+        mock_redis = AsyncMock()
+        mock_redis.incr = AsyncMock(return_value=101)
+        mock_redis.ttl = AsyncMock(return_value=4)
+
+        with (
+            patch("app.services.ghl_service.get_redis", return_value=mock_redis),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await ghl_service.check_rate_limit(_TENANT_ID)
+
+        mock_sleep.assert_awaited_once_with(4)
+
+    @pytest.mark.anyio
+    async def test_sets_expiry_on_first_request_in_window(self):
+        mock_redis = AsyncMock()
+        mock_redis.incr = AsyncMock(return_value=1)
+        mock_redis.expire = AsyncMock()
+
+        with patch("app.services.ghl_service.get_redis", return_value=mock_redis):
+            await ghl_service.check_rate_limit(_TENANT_ID)
+
+        mock_redis.expire.assert_awaited_once_with(
+            f"ghl:rate_limit:{_TENANT_ID}", ghl_service._RATE_LIMIT_WINDOW_SECONDS
+        )
+
+    @pytest.mark.anyio
+    async def test_under_budget_does_not_sleep(self):
+        mock_redis = AsyncMock()
+        mock_redis.incr = AsyncMock(return_value=5)
+
+        with (
+            patch("app.services.ghl_service.get_redis", return_value=mock_redis),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await ghl_service.check_rate_limit(_TENANT_ID)
+
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_fails_open_on_redis_error(self):
+        mock_redis = AsyncMock()
+        mock_redis.incr = AsyncMock(side_effect=Exception("redis down"))
+
+        with patch("app.services.ghl_service.get_redis", return_value=mock_redis):
+            # Must not raise.
+            await ghl_service.check_rate_limit(_TENANT_ID)
+
+
+# ── Phone normalization ───────────────────────────────────────────────────────────
+
+
+class TestPhoneNormalization:
+    def test_normalize_to_e164(self):
+        assert ghl_service.normalize_to_e164("5550001111") == "+15550001111"
+        assert ghl_service.normalize_to_e164("15550001111") == "+15550001111"
+        assert ghl_service.normalize_to_e164("+61412345678") == "+61412345678"
+        assert ghl_service.normalize_to_e164("") == ""
+
+
+# ── Sync status / settings ─────────────────────────────────────────────────────
+
+
+class TestIntegrationSettings:
+    def test_not_connected_returns_disconnected_defaults(self):
+        db = MagicMock()
+        with patch("app.services.ghl_service.get_integration", return_value=None):
+            result = ghl_service.get_integration_settings(db, _TENANT_ID)
+        assert result["connected"] is False
+        assert result["write_back_enabled"] is True
+
+    def test_update_settings_raises_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.ghl_service.get_integration", return_value=None):
+            with pytest.raises(ValueError):
+                ghl_service.update_integration_settings(db, _TENANT_ID, write_back_enabled=False)
+
+
+class TestSyncStatus:
+    def test_returns_defaults_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.ghl_service.get_integration", return_value=None):
+            result = ghl_service.get_sync_status(db, _TENANT_ID)
+        assert result == {
+            "last_lookup_at": None,
+            "last_write_back_at": None,
+            "last_write_back_status": None,
+            "last_ghl_error": None,
+            "error_count_24h": 0,
+        }
+
+
+class TestSafeErrorMsg:
+    def test_redacts_bearer_token(self):
+        exc = Exception("failed with Bearer abc123.def456==")
+        msg = ghl_service._safe_error_msg(exc)
+        assert "abc123" not in msg
+        assert "Bearer [redacted]" in msg


### PR DESCRIPTION
## Summary
- OAuth 2.0 connect/disconnect flow for GoHighLevel (GHL), with tokens encrypted at rest (AES-256-GCM)
- Contact lookup by phone (Redis-cached 5 min, E.164 + local-format fallback)
- In-call CRM context injection into the LLM system prompt (fail-open, cached per call)
- Post-call note write-back via an ARQ background job, with a 2-sentence Gemini transcript summary, single retry, and rolling 24h failure alerting
- Follows the same fail-open, tenant-scoped patterns established by the HubSpot/Salesforce integrations

## Review notes
- Reviewed the implementation and fixed one authorization gap: `POST /integrations/leadconnector/note` was gated behind `require_tenant` (any authenticated member, including `read_only`), allowing a read-only user to write notes into a tenant's live GHL CRM. Changed to `require_manager`, matching the write-access baseline used elsewhere (e.g. `scheduled_calls.py`) and the sibling `PUT /settings` endpoint.

## Test plan
- [x] `pytest tests/api/test_ghl_integration.py tests/services/test_ghl_service.py -v` — 72 passed
- [x] `pytest tests/ -v` — full suite: 1669 passed, 65 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)