### PR TITLE
fix: resolve ruff lint findings (subprocess check, type hints, blind exceptions)

### DIFF
--- a/tests/api/test_ghl_integration.py
+++ b/tests/api/test_ghl_integration.py
@@ -95,9 +95,8 @@ class TestCallback:
         with patch(
             "app.routers.ghl_integration.ghl_service.verify_oauth_state",
             side_effect=ValueError("Invalid or expired OAuth state"),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await ghl_callback(code="mock-auth-code", state="bad-state", db=MagicMock())
+        ), pytest.raises(HTTPException) as exc_info:
+            await ghl_callback(code="mock-auth-code", state="bad-state", db=MagicMock())
 
         assert exc_info.value.status_code == 400
 
@@ -161,11 +160,10 @@ class TestContactEndpoint:
         with patch(
             "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
             return_value=False,
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await ghl_get_contact(
-                    phone="+61412345678", principal=_principal(), db=MagicMock()
-                )
+        ), pytest.raises(HTTPException) as exc_info:
+            await ghl_get_contact(
+                phone="+61412345678", principal=_principal(), db=MagicMock()
+            )
 
         assert exc_info.value.status_code == 400
 
@@ -181,12 +179,11 @@ class TestContactEndpoint:
             patch(
                 "app.routers.ghl_integration.ghl_service.get_contact_for_phone",
                 new=AsyncMock(return_value=None),
-            ),
+            ),pytest.raises(HTTPException) as exc_info
         ):
-            with pytest.raises(HTTPException) as exc_info:
-                await ghl_get_contact(
-                    phone="+61412345678", principal=_principal(), db=MagicMock()
-                )
+            await ghl_get_contact(
+                phone="+61412345678", principal=_principal(), db=MagicMock()
+            )
 
         assert exc_info.value.status_code == 404
 
@@ -367,11 +364,10 @@ class TestSettingsEndpoint:
         with patch(
             "app.routers.ghl_integration.ghl_service.tenant_has_ghl_connected",
             return_value=False,
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await ghl_update_settings(
-                    payload=payload, principal=_principal(), db=MagicMock()
-                )
+        ), pytest.raises(HTTPException) as exc_info:
+            await ghl_update_settings(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
 
         assert exc_info.value.status_code == 400
 
@@ -421,9 +417,8 @@ class TestDisconnectEndpoint:
         with patch(
             "app.routers.ghl_integration.ghl_service.disconnect",
             new=AsyncMock(return_value=False),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await ghl_disconnect(principal=_principal(), db=MagicMock())
+        ), pytest.raises(HTTPException) as exc_info:
+            await ghl_disconnect(principal=_principal(), db=MagicMock())
 
         assert exc_info.value.status_code == 404
 

--- a/tests/api/test_hubspot_integration.py
+++ b/tests/api/test_hubspot_integration.py
@@ -503,9 +503,8 @@ class TestDisconnectEndpoint:
         with patch(
             "app.routers.hubspot_integration.hubspot_service.disconnect",
             new=AsyncMock(return_value=False),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await hubspot_disconnect(principal=_principal(), db=MagicMock())
+        ), pytest.raises(HTTPException) as exc_info:
+            await hubspot_disconnect(principal=_principal(), db=MagicMock())
 
         assert exc_info.value.status_code == 404
 

--- a/tests/api/test_integrations.py
+++ b/tests/api/test_integrations.py
@@ -228,14 +228,13 @@ class TestMakeTrigger:
         request.scope = {"type": "http", "headers": []}
         request.receive = AsyncMock()
 
-        with _patch_resolve_tenant():
-            with pytest.raises(HTTPException) as exc_info:
-                await make_trigger(
-                    body=body,
-                    request=request,
-                    db=_db(),
-                    x_make_secret="wrong-secret",
-                )
+        with _patch_resolve_tenant(), pytest.raises(HTTPException) as exc_info:
+            await make_trigger(
+                body=body,
+                request=request,
+                db=_db(),
+                x_make_secret="wrong-secret",
+            )
 
         assert exc_info.value.status_code == 403
         assert exc_info.value.detail["code"] == "unauthorized"
@@ -252,14 +251,13 @@ class TestMakeTrigger:
         request.scope = {"type": "http", "headers": []}
         request.receive = AsyncMock()
 
-        with _patch_resolve_tenant():
-            with pytest.raises(HTTPException) as exc_info:
-                await make_trigger(
-                    body=body,
-                    request=request,
-                    db=_db(),
-                    x_make_secret=None,
-                )
+        with _patch_resolve_tenant(), pytest.raises(HTTPException) as exc_info:
+            await make_trigger(
+                body=body,
+                request=request,
+                db=_db(),
+                x_make_secret=None,
+            )
 
         assert exc_info.value.status_code == 403
 
@@ -349,14 +347,13 @@ class TestN8nTrigger:
         body = CallInitiateRequest(agentId=str(_AGENT_ID), toNumber="+15550002222")
         request = MagicMock()
 
-        with _patch_resolve_tenant():
-            with pytest.raises(HTTPException) as exc_info:
-                await n8n_trigger(
-                    body=body,
-                    request=request,
-                    db=_db(),
-                    x_n8n_webhook_secret="wrong-secret",
-                )
+        with _patch_resolve_tenant(), pytest.raises(HTTPException) as exc_info:
+            await n8n_trigger(
+                body=body,
+                request=request,
+                db=_db(),
+                x_n8n_webhook_secret="wrong-secret",
+            )
 
         assert exc_info.value.status_code == 403
         assert exc_info.value.detail["code"] == "unauthorized"
@@ -370,14 +367,13 @@ class TestN8nTrigger:
         body = CallInitiateRequest(agentId=str(_AGENT_ID), toNumber="+15550002222")
         request = MagicMock()
 
-        with _patch_resolve_tenant():
-            with pytest.raises(HTTPException) as exc_info:
-                await n8n_trigger(
-                    body=body,
-                    request=request,
-                    db=_db(),
-                    x_n8n_webhook_secret=None,
-                )
+        with _patch_resolve_tenant(), pytest.raises(HTTPException) as exc_info:
+            await n8n_trigger(
+                body=body,
+                request=request,
+                db=_db(),
+                x_n8n_webhook_secret=None,
+            )
 
         assert exc_info.value.status_code == 403
 

--- a/tests/api/test_salesforce_integration.py
+++ b/tests/api/test_salesforce_integration.py
@@ -95,11 +95,10 @@ class TestCallback:
         with patch(
             "app.routers.salesforce_integration.salesforce_service.verify_oauth_state",
             side_effect=ValueError("Invalid or expired OAuth state"),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await salesforce_callback(
-                    code="mock-auth-code", state="bad-state", db=MagicMock()
-                )
+        ), pytest.raises(HTTPException) as exc_info:
+            await salesforce_callback(
+                code="mock-auth-code", state="bad-state", db=MagicMock()
+            )
 
         assert exc_info.value.status_code == 400
 
@@ -318,9 +317,8 @@ class TestDisconnectEndpoint:
         with patch(
             "app.routers.salesforce_integration.salesforce_service.disconnect",
             new=AsyncMock(return_value=False),
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                await salesforce_disconnect(principal=_principal(), db=MagicMock())
+        ), pytest.raises(HTTPException) as exc_info:
+            await salesforce_disconnect(principal=_principal(), db=MagicMock())
 
         assert exc_info.value.status_code == 404
 

--- a/tests/api/v2/test_health.py
+++ b/tests/api/v2/test_health.py
@@ -23,9 +23,8 @@ def test_v2_health_response_schema_all_ok():
         "app.api.v2.routers.health._probe_redis", AsyncMock(return_value=True)
     ), patch(
         "app.api.v2.routers.health._probe_voice_pipeline", AsyncMock(return_value=True)
-    ):
-        with TestClient(app, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v2/health")
+    ), TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/v2/health")
 
     body = resp.json()
     assert body["status"] == "ok"
@@ -45,9 +44,8 @@ def test_v2_health_degraded_when_redis_fails():
         "app.api.v2.routers.health._probe_redis", AsyncMock(return_value=False)
     ), patch(
         "app.api.v2.routers.health._probe_voice_pipeline", AsyncMock(return_value=True)
-    ):
-        with TestClient(app, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v2/health")
+    ), TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/v2/health")
 
     body = resp.json()
     assert body["status"] == "degraded"
@@ -67,9 +65,8 @@ def test_v2_health_degraded_when_voice_pipeline_times_out():
     ), patch(
         "app.services.livekit_service.livekit_service.health_check",
         side_effect=_slow_health_check,
-    ):
-        with TestClient(app, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v2/health")
+    ), TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/v2/health")
 
     body = resp.json()
     assert body["status"] == "degraded"
@@ -83,9 +80,8 @@ def test_v2_health_down_when_database_fails():
         "app.api.v2.routers.health._probe_redis", AsyncMock(return_value=True)
     ), patch(
         "app.api.v2.routers.health._probe_voice_pipeline", AsyncMock(return_value=True)
-    ):
-        with TestClient(app, raise_server_exceptions=False) as client:
-            resp = client.get("/api/v2/health")
+    ), TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/api/v2/health")
 
     body = resp.json()
     assert body["status"] == "down"

--- a/tests/api/v2/test_hipaa.py
+++ b/tests/api/v2/test_hipaa.py
@@ -16,6 +16,7 @@ Coverage:
 """
 from __future__ import annotations
 
+import logging
 import sys
 import uuid
 from unittest.mock import MagicMock, patch, call
@@ -25,6 +26,8 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.core.exception_handlers import register_exception_handlers
+
+logger = logging.getLogger(__name__)
 
 # ── Shared IDs ────────────────────────────────────────────────────────────────
 
@@ -474,8 +477,10 @@ class TestVoiceAnalysisHipaaRedaction:
                             VoiceAnalysisService().analyze_call_transcript(
                                 db=db, call_session=session, user_id=USER_ID
                             )
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            # Only redaction calls are asserted below; downstream
+                            # assembly against the stub db is allowed to fail.
+                            logger.debug("analyze_call_transcript failed in test stub: %s", e)
 
         # At least the summary, sentiment, and caller_name fields must have been
         # passed to redact_phi_if_hipaa with hipaa_enabled=True
@@ -504,8 +509,10 @@ class TestVoiceAnalysisHipaaRedaction:
                         VoiceAnalysisService().analyze_call_transcript(
                             db=db, call_session=session, user_id=USER_ID
                         )
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        # Only redaction calls are asserted below; downstream
+                        # assembly against the stub db is allowed to fail.
+                        logger.debug("analyze_call_transcript failed in test stub: %s", e)
 
             # If redact was called, it must have been with hipaa_enabled=False
             for c in mock_redact.call_args_list:

--- a/tests/api/v2/test_webhooks.py
+++ b/tests/api/v2/test_webhooks.py
@@ -596,9 +596,8 @@ class TestSSRFGuard:
         with patch(
             "socket.getaddrinfo",
             return_value=self._make_getaddrinfo("169.254.169.254"),
-        ):
-            with pytest.raises(SSRFBlockedError, match="blocked"):
-                assert_public_url("https://169.254.169.254/latest/meta-data/")
+        ), pytest.raises(SSRFBlockedError, match="blocked"):
+            assert_public_url("https://169.254.169.254/latest/meta-data/")
 
     def test_other_link_local_blocked(self):
         from app.utils.ssrf import SSRFBlockedError, assert_public_url
@@ -623,9 +622,8 @@ class TestSSRFGuard:
         with patch(
             "socket.getaddrinfo",
             side_effect=socket.gaierror("Name or service not known"),
-        ):
-            with pytest.raises(SSRFBlockedError, match="could not be resolved"):
-                assert_public_url("https://no-such-host.invalid/hook")
+        ), pytest.raises(SSRFBlockedError, match="could not be resolved"):
+            assert_public_url("https://no-such-host.invalid/hook")
 
     def test_ssrf_is_blocked_at_schema_validation(self):
         """A URL resolving to a private IP must be rejected by WebhookEndpointCreate."""
@@ -635,11 +633,10 @@ class TestSSRFGuard:
         with patch(
             "socket.getaddrinfo",
             return_value=self._make_getaddrinfo("192.168.0.1"),
-        ):
-            with pytest.raises((ValueError, Exception)):
-                WebhookEndpointCreate(
-                    url="https://internal.corp/hook", secret=SECRET
-                )
+        ), pytest.raises((SSRFBlockedError, ValueError)):
+            WebhookEndpointCreate(
+                url="https://internal.corp/hook", secret=SECRET
+            )
 
     def test_ssrf_blocked_delivery_is_logged_as_failed(self):
         """When SSRF blocks a delivery, it must be persisted as status=failed."""
@@ -826,17 +823,16 @@ class TestSecretEncryption:
         with patch(
             "app.services.webhook_service.encrypt_webhook_secret",
             return_value="pgcrypto-ciphertext",
-        ) as mock_enc:
-            with patch("app.core.security.encrypt_api_key") as mock_jwt_enc:
-                # Patch WebhookEndpoint so instantiation doesn't trigger SQLAlchemy
-                # mapper configuration (which fails in isolated tests due to
-                # unresolved Tenant relationships with partially-imported models).
-                with patch(
-                    "app.services.webhook_service.WebhookEndpoint",
-                    _FakeEndpoint,
-                ):
-                    svc = WebhookService(db)
-                    svc.create_endpoint(WORKSPACE_ID, "https://example.com/hook", SECRET)
+        ) as mock_enc, patch("app.core.security.encrypt_api_key") as mock_jwt_enc:
+            # Patch WebhookEndpoint so instantiation doesn't trigger SQLAlchemy
+            # mapper configuration (which fails in isolated tests due to
+            # unresolved Tenant relationships with partially-imported models).
+            with patch(
+                "app.services.webhook_service.WebhookEndpoint",
+                _FakeEndpoint,
+            ):
+                svc = WebhookService(db)
+                svc.create_endpoint(WORKSPACE_ID, "https://example.com/hook", SECRET)
 
         mock_enc.assert_called_once_with(SECRET, db)
         mock_jwt_enc.assert_not_called()

--- a/tests/db/test_user_soft_delete_auth.py
+++ b/tests/db/test_user_soft_delete_auth.py
@@ -10,6 +10,7 @@ Covers:
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
@@ -38,6 +39,8 @@ from app.models.role import Role
 from app.models.tenant import Tenant
 from app.models.refresh_token import RefreshToken
 from app.models.user import User, user_tenant_association
+
+logger = logging.getLogger(__name__)
 
 
 # ------------------------------------------------------------------ fixtures
@@ -119,9 +122,8 @@ class TestRequireWriteAccessUnit:
         role.name = "read_only"
         with patch(
             "app.api.deps.rbac.get_user_role_in_tenant", return_value=role
-        ):
-            with pytest.raises(HTTPException) as exc_info:
-                require_write_access(request=request, user=user, db=db)
+        ), pytest.raises(HTTPException) as exc_info:
+            require_write_access(request=request, user=user, db=db)
         assert exc_info.value.status_code == 403
 
     def test_readonly_get_allowed(self, db):
@@ -341,8 +343,10 @@ class TestInitRoles:
         with patch("app.db.session.SessionLocal"):
             try:
                 spec.loader.exec_module(mod)
-            except Exception:
-                pass
+            except Exception as e:
+                # Only the source text is checked below; a patched-out DB
+                # dependency failing at import time is expected here.
+                logger.debug("init_roles.py exec_module failed under test patch: %s", e)
 
         # We read the source directly to check role names
         src = path.read_text()

--- a/tests/integration/test_sso_callback_postgres.py
+++ b/tests/integration/test_sso_callback_postgres.py
@@ -30,6 +30,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 
 from app.models.role import Role
 from app.models.sso_config import SsoConfig
@@ -224,7 +225,7 @@ class TestSsoConfigDbConstraints:
             is_active=False,
         )
         pg_session.add(bad_config)
-        with pytest.raises(Exception):
+        with pytest.raises(IntegrityError):
             pg_session.flush()
         pg_session.rollback()
 
@@ -239,7 +240,7 @@ class TestSsoConfigDbConstraints:
         pg_session.add(
             SsoConfig(workspace_id=tenant.id, protocol="oidc", is_active=False)
         )
-        with pytest.raises(Exception):
+        with pytest.raises(IntegrityError):
             pg_session.flush()
         pg_session.rollback()
 
@@ -252,7 +253,7 @@ class TestSsoConfigDbConstraints:
             is_active=False,
         )
         pg_session.add(bad)
-        with pytest.raises(Exception):
+        with pytest.raises(IntegrityError):
             pg_session.flush()
         pg_session.rollback()
 

--- a/tests/services/test_hubspot_service.py
+++ b/tests/services/test_hubspot_service.py
@@ -1343,10 +1343,9 @@ class TestGetHubSpotContactProperties:
             patch(
                 "app.services.hubspot_service.get_valid_access_token",
                 new=AsyncMock(return_value=None),
-            ),
+            ),pytest.raises(ValueError)
         ):
-            with pytest.raises(ValueError):
-                await hubspot_service.get_hubspot_contact_properties(db, _TENANT_ID)
+            await hubspot_service.get_hubspot_contact_properties(db, _TENANT_ID)
 
 
 # ── Forced pre-writeback token refresh ──────────────────────────────────────────

--- a/tests/voice/test_rime_tts_and_barge_in.py
+++ b/tests/voice/test_rime_tts_and_barge_in.py
@@ -127,9 +127,8 @@ class TestRimeTTSAdapter:
         with patch(
             "app.utils.tts_adapter.get_rime_api_key",
             side_effect=ValueError("RIME_API_KEY is not set"),
-        ):
-            with pytest.raises(ValueError, match="RIME_API_KEY is not set"):
-                RimeTTSAdapter()
+        ), pytest.raises(ValueError, match="RIME_API_KEY is not set"):
+            RimeTTSAdapter()
 
     def test_rime_default_voice_fallback(self):
         from app.utils.tts_adapter import RimeTTSAdapter


### PR DESCRIPTION
## Summary
- `agents/github_review_agent.py`: added explicit `check=False` to three `subprocess.run` calls (PLW1510) and modernized `Optional[str]` → `str | None` (UP045).
- Repo-wide `ruff --fix` (`--select BLE001,S110,B017,SIM117`) auto-combined 23 nested `with` statements across GHL/HubSpot/Salesforce integration tests, health, webhooks, soft-delete auth, and Rime TTS tests.
- Manually narrowed four broad exception-handling spots flagged by BLE001/S110:
  - `tests/api/v2/test_hipaa.py` (x2): log instead of silently swallowing exceptions from a stubbed `analyze_call_transcript` call — only the redaction side-effect is asserted, so downstream failure against the mock `db` is expected and now visible at debug level instead of hidden.
  - `tests/db/test_user_soft_delete_auth.py`: same pattern for a patched-out `init_roles.py` module exec.
  - `tests/api/v2/test_webhooks.py`: narrowed `pytest.raises((ValueError, Exception))` → `(SSRFBlockedError, ValueError)` — `Exception` added nothing since both are `ValueError` subclasses (verified pydantic's `ValidationError` also subclasses `ValueError`).
  - `tests/integration/test_sso_callback_postgres.py` (x3): narrowed `pytest.raises(Exception)` → `sqlalchemy.exc.IntegrityError` for FK/unique/CHECK constraint violation assertions.

The remaining ~900 BLE001/S110/B017 instances repo-wide were intentionally left untouched — most are legitimate broad catches in test code and warrant a deliberate file-by-file pass rather than a blanket rewrite.

## Test plan
- [x] `pytest tests/` (excluding `integration`/`db`): 1548 passed, 3 skipped
- [x] `pytest tests/db/`: 121 passed, 2 skipped
- [x] `pytest tests/integration/`: 60 skipped as expected (no `TEST_DATABASE_URL` locally)
- [x] `ruff check` confirms the four manually-fixed spots and three `subprocess.run` calls no longer flag PLW1510/UP045