### PR TITLE
fix: resolve remaining F841 KNOWN GAP bugs (accept-invite tokens, ClickUp OAuth state, tenant authz, error context)

### DIFF
--- a/app/api/api_v1/endpoints/accept_invite.py
+++ b/app/api/api_v1/endpoints/accept_invite.py
@@ -4,7 +4,7 @@ from app.api.deps import get_db
 from app.models.invite import Invite
 from app.models.user import User, user_tenant_association
 from app.models.role import Role
-from app.schemas.user import UserOut
+from app.schemas.user import AcceptInviteOut
 from app.schemas.base import SuccessResponse
 from app.core.security import get_password_hash, create_user_token, create_refresh_token_value, refresh_token_expires_at
 from app.models.refresh_token import RefreshToken
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-@router.post("/accept-invite", response_model=SuccessResponse[UserOut])
+@router.post("/accept-invite", response_model=SuccessResponse[AcceptInviteOut])
 def accept_invite(
     token: str,
     password: str,
@@ -141,16 +141,13 @@ def accept_invite(
     db.commit()
     
     # Create access token
-    # KNOWN GAP: computed but never returned/set as a cookie below, unlike the
-    # analogous flow in tenant.py. Looks like a missing wiring step, not dead code.
-    access_token = create_user_token(  # noqa: F841
+    access_token = create_user_token(
         user_id=user.id,
         email=user.email,
         tenant_id=invite.tenant_id,
         role=role_obj.name
     )
 
-    
     # Create refresh token
     rt_value = create_refresh_token_value()
     rt = RefreshToken(
@@ -162,8 +159,8 @@ def accept_invite(
     db.add(rt)
     db.commit()
     
-    # Return user details
-    user_out = UserOut(
+    # Return user details plus the session tokens
+    user_out = AcceptInviteOut(
         id=user.id,
         first_name=user.first_name,
         last_name=user.last_name,
@@ -171,7 +168,9 @@ def accept_invite(
         phone=user.phone,
         join_date=user.join_date,
         created_at=user.created_at,
-        current_tenant_id=user.current_tenant_id
+        current_tenant_id=user.current_tenant_id,
+        access_token=access_token,
+        refresh_token=rt_value
     )
     
     # Determine response message based on whether user was new or existing

--- a/app/routers/clickup_oauth.py
+++ b/app/routers/clickup_oauth.py
@@ -2,10 +2,12 @@
 ClickUp OAuth 2.0 Integration Router
 """
 
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, Depends, HTTPException, Query
+from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 import requests
-import uuid
 import json
 
 from app.api.deps import get_db, require_owner
@@ -20,6 +22,33 @@ router = APIRouter()
 
 CLICKUP_AUTH_URL = "https://app.clickup.com/api"
 CLICKUP_TOKEN_URL = "https://api.clickup.com/api/v2/oauth/token"
+
+# Signed, stateless CSRF state token — same JWT-signed-state pattern used by
+# the HubSpot/Salesforce OAuth flows (see hubspot_service.build_oauth_state /
+# verify_oauth_state). No server-side storage needed: the signature + expiry
+# + purpose claim are enough to prove this callback matches an authorize call
+# we issued.
+_STATE_PURPOSE = "clickup_oauth_state"
+_STATE_TTL_MINUTES = 10
+
+
+def _build_oauth_state() -> str:
+    payload = {
+        "purpose": _STATE_PURPOSE,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=_STATE_TTL_MINUTES),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def _verify_oauth_state(state: str) -> None:
+    """Raises ValueError if state is missing, expired, tampered, or malformed."""
+    try:
+        payload = jwt.decode(state, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+    except JWTError as exc:
+        raise ValueError("Invalid or expired OAuth state") from exc
+
+    if payload.get("purpose") != _STATE_PURPOSE:
+        raise ValueError("Invalid OAuth state purpose")
 
 
 @router.get("/authorize")
@@ -65,15 +94,9 @@ async def clickup_authorize(
     # Get redirect_uri from additional_config or use default
     redirect_uri = additional_config.get("redirect_uri") or f"{settings.WEBHOOK_BASE_URL}/api/v1/auth/clickup/callback"
     
-    # Generate state (optional, for security)
-    # KNOWN GAP: never embedded in auth_url below or persisted for later
-    # verification, so the CSRF `state` check is effectively a no-op. Not
-    # removing — this is a missing OAuth security wiring step, not dead code.
-    state = str(uuid.uuid4())  # noqa: F841
+    # Generate a signed, stateless CSRF state token (see _build_oauth_state).
+    state = _build_oauth_state()
 
-    # Store state in additional_config temporarily (or use session/cache)
-    # For now, we'll just use it in the URL
-    
     # Build authorization URL with required scopes
     # Scopes needed: read (to read teams/spaces), write (to create lists)
     scopes = "read write"
@@ -81,7 +104,8 @@ async def clickup_authorize(
         f"{CLICKUP_AUTH_URL}?"
         f"client_id={client_id}&"
         f"redirect_uri={redirect_uri}&"
-        f"scope={scopes}"
+        f"scope={scopes}&"
+        f"state={state}"
     )
     
     return create_success_response(
@@ -97,13 +121,19 @@ async def clickup_authorize(
 @router.get("/callback")
 async def clickup_oauth_callback(
     code: str = Query(..., description="Authorization code from ClickUp"),
-    state: str | None = Query(None, description="State parameter (optional)"),
+    state: str = Query(..., description="Signed CSRF state token from /authorize"),
     db: Session = Depends(get_db)
 ):
     """
     ClickUp OAuth callback endpoint.
     Receives authorization code and exchanges it for access token.
     """
+    # Validate the CSRF state before doing anything else.
+    try:
+        _verify_oauth_state(state)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
     # Get ClickUp config
     crm_config_service = CRMConfigService()
     clickup_config = crm_config_service.get_crm_config_by_type(db, "clickup")
@@ -129,10 +159,8 @@ async def clickup_oauth_callback(
     
     client_id = additional_config.get("client_id")
     client_secret_encrypted = additional_config.get("client_secret")
-    # KNOWN GAP: never included in the token_data payload sent to ClickUp below,
-    # even though OAuth token exchange typically requires it to match the
-    # authorization request. Not removing — possible missing param, not dead code.
-    redirect_uri = additional_config.get("redirect_uri") or f"{settings.WEBHOOK_BASE_URL}/api/v1/auth/clickup/callback"  # noqa: F841
+    # Must match the redirect_uri sent in the /authorize request above.
+    redirect_uri = additional_config.get("redirect_uri") or f"{settings.WEBHOOK_BASE_URL}/api/v1/auth/clickup/callback"
 
     if not client_id or not client_secret_encrypted:
         raise HTTPException(
@@ -158,7 +186,8 @@ async def clickup_oauth_callback(
         token_data = {
             "client_id": client_id,
             "client_secret": client_secret,
-            "code": code
+            "code": code,
+            "redirect_uri": redirect_uri
         }
         
         response = requests.post(

--- a/app/routers/scheduled_calls.py
+++ b/app/routers/scheduled_calls.py
@@ -2052,11 +2052,8 @@ async def get_jira_credentials(
             )
         
         # Decrypt API token
-        # KNOWN GAP: the docstring above documents `api_token` as part of this
-        # endpoint's response, but it is never included in `result` below. Not
-        # removing — likely a missing field, not dead code.
         from app.core.security import decrypt_api_key
-        api_token = decrypt_api_key(jira_config.encrypted_api_key)  # noqa: F841
+        api_token = decrypt_api_key(jira_config.encrypted_api_key)
 
         # Parse additional_config for email and server_url
         import json
@@ -2077,24 +2074,29 @@ async def get_jira_credentials(
         if tenant_id and user_id:
             if is_webhook:
                 try:
-                    # KNOWN GAP: validated as a UUID but never used to confirm
-                    # `user` (looked up by user_uuid only) actually belongs to
-                    # this tenant_id. Not removing — possible missing authz
-                    # check, not dead code.
-                    tenant_uuid = uuid.UUID(tenant_id)  # noqa: F841
+                    tenant_uuid = uuid.UUID(tenant_id)
                     user_uuid = uuid.UUID(user_id)
                 except ValueError:
                     raise HTTPException(
                         status_code=status.HTTP_400_BAD_REQUEST,
                         detail="Invalid UUID format for tenant_id or user_id"
                     )
-                
+
                 # Get user from database
                 user = db.query(User).filter(User.id == user_uuid).first()
                 if not user:
                     raise HTTPException(
                         status_code=status.HTTP_404_NOT_FOUND,
                         detail="User not found"
+                    )
+
+                # Verify the resolved user actually belongs to the requested
+                # tenant (same check/error style as tenant.py's switch_tenant).
+                user_tenant_ids = [t.id for t in user.tenants]
+                if tenant_uuid not in user_tenant_ids:
+                    raise HTTPException(
+                        status_code=status.HTTP_401_UNAUTHORIZED,
+                        detail="Access denied to this tenant"
                     )
             else:
                 # JWT authentication - user already available from Depends
@@ -2135,6 +2137,7 @@ async def get_jira_credentials(
                 tenant_id_value = str(user.tenants[0].id)
             
             result = {
+                "api_token": api_token,
                 "email": email,
                 "server_url": server_url,
                 "project_key": project_key,
@@ -2178,6 +2181,7 @@ async def get_jira_credentials(
                     })
             
             result = {
+                "api_token": api_token,
                 "email": email,
                 "server_url": server_url,
                 "users": users_list,

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -35,8 +35,14 @@ class UserOut(UserBase):
     role_id: uuid.UUID | None = None
     join_date: datetime
     created_at: datetime
-    
+
     model_config = ConfigDict(from_attributes=True)
+
+
+class AcceptInviteOut(UserOut):
+    """UserOut plus the session tokens issued on invite acceptance."""
+    access_token: str
+    refresh_token: str
 
 
 class RoleInfo(BaseModel):

--- a/app/services/voice_analysis_service.py
+++ b/app/services/voice_analysis_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from fastapi import HTTPException
 
 from app.core.logger import logger
+from app.core.pii_redactor import redact_pii
 from app.models.call_flow import CallFlow
 from app.models.call_log import CallLog
 from app.models.call_session import CallSession
@@ -124,17 +125,14 @@ class VoiceAnalysisService:
                     break
             except Exception as e:  # pragma: no cover - defensive
                 logger.warning("⚠️ Model %s not available: %s", model_name, e)
-                # KNOWN GAP: captured but never included in the HTTPException
-                # detail below. Not removing — looks like a missing error detail,
-                # not dead code.
-                last_error = e  # noqa: F841
+                last_error = e
                 continue
 
         if not model:
-            raise HTTPException(
-                status_code=404,
-                detail=f"No available model found. Tried: {', '.join(fallback_models)}",
-            )
+            detail = f"No available model found. Tried: {', '.join(fallback_models)}"
+            if last_error is not None:
+                detail += f". Last error: {redact_pii(str(last_error))}"
+            raise HTTPException(status_code=404, detail=detail)
 
         # Get transcript messages
         transcript_messages = transcript_service.get_messages_by_session(

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -170,12 +170,6 @@ class TtsStreamMixin:
                                 MULAW_FRAME_BYTES,
                             )
 
-                            # We crossfade at chunk boundaries with a single 20ms overlap for speed.
-                            # KNOWN GAP: never passed to send_frame/crossfade below, unlike
-                            # the working crossfade_mulaw_segments() usage elsewhere in this
-                            # file. Not removing — looks like unfinished crossfade wiring.
-                            overlap_bytes = MULAW_FRAME_BYTES  # 160 bytes (20ms)  # noqa: F841
-
                             async def send_frame(frame: bytes, pace: bool = True, state: dict = None):
                                 if not frame:
                                     return

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -3166,7 +3166,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SuccessResponse_UserOut_'
+                $ref: '#/components/schemas/SuccessResponse_AcceptInviteOut_'
         '422':
           description: Validation Error
           content:
@@ -9604,6 +9604,60 @@ components:
       required:
       - variant
       title: AbTestWinnerUpdate
+    AcceptInviteOut:
+      properties:
+        first_name:
+          type: string
+          minLength: 1
+          title: First Name
+          description: First name is required
+        last_name:
+          type: string
+          minLength: 1
+          title: Last Name
+          description: Last name is required
+        email:
+          type: string
+          format: email
+          title: Email
+          description: Valid email address is required
+        phone:
+          type: string
+          nullable: true
+        id:
+          type: string
+          format: uuid
+          title: Id
+        role_id:
+          type: string
+          format: uuid
+          nullable: true
+        join_date:
+          type: string
+          format: date-time
+          title: Join Date
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        access_token:
+          type: string
+          title: Access Token
+        refresh_token:
+          type: string
+          title: Refresh Token
+      type: object
+      required:
+      - first_name
+      - last_name
+      - email
+      - id
+      - join_date
+      - created_at
+      - access_token
+      - refresh_token
+      title: AcceptInviteOut
+      description: UserOut plus the session tokens issued on invite acceptance.
     AccountDeletionRequest:
       properties:
         confirmation:
@@ -16422,6 +16476,22 @@ components:
           nullable: true
       type: object
       title: SubAccountUpdate
+    SuccessResponse_AcceptInviteOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/AcceptInviteOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[AcceptInviteOut]
     SuccessResponse_ApiKeyCreated_:
       properties:
         data:

--- a/tests/api/test_outbound_call_dispatch.py
+++ b/tests/api/test_outbound_call_dispatch.py
@@ -452,10 +452,10 @@ class TestLivekitRoomCreationFailure:
                 MagicMock(return_value=("AC_test", "tok")),
             ),
         ):
-            # KNOWN GAP: unlike sibling tests in this file, the response is never
-            # asserted on (e.g. status_code). Not removing — looks like a missing
-            # assertion / test-coverage gap, not dead code.
-            result = await _run_direct(req)  # noqa: F841
+            result = await _run_direct(req)
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_503_SERVICE_UNAVAILABLE
 
         # create_call_session must NOT have been called
         mock_css.create_call_session.assert_not_called()

--- a/tests/voice/test_rime_tts_and_barge_in.py
+++ b/tests/voice/test_rime_tts_and_barge_in.py
@@ -660,19 +660,11 @@ class TestFirstAudioLatency:
         h._background_audio.mix_tts_frame = lambda frame: frame
         h._is_background_audio_enabled = lambda: False
 
-        # send_frame is a closure inside _stream_tts_chunk — we call it directly by
-        # reconstructing the minimal pacing-state environment it expects.
+        # send_frame is a closure inside _stream_tts_chunk — we call it directly with
+        # a minimal reimplementation covering only the metric-capture behavior this
+        # test exercises. Called with pace=False, so no pacing state is needed.
         async def _run():
             import time as _time
-
-            # KNOWN GAP: built per the comment above but never passed into the
-            # send_frame(...) call below (state= is left at its default). Not
-            # removing — looks like an incomplete test setup, not dead code.
-            pace_state = {  # noqa: F841
-                "send_interval": 0.0,  # no sleep in test
-                "first": True,
-                "next_send": _time.perf_counter(),
-            }
 
             # Record when first token arrives
             h._metric_first_token_ts = _time.perf_counter()


### PR DESCRIPTION
## Summary

Follow-up to #158 (SIM117/F811/F841 Ruff cleanup). That branch left 17 `F841` violations intentionally suppressed with `# noqa: F841` and a `KNOWN GAP` comment where the "unused" variable looked like a real bug rather than dead code. This PR investigates and fixes 7 of those gaps individually — the ones that were self-contained, single-endpoint/single-function fixes. All 17 original suppressions are resolved; **zero `# noqa: F841` comments remain in the diff for these files.**

- **`accept_invite.py`**: `access_token`/`refresh_token` were generated but never returned to the client. Added `AcceptInviteOut` (`UserOut` + both token fields) and wired them into the response, matching the `TokenResponse` pattern used by `login`/`create_tenant`/`switch_tenant`.
- **`clickup_oauth.py`**: the CSRF `state` was generated but never embedded in the auth URL or validated on callback (a no-op CSRF check). Added a signed, stateless JWT state — same pattern as `hubspot_service.build_oauth_state`/`verify_oauth_state` — now required on `/callback`. Also wired the previously-unused `redirect_uri` into the ClickUp token-exchange request body.
- **`scheduled_calls.py`**: `/jira-credentials` now actually includes `api_token` in the response (it was decrypted but silently dropped, despite being documented in the endpoint's own docstring). The webhook-auth path now verifies the resolved user actually belongs to the requested `tenant_id` before returning credentials — same check/error style (`401 Access denied to this tenant`) as `tenant.py`'s `switch_tenant`.
- **`voice_analysis_service.py`**: the 404 raised when no fallback LLM model is available now includes a redacted summary of the last underlying error, reusing `app.core.pii_redactor.redact_pii` (the same sanitizer already used for exception content in `exception_handlers.py`) so no secrets/tokens leak into the response.
- **`tts_stream_mixin.py`**: removed a dead `overlap_bytes` — in-file comments (predating this PR) document that crossfading was deliberately reverted here after causing an audible stutter/click regression, so wiring it into the existing `crossfade_mulaw_segments` helper would have reintroduced that bug. Left unwired, variable removed.
- Two test-only gaps: added the missing status-code assertion to `test_livekit_failure_db_not_committed` (mirrors its sibling test), and removed a `pace_state` fixture in `test_rime_tts_and_barge_in.py` that was never read because the test calls `send_frame` with `pace=False`.

## Test plan
- [x] `ruff check --select F841` → 0 violations, no `noqa` suppressions left in these files
- [x] `ruff check .` (whole repo) → error count unchanged from the branch point (no new violations)
- [x] `python -c "import app.main"` → app boots cleanly
- [x] Combined run of all 15 directly-affected test files (workspace invite, ClickUp service, API-key middleware, scheduled calls, RBAC, voice analysis, HIPAA, TTS/barge-in, call pipeline, outbound dispatch, LiveKit) — 325 passed, 0 failed
- [x] Self-reviewed the full diff before opening this PR: verified no accidental behavior changes (e.g. Pydantic extra-field handling for the new response schema), no stray debug code, `git diff --check` clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>