### PR TITLE
Folder-flow linking, call-flow status, KB docs, auth error messages

### DIFF
--- a/alembic/versions/85f24740c31a_add_status_to_callflow.py
+++ b/alembic/versions/85f24740c31a_add_status_to_callflow.py
@@ -1,0 +1,42 @@
+"""add_status_to_callflow
+
+Revision ID: 85f24740c31a
+Revises: 20260721_prompt_soft_del
+Create Date: 2026-07-28 23:09:44.798817
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '85f24740c31a'
+down_revision: Union[str, Sequence[str], None] = '20260721_prompt_soft_del'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "callflow",
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="active",
+        ),
+    )
+    op.create_check_constraint(
+        "ck_callflow_status",
+        "callflow",
+        "status IN ('active', 'inactive')",
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_constraint("ck_callflow_status", "callflow", type_="check")
+    op.drop_column("callflow", "status")

--- a/app/core/exception_handlers.py
+++ b/app/core/exception_handlers.py
@@ -33,18 +33,21 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
                 "X-Request-ID": request_id,
             },
         )
-    if (
-        isinstance(exc.detail, dict)
-        and "code" in exc.detail
-        and "message" in exc.detail
-    ):
+    if isinstance(exc.detail, dict) and "message" in exc.detail:
+        # "code" is the standard key; "error_type" is an older convention still
+        # used by the password-auth endpoints (login/register/reset-password) —
+        # accept either so those specific messages aren't collapsed to a
+        # generic "Request failed" by the dict branch below.
+        error_code = exc.detail.get("code") or exc.detail.get("error_type")
         extras = {
-            k: v for k, v in exc.detail.items() if k not in ("code", "message")
+            k: v
+            for k, v in exc.detail.items()
+            if k not in ("code", "message", "error_type")
         }
         payload = build_api_error_payload(
             exc.status_code,
             exc.detail["message"],
-            error_code=exc.detail["code"],
+            error_code=error_code,
             request_id=request_id,
             extras=extras or None,
         )

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -48,6 +48,9 @@ class CallFlow(Base):
 
     hipaa_compliance = Column(Boolean, default=False, nullable=False, server_default="false")
     public_access = Column(Boolean, default=False, nullable=False, server_default="false")
+    # "active" flows can be used to initiate outbound calls; "inactive" ones are rejected
+    # at dispatch time (see voice_call_service.initiate_call) without being deleted.
+    status = Column(String(20), default="active", nullable=False, server_default="active")
     is_deleted = Column(Boolean, default=False, nullable=False, server_default="false")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=True)
@@ -99,5 +102,9 @@ class CallFlow(Base):
         CheckConstraint(
             "caller_memory_window >= 1 AND caller_memory_window <= 10",
             name="ck_callflow_caller_memory_window",
+        ),
+        CheckConstraint(
+            "status IN ('active', 'inactive')",
+            name="ck_callflow_status",
         ),
     )

--- a/app/repositories/folder_repository.py
+++ b/app/repositories/folder_repository.py
@@ -71,6 +71,10 @@ class FolderRepository:
         self.db.refresh(link)
         return link
 
+    def remove_flow(self, link: FolderFlow) -> None:
+        self.db.delete(link)
+        self.db.flush()
+
     def find_flows_by_folder(
         self, folder_id: uuid.UUID, tenant_id: uuid.UUID
     ) -> list[CallFlow]:

--- a/app/routers/folders.py
+++ b/app/routers/folders.py
@@ -74,3 +74,20 @@ def list_folder_flows(
     db: Session = Depends(get_db),
 ):
     return folder_service.list_flows_in_folder(db, folder_id, _workspace_id(principal))
+
+
+@router.delete(
+    "/{folder_id}/flows/{flow_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def remove_flow_from_folder(
+    folder_id: uuid.UUID,
+    flow_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    folder_service.remove_flow_from_folder(
+        db, folder_id, _workspace_id(principal), flow_id
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/knowledge_base.py
+++ b/app/routers/knowledge_base.py
@@ -195,12 +195,49 @@ def _is_kb_linked_to_active_flow(db: Session, kb_id: uuid.UUID) -> bool:
 
 # ── Knowledge base CRUD ───────────────────────────────────────────────────────
 
-@router.post("/", response_model=SuccessResponse[KbOut], status_code=201)
+@router.post(
+    "/",
+    response_model=SuccessResponse[KbOut],
+    status_code=201,
+    summary="Create a knowledge base",
+)
 def create_knowledge_base(
     payload: KbCreate,
     user=Depends(require_admin_or_owner),
     db: Session = Depends(get_db),
 ):
+    """
+    Create an empty knowledge base (KB) container, scoped to the caller's
+    current workspace. This only creates the KB record — it has no content
+    yet, so it won't affect any calls until you populate and attach it.
+
+    **Auth:** requires `admin` or `owner` role (JWT). Workspace is taken from
+    the authenticated user's `current_tenant_id` — there is no `workspaceId`
+    in the request body.
+
+    **Typical frontend flow:**
+    1. `POST /api/v1/kb/` (this endpoint) → get back `data.id` (the `kb_id`).
+    2. Add content to the KB, either or both:
+       - `POST /api/v1/kb/{kb_id}/file` — upload a PDF/DOCX/TXT file (≤ 50 MB).
+         Returns `202` immediately with a `job_id`; ingestion (chunking +
+         embedding) runs asynchronously. Poll
+         `GET /api/v1/kb/{kb_id}/files/{file_id}/status` to know when it's
+         ready.
+       - `POST /api/v1/kb/{kb_id}/text` — ingest raw text directly.
+         Synchronous — chunks + embeddings are ready when this call returns
+         `201`.
+    3. Attach the KB to a call flow so the voice agent can retrieve from it:
+       `PUT /api/v1/call-flows/{flow_id}/knowledge-bases` with
+       `{"kb_ids": ["<kb_id>", ...]}`. A call flow can have multiple KBs;
+       passing an empty list detaches all of them.
+
+    **Request body:**
+    - `name` (required) — display name, 1–255 characters.
+    - `description` (optional) — free-text summary of the KB's contents.
+
+    **Response (`201`):** `data` is the created KB —
+    `{id, workspace_id, name, description, created_at, updated_at}`.
+    """
     workspace_id = user.current_tenant_id
     kb = KnowledgeBase(
         id=uuid.uuid4(),

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -22,6 +22,11 @@ class WelcomeMessageTypeEnum(str, Enum):
     ai_custom = "ai_custom"
 
 
+class CallFlowStatusEnum(str, Enum):
+    active = "active"
+    inactive = "inactive"
+
+
 class FlowDataSchema(BaseModel):
     """Structural validation for flowData JSONB — future visual-editor format."""
 
@@ -56,6 +61,7 @@ class CallFlowCreate(BaseModel):
     #   function-calling + Calendly instead of the legacy [BOOK_APPOINTMENT:...]
     #   regex-token pipeline (see app/voice/booking_mixin.py::_calendly_enabled).
     settings: Dict[str, Any] | None = None
+    status: CallFlowStatusEnum = CallFlowStatusEnum.active
 
 
 class CallFlowUpdate(BaseModel):
@@ -71,6 +77,7 @@ class CallFlowUpdate(BaseModel):
     current_prompt_id: uuid.UUID | None = Field(None, alias="currentPromptId")
     flow_data: FlowDataSchema | None = Field(None, alias="flowData")
     settings: Dict[str, Any] | None = None
+    status: CallFlowStatusEnum | None = None
 
     @model_validator(mode="after")
     def prompt_and_rollback_exclusive(self) -> "CallFlowUpdate":
@@ -126,6 +133,7 @@ class CallFlowOut(BaseModel):
     knowledge_base_ids: List[str] = Field(default_factory=list, serialization_alias="knowledgeBaseIds")
     folder_ids: List[uuid.UUID] = Field(default_factory=list, serialization_alias="folderIds")
     public_access: bool = Field(False, serialization_alias="publicAccess")
+    status: str = "active"
     created_at: datetime = Field(..., serialization_alias="createdAt")
     updated_at: datetime | None = Field(None, serialization_alias="updatedAt")
 
@@ -148,6 +156,7 @@ class CallFlowListItem(BaseModel):
     knowledge_base_ids: List[str] = Field(default_factory=list, serialization_alias="knowledgeBaseIds")
     folder_ids: List[uuid.UUID] = Field(default_factory=list, serialization_alias="folderIds")
     public_access: bool = Field(False, serialization_alias="publicAccess")
+    status: str = "active"
     created_at: datetime = Field(..., serialization_alias="createdAt")
     updated_at: datetime | None = Field(None, serialization_alias="updatedAt")
 

--- a/app/schemas/knowledge_base.py
+++ b/app/schemas/knowledge_base.py
@@ -9,8 +9,18 @@ from datetime import datetime
 # ── Knowledge Base CRUD ───────────────────────────────────────────────────────
 
 class KbCreate(BaseModel):
-    name: str = Field(..., min_length=1, max_length=255)
-    description: str | None = None
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Display name for the knowledge base.",
+        examples=["Product FAQ"],
+    )
+    description: str | None = Field(
+        None,
+        description="Optional human-readable summary of what this KB contains.",
+        examples=["Answers to common pricing and refund questions"],
+    )
 
 
 class KbUpdate(BaseModel):

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -185,6 +185,7 @@ class CallFlowService:
             knowledge_base_ids=flow.knowledge_base_ids or [],
             folder_ids=folder_ids,
             public_access=flow.public_access,
+            status=flow.status,
             created_at=flow.created_at,
             updated_at=flow.updated_at,
         )
@@ -217,6 +218,7 @@ class CallFlowService:
             knowledge_base_ids=flow.knowledge_base_ids or [],
             folder_ids=folder_ids or [],
             public_access=flow.public_access,
+            status=flow.status,
             created_at=flow.created_at,
             updated_at=flow.updated_at,
         )
@@ -257,6 +259,7 @@ class CallFlowService:
                 "custom_welcome_message": body.custom_welcome_message,
                 "flow_data": flow_data_dict,
                 "settings": body.settings,
+                "status": body.status.value,
             }
         )
 
@@ -335,6 +338,8 @@ class CallFlowService:
             scalar_updates["flow_data"] = body.flow_data.model_dump()
         if body.settings is not None:
             scalar_updates["settings"] = body.settings
+        if body.status is not None:
+            scalar_updates["status"] = body.status.value
 
         # Prompt versioning logic
         if body.prompt is not None and body.prompt.strip():

--- a/app/services/folder_service.py
+++ b/app/services/folder_service.py
@@ -95,6 +95,31 @@ class FolderService:
 
         return {"folderId": str(folder_id), "flowId": str(flow_id)}
 
+    def remove_flow_from_folder(
+        self,
+        db: Session,
+        folder_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        flow_id: uuid.UUID,
+    ) -> None:
+        """Unlink a flow from a folder without touching the call flow itself.
+
+        Once a flow has no remaining folder links, it naturally reappears
+        under "All Files" — that view is just "flows with no FolderFlow row".
+        """
+        self._get_folder_or_404(db, folder_id, tenant_id)
+
+        repo = FolderRepository(db)
+        link = repo.find_folder_flow(folder_id, flow_id)
+        if link is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Call flow {flow_id} is not in folder {folder_id}",
+            )
+
+        repo.remove_flow(link)
+        db.commit()
+
     def list_flows_in_folder(
         self, db: Session, folder_id: uuid.UUID, tenant_id: uuid.UUID
     ) -> dict:

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -247,6 +247,26 @@ async def initiate_call(
                     detail="Invalid callFlowId format: must be a valid UUID",
                 )
 
+            requested_flow = db.execute(
+                select(CallFlow).where(
+                    CallFlow.id == flow_uuid,
+                    CallFlow.tenant_id == tenant_id_filter,
+                    CallFlow.is_deleted == False,  # noqa: E712
+                )
+            ).scalar_one_or_none()
+            if requested_flow is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Call flow {flow_uuid} not found in workspace",
+                )
+            if requested_flow.status != "active":
+                return _err(
+                    status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    "call_flow_inactive",
+                    f"Call flow {flow_uuid} is inactive and cannot be used to initiate calls. "
+                    "Set it to active first.",
+                )
+
         # ── Resolve Twilio credentials upfront ───────────────────────────
         use_custom_credentials = False
         account_sid: str | None = None
@@ -433,13 +453,12 @@ async def initiate_call(
             # A/B prompt testing: assign + persist the variant now, before any
             # LLM request, so it's known even if the call fails mid-way. Locked
             # for the duration of the call via call_metadata["ab_prompt_text"].
-            call_flow_row = db.execute(
-                select(CallFlow).where(CallFlow.id == flow_uuid)
-            ).scalar_one_or_none()
-            if call_flow_row is not None:
-                ab_testing_service.assign_and_lock_variant(
-                    db, call_session, call_flow_row
-                )
+            # Reuse the row already fetched by the active-status gate above —
+            # intervening db.commit() calls expire it, so SQLAlchemy transparently
+            # reloads fresh attributes on next access; no extra explicit SELECT needed.
+            ab_testing_service.assign_and_lock_variant(
+                db, call_session, requested_flow
+            )
 
         # JD / resume enrichment (non-blocking on failure)
         _ctx = call_request.jd_context or {}

--- a/app/workers/batch_call_worker.py
+++ b/app/workers/batch_call_worker.py
@@ -22,6 +22,18 @@ from datetime import datetime, timedelta, timezone
 from app.core.config import settings
 from app.core.logger import logger
 
+# Populate SQLAlchemy's class registry before any job (including on_startup)
+# can run a query. Unlike the FastAPI process — where importing the router
+# tree transitively imports every model — this worker imports models lazily
+# per-function, so nothing has registered CallSession by the time
+# startup_recover_callbacks queries CallbackSchedule, whose `original_call`
+# relationship resolves "CallSession" as a string at mapper-configure time.
+# app/db/base.py imports every model for exactly this reason (alembic/env.py
+# relies on it too); import it here, not just the one class currently
+# missing, so this doesn't recur the next time a new string relationship is
+# added to a model this worker doesn't otherwise import.
+import app.db.base  # noqa: F401
+
 # ── Job functions ─────────────────────────────────────────────────────────────
 
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1775,6 +1775,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/folders/{folder_id}/flows/{flow_id}:
+    delete:
+      tags:
+      - Folders
+      summary: Remove Flow From Folder
+      operationId: remove_flow_from_folder_api_v1_folders__folder_id__flows__flow_id__delete
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: folder_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Folder Id
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/voice/call/initiate/send:
     post:
       tags:
@@ -4821,7 +4853,27 @@ paths:
     post:
       tags:
       - Knowledge Base
-      summary: Create Knowledge Base
+      summary: Create a knowledge base
+      description: "Create an empty knowledge base (KB) container, scoped to the caller's\n\
+        current workspace. This only creates the KB record — it has no content\nyet,\
+        \ so it won't affect any calls until you populate and attach it.\n\n**Auth:**\
+        \ requires `admin` or `owner` role (JWT). Workspace is taken from\nthe authenticated\
+        \ user's `current_tenant_id` — there is no `workspaceId`\nin the request body.\n\
+        \n**Typical frontend flow:**\n1. `POST /api/v1/kb/` (this endpoint) → get\
+        \ back `data.id` (the `kb_id`).\n2. Add content to the KB, either or both:\n\
+        \   - `POST /api/v1/kb/{kb_id}/file` — upload a PDF/DOCX/TXT file (≤ 50 MB).\n\
+        \     Returns `202` immediately with a `job_id`; ingestion (chunking +\n \
+        \    embedding) runs asynchronously. Poll\n     `GET /api/v1/kb/{kb_id}/files/{file_id}/status`\
+        \ to know when it's\n     ready.\n   - `POST /api/v1/kb/{kb_id}/text` — ingest\
+        \ raw text directly.\n     Synchronous — chunks + embeddings are ready when\
+        \ this call returns\n     `201`.\n3. Attach the KB to a call flow so the voice\
+        \ agent can retrieve from it:\n   `PUT /api/v1/call-flows/{flow_id}/knowledge-bases`\
+        \ with\n   `{\"kb_ids\": [\"<kb_id>\", ...]}`. A call flow can have multiple\
+        \ KBs;\n   passing an empty list detaches all of them.\n\n**Request body:**\n\
+        - `name` (required) — display name, 1–255 characters.\n- `description` (optional)\
+        \ — free-text summary of the KB's contents.\n\n**Response (`201`):** `data`\
+        \ is the created KB —\n`{id, workspace_id, name, description, created_at,\
+        \ updated_at}`."
       operationId: create_knowledge_base_api_v1_kb__post
       security:
       - HTTPBearer: []
@@ -11525,6 +11577,9 @@ components:
           additionalProperties: true
           type: object
           nullable: true
+        status:
+          $ref: '#/components/schemas/CallFlowStatusEnum'
+          default: active
       additionalProperties: false
       type: object
       required:
@@ -11543,6 +11598,12 @@ components:
       - public_access
       title: CallFlowSettingsUpdate
       description: Request body for ``PUT /api/v1/call-flows/{id}/settings``.
+    CallFlowStatusEnum:
+      type: string
+      enum:
+      - active
+      - inactive
+      title: CallFlowStatusEnum
     CallFlowUpdate:
       properties:
         name:
@@ -11582,6 +11643,10 @@ components:
         settings:
           additionalProperties: true
           type: object
+          nullable: true
+        status:
+          allOf:
+          - $ref: '#/components/schemas/CallFlowStatusEnum'
           nullable: true
       additionalProperties: false
       type: object
@@ -13592,6 +13657,9 @@ components:
           maxLength: 255
           minLength: 1
           title: Name
+          description: Display name for the knowledge base.
+          examples:
+          - Product FAQ
         description:
           type: string
           nullable: true

--- a/tests/api/test_call_flows.py
+++ b/tests/api/test_call_flows.py
@@ -229,6 +229,89 @@ class TestCreateCallFlow:
 
 
 @pytest.mark.usefixtures("db")
+class TestCallFlowStatus:
+    def test_create_defaults_to_active_status(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        resp = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id),
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["status"] == "active"
+
+    def test_create_with_explicit_inactive_status(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        resp = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, status="inactive"),
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["status"] == "inactive"
+
+    def test_update_status_to_inactive_and_back(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        created = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id),
+            headers=_headers(auth_tenant),
+        ).json()
+        assert created["status"] == "active"
+
+        resp = authed_client.put(
+            f"/api/v1/call-flows/{created['id']}",
+            json={"status": "inactive"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "inactive"
+
+        resp = authed_client.put(
+            f"/api/v1/call-flows/{created['id']}",
+            json={"status": "active"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "active"
+
+    def test_invalid_status_value_rejected(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        resp = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, status="paused"),
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+
+    def test_list_and_get_include_status(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        created = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, status="inactive"),
+            headers=_headers(auth_tenant),
+        ).json()
+
+        get_resp = authed_client.get(
+            f"/api/v1/call-flows/{created['id']}",
+            headers=_headers(auth_tenant),
+        )
+        assert get_resp.json()["status"] == "inactive"
+
+        list_resp = authed_client.get(
+            "/api/v1/call-flows",
+            headers=_headers(auth_tenant),
+        )
+        item = next(f for f in list_resp.json()["data"] if f["id"] == created["id"])
+        assert item["status"] == "inactive"
+
+
+@pytest.mark.usefixtures("db")
 class TestUpdateCallFlow:
     def _create_flow(self, client, tenant, agent) -> dict:
         resp = client.post(

--- a/tests/api/test_folders.py
+++ b/tests/api/test_folders.py
@@ -332,3 +332,140 @@ class TestListFolderFlows:
         body = resp.json()
         assert body["total"] == 0
         assert body["data"] == []
+
+
+@pytest.mark.usefixtures("db")
+class TestRemoveFlowFromFolder:
+    def test_remove_flow_deletes_join_row_not_flow(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        folder = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Removal Folder"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Removable Flow")
+        authed_client.post(
+            f"/api/v1/folders/{folder['id']}/flows",
+            json={"flowId": str(flow.id)},
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.delete(
+            f"/api/v1/folders/{folder['id']}/flows/{flow.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 204, resp.text
+
+        # Join row is gone
+        link = (
+            db.query(FolderFlow)
+            .filter(
+                FolderFlow.folder_id == uuid.UUID(folder["id"]),
+                FolderFlow.flow_id == flow.id,
+            )
+            .first()
+        )
+        assert link is None
+
+        # The call flow itself is untouched
+        flow_row = db.query(CallFlow).filter(CallFlow.id == flow.id).first()
+        assert flow_row is not None
+        assert flow_row.is_deleted is False
+
+        # No longer listed under this folder
+        list_resp = authed_client.get(
+            f"/api/v1/folders/{folder['id']}/flows",
+            headers=_headers(auth_tenant),
+        )
+        assert list_resp.json()["total"] == 0
+
+        # Reappears with an empty folderIds list — i.e. "All Files"
+        get_resp = authed_client.get(
+            f"/api/v1/call-flows/{flow.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert get_resp.json()["folderIds"] == []
+
+    def test_remove_flow_not_in_folder_returns_404(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        folder = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "No Link Folder"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Never Linked Flow")
+
+        resp = authed_client.delete(
+            f"/api/v1/folders/{folder['id']}/flows/{flow.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_remove_flow_from_unknown_folder_returns_404(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        flow = _make_flow(db, auth_tenant, test_agent)
+        resp = authed_client.delete(
+            f"/api/v1/folders/{uuid.uuid4()}/flows/{flow.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_remove_flow_keeps_other_folder_links(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        """A flow linked to two folders should only lose the one it's removed from."""
+        folder_a = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Folder A"},
+            headers=_headers(auth_tenant),
+        ).json()
+        folder_b = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Folder B"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Multi-folder Flow")
+
+        for folder in (folder_a, folder_b):
+            authed_client.post(
+                f"/api/v1/folders/{folder['id']}/flows",
+                json={"flowId": str(flow.id)},
+                headers=_headers(auth_tenant),
+            )
+
+        resp = authed_client.delete(
+            f"/api/v1/folders/{folder_a['id']}/flows/{flow.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 204
+
+        get_resp = authed_client.get(
+            f"/api/v1/call-flows/{flow.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert get_resp.json()["folderIds"] == [folder_b["id"]]
+
+    def test_put_call_flow_rejects_folder_id_field(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        """folderId must never be accepted via the call-flow update endpoint —
+        folder membership is only managed through the dedicated folder endpoints."""
+        created = authed_client.post(
+            "/api/v1/call-flows",
+            json={
+                "name": "My Flow",
+                "direction": "inbound",
+                "agentId": str(test_agent.id),
+            },
+            headers=_headers(auth_tenant),
+        ).json()
+
+        resp = authed_client.put(
+            f"/api/v1/call-flows/{created['id']}",
+            json={"folderId": None},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400

--- a/tests/db/test_user_soft_delete_auth.py
+++ b/tests/db/test_user_soft_delete_auth.py
@@ -200,14 +200,12 @@ class TestSoftDeleteLogin:
             )
         # We accept 200 (login ok) or 404/422 if tenant/role wiring incomplete in test DB
         # The critical assertion: it must NOT be a deleted-user 404 from our code path
-        # (deleted user returns 404 with specific error_type)
+        # (deleted user returns 404 with error.code="email_not_found")
         if resp.status_code == 404:
             body = resp.json()
-            detail = body.get("detail", {})
-            if isinstance(detail, dict):
-                assert detail.get("error_type") != "email_not_found", (
-                    "Active user was rejected as if soft-deleted"
-                )
+            assert body.get("error", {}).get("code") != "email_not_found", (
+                "Active user was rejected as if soft-deleted"
+            )
 
 
 class TestSoftDeleteRefresh:

--- a/tests/services/test_voice_call_livekit.py
+++ b/tests/services/test_voice_call_livekit.py
@@ -68,11 +68,29 @@ def _session(*, call_flow_id: uuid.UUID | None = None):
     return cs
 
 
-def _db():
+def _fake_call_flow(*, status: str = "active"):
+    """Minimal CallFlow-shaped stub covering both the active-status gate and
+    the (unmocked) A/B-testing lookup that also runs against db.execute()."""
+    return SimpleNamespace(
+        id=_FLOW_ID,
+        tenant_id=_TENANT_ID,
+        status=status,
+        ab_test_enabled=False,
+        ab_prompt_a_id=None,
+        ab_prompt_b_id=None,
+        ab_split_ratio=0.5,
+    )
+
+
+def _db(*, flow_status: str = "active"):
     db = MagicMock()
     db.query.return_value.filter.return_value.first.return_value = _phone_number()
     # concurrent outbound count query returns 0 (below any limit)
     db.query.return_value.filter.return_value.scalar.return_value = 0
+    # select(CallFlow)... lookups: the active-status gate and the A/B-testing block
+    db.execute.return_value.scalar_one_or_none.return_value = _fake_call_flow(
+        status=flow_status
+    )
     return db
 
 
@@ -94,6 +112,7 @@ async def _run(
     *,
     session_obj=None,
     livekit_enabled: bool = True,
+    flow_status: str = "active",
 ) -> AsyncMock:
     """
     Call initiate_call with all external dependencies mocked.
@@ -157,7 +176,7 @@ async def _run(
     ):
         await initiate_call(
             call_request=request,
-            db=_db(),
+            db=_db(flow_status=flow_status),
             is_system_call=False,
             tenant_id=mock_user.current_tenant_id,
             user_id=mock_user.id,
@@ -245,8 +264,34 @@ class TestFlowIdPassThrough:
         assert isinstance(result, JSONResponse)
         assert result.status_code == 400
 
+    @pytest.mark.asyncio
+    async def test_inactive_call_flow_rejects_call_before_create_room(self):
+        """An inactive call flow must block dispatch with a 422, and
+        create_room must never be reached."""
+        import json
 
-async def _run_raw(request) -> object:
+        from fastapi.responses import JSONResponse
+
+        req = _call_request(callFlowId=str(_FLOW_ID))
+
+        result = await _run_raw(req, flow_status="inactive")
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == 422
+        body = json.loads(result.body)
+        assert body["error"]["code"] == "call_flow_inactive"
+
+    @pytest.mark.asyncio
+    async def test_active_call_flow_allows_create_room(self):
+        """An active call flow must not block dispatch — create_room is reached."""
+        req = _call_request(callFlowId=str(_FLOW_ID))
+
+        mock = await _run(req, flow_status="active")
+
+        mock.assert_awaited_once()
+
+
+async def _run_raw(request, *, flow_status: str = "active") -> object:
     """Like _run but returns the raw return value of initiate_call."""
     from app.services.voice_call_service import initiate_call
 
@@ -302,7 +347,7 @@ async def _run_raw(request) -> object:
     ):
         return await initiate_call(
             call_request=request,
-            db=_db(),
+            db=_db(flow_status=flow_status),
             is_system_call=False,
             tenant_id=mock_user.current_tenant_id,
             user_id=mock_user.id,

--- a/tests/workers/test_batch_call_worker_startup.py
+++ b/tests/workers/test_batch_call_worker_startup.py
@@ -1,0 +1,70 @@
+"""
+Regression test: the ARQ worker must register every SQLAlchemy model before
+any query can run against a model with a string-based relationship() to a
+class the worker doesn't otherwise import.
+
+Unlike the FastAPI process — where importing the router tree transitively
+imports nearly every model — app/workers/batch_call_worker.py imports models
+lazily, function-by-function. Its on_startup hook queries CallbackSchedule
+before any job has run, and CallbackSchedule.original_call resolves the
+string "CallSession" against SQLAlchemy's class registry at mapper-configure
+time. If CallSession was never imported in-process, that lookup fails with
+InvalidRequestError, and the worker's on_startup hook (and every subsequent
+job touching CallbackSchedule) crashes.
+
+This can only be verified in a genuinely fresh interpreter — an in-process
+pytest run already has every model imported via conftest.py — so this test
+spawns a subprocess that imports nothing but the worker module itself.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+_PROBE = """
+import os, sys
+os.environ.setdefault("RATE_LIMIT_ENABLED", "False")
+os.environ.setdefault("RIME_API_KEY", "test-rime-key")
+os.environ.setdefault("ELEVENLABS_ENCRYPTION_KEY", "test-elevenlabs-key-32-chars-long!!")
+os.environ.setdefault("WEBHOOK_SECRET_ENCRYPTION_KEY", "test-webhook-key")
+os.environ.setdefault("HUBSPOT_TOKEN_ENCRYPTION_KEY", "test-hubspot-key")
+
+from unittest.mock import MagicMock
+for name in (
+    "google", "google.genai", "google.oauth2", "google.auth",
+    "google.auth.transport", "google.auth.transport.requests",
+    "google.cloud", "google.cloud.speech_v1p1beta1",
+    "google.api_core", "google.api_core.client_options",
+    "google.api_core.exceptions",
+):
+    sys.modules[name] = MagicMock()
+
+# Import ONLY the worker module, exactly as `arq app.workers.batch_call_worker.WorkerSettings`
+# would — nothing else has imported CallSession into the registry yet.
+import app.workers.batch_call_worker  # noqa: F401
+from app.models.callback_schedule import CallbackSchedule
+from sqlalchemy.orm import configure_mappers
+
+# This is exactly what fails inside startup_recover_callbacks if CallSession
+# was never registered: SQLAlchemy resolves relationship() string targets
+# lazily, the first time the mapper is configured.
+configure_mappers()
+assert CallbackSchedule.original_call.property.mapper.class_.__name__ == "CallSession"
+print("OK")
+"""
+
+
+def test_worker_module_registers_all_models_before_startup_query():
+    """Importing the worker module alone must be enough to resolve every
+    string-based relationship() used by models it queries in on_startup."""
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"Worker module import failed to register all models.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
## Summary

Four independent, self-contained changes:

**1. Remove a call flow from a folder**
- `DELETE /api/v1/folders/{folder_id}/flows/{flow_id}` — removes only the `FolderFlow` join row; the call flow itself is untouched. Once a flow has zero folder links it naturally reappears under "All Files" (via the existing `folderIds` field on call-flow responses).
- `PUT /api/v1/call-flows/{flow_id}` already rejected an unknown `folderId` field (schema is `extra="forbid"`) — added a regression test to lock that in, since folder membership should only be managed through the folder endpoints.

**2. Swagger docs for KB creation**
- `POST /api/v1/kb/` now has a full `summary` + step-by-step `description` in the OpenAPI schema: auth requirements, and the create → upload/ingest-content → attach-to-call-flow flow. Field descriptions/examples added to `KbCreate`. Docs-only, no behavior change.

**3. Call-flow `status` (active/inactive)**
- New `status` field on `CallFlow` (migration + model + schema + service), defaults to `active`.
- Enforced in `voice_call_service.initiate_call()` — the single outbound-dispatch chokepoint used by manual calls, batch calls, and the callback scheduler. Any call explicitly targeting an inactive flow via `callFlowId` is rejected with `422 call_flow_inactive` before any LiveKit/Twilio side effects.
- Scope note: this only gates outbound calls that pass `callFlowId` explicitly. Inbound calls don't consult `CallFlow` at all today, so `status` has no effect there yet.

**4. Auth error messages: stop collapsing to "Request failed"**
- Root cause: the global exception handler only recognized structured error dicts keyed by `code`, but `login`/`register`/`forgot-password`/`reset-password` use an older `error_type` key. Since neither matched, the whole dict fell through to the generic branch, which by design collapses any dict to the literal string `"Request failed"` (to avoid leaking arbitrary payload shapes) — silently discarding messages like "Password is incorrect for this email" that were already correct server-side.
- Fix: the handler now accepts `error_type` as an alias for `code`, and forwards other dict keys (e.g. `field`) as structured extras, matching the convention already used for `validation_error`/`rate_limit_exceeded`.
- Side effect (verified safe, not a regression): two other endpoints with the same latent bug (`calendar.py` business-hours conflict, `batch_call_service.py` CSV validation) now also correctly surface their specific messages instead of the generic fallback. Neither is a 5xx, so the "always generic on server errors" security rule is untouched.
- Also fixed a dead assertion in `test_user_soft_delete_auth.py` that checked a response shape (`body["detail"]`) that never matched the real `{"error": {...}}` envelope, so it silently never verified anything.

## Test plan
- [x] `ruff check .` — clean
- [x] Full suite: 1685 passed, 5 skipped (pre-existing), 0 failures
- [x] Migration applied and verified against the dev database (column + check constraint + existing rows backfilled to `active`)
- [x] Manually verified login error responses end-to-end (wrong password → 401 `invalid_password`; unknown email → 404 `email_not_found`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)