### PR TITLE
fix: harden Twilio webhook security and voice pipeline correctness

### DIFF
--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -835,6 +835,10 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin,
                 pass
         if self._tts_pipeline:
             await self._tts_pipeline.cancel_current_and_clear_queue()
+        # Twilio Media Streams protocol: cancelling our TTS task locally does not
+        # stop Twilio from continuing to play audio frames already sent to it —
+        # tell Twilio to flush its buffer too (no-op if nothing is queued/playing).
+        await self._send_twilio_clear_event()
         # Discard stale RAG prefetch so the next turn gets a fresh retrieval.
         prefetch = getattr(self, "_rag_prefetch_task", None)
         if prefetch and not prefetch.done():

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -788,6 +788,76 @@ async def handle_call_events_webhook(
             
             return HTMLResponse("", media_type="application/xml")
         
+        elif call_status == "canceled":
+            # Call canceled via REST API before it was answered — same "never
+            # completed" business effects as "failed" (GAP 4 follow-up): fire the
+            # webhook, stop credit monitoring, and notify batch-call completion so
+            # a canceled outbound batch call doesn't get stuck as permanently "active".
+            logger.info(f"Call canceled - SID: {call_sid}")
+
+            # Fire call.failed webhook (no dedicated call.canceled event type)
+            if call_session:
+                try:
+                    from app.services.webhook_service import fire_webhooks
+                    background_tasks.add_task(
+                        fire_webhooks,
+                        call_session.tenant_id,
+                        "call.failed",
+                        {
+                            "call_session_id": str(call_session.id),
+                            "call_sid": call_sid,
+                            "direction": direction,
+                            "from_number": from_number,
+                            "to_number": to_number,
+                            "reason": "canceled",
+                        },
+                    )
+                except Exception as _wh_exc:
+                    logger.warning("call.failed (canceled) webhook fire failed: %s", _wh_exc)
+
+            # Broadcast call canceled event (non-blocking - fire and forget)
+            if call_session:
+                try:
+                    asyncio.create_task(broadcast_call_status_update(
+                        call_session_id=str(call_session.id),
+                        status="failed",
+                        metadata={
+                            "call_sid": call_sid,
+                            "twilio_status": call_status,
+                            "direction": direction,
+                            "timestamp": datetime.now(timezone.utc).isoformat()
+                        }
+                    ))
+                    logger.debug(f"✅ Queued call canceled event for session {call_session.id}")
+
+                    asyncio.create_task(broadcast_call_ended(
+                        call_session_id=str(call_session.id),
+                        reason="canceled",
+                        final_data={
+                            "call_sid": call_sid,
+                            "direction": direction,
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "duration": 0
+                        }
+                    ))
+                    logger.debug(f"✅ Queued call ended (canceled) event for session {call_session.id}")
+                except Exception as e:
+                    logger.error(f"❌ Failed to broadcast call canceled event: {e}")
+
+                # Stop credit monitoring when call is canceled
+                try:
+                    credit_service.stop_credit_monitoring(call_session.id)
+                    logger.debug(f"✅ Stopped credit monitoring for canceled call session {call_session.id}")
+                except Exception as e:
+                    logger.warning(f"⚠️ Failed to stop credit monitoring (non-critical): {e}")
+
+                try:
+                    await notify_batch_call_ended(db, call_session.id, call_status)
+                except Exception as batch_exc:
+                    logger.warning("Batch call completion hook failed: %s", batch_exc, exc_info=True)
+
+            return HTMLResponse("", media_type="application/xml")
+
         elif call_status in ("busy", "no-answer"):
             # Both busy and no-answer → internal "no_answer" (per ticket spec)
             logger.info(f"Call {call_status} (internal: no_answer) - SID: {call_sid}")

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -23,7 +23,6 @@ from app.services.voice_logging_service import VoiceLoggingService
 from app.utils.twilio_validation import (
     validate_twilio_signature,
     validate_twilio_signature_with_token,
-    validate_webrtc_auth,
     get_request_body,
 )
 from app.utils.response import create_success_response
@@ -406,9 +405,21 @@ async def handle_call_events_webhook(
                     except Exception:
                         agent = None
         
-        # Validate request (Twilio signature or WebRTC auth)
+        # Validate request — Twilio signature only.
+        #
+        # This endpoint is exclusively used as a Twilio `status_callback` URL (see
+        # phone_number_service.py / voice_call_service.py / call_control_mixin.py —
+        # every caller that builds this URL does so for a Twilio `calls.create` /
+        # `<Dial>` status_callback). There is no browser/WebRTC-originated caller of
+        # this endpoint anywhere in the codebase: the Web SDK calling feature
+        # (app/routers/sdk.py `public-call-token`) connects browser clients directly
+        # to a LiveKit room and never posts here. The previous `elif is_webrtc` branch
+        # accepted *any* `Authorization: Bearer <anything>` header via a no-op stub
+        # (`validate_webrtc_auth`), which let an attacker bypass X-Twilio-Signature
+        # enforcement entirely by sending an arbitrary Authorization header instead —
+        # removed rather than wired up, since there's no real auth mechanism to wire
+        # it to.
         is_twilio = 'X-Twilio-Signature' in request.headers
-        is_webrtc = 'Authorization' in request.headers
 
         if is_twilio:
             form_params = dict(form_data)
@@ -419,12 +430,9 @@ async def handle_call_events_webhook(
                     callSessionId,
                 )
                 raise HTTPException(status_code=403, detail="Invalid Twilio signature")
-        elif is_webrtc:
-            if not validate_webrtc_auth(request):
-                raise HTTPException(status_code=403, detail="Invalid WebRTC authentication")
         else:
             if not settings.ALLOW_UNAUTHENTICATED_WEBHOOKS:
-                logger.warning("Call events webhook: no auth headers present and unauthenticated webhooks disallowed")
+                logger.warning("Call events webhook: no Twilio signature present and unauthenticated webhooks disallowed")
                 raise HTTPException(status_code=403, detail="Missing Twilio signature")
             logger.info("No authentication headers found, allowing for testing")
         

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -36,7 +36,8 @@ from app.routers.general_websocket import (
 from app.services.model_service import ModelService
 from app.services.credit_service import credit_service
 from app.services.batch_call_completion_service import notify_batch_call_ended
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
+import re
 from app.routers.bidirectional_stream import build_streaming_twiml
 from app.utils.voice_twilio_utils import (
     get_twilio_credentials_for_call,
@@ -278,13 +279,20 @@ async def handle_incoming_call(
 # "busy" maps to "no_answer" per ticket spec (both mean the callee was unreachable).
 # "in-progress" and "answered" are skipped for outbound (handled by first media packet
 # in bidirectional_stream.py); they map to "connected" for inbound/other flows.
+# Documented Twilio CallStatus values: https://www.twilio.com/docs/voice/api/call-resource#call-status-values
+# "queued" (call queued before dialing) maps to "initiated" — same pre-connection
+# semantics as the existing "initiated" entry.
+# "canceled" (call canceled via REST API before it was answered) maps to "failed" —
+# same "never completed" semantics as the existing "failed" entry.
 _TWILIO_TO_INTERNAL_STATUS: dict[str, str] = {
+    "queued": "initiated",
     "initiated": "initiated",
     "ringing": "ringing",
     "in-progress": "connected",
     "answered": "connected",
     "completed": "completed",
     "failed": "failed",
+    "canceled": "failed",
     "no-answer": "no_answer",
     "busy": "no_answer",
 }
@@ -401,16 +409,23 @@ async def handle_call_events_webhook(
         # Validate request (Twilio signature or WebRTC auth)
         is_twilio = 'X-Twilio-Signature' in request.headers
         is_webrtc = 'Authorization' in request.headers
-        
+
         if is_twilio:
-            logger.info("Twilio signature found, but skipping validation for testing")
-            # if not validate_twilio_signature(request, body):
-            #     raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+            form_params = dict(form_data)
+            if not await _validate_transfer_webhook_signature(request, db, call_session, form_params):
+                logger.warning(
+                    "Call events webhook: invalid Twilio signature (call_sid=%s, callSessionId=%s)",
+                    call_sid,
+                    callSessionId,
+                )
+                raise HTTPException(status_code=403, detail="Invalid Twilio signature")
         elif is_webrtc:
             if not validate_webrtc_auth(request):
                 raise HTTPException(status_code=403, detail="Invalid WebRTC authentication")
         else:
-            # For testing purposes, allow requests without validation
+            if not settings.ALLOW_UNAUTHENTICATED_WEBHOOKS:
+                logger.warning("Call events webhook: no auth headers present and unauthenticated webhooks disallowed")
+                raise HTTPException(status_code=403, detail="Missing Twilio signature")
             logger.info("No authentication headers found, allowing for testing")
         
         # (Removed outbound in-progress gating based on AnsweredBy/has_media)
@@ -891,6 +906,40 @@ async def get_dashboard_analytics(
         )
 
 
+# Twilio's documented recording resource path (GAP 2 / SSRF hardening):
+# https://www.twilio.com/docs/voice/api/recording#recording-uris
+# https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/Recordings/{RecordingSid}
+_TWILIO_RECORDING_URL_PATH_RE = re.compile(
+    r"^/2010-04-01/Accounts/[A-Za-z0-9]+/Recordings/[A-Za-z0-9]+$"
+)
+
+
+def _build_authenticated_recording_url(
+    recording_url: str, account_sid: str, auth_token: str
+) -> str | None:
+    """
+    Validate that `recording_url` is a genuine Twilio recording resource before
+    injecting credentials and fetching it, and build the authenticated URL.
+
+    Returns None if `recording_url` doesn't match Twilio's documented recording
+    URL shape — callers must reject the request rather than fetching an
+    attacker-controlled URL (SSRF guard).
+    """
+    if recording_url.startswith("http://") or recording_url.startswith("https://"):
+        parsed = urlparse(recording_url)
+        if parsed.scheme != "https" or parsed.netloc != "api.twilio.com":
+            return None
+        path = parsed.path
+    else:
+        # Twilio also sends relative recording URLs on some webhook shapes.
+        path = recording_url
+
+    if not _TWILIO_RECORDING_URL_PATH_RE.match(path):
+        return None
+
+    return f"https://{account_sid}:{auth_token}@api.twilio.com{path}.wav"
+
+
 @router.post("/webhook/recording-callback", response_class=HTMLResponse)
 async def handle_recording_callback(
     request: Request,
@@ -914,19 +963,42 @@ async def handle_recording_callback(
     
     try:
         form_data = await request.form()
-        
+
         # Extract recording details
         recording_url = form_data.get("RecordingUrl", "")
         recording_sid = form_data.get("RecordingSid", "")
         recording_duration = form_data.get("RecordingDuration", "0")
         call_sid = form_data.get("CallSid", "")
         recording_status = form_data.get("RecordingStatus", "")
-        
+
+        # Resolve call session up front so per-tenant Twilio credentials are
+        # available for signature validation below.
+        call_session = None
+        agent = None
+        if callSessionId:
+            try:
+                session_uuid = uuid.UUID(callSessionId)
+                call_session = call_session_service.get_call_session_by_id(db, session_uuid)
+                if call_session and agentId:
+                    agent = agent_service.get_agent_by_id(db, uuid.UUID(agentId), call_session.tenant_id)
+                    logger.debug(f"✅ Found call session and agent: {agent.name if agent else 'Unknown'}")
+            except ValueError:
+                logger.warning(f"⚠️ Invalid call session ID: {callSessionId}")
+
+        form_params = dict(form_data)
+        if not await _validate_transfer_webhook_signature(request, db, call_session, form_params):
+            logger.warning(
+                "Recording callback webhook: invalid Twilio signature (call_sid=%s, callSessionId=%s)",
+                call_sid,
+                callSessionId,
+            )
+            raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+
         logger.debug(f"🎵 Recording URL: {recording_url}")
         logger.debug(f"📝 Recording SID: {recording_sid}")
         logger.debug(f"⏱️ Duration: {recording_duration}s")
         logger.debug(f"📊 Status: {recording_status}")
-        
+
         # IMPORTANT: Twilio calls this webhook twice:
         # 1. 'action' callback (no status, has URL) - User finished speaking → PROCESS THIS for TTS
         # 2. 'recordingStatusCallback' (has status) - Recording processed → SKIP (just for logging)
@@ -945,22 +1017,7 @@ async def handle_recording_callback(
         # This is the 'action' callback - user finished speaking
         # Process this for TTS response
         logger.info("✅ Action callback detected - processing for TTS response")
-        
-        # Get call session
-        call_session = None
-        agent = None
-        
-        if callSessionId:
-            try:
-                session_uuid = uuid.UUID(callSessionId)
-                call_session = call_session_service.get_call_session_by_id(db, session_uuid)
-                
-                if call_session and agentId:
-                    agent = agent_service.get_agent_by_id(db, uuid.UUID(agentId), call_session.tenant_id)
-                    logger.debug(f"✅ Found call session and agent: {agent.name if agent else 'Unknown'}")
-            except ValueError:
-                logger.warning(f"⚠️ Invalid call session ID: {callSessionId}")
-        
+
         # Process recording if available
         if recording_url and call_session:
             try:
@@ -968,16 +1025,17 @@ async def handle_recording_callback(
                 
                 # ✅ Get Twilio credentials based on call session (DB or Env)
                 account_sid, auth_token = get_twilio_credentials_for_call(db, call_session)
-                
-                # Build authenticated recording URL
-                # Twilio recordings are usually at /Recordings/{RecordingSid}
-                if not recording_url.startswith('http'):
-                    # Relative URL - build full URL
-                    auth_url = f"https://{account_sid}:{auth_token}@api.twilio.com{recording_url}.wav"
-                else:
-                    # Full URL - add auth
-                    auth_url = recording_url.replace('https://api.twilio.com', f'https://{account_sid}:{auth_token}@api.twilio.com') + '.wav'
-                
+
+                # Build authenticated recording URL — strictly validated against
+                # Twilio's documented recording resource shape (SSRF guard, GAP 2).
+                auth_url = _build_authenticated_recording_url(recording_url, account_sid, auth_token)
+                if auth_url is None:
+                    logger.error(
+                        "❌ Rejected recording URL that does not match Twilio's recording resource pattern: %s",
+                        recording_url,
+                    )
+                    raise Exception("Invalid Twilio recording URL")
+
                 logger.debug("📥 Downloading audio from Twilio...")
                 
                 # Download the recording
@@ -1176,10 +1234,12 @@ async def handle_recording_callback(
         )
         
         return HTMLResponse(str(response), media_type="application/xml")
-    
+
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"❌ Error in recording callback webhook: {e}", exc_info=True)
-        
+
         # Ultimate fallback - use streaming TwiML if we have session info
         if call_session and agent:
             streaming_twiml = build_streaming_twiml(str(call_session.id), str(agent.id))
@@ -1240,22 +1300,38 @@ async def handle_gather_speech_webhook(
                 logger.debug(f"✅ Agent: {agent.name}")
             except Exception as e:
                 logger.warning(f"⚠️ Error fetching agent: {e}")
-        
+
+        form_params = dict(form_data)
+        if not await _validate_transfer_webhook_signature(request, db, call_session, form_params):
+            logger.warning(
+                "Gather speech webhook: invalid Twilio signature (call_sid=%s, callSessionId=%s)",
+                call_sid,
+                callSessionId,
+            )
+            raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+
         # Download audio from Twilio recording
         if recording_url and call_session:
             try:
                 import requests
-                
+
                 # Get Twilio credentials
                 client = twilio_service.get_client()
                 account_sid = client.username
                 auth_token = client.password
-                
-                # Download recording with authentication
-                auth_url = f"https://{account_sid}:{auth_token}@api.twilio.com{recording_url}.wav"
+
+                # Download recording with authentication — strictly validated
+                # against Twilio's documented recording resource shape (SSRF guard).
+                auth_url = _build_authenticated_recording_url(recording_url, account_sid, auth_token)
+                if auth_url is None:
+                    logger.error(
+                        "❌ Rejected recording URL that does not match Twilio's recording resource pattern: %s",
+                        recording_url,
+                    )
+                    raise Exception("Invalid Twilio recording URL")
                 logger.debug("📥 Downloading audio from Twilio...")
-                
-                audio_response = requests.get(auth_url)
+
+                audio_response = requests.get(auth_url, timeout=10)
                 audio_content = audio_response.content
                 
                 logger.debug(f"✅ Downloaded {len(audio_content)} bytes of audio")
@@ -1407,10 +1483,23 @@ async def handle_recording_status_webhook(
         logger.debug(f"Status: {recording_status}")
         logger.debug(f"URL: {recording_url}")
         logger.debug(f"Duration: {recording_duration}")
-        
+
         # Find the call session
+        call_session = (
+            call_session_service.get_call_session_by_twilio_sid(db, call_sid)
+            if call_sid
+            else None
+        )
+
+        form_params = dict(form_data)
+        if not await _validate_transfer_webhook_signature(request, db, call_session, form_params):
+            logger.warning(
+                "Recording status webhook: invalid Twilio signature (call_sid=%s)",
+                call_sid,
+            )
+            raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+
         if call_sid:
-            call_session = call_session_service.get_call_session_by_twilio_sid(db, call_sid)
             if call_session:
                 # Update recording URL when recording is completed
                 if recording_status == "completed" and recording_url:
@@ -1440,7 +1529,9 @@ async def handle_recording_status_webhook(
         
         # Return empty TwiML response
         return HTMLResponse("", media_type="application/xml")
-        
+
+    except HTTPException:
+        raise
     except Exception as e:
         logger.warning(f"⚠️ Error handling recording status webhook: {e}")
         return HTMLResponse("", media_type="application/xml")

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -297,6 +297,33 @@ _TWILIO_TO_INTERNAL_STATUS: dict[str, str] = {
 }
 
 
+def _commit_terminal_call_session_status(db: Session, call_session: CallSession | None) -> None:
+    """
+    Persist the call_session.status mutation applied earlier in
+    handle_call_events_webhook (`call_session.status = internal_status`).
+
+    Only the "completed" branch persists status today, via
+    call_session_service.update_call_session_status() (which commits). The
+    "failed" / "busy" / "no-answer" / "canceled" branches previously only
+    mutated the in-memory ORM object with no commit anywhere in the request —
+    the transition was silently lost once the request's DB session closed
+    without a commit (SessionLocal is autocommit=False/autoflush=False).
+
+    Deliberately NOT a swap to update_call_session_status(): that method has
+    additional side effects (end_time/duration, call log update, inbound CRM
+    sync scheduling for completed/failed/busy) that aren't a byproduct-free fit
+    here and would risk double-firing behavior already handled explicitly by
+    this webhook's elif chain (webhook fire, credit-monitoring stop, batch
+    completion notify). This is intentionally just the missing commit.
+    """
+    if call_session is None:
+        return
+    try:
+        db.commit()
+    except Exception as e:
+        logger.warning(f"⚠️ Failed to persist call session status update (non-critical): {e}")
+
+
 @router.post("/call-events", response_class=HTMLResponse, include_in_schema=False)
 @router.post("/webhook/call-events", response_class=HTMLResponse, include_in_schema=False)
 async def handle_call_events_webhook(
@@ -733,6 +760,10 @@ async def handle_call_events_webhook(
             # Call failed - handle error
             logger.error(f"Call failed - SID: {call_sid}")
 
+            # Persist the "failed" status set earlier in this function (Blocker B
+            # follow-up: previously never committed for this branch).
+            _commit_terminal_call_session_status(db, call_session)
+
             # Fire call.failed webhook
             if call_session:
                 try:
@@ -803,6 +834,10 @@ async def handle_call_events_webhook(
             # a canceled outbound batch call doesn't get stuck as permanently "active".
             logger.info(f"Call canceled - SID: {call_sid}")
 
+            # Persist the "failed" status set earlier in this function (Blocker B
+            # follow-up: previously never committed for this branch).
+            _commit_terminal_call_session_status(db, call_session)
+
             # Fire call.failed webhook (no dedicated call.canceled event type)
             if call_session:
                 try:
@@ -869,6 +904,10 @@ async def handle_call_events_webhook(
         elif call_status in ("busy", "no-answer"):
             # Both busy and no-answer → internal "no_answer" (per ticket spec)
             logger.info(f"Call {call_status} (internal: no_answer) - SID: {call_sid}")
+
+            # Persist the "no_answer" status set earlier in this function (Blocker B
+            # follow-up: previously never committed for this branch).
+            _commit_terminal_call_session_status(db, call_session)
 
             # Fire call.failed webhook for no_answer/busy
             if call_session:

--- a/app/routers/voice_gather.py
+++ b/app/routers/voice_gather.py
@@ -3,7 +3,7 @@ Fast Conversational AI Router using Twilio Gather + Deepgram STT + LLM + TTS
 Optimized for 3-4 second latency per turn
 """
 
-from fastapi import APIRouter, Request, Query, Depends
+from fastapi import APIRouter, Request, Query, Depends, HTTPException, status
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 from twilio.twiml.voice_response import VoiceResponse
@@ -22,7 +22,12 @@ from app.services.google_tts_service import google_tts_service
 from app.services.voice_logging_service import VoiceLoggingService
 from app.services.model_service import ModelService
 from app.core.config import settings
-from app.utils.twilio_validation import get_request_body
+from app.utils.twilio_validation import (
+    get_request_body,
+    validate_twilio_signature,
+    validate_twilio_signature_with_token,
+)
+from app.utils.voice_twilio_utils import get_twilio_credentials_for_call
 from app.routers.general_websocket import broadcast_call_event
 from urllib.parse import quote
 import hashlib
@@ -33,6 +38,26 @@ from app.routers.tts_audio import audio_cache
 
 router = APIRouter()
 model_service = ModelService()
+
+
+async def _validate_streaming_webhook_signature(
+    request: Request, db: Session, call_session, form_params: dict
+) -> bool:
+    """Same per-tenant-token-with-global-fallback pattern used across the other
+    Twilio-facing webhooks in this codebase (see voice.py / amd_webhook.py)."""
+    if settings.ALLOW_UNAUTHENTICATED_WEBHOOKS:
+        return True
+    if call_session is not None:
+        try:
+            _, auth_token = get_twilio_credentials_for_call(db, call_session)
+            if validate_twilio_signature_with_token(request, form_params, auth_token):
+                return True
+        except Exception as cred_err:
+            logger.warning(
+                "Streaming greeting webhook: per-session Twilio token unavailable (%s); falling back to env token",
+                cred_err,
+            )
+    return validate_twilio_signature(request, form_params)
 
 
 def generate_cache_key(text: str, language: str, voice_type: str, use_chirp3_hd: bool = False, format: str = "mp3") -> str:
@@ -659,7 +684,28 @@ async def streaming_greeting_webhook(
         form_data = await request.form()
         call_sid = form_data.get("CallSid", "")
         call_status = form_data.get("CallStatus", "")
-        
+
+        call_session_for_auth = None
+        if callSessionId:
+            try:
+                call_session_for_auth = call_session_service.get_call_session_by_id(
+                    db, uuid.UUID(callSessionId)
+                )
+            except ValueError:
+                call_session_for_auth = None
+
+        if not await _validate_streaming_webhook_signature(
+            request, db, call_session_for_auth, dict(form_data)
+        ):
+            logger.warning(
+                "Streaming greeting webhook: invalid Twilio signature (call_sid=%s, callSessionId=%s)",
+                call_sid,
+                callSessionId,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Invalid Twilio signature"
+            )
+
         # 🎯 WAIT FOR USER TO ANSWER - Only connect when call is answered!
         logger.info(f"🔍 Streaming webhook - Call Status: '{call_status}'")
         
@@ -728,10 +774,12 @@ async def streaming_greeting_webhook(
         logger.debug("🔗 WebSocket: %s", ws_url)
 
         return HTMLResponse(str(response), media_type="application/xml")
-    
+
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"❌ Error in streaming webhook: {e}", exc_info=True)
-        
+
         # Fallback response
         response = VoiceResponse()
         response.say("Sorry, something went wrong. Please call back later.", voice="Polly.Joanna")

--- a/app/services/batch_call_completion_service.py
+++ b/app/services/batch_call_completion_service.py
@@ -12,11 +12,17 @@ from app.core.logger import logger
 from app.models.batch_call_record import BatchCallRecord
 
 # Twilio terminal statuses we care about for batch lifecycle
+# "canceled" (call canceled via REST API before it was answered) maps to "failed" —
+# same "never completed" semantics as the existing "failed" entry (GAP 4 follow-up):
+# without this, a canceled outbound batch call would never advance out of
+# BatchCallRecord.status == "active" (see notify_batch_call_ended's early-return
+# on an unmapped ended_reason).
 _TWILIO_TO_ENDED_REASON = {
     "completed": "completed",
     "busy": "busy",
     "no-answer": "no-answer",
     "failed": "failed",
+    "canceled": "failed",
 }
 
 

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException, status
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
+from twilio.base.exceptions import TwilioRestException
 
 from app.core.config import settings
 from app.core.error_responses import build_call_initiate_error_payload
@@ -32,6 +33,49 @@ from app.routers.general_websocket import broadcast_call_status_update
 
 # Outbound sessions occupying a workspace concurrent-call slot (must match DB values).
 _ACTIVE_OUTBOUND_STATUSES = ("initiated", "ringing", "connected", "in-progress")
+
+# Retry/backoff for transient Twilio call-creation failures (rate limiting / Twilio-side
+# outages) — never retried for permanent 4xx errors (invalid number, unverified caller ID,
+# etc: Twilio error codes like 21211, 21214). Mirrors the pattern used for CRM outbound
+# HTTP calls elsewhere in this codebase (see ghl_service.py / hubspot_service.py
+# _request_with_backoff).
+_TWILIO_CALL_MAX_RETRIES = 2
+_TWILIO_CALL_BASE_BACKOFF_SECONDS = 0.5
+
+
+def _is_transient_twilio_error(exc: TwilioRestException) -> bool:
+    """True for HTTP 429 (rate limited) or 5xx (Twilio-side) errors — retryable.
+    False for everything else, including 4xx errors like invalid/unverified numbers."""
+    status_code = getattr(exc, "status", None)
+    if status_code is None:
+        return False
+    return status_code == 429 or 500 <= status_code < 600
+
+
+async def _create_twilio_call_with_retry(call_fn, **kwargs):
+    """
+    Call `twilio_service.make_call` / `make_call_with_credentials` with exponential
+    backoff retry on transient failures only. Permanent errors raise immediately on
+    the first attempt so the caller can fail fast.
+    """
+    attempt = 0
+    while True:
+        try:
+            return call_fn(**kwargs)
+        except TwilioRestException as exc:
+            if not _is_transient_twilio_error(exc) or attempt >= _TWILIO_CALL_MAX_RETRIES:
+                raise
+            wait_seconds = _TWILIO_CALL_BASE_BACKOFF_SECONDS * (2 ** attempt)
+            logger.warning(
+                "Transient Twilio call-creation error (status=%s code=%s); retrying in %.1fs (attempt %d/%d)",
+                exc.status,
+                getattr(exc, "code", None),
+                wait_seconds,
+                attempt + 1,
+                _TWILIO_CALL_MAX_RETRIES,
+            )
+            await asyncio.sleep(wait_seconds)
+            attempt += 1
 
 
 async def initiate_call(
@@ -561,7 +605,8 @@ async def initiate_call(
                 else {}
             )
             if use_custom_credentials:
-                call = twilio_service.make_call_with_credentials(
+                call = await _create_twilio_call_with_retry(
+                    twilio_service.make_call_with_credentials,
                     to_number=call_request.toNumber,
                     from_number=from_number,
                     webhook_url=webhook_url,
@@ -572,7 +617,8 @@ async def initiate_call(
                     **amd_kwargs,
                 )
             else:
-                call = twilio_service.make_call(
+                call = await _create_twilio_call_with_retry(
+                    twilio_service.make_call,
                     to_number=call_request.toNumber,
                     from_number=from_number,
                     webhook_url=webhook_url,

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -34,22 +34,29 @@ from app.routers.general_websocket import broadcast_call_status_update
 # Outbound sessions occupying a workspace concurrent-call slot (must match DB values).
 _ACTIVE_OUTBOUND_STATUSES = ("initiated", "ringing", "connected", "in-progress")
 
-# Retry/backoff for transient Twilio call-creation failures (rate limiting / Twilio-side
-# outages) — never retried for permanent 4xx errors (invalid number, unverified caller ID,
-# etc: Twilio error codes like 21211, 21214). Mirrors the pattern used for CRM outbound
-# HTTP calls elsewhere in this codebase (see ghl_service.py / hubspot_service.py
-# _request_with_backoff).
+# Retry/backoff for transient Twilio call-creation failures — deliberately narrow:
+# `calls.create` is a non-idempotent, side-effecting operation (it actually dials the
+# customer) and Twilio provides no idempotency-key mechanism for it. Only HTTP 429 is
+# retried, because Twilio guarantees a 429 means the request was rejected before being
+# queued/dialed. A 5xx is ambiguous — it can mean the call was already dialed server-side
+# before the error was returned (e.g. a gateway timeout) — so retrying on 5xx risks a real
+# duplicate outbound call to the customer that would go untracked (only one
+# call_session.twilio_call_sid is ever stored). 5xx / permanent 4xx errors (invalid number,
+# unverified caller ID — Twilio error codes like 21211, 21214) all fail immediately.
+# Mirrors the retry/backoff *pattern* used for CRM outbound HTTP calls elsewhere in this
+# codebase (see ghl_service.py / hubspot_service.py _request_with_backoff), which retry
+# only on 429 for the same "don't double-fire a side-effecting request" reasoning.
 _TWILIO_CALL_MAX_RETRIES = 2
 _TWILIO_CALL_BASE_BACKOFF_SECONDS = 0.5
 
 
 def _is_transient_twilio_error(exc: TwilioRestException) -> bool:
-    """True for HTTP 429 (rate limited) or 5xx (Twilio-side) errors — retryable.
-    False for everything else, including 4xx errors like invalid/unverified numbers."""
+    """True only for HTTP 429 (rate limited — Twilio guarantees the call was never
+    dialed). False for everything else, including 5xx: `calls.create` is
+    non-idempotent and side-effecting, so an ambiguous 5xx must not be retried
+    (risk of dialing the customer twice)."""
     status_code = getattr(exc, "status", None)
-    if status_code is None:
-        return False
-    return status_code == 429 or 500 <= status_code < 600
+    return status_code == 429
 
 
 async def _create_twilio_call_with_retry(call_fn, **kwargs):

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -39,6 +39,29 @@ class TtsStreamMixin:
             return pub.publish_mulaw
         return None
 
+    async def _send_twilio_clear_event(self) -> None:
+        """
+        Tell Twilio to discard any audio already buffered/sent for this stream.
+
+        Required by the Media Streams protocol on barge-in: cancelling our own
+        in-flight TTS task only stops *us* from sending more frames — it does
+        not stop Twilio from continuing to play frames it already received.
+        See: https://www.twilio.com/docs/voice/media-streams/websocket-messages
+        """
+        stream_sid = getattr(self, "stream_sid", None)
+        if not stream_sid:
+            return
+        try:
+            await self.websocket.send_json({
+                "event": "clear",
+                "streamSid": stream_sid,
+            })
+        except RuntimeError:
+            # WebSocket already closed (hangup) — nothing to clear.
+            pass
+        except Exception as e:
+            logger.warning(f"Failed to send Twilio 'clear' event: {e}")
+
     async def _start_background_audio_with_delay(self):
         """Start background loop after call stabilizes (dev-branch behavior)."""
         try:

--- a/tests/routers/test_voice_twilio_hardening.py
+++ b/tests/routers/test_voice_twilio_hardening.py
@@ -813,20 +813,13 @@ class TestCanceledStatusSideEffects:
         assert scheduled.args[1] == "call.failed"
         assert scheduled.args[2]["reason"] == "canceled"
 
-    def test_canceled_applies_internal_status_mapping_in_memory(self, db):
+    def test_canceled_status_is_persisted_via_fresh_db_read(self, db):
         """
-        The status-update block (separate from the business-effect elif chain)
-        must apply the canceled -> "failed" mapping from _TWILIO_TO_INTERNAL_STATUS
-        to the in-memory call_session object.
-
-        NOTE: this assertion intentionally does NOT go through db.refresh(). This
-        webhook path only persists call_session.status via
-        call_session_service.update_call_session_status(), which is exclusively
-        called from the "completed" branch — "failed"/"busy"/"no-answer"/"canceled"
-        all set call_session.status in memory without an explicit db.commit(), so
-        the change does not survive a refresh. That's a pre-existing gap shared by
-        "failed"/"busy"/"no-answer" (reproduced independently, not introduced by
-        this change) — out of scope here; flagged separately in the fix report.
+        Blocker B fix: the "canceled" -> "failed" status mutation must actually be
+        committed, not just set on the in-memory ORM object. Verified via a fresh
+        query on a separate Session bound to the same underlying connection (not
+        db.refresh() on the same session/object, which would trivially pass even
+        without a commit as long as the object is still attached and unexpired).
         """
         from app.routers.voice import handle_call_events_webhook
 
@@ -834,6 +827,7 @@ class TestCanceledStatusSideEffects:
         agent_id = _make_agent(db, workspace_id)
         user_id = _make_user(db)
         cs = _make_call_session(db, workspace_id, agent_id, user_id)
+        cs_id = cs.id
 
         request = _FakeRequest(
             {
@@ -862,7 +856,85 @@ class TestCanceledStatusSideEffects:
                 )
             )
 
-        assert cs.status == "failed"
+        fresh_session = _Session()
+        try:
+            from app.models.call_session import CallSession
+
+            reloaded = fresh_session.get(CallSession, cs_id)
+            assert reloaded.status == "failed"
+        finally:
+            fresh_session.close()
+
+
+class TestTerminalStatusPersistence:
+    """
+    Blocker B regression coverage: "failed" / "busy" / "no-answer" previously had
+    the exact same missing-commit bug as "canceled" (they all only mutated the
+    in-memory call_session.status with no db.commit() anywhere in the request).
+    Each is verified via a fresh Session/query, not db.refresh() on the same
+    session (which doesn't prove persistence).
+    """
+
+    def _run_and_reload(self, db, cs, call_status: str):
+        from app.models.call_session import CallSession
+        from app.routers.voice import handle_call_events_webhook
+
+        request = _FakeRequest(
+            {
+                "CallStatus": call_status,
+                "CallSid": cs.twilio_call_sid,
+                "From": "+15550001111",
+                "To": "+15550002222",
+                "Direction": "outbound-api",
+            }
+        )
+
+        with (
+            patch("app.routers.voice.credit_service.stop_credit_monitoring"),
+            patch("app.routers.voice.notify_batch_call_ended", new=AsyncMock()),
+        ):
+            asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=str(cs.agent_id),
+                    userId=None,
+                    callSessionId=str(cs.id),
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+
+        fresh_session = _Session()
+        try:
+            return fresh_session.get(CallSession, cs.id).status
+        finally:
+            fresh_session.close()
+
+    def test_failed_status_is_persisted(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        assert self._run_and_reload(db, cs, "failed") == "failed"
+
+    def test_busy_status_is_persisted_as_no_answer(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        assert self._run_and_reload(db, cs, "busy") == "no_answer"
+
+    def test_no_answer_status_is_persisted(self, db):
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        assert self._run_and_reload(db, cs, "no-answer") == "no_answer"
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/routers/test_voice_twilio_hardening.py
+++ b/tests/routers/test_voice_twilio_hardening.py
@@ -248,6 +248,47 @@ class TestCallEventsWebhookSignature:
             )
         assert resp.status_code == 200
 
+    def test_forged_authorization_header_no_longer_bypasses_signature_check(self, db):
+        """
+        Regression guard: this endpoint used to accept ANY `Authorization: Bearer
+        <anything>` header via a no-op `validate_webrtc_auth()` stub, letting an
+        attacker skip X-Twilio-Signature enforcement entirely by sending an
+        Authorization header instead of (or without) a valid Twilio signature.
+        This endpoint is Twilio-status-callback-only (no real WebRTC caller exists
+        anywhere in the codebase) — the bypass branch was removed, not fixed.
+        """
+        from app.routers.voice import handle_call_events_webhook
+
+        request = _FakeRequest(
+            {"CallStatus": "completed", "CallSid": "CA1"},
+            headers={"Authorization": "Bearer attacker-supplied-token"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_validate_webrtc_auth_no_longer_imported_or_referenced(self):
+        """The dead WebRTC-bypass branch (and its no-op stub import) must be gone,
+        not just unreachable."""
+        import app.routers.voice as voice_module
+
+        assert not hasattr(voice_module, "validate_webrtc_auth")
+
 
 class TestRecordingCallbackSignature:
     def test_rejects_invalid_signature(self, db):

--- a/tests/routers/test_voice_twilio_hardening.py
+++ b/tests/routers/test_voice_twilio_hardening.py
@@ -1,0 +1,694 @@
+"""
+Unit tests for the Twilio security-hardening fixes on the Media Streams webhook
+surface (branch fix/twilio-security-hardening):
+
+1. X-Twilio-Signature validation re-enabled / added on previously-unprotected
+   webhooks in app/routers/voice.py and app/routers/voice_gather.py.
+2. SSRF guard on RecordingUrl before it is fetched with injected credentials.
+3. Twilio Media Streams `clear` event sent on barge-in.
+4. Twilio CallStatus -> internal status mapping gaps (queued / canceled).
+5. Retry/backoff for transient (429 / 5xx) Twilio call-creation failures.
+
+DB is an in-memory SQLite fixture (same pattern as tests/routers/test_amd_webhook.py).
+Signature math itself is not exercised here (that's twilio_validation's own
+responsibility) — these tests verify the *call sites* enforce validation and
+propagate a 403 on failure, using the same bypass/patch pattern as
+test_amd_webhook.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import JSONB, UUID as PG_UUID
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import sessionmaker
+
+from app.core.config import settings
+from app.db.base import Base
+
+
+@compiles(JSONB, "sqlite")
+def _jsonb_sqlite(type_, compiler, **kw):
+    return "JSON"
+
+
+@compiles(PG_UUID, "sqlite")
+def _uuid_sqlite(type_, compiler, **kw):
+    return "VARCHAR(36)"
+
+
+_SHARED_CONN = sqlite3.connect(":memory:", check_same_thread=False)
+_engine = create_engine(
+    "sqlite://", creator=lambda: _SHARED_CONN, connect_args={"check_same_thread": False}
+)
+_Session = sessionmaker(bind=_engine)
+
+
+def _setup_db():
+    import app.models.agent  # noqa: F401
+    import app.models.call_session  # noqa: F401
+    import app.models.tenant  # noqa: F401
+    import app.models.user  # noqa: F401
+    import app.models.plan  # noqa: F401
+    import app.models.subscription  # noqa: F401
+    import app.models.usage_record  # noqa: F401
+    import app.models.role  # noqa: F401
+    import app.models.phone_number  # noqa: F401
+
+    Base.metadata.drop_all(bind=_engine)
+    Base.metadata.create_all(bind=_engine)
+
+
+@pytest.fixture()
+def db():
+    _setup_db()
+    session = _Session()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture(autouse=True)
+def _bypass_signature_validation():
+    """Most tests exercise business logic, not signature validation — bypass it
+    by default; signature-focused tests override this explicitly."""
+    with patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", True):
+        yield
+
+
+class _FakeURL:
+    def __init__(self, path="/api/v1/voice/webhook/call-events"):
+        self.path = path
+        self.query = ""
+        self.scheme = "https"
+        self.netloc = "example.com"
+
+
+class _FakeRequest:
+    def __init__(self, form_data: dict, headers: dict | None = None):
+        self._form_data = form_data
+        self.headers = headers or {}
+        self.method = "POST"
+        self.url = _FakeURL()
+
+    async def form(self):
+        return self._form_data
+
+    async def body(self):
+        return b""
+
+
+def _make_tenant(db):
+    from app.models.tenant import Tenant
+
+    t = Tenant(name="WS", schema_name=f"ws_{uuid.uuid4().hex[:8]}")
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t.id
+
+
+def _make_agent(db, tenant_id):
+    from app.models.agent import Agent
+
+    a = Agent(tenant_id=tenant_id, name="TestAgent", system_prompt="", status="ready")
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a.id
+
+
+def _make_user(db):
+    from app.models.user import User
+
+    u = User(
+        id=uuid.uuid4(),
+        first_name="Voice",
+        last_name="Test",
+        email=f"voice-{uuid.uuid4().hex}@example.com",
+        hashed_password="x",
+    )
+    db.add(u)
+    db.flush()
+    return u.id
+
+
+def _make_call_session(db, tenant_id, agent_id, user_id):
+    from datetime import datetime, timezone
+
+    from app.models.call_session import CallSession
+
+    cs = CallSession(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        agent_id=agent_id,
+        tenant_id=tenant_id,
+        start_time=datetime.now(timezone.utc),
+        status="active",
+        call_type="outbound",
+        twilio_call_sid="CAtest123",
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+    return cs
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Signature validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCallEventsWebhookSignature:
+    def test_rejects_missing_auth_headers_when_not_bypassed(self, db):
+        from app.routers.voice import handle_call_events_webhook
+
+        request = _FakeRequest({"CallStatus": "ringing", "CallSid": "CA1"}, headers={})
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_rejects_invalid_twilio_signature(self, db):
+        from app.routers.voice import handle_call_events_webhook
+
+        request = _FakeRequest(
+            {"CallStatus": "ringing", "CallSid": "CA1"},
+            headers={"X-Twilio-Signature": "bogus"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice.validate_twilio_signature", return_value=False),
+            patch(
+                "app.routers.voice.validate_twilio_signature_with_token", return_value=False
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_accepts_valid_twilio_signature(self, db):
+        from app.routers.voice import handle_call_events_webhook
+
+        request = _FakeRequest(
+            {"CallStatus": "ringing", "CallSid": "CA1"},
+            headers={"X-Twilio-Signature": "goodsig"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice.validate_twilio_signature", return_value=True),
+        ):
+            resp = asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert resp.status_code == 200
+
+
+class TestRecordingCallbackSignature:
+    def test_rejects_invalid_signature(self, db):
+        from app.routers.voice import handle_recording_callback
+
+        request = _FakeRequest(
+            {"RecordingStatus": "completed", "CallSid": "CA1"},
+            headers={"X-Twilio-Signature": "bogus"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice.validate_twilio_signature", return_value=False),
+            patch(
+                "app.routers.voice.validate_twilio_signature_with_token", return_value=False
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            asyncio.run(
+                handle_recording_callback(
+                    request=request,
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_accepts_valid_signature_for_status_callback(self, db):
+        from app.routers.voice import handle_recording_callback
+
+        request = _FakeRequest(
+            {"RecordingStatus": "completed", "CallSid": "CA1"},
+            headers={"X-Twilio-Signature": "goodsig"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice.validate_twilio_signature", return_value=True),
+        ):
+            resp = asyncio.run(
+                handle_recording_callback(
+                    request=request,
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert resp.status_code == 200
+
+
+class TestGatherSpeechWebhookSignature:
+    def test_rejects_invalid_signature(self, db):
+        from app.routers.voice import handle_gather_speech_webhook
+
+        request = _FakeRequest(
+            {"CallSid": "CA1", "SpeechResult": "hello"},
+            headers={"X-Twilio-Signature": "bogus"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice.validate_twilio_signature", return_value=False),
+            patch(
+                "app.routers.voice.validate_twilio_signature_with_token", return_value=False
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            asyncio.run(
+                handle_gather_speech_webhook(
+                    request=request,
+                    agentId=None,
+                    callSessionId=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert exc_info.value.status_code == 403
+
+
+class TestRecordingStatusWebhookSignature:
+    def test_rejects_invalid_signature(self, db):
+        from app.routers.voice import handle_recording_status_webhook
+
+        request = _FakeRequest(
+            {"RecordingSid": "RE1", "CallSid": "CA1", "RecordingStatus": "completed"},
+            headers={"X-Twilio-Signature": "bogus"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice.validate_twilio_signature", return_value=False),
+            patch(
+                "app.routers.voice.validate_twilio_signature_with_token", return_value=False
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            asyncio.run(handle_recording_status_webhook(request=request, db=db))
+        assert exc_info.value.status_code == 403
+
+    def test_accepts_valid_signature_and_updates_session(self, db):
+        from app.routers.voice import handle_recording_status_webhook
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest(
+            {
+                "RecordingSid": "RE1",
+                "CallSid": cs.twilio_call_sid,
+                "RecordingStatus": "completed",
+                "RecordingUrl": "https://api.twilio.com/2010-04-01/Accounts/ACxx/Recordings/RExx",
+                "RecordingDuration": "5",
+            },
+            headers={"X-Twilio-Signature": "goodsig"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice.validate_twilio_signature", return_value=True),
+        ):
+            resp = asyncio.run(handle_recording_status_webhook(request=request, db=db))
+        assert resp.status_code == 200
+        db.refresh(cs)
+        assert cs.recording_url == "https://api.twilio.com/2010-04-01/Accounts/ACxx/Recordings/RExx"
+
+
+class TestStreamingGreetingWebhookSignature:
+    def test_rejects_invalid_signature(self, db):
+        from app.routers.voice_gather import streaming_greeting_webhook
+
+        request = _FakeRequest(
+            {"CallSid": "CA1", "CallStatus": "in-progress"},
+            headers={"X-Twilio-Signature": "bogus"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice_gather.validate_twilio_signature", return_value=False),
+            patch(
+                "app.routers.voice_gather.validate_twilio_signature_with_token",
+                return_value=False,
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            asyncio.run(
+                streaming_greeting_webhook(
+                    request=request,
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    body="",
+                    db=db,
+                )
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_accepts_valid_signature(self, db):
+        from app.routers.voice_gather import streaming_greeting_webhook
+
+        request = _FakeRequest(
+            {"CallSid": "CA1", "CallStatus": "queued"},
+            headers={"X-Twilio-Signature": "goodsig"},
+        )
+
+        with (
+            patch.object(settings, "ALLOW_UNAUTHENTICATED_WEBHOOKS", False),
+            patch("app.routers.voice_gather.validate_twilio_signature", return_value=True),
+        ):
+            resp = asyncio.run(
+                streaming_greeting_webhook(
+                    request=request,
+                    agentId=None,
+                    userId=None,
+                    callSessionId=None,
+                    body="",
+                    db=db,
+                )
+            )
+        # "queued" isn't answered/in-progress yet -> pause/redirect TwiML, not an error
+        assert resp.status_code == 200
+        assert "Redirect" in resp.body.decode()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. SSRF guard on RecordingUrl
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRecordingUrlSSRFGuard:
+    def test_build_authenticated_recording_url_accepts_documented_shape(self):
+        from app.routers.voice import _build_authenticated_recording_url
+
+        url = _build_authenticated_recording_url(
+            "https://api.twilio.com/2010-04-01/Accounts/ACxx/Recordings/RExx",
+            "ACxx",
+            "secret",
+        )
+        assert url == (
+            "https://ACxx:secret@api.twilio.com"
+            "/2010-04-01/Accounts/ACxx/Recordings/RExx.wav"
+        )
+
+    def test_build_authenticated_recording_url_accepts_relative_path(self):
+        from app.routers.voice import _build_authenticated_recording_url
+
+        url = _build_authenticated_recording_url(
+            "/2010-04-01/Accounts/ACxx/Recordings/RExx", "ACxx", "secret"
+        )
+        assert url == (
+            "https://ACxx:secret@api.twilio.com"
+            "/2010-04-01/Accounts/ACxx/Recordings/RExx.wav"
+        )
+
+    def test_build_authenticated_recording_url_rejects_foreign_host(self):
+        from app.routers.voice import _build_authenticated_recording_url
+
+        url = _build_authenticated_recording_url(
+            "https://evil.example.com/2010-04-01/Accounts/ACxx/Recordings/RExx",
+            "ACxx",
+            "secret",
+        )
+        assert url is None
+
+    def test_build_authenticated_recording_url_rejects_no_op_replace_bypass(self):
+        """Regression guard: a URL that doesn't start with the Twilio host must
+        not silently pass through the old naive .replace()-based construction."""
+        from app.routers.voice import _build_authenticated_recording_url
+
+        url = _build_authenticated_recording_url(
+            "http://attacker.example.com/steal-me", "ACxx", "secret"
+        )
+        assert url is None
+
+    def test_build_authenticated_recording_url_rejects_malformed_path(self):
+        from app.routers.voice import _build_authenticated_recording_url
+
+        url = _build_authenticated_recording_url(
+            "https://api.twilio.com/../../etc/passwd", "ACxx", "secret"
+        )
+        assert url is None
+
+    def test_recording_callback_rejects_malicious_recording_url(self, db):
+        """End-to-end: a malicious RecordingUrl must never reach requests.get()."""
+        from app.routers.voice import handle_recording_callback
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest(
+            {
+                "RecordingUrl": "https://attacker.example.com/payload",
+                "CallSid": cs.twilio_call_sid,
+            }
+        )
+
+        with (
+            patch(
+                "app.routers.voice.get_twilio_credentials_for_call",
+                return_value=("ACxx", "secret"),
+            ),
+            patch("app.routers.voice.requests.get") as mock_get,
+        ):
+            resp = asyncio.run(
+                handle_recording_callback(
+                    request=request,
+                    agentId=str(agent_id),
+                    userId=None,
+                    callSessionId=str(cs.id),
+                    body="",
+                    db=db,
+                )
+            )
+
+        mock_get.assert_not_called()
+        assert resp.status_code == 200
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Twilio Media Streams `clear` event on barge-in
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBargeInClearEvent:
+    def _handler(self, *, stream_sid="MZ123"):
+        from app.routers.bidirectional_stream import BidirectionalStreamHandler
+
+        h = object.__new__(BidirectionalStreamHandler)
+        h.websocket = MagicMock()
+        h.websocket.send_json = AsyncMock()
+        h.stream_sid = stream_sid
+        h._llm_response_task = None
+        h._tts_pipeline = None
+        h._rag_prefetch_task = None
+        h._speculative_prefetch_task = None
+        h._rag_prefetch_user_text = ""
+        return h
+
+    def test_send_twilio_clear_event_sends_clear_with_stream_sid(self):
+        h = self._handler(stream_sid="MZ999")
+        asyncio.run(h._send_twilio_clear_event())
+        h.websocket.send_json.assert_awaited_once_with(
+            {"event": "clear", "streamSid": "MZ999"}
+        )
+
+    def test_send_twilio_clear_event_noop_without_stream_sid(self):
+        h = self._handler(stream_sid=None)
+        asyncio.run(h._send_twilio_clear_event())
+        h.websocket.send_json.assert_not_called()
+
+    def test_cancel_inflight_llm_response_sends_clear_event(self):
+        """The barge-in cancellation path must flush Twilio's already-buffered
+        audio, not just stop our own local TTS task."""
+        h = self._handler(stream_sid="MZbargein")
+        asyncio.run(h._cancel_inflight_llm_response())
+        h.websocket.send_json.assert_awaited_once_with(
+            {"event": "clear", "streamSid": "MZbargein"}
+        )
+
+    def test_cancel_inflight_llm_response_cancels_tts_pipeline_and_sends_clear(self):
+        h = self._handler(stream_sid="MZbargein2")
+        h._tts_pipeline = MagicMock()
+        h._tts_pipeline.cancel_current_and_clear_queue = AsyncMock()
+
+        asyncio.run(h._cancel_inflight_llm_response())
+
+        h._tts_pipeline.cancel_current_and_clear_queue.assert_awaited_once()
+        h.websocket.send_json.assert_awaited_once_with(
+            {"event": "clear", "streamSid": "MZbargein2"}
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Twilio CallStatus -> internal status mapping gaps
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCallStatusMapping:
+    def test_queued_maps_to_initiated(self):
+        from app.routers.voice import _TWILIO_TO_INTERNAL_STATUS
+
+        assert _TWILIO_TO_INTERNAL_STATUS["queued"] == "initiated"
+
+    def test_canceled_maps_to_failed(self):
+        from app.routers.voice import _TWILIO_TO_INTERNAL_STATUS
+
+        assert _TWILIO_TO_INTERNAL_STATUS["canceled"] == "failed"
+
+    def test_existing_mappings_unchanged(self):
+        from app.routers.voice import _TWILIO_TO_INTERNAL_STATUS
+
+        assert _TWILIO_TO_INTERNAL_STATUS["initiated"] == "initiated"
+        assert _TWILIO_TO_INTERNAL_STATUS["ringing"] == "ringing"
+        assert _TWILIO_TO_INTERNAL_STATUS["in-progress"] == "connected"
+        assert _TWILIO_TO_INTERNAL_STATUS["answered"] == "connected"
+        assert _TWILIO_TO_INTERNAL_STATUS["completed"] == "completed"
+        assert _TWILIO_TO_INTERNAL_STATUS["failed"] == "failed"
+        assert _TWILIO_TO_INTERNAL_STATUS["no-answer"] == "no_answer"
+        assert _TWILIO_TO_INTERNAL_STATUS["busy"] == "no_answer"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. Retry/backoff for transient Twilio call-creation failures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTwilioCallRetryBackoff:
+    def test_is_transient_twilio_error_true_for_429_and_5xx(self):
+        from app.services.voice_call_service import _is_transient_twilio_error
+
+        assert _is_transient_twilio_error(SimpleNamespace(status=429)) is True
+        assert _is_transient_twilio_error(SimpleNamespace(status=500)) is True
+        assert _is_transient_twilio_error(SimpleNamespace(status=503)) is True
+
+    def test_is_transient_twilio_error_false_for_permanent_4xx(self):
+        from app.services.voice_call_service import _is_transient_twilio_error
+
+        # e.g. Twilio 21211 (invalid 'To' number) / 21214 (unverified caller id)
+        assert _is_transient_twilio_error(SimpleNamespace(status=400)) is False
+        assert _is_transient_twilio_error(SimpleNamespace(status=401)) is False
+        assert _is_transient_twilio_error(SimpleNamespace(status=404)) is False
+
+    def test_retries_transient_error_then_succeeds(self):
+        from twilio.base.exceptions import TwilioRestException
+
+        from app.services.voice_call_service import _create_twilio_call_with_retry
+
+        call_fn = MagicMock(
+            side_effect=[
+                TwilioRestException(status=429, uri="/Calls", msg="rate limited"),
+                TwilioRestException(status=503, uri="/Calls", msg="unavailable"),
+                SimpleNamespace(sid="CAsuccess"),
+            ]
+        )
+
+        with patch("app.services.voice_call_service.asyncio.sleep", new=AsyncMock()):
+            result = asyncio.run(_create_twilio_call_with_retry(call_fn, to_number="+1"))
+
+        assert result.sid == "CAsuccess"
+        assert call_fn.call_count == 3
+
+    def test_does_not_retry_permanent_error(self):
+        from twilio.base.exceptions import TwilioRestException
+
+        from app.services.voice_call_service import _create_twilio_call_with_retry
+
+        call_fn = MagicMock(
+            side_effect=TwilioRestException(
+                status=400, uri="/Calls", msg="invalid number", code=21211
+            )
+        )
+
+        with patch("app.services.voice_call_service.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            with pytest.raises(TwilioRestException):
+                asyncio.run(_create_twilio_call_with_retry(call_fn, to_number="+1"))
+
+        assert call_fn.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_exhausts_retries_and_raises(self):
+        from twilio.base.exceptions import TwilioRestException
+
+        from app.services.voice_call_service import (
+            _TWILIO_CALL_MAX_RETRIES,
+            _create_twilio_call_with_retry,
+        )
+
+        call_fn = MagicMock(
+            side_effect=TwilioRestException(status=500, uri="/Calls", msg="server error")
+        )
+
+        with patch("app.services.voice_call_service.asyncio.sleep", new=AsyncMock()):
+            with pytest.raises(TwilioRestException):
+                asyncio.run(_create_twilio_call_with_retry(call_fn, to_number="+1"))
+
+        assert call_fn.call_count == _TWILIO_CALL_MAX_RETRIES + 1

--- a/tests/routers/test_voice_twilio_hardening.py
+++ b/tests/routers/test_voice_twilio_hardening.py
@@ -616,6 +616,213 @@ class TestCallStatusMapping:
         assert _TWILIO_TO_INTERNAL_STATUS["no-answer"] == "no_answer"
         assert _TWILIO_TO_INTERNAL_STATUS["busy"] == "no_answer"
 
+    def test_batch_ended_reason_mapping_includes_canceled(self):
+        """notify_batch_call_ended() silently no-ops on an unmapped ended_reason —
+        without this entry a canceled batch call would never leave 'active'."""
+        from app.services.batch_call_completion_service import _TWILIO_TO_ENDED_REASON
+
+        assert _TWILIO_TO_ENDED_REASON["canceled"] == "failed"
+        assert _TWILIO_TO_ENDED_REASON["failed"] == "failed"
+
+
+class TestQueuedStatusIsPreConnectionNoOp:
+    """
+    Confirms the reviewer's stated assumption: unlike "canceled", "queued" needs no
+    business-effect wiring. Credit monitoring only starts on first media packet
+    (app/voice/tts_stream_mixin.py, on call answer) and a batch record is marked
+    "active" at dispatch time (before any status webhook arrives) — so at "queued"
+    (before ringing) there is no batch/credit state open yet that needs closing.
+    """
+
+    def test_queued_does_not_stop_credit_monitoring_or_notify_batch(self, db):
+        from app.routers.voice import handle_call_events_webhook
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest(
+            {
+                "CallStatus": "queued",
+                "CallSid": cs.twilio_call_sid,
+                "From": "+15550001111",
+                "To": "+15550002222",
+                "Direction": "outbound-api",
+            }
+        )
+
+        with (
+            patch("app.routers.voice.credit_service.stop_credit_monitoring") as mock_stop,
+            patch(
+                "app.routers.voice.notify_batch_call_ended", new=AsyncMock()
+            ) as mock_notify,
+        ):
+            resp = asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=str(agent_id),
+                    userId=None,
+                    callSessionId=str(cs.id),
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+
+        assert resp.status_code == 200
+        mock_stop.assert_not_called()
+        mock_notify.assert_not_awaited()
+
+
+class TestCanceledStatusSideEffects:
+    """
+    Blocker 2 follow-up: `handle_call_events_webhook`'s business-effect dispatch
+    branches on the literal Twilio CallStatus string, not the mapped internal
+    status, so "canceled" needs its own elif mirroring "failed" — otherwise a
+    canceled outbound (esp. batch) call is left stuck without ever being marked
+    ended (no webhook fire, no credit-monitoring stop, no batch completion).
+    """
+
+    def test_canceled_stops_credit_monitoring_and_notifies_batch(self, db):
+        from app.routers.voice import handle_call_events_webhook
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest(
+            {
+                "CallStatus": "canceled",
+                "CallSid": cs.twilio_call_sid,
+                "From": "+15550001111",
+                "To": "+15550002222",
+                "Direction": "outbound-api",
+            }
+        )
+
+        with (
+            patch("app.routers.voice.credit_service.stop_credit_monitoring") as mock_stop,
+            patch(
+                "app.routers.voice.notify_batch_call_ended", new=AsyncMock()
+            ) as mock_notify,
+            patch("app.services.webhook_service.fire_webhooks", new=AsyncMock()),
+        ):
+            resp = asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=str(agent_id),
+                    userId=None,
+                    callSessionId=str(cs.id),
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+
+        assert resp.status_code == 200
+        mock_stop.assert_called_once_with(cs.id)
+        mock_notify.assert_awaited_once()
+        assert mock_notify.call_args.args[1] == cs.id
+        assert mock_notify.call_args.args[2] == "canceled"
+
+    def test_canceled_fires_call_failed_webhook(self, db):
+        from app.routers.voice import handle_call_events_webhook
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest(
+            {
+                "CallStatus": "canceled",
+                "CallSid": cs.twilio_call_sid,
+                "From": "+15550001111",
+                "To": "+15550002222",
+                "Direction": "outbound-api",
+            }
+        )
+
+        background_tasks = BackgroundTasks()
+
+        with (
+            patch("app.routers.voice.credit_service.stop_credit_monitoring"),
+            patch("app.routers.voice.notify_batch_call_ended", new=AsyncMock()),
+        ):
+            asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=background_tasks,
+                    agentId=str(agent_id),
+                    userId=None,
+                    callSessionId=str(cs.id),
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+
+        # A call.failed webhook (reason=canceled) was scheduled as a background task.
+        assert len(background_tasks.tasks) == 1
+        scheduled = background_tasks.tasks[0]
+        assert scheduled.args[1] == "call.failed"
+        assert scheduled.args[2]["reason"] == "canceled"
+
+    def test_canceled_applies_internal_status_mapping_in_memory(self, db):
+        """
+        The status-update block (separate from the business-effect elif chain)
+        must apply the canceled -> "failed" mapping from _TWILIO_TO_INTERNAL_STATUS
+        to the in-memory call_session object.
+
+        NOTE: this assertion intentionally does NOT go through db.refresh(). This
+        webhook path only persists call_session.status via
+        call_session_service.update_call_session_status(), which is exclusively
+        called from the "completed" branch — "failed"/"busy"/"no-answer"/"canceled"
+        all set call_session.status in memory without an explicit db.commit(), so
+        the change does not survive a refresh. That's a pre-existing gap shared by
+        "failed"/"busy"/"no-answer" (reproduced independently, not introduced by
+        this change) — out of scope here; flagged separately in the fix report.
+        """
+        from app.routers.voice import handle_call_events_webhook
+
+        workspace_id = _make_tenant(db)
+        agent_id = _make_agent(db, workspace_id)
+        user_id = _make_user(db)
+        cs = _make_call_session(db, workspace_id, agent_id, user_id)
+
+        request = _FakeRequest(
+            {
+                "CallStatus": "canceled",
+                "CallSid": cs.twilio_call_sid,
+                "From": "+15550001111",
+                "To": "+15550002222",
+                "Direction": "outbound-api",
+            }
+        )
+
+        with (
+            patch("app.routers.voice.credit_service.stop_credit_monitoring"),
+            patch("app.routers.voice.notify_batch_call_ended", new=AsyncMock()),
+        ):
+            asyncio.run(
+                handle_call_events_webhook(
+                    request=request,
+                    background_tasks=BackgroundTasks(),
+                    agentId=str(agent_id),
+                    userId=None,
+                    callSessionId=str(cs.id),
+                    timeout=None,
+                    body="",
+                    db=db,
+                )
+            )
+
+        assert cs.status == "failed"
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # 5. Retry/backoff for transient Twilio call-creation failures
@@ -623,12 +830,27 @@ class TestCallStatusMapping:
 
 
 class TestTwilioCallRetryBackoff:
-    def test_is_transient_twilio_error_true_for_429_and_5xx(self):
+    """
+    `calls.create` is non-idempotent and side-effecting (it dials the customer) and
+    Twilio has no idempotency-key mechanism for it. Only 429 is safe to retry —
+    Twilio guarantees a 429 means the call was never queued/dialed. A 5xx is
+    ambiguous (may have already dialed before erroring) and must NOT be retried,
+    to avoid double-dialing a customer with no way to detect/track the duplicate
+    (only one call_session.twilio_call_sid is ever stored).
+    """
+
+    def test_is_transient_twilio_error_true_only_for_429(self):
         from app.services.voice_call_service import _is_transient_twilio_error
 
         assert _is_transient_twilio_error(SimpleNamespace(status=429)) is True
-        assert _is_transient_twilio_error(SimpleNamespace(status=500)) is True
-        assert _is_transient_twilio_error(SimpleNamespace(status=503)) is True
+
+    def test_is_transient_twilio_error_false_for_5xx(self):
+        """5xx must NOT be retried — ambiguous whether Twilio already dialed."""
+        from app.services.voice_call_service import _is_transient_twilio_error
+
+        assert _is_transient_twilio_error(SimpleNamespace(status=500)) is False
+        assert _is_transient_twilio_error(SimpleNamespace(status=502)) is False
+        assert _is_transient_twilio_error(SimpleNamespace(status=503)) is False
 
     def test_is_transient_twilio_error_false_for_permanent_4xx(self):
         from app.services.voice_call_service import _is_transient_twilio_error
@@ -638,7 +860,7 @@ class TestTwilioCallRetryBackoff:
         assert _is_transient_twilio_error(SimpleNamespace(status=401)) is False
         assert _is_transient_twilio_error(SimpleNamespace(status=404)) is False
 
-    def test_retries_transient_error_then_succeeds(self):
+    def test_retries_429_then_succeeds(self):
         from twilio.base.exceptions import TwilioRestException
 
         from app.services.voice_call_service import _create_twilio_call_with_retry
@@ -646,7 +868,7 @@ class TestTwilioCallRetryBackoff:
         call_fn = MagicMock(
             side_effect=[
                 TwilioRestException(status=429, uri="/Calls", msg="rate limited"),
-                TwilioRestException(status=503, uri="/Calls", msg="unavailable"),
+                TwilioRestException(status=429, uri="/Calls", msg="rate limited"),
                 SimpleNamespace(sid="CAsuccess"),
             ]
         )
@@ -657,7 +879,7 @@ class TestTwilioCallRetryBackoff:
         assert result.sid == "CAsuccess"
         assert call_fn.call_count == 3
 
-    def test_does_not_retry_permanent_error(self):
+    def test_does_not_retry_permanent_4xx_error(self):
         from twilio.base.exceptions import TwilioRestException
 
         from app.services.voice_call_service import _create_twilio_call_with_retry
@@ -675,7 +897,26 @@ class TestTwilioCallRetryBackoff:
         assert call_fn.call_count == 1
         mock_sleep.assert_not_called()
 
-    def test_exhausts_retries_and_raises(self):
+    def test_does_not_retry_5xx_error(self):
+        """Regression guard for the double-dial risk: a 5xx must fail on the
+        first attempt, never retried, since the call may have already been
+        dialed server-side before Twilio returned the error."""
+        from twilio.base.exceptions import TwilioRestException
+
+        from app.services.voice_call_service import _create_twilio_call_with_retry
+
+        call_fn = MagicMock(
+            side_effect=TwilioRestException(status=500, uri="/Calls", msg="server error")
+        )
+
+        with patch("app.services.voice_call_service.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            with pytest.raises(TwilioRestException):
+                asyncio.run(_create_twilio_call_with_retry(call_fn, to_number="+1"))
+
+        assert call_fn.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_exhausts_429_retries_and_raises(self):
         from twilio.base.exceptions import TwilioRestException
 
         from app.services.voice_call_service import (
@@ -684,7 +925,7 @@ class TestTwilioCallRetryBackoff:
         )
 
         call_fn = MagicMock(
-            side_effect=TwilioRestException(status=500, uri="/Calls", msg="server error")
+            side_effect=TwilioRestException(status=429, uri="/Calls", msg="rate limited")
         )
 
         with patch("app.services.voice_call_service.asyncio.sleep", new=AsyncMock()):


### PR DESCRIPTION
## Summary

A review of the Twilio calling service and voice pipeline against Twilio's official documentation surfaced several security and correctness gaps. This PR fixes all of them in four commits.

- **Enable `X-Twilio-Signature` validation** on webhooks that previously skipped or never performed it: `handle_call_events_webhook`, `handle_recording_callback`, `handle_gather_speech_webhook`, `handle_recording_status_webhook` (`app/routers/voice.py`), and `streaming_greeting_webhook` (`app/routers/voice_gather.py`). Fails closed (403) unless `ALLOW_UNAUTHENTICATED_WEBHOOKS` is explicitly set.
- **Fix SSRF in the recording callback**: `RecordingUrl` is now strictly validated against Twilio's documented recording resource path (`_build_authenticated_recording_url`, `app/routers/voice.py`) before being fetched — closes a bypass where a non-`api.twilio.com` URL made the old credential-injection `.replace()` a no-op.
- **Implement the Twilio Media Streams `clear` event** on barge-in (`_send_twilio_clear_event`, `app/voice/tts_stream_mixin.py`, wired into `_cancel_inflight_llm_response` in `app/routers/bidirectional_stream.py`) so audio Twilio already buffered actually stops playing when the caller interrupts, per Twilio's documented protocol.
- **Map `queued`/`canceled` CallStatus values** (`_TWILIO_TO_INTERNAL_STATUS`, `app/routers/voice.py`), and wire `canceled` into the same webhook/credit-stop/batch-notify business-effect path that `failed` already gets.
- **Add retry-with-backoff for transient Twilio call-dispatch errors**, restricted to HTTP 429 only — `calls.create` is a non-idempotent, side-effecting operation (it dials the phone), so 5xx is deliberately *not* retried to avoid risking a duplicate outbound call to the customer (`app/services/voice_call_service.py`).
- **Persist `call_session.status`** for the `failed`/`busy`/`no-answer`/`canceled` branches of `handle_call_events_webhook`, which previously only mutated the in-memory ORM object with no commit (`_commit_terminal_call_session_status`, `app/routers/voice.py`).
- **Remove the `validate_webrtc_auth()` bypass** on `handle_call_events_webhook` — it was a no-op stub that accepted any `Authorization` header, letting an attacker forge call-status webhooks by sending any Bearer token instead of a valid Twilio signature. Confirmed there's no real WebRTC caller for this endpoint (browser calling uses a separate LiveKit-token flow); the bypass branch was deleted rather than stubbed further.

Commits:
- `cafba14` — signature validation, SSRF fix, `clear` event, status mapping, retry/backoff
- `81e328b` — code-review follow-up: restrict retry to 429 only (no double-dial risk), complete `canceled` status wiring
- `206486a` — remove WebRTC auth bypass
- `7bf3778` — persist terminal call_session.status

## Test plan
- [x] `pytest tests/routers/test_voice_twilio_hardening.py -v` — 40 passed, covering signature enforcement (valid/invalid/missing) on every hardened webhook, the SSRF guard (asserts the malicious-URL fetch never happens), the `clear` event on barge-in, `queued`/`canceled` status mapping and side effects, retry/backoff behavior (429 retried, 5xx not retried), the WebRTC bypass removal, and status persistence via fresh DB reads.
- [x] Full suite: `pytest tests/ -q` — 1746 passed, 65 skipped (Postgres-backed `*_postgres.py` integration tests, skipped without `TEST_DATABASE_URL`), 0 failed.
- [x] Independent `code-reviewer` pass on the initial fix, findings addressed in the follow-up commit.

## Known follow-up (not in scope for this PR)
None outstanding — all findings from the review were addressed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)