### PR TITLE
feat: add call-flow demo links for browser-based agent trials

### DIFF
--- a/alembic/versions/c35f4e3d5e3f_add_call_flow_demo_link_tables.py
+++ b/alembic/versions/c35f4e3d5e3f_add_call_flow_demo_link_tables.py
@@ -1,0 +1,81 @@
+"""add_call_flow_demo_link_tables
+
+Revision ID: c35f4e3d5e3f
+Revises: 20260729_nova_meta
+Create Date: 2026-07-31 19:59:54.232646
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c35f4e3d5e3f'
+down_revision: Union[str, Sequence[str], None] = '20260729_nova_meta'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'callflowdemolink',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('tenant_id', sa.UUID(), nullable=False),
+        sa.Column('call_flow_id', sa.UUID(), nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=True),
+        sa.Column('token', sa.String(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), server_default='true', nullable=False),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('per_user_limit_minutes', sa.Numeric(), nullable=True),
+        sa.Column('total_budget_minutes', sa.Numeric(), nullable=True),
+        sa.Column('total_minutes_used', sa.Numeric(), server_default='0', nullable=False),
+        sa.Column('created_by_user_id', sa.UUID(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['call_flow_id'], ['callflow.id'], ),
+        sa.ForeignKeyConstraint(['created_by_user_id'], ['user.id'], ),
+        sa.ForeignKeyConstraint(['tenant_id'], ['tenant.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('ix_callflowdemolink_call_flow_id', 'callflowdemolink', ['call_flow_id'], unique=False)
+    op.create_index('ix_callflowdemolink_tenant_id', 'callflowdemolink', ['tenant_id'], unique=False)
+    op.create_index(op.f('ix_callflowdemolink_token'), 'callflowdemolink', ['token'], unique=True)
+
+    op.create_table(
+        'callflowdemolinkvisitorusage',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('demo_link_id', sa.UUID(), nullable=False),
+        sa.Column('visitor_id', sa.String(), nullable=False),
+        sa.Column('minutes_used', sa.Numeric(), server_default='0', nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['demo_link_id'], ['callflowdemolink.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('demo_link_id', 'visitor_id', name='uq_calldemolink_visitor'),
+    )
+    op.create_index(
+        'ix_callflowdemolinkvisitorusage_demo_link_id',
+        'callflowdemolinkvisitorusage',
+        ['demo_link_id'],
+        unique=False,
+    )
+    op.create_index(
+        op.f('ix_callflowdemolinkvisitorusage_visitor_id'),
+        'callflowdemolinkvisitorusage',
+        ['visitor_id'],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_callflowdemolinkvisitorusage_visitor_id'), table_name='callflowdemolinkvisitorusage')
+    op.drop_index('ix_callflowdemolinkvisitorusage_demo_link_id', table_name='callflowdemolinkvisitorusage')
+    op.drop_table('callflowdemolinkvisitorusage')
+
+    op.drop_index(op.f('ix_callflowdemolink_token'), table_name='callflowdemolink')
+    op.drop_index('ix_callflowdemolink_tenant_id', table_name='callflowdemolink')
+    op.drop_index('ix_callflowdemolink_call_flow_id', table_name='callflowdemolink')
+    op.drop_table('callflowdemolink')

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -92,3 +92,8 @@ from app.models.payment_record import PaymentRecord  # noqa: F401
 
 # Outbound number reputation monitoring / auto-rotation
 from app.models.phone_number_reputation import PhoneNumberReputation  # noqa: F401
+
+# Call flow demo links (origin-unrestricted shareable links, separate from
+# the embedded-widget public-call-token / AllowedDomain flow)
+from app.models.call_flow_demo_link import CallFlowDemoLink  # noqa: F401
+from app.models.call_flow_demo_link_visitor_usage import CallFlowDemoLinkVisitorUsage  # noqa: F401

--- a/app/middleware/api_key_middleware.py
+++ b/app/middleware/api_key_middleware.py
@@ -67,6 +67,9 @@ _SKIP_PREFIXES = (
     "/api/v1/webhooks/twilio/",
     # Public Web SDK endpoints — security enforced via flow.public_access +
     # allowed_domains Origin check inside the handler, not API credentials.
+    # This prefix also covers /api/v1/sdk/demo/{token}/call-token (share-demo-link
+    # flow), whose handler enforces token validity/expiry/budget instead of an
+    # Origin allowlist — see app/routers/sdk.py::demo_call_token.
     "/api/v1/sdk/",
     "/api/v1/integrations/hubspot/callback",
     "/health",

--- a/app/middleware/pii_logging_middleware.py
+++ b/app/middleware/pii_logging_middleware.py
@@ -9,6 +9,7 @@ passes through :func:`~app.core.pii_redactor.prepare_request_log_context` first.
 from __future__ import annotations
 
 import logging
+import re
 import time
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -17,6 +18,15 @@ from starlette.responses import Response
 
 from app.core.logger import logger
 from app.core.pii_redactor import prepare_request_log_context
+
+# The demo-link token is a bearer-style credential embedded in the URL path
+# (unlike other secrets in this codebase, which travel in the body/query) —
+# redact it before it lands in the access log.
+_DEMO_LINK_TOKEN_PATH = re.compile(r"(/api/v1/sdk/demo/)[^/]+(/call-token)")
+
+
+def _redact_path(path: str) -> str:
+    return _DEMO_LINK_TOKEN_PATH.sub(r"\1[redacted]\2", path)
 
 
 class PiiLoggingMiddleware(BaseHTTPMiddleware):
@@ -34,7 +44,7 @@ class PiiLoggingMiddleware(BaseHTTPMiddleware):
 
             ctx = prepare_request_log_context(
                 request.method,
-                request.url.path,
+                _redact_path(request.url.path),
                 request.headers,
                 query_params=request.query_params,
                 body_length=body_length,
@@ -49,7 +59,7 @@ class PiiLoggingMiddleware(BaseHTTPMiddleware):
         logger.info(
             "%s %s %s %dms requestId=%s",
             request.method,
-            request.url.path,
+            _redact_path(request.url.path),
             response.status_code,
             duration_ms,
             request_id,

--- a/app/middleware/public_sdk_cors_middleware.py
+++ b/app/middleware/public_sdk_cors_middleware.py
@@ -1,4 +1,4 @@
-"""Dynamic CORS for the public Web SDK endpoint.
+"""Dynamic CORS for the public Web SDK endpoints.
 
 The global ``CORSMiddleware`` only allows origins listed in the static
 ``ALLOWED_ORIGINS`` env var. But /api/v1/sdk/public-call-token must be
@@ -9,9 +9,16 @@ rejects the browser's preflight OPTIONS for any origin outside the static
 list before the request ever reaches our handler, so a whitelisted tenant
 domain could never actually call the endpoint from a browser.
 
-This middleware reflects the request's Origin for that one path only — it
+/api/v1/sdk/demo/{token}/call-token has an even looser requirement: it is
+origin-unrestricted by design (any site holding the token may use it, see
+app/models/call_flow_demo_link.py), so it needs the same Origin reflection
+with no allowlist check at all — that check lives entirely inside the
+handler (token/expiry/budget validation), not here.
+
+This middleware reflects the request's Origin for these paths only — it
 grants no security by itself. The real authorization boundary is the
-allowed_domains check inside app/routers/sdk.py (403 domain_not_allowed).
+allowed_domains check (public-call-token) or the demo-link validation
+(demo/{token}/call-token) inside app/routers/sdk.py.
 Must be registered OUTERMOST (added after CORSMiddleware in main.py) so it
 intercepts preflight before the static-origin CORSMiddleware can 400 it.
 """
@@ -22,12 +29,22 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 _PUBLIC_SDK_PATHS = frozenset({"/api/v1/sdk/public-call-token"})
 
 
+def _is_public_sdk_path(path: str) -> bool:
+    if path in _PUBLIC_SDK_PATHS:
+        return True
+    # /api/v1/sdk/demo/{token}/call-token — token is opaque, so match by shape
+    # rather than adding every issued token to a static set.
+    if path.startswith("/api/v1/sdk/demo/") and path.endswith("/call-token"):
+        return True
+    return False
+
+
 class PublicSdkCorsMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http" or scope.get("path") not in _PUBLIC_SDK_PATHS:
+        if scope["type"] != "http" or not _is_public_sdk_path(scope.get("path", "")):
             await self.app(scope, receive, send)
             return
 

--- a/app/middleware/rate_limit_middleware.py
+++ b/app/middleware/rate_limit_middleware.py
@@ -69,6 +69,9 @@ _PUBLIC_TOKEN_POST_PATHS: frozenset[str] = frozenset({
     "/api/v1/sdk/public-call-token",
 })
 
+_DEMO_LINK_PATH_PREFIX = "/api/v1/sdk/demo/"
+_DEMO_LINK_PATH_SUFFIX = "/call-token"
+
 
 def _should_skip(path: str) -> bool:
     if path in _SKIP_EXACT:
@@ -92,7 +95,12 @@ def _is_public_token_post(scope: Scope) -> bool:
     if scope.get("method") != "POST":
         return False
     path = scope.get("path", "")
-    return path in _PUBLIC_TOKEN_POST_PATHS
+    if path in _PUBLIC_TOKEN_POST_PATHS:
+        return True
+    # /api/v1/sdk/demo/{token}/call-token — same "no auth identity to bucket
+    # on" reasoning as public-call-token; matched by shape since the token
+    # segment is opaque/dynamic.
+    return path.startswith(_DEMO_LINK_PATH_PREFIX) and path.endswith(_DEMO_LINK_PATH_SUFFIX)
 
 
 def _sha256(raw: str) -> str:

--- a/app/models/call_flow_demo_link.py
+++ b/app/models/call_flow_demo_link.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base_class import Base
+
+
+class CallFlowDemoLink(Base):
+    """Named, shareable demo link for a call flow.
+
+    Origin-unrestricted (unlike the embedded-widget public-call-token flow,
+    which is gated by AllowedDomain) — access is controlled purely by
+    possession of the opaque `token`, expiry, and usage-budget fields below.
+    """
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # Not indexed here via column(index=True) — the explicit Index() entries in
+    # __table_args__ below cover these columns. Declaring both produces two
+    # identically-named indexes, which SQLite (and Postgres) reject as a
+    # duplicate object.
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id"), nullable=False)
+    call_flow_id = Column(UUID(as_uuid=True), ForeignKey("callflow.id"), nullable=False)
+
+    name = Column(String(255), nullable=True)
+    # Opaque unguessable public identifier for the link, generated via
+    # secrets.token_urlsafe(32) at creation time in the service layer.
+    token = Column(String, nullable=False, unique=True, index=True)
+
+    is_active = Column(Boolean, nullable=False, default=True, server_default="true")
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+
+    per_user_limit_minutes = Column(Numeric, nullable=True)
+    total_budget_minutes = Column(Numeric, nullable=True)
+    # TODO(known limitation, not missing logic): incremented by
+    # CallSessionService._record_demo_link_usage(), but nothing in
+    # production currently calls update_call_session_status() for a
+    # browser-only demo-link CallSession (no LiveKit call-end signal
+    # exists yet — see that method's docstring). Checked at token-issuance
+    # time; does not yet decrement from real call activity.
+    total_minutes_used = Column(Numeric, nullable=False, default=0, server_default="0")
+
+    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("user.id"), nullable=True)
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=True)
+
+    # Relationships
+    tenant = relationship("Tenant")
+    call_flow = relationship("CallFlow")
+    created_by_user = relationship("User")
+    visitor_usages = relationship(
+        "CallFlowDemoLinkVisitorUsage",
+        back_populates="demo_link",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        Index("ix_callflowdemolink_tenant_id", "tenant_id"),
+        Index("ix_callflowdemolink_call_flow_id", "call_flow_id"),
+    )

--- a/app/models/call_flow_demo_link_visitor_usage.py
+++ b/app/models/call_flow_demo_link_visitor_usage.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Numeric, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.db.base_class import Base
+
+
+class CallFlowDemoLinkVisitorUsage(Base):
+    """Per-anonymous-visitor minute consumption against a demo link's
+    per_user_limit_minutes budget.
+
+    `visitor_id` is a client-supplied opaque identifier, not a FK — there is
+    no `user` row for anonymous public demo-link visitors.
+    """
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # demo_link_id is not indexed here via column(index=True) — see the
+    # explicit Index() in __table_args__ below; declaring both would create
+    # two identically-named indexes (rejected as duplicates by SQLite/Postgres).
+    demo_link_id = Column(
+        UUID(as_uuid=True), ForeignKey("callflowdemolink.id"), nullable=False
+    )
+    visitor_id = Column(String, nullable=False, index=True)
+
+    # TODO(known limitation, not missing logic): see the matching comment
+    # on CallFlowDemoLink.total_minutes_used — same accepted gap, same
+    # accounting hook, currently untriggered in production.
+    minutes_used = Column(Numeric, nullable=False, default=0, server_default="0")
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=True)
+
+    demo_link = relationship("CallFlowDemoLink", back_populates="visitor_usages")
+
+    __table_args__ = (
+        Index("ix_callflowdemolinkvisitorusage_demo_link_id", "demo_link_id"),
+        UniqueConstraint("demo_link_id", "visitor_id", name="uq_calldemolink_visitor"),
+    )

--- a/app/routers/call_flows.py
+++ b/app/routers/call_flows.py
@@ -18,8 +18,15 @@ from app.models.call_flow import CallFlow
 from app.models.knowledge_base_document import KnowledgeBase
 from app.models.user import User
 from app.schemas.call_flow import CallFlowCreate, CallFlowSettingsUpdate, CallFlowUpdate
+from app.schemas.call_flow_demo_link import (
+    CallFlowDemoLinkCreate,
+    CallFlowDemoLinkListResponse,
+    CallFlowDemoLinkOut,
+    CallFlowDemoLinkUpdate,
+)
 from app.schemas.knowledge_base import FlowKbUpdate
 from app.services.audit_service import log_audit_event
+from app.services.call_flow_demo_link_service import call_flow_demo_link_service
 from app.services.call_flow_service import call_flow_service
 from app.utils.response import create_success_response
 
@@ -262,3 +269,105 @@ def update_flow_knowledge_bases(
         {"flow_id": str(flow_id), "kb_ids": flow.knowledge_base_ids},
         "Knowledge bases updated",
     )
+
+
+# ── Demo links ────────────────────────────────────────────────────────────
+# Tenant-facing CRUD only. Public/anonymous consumption of a demo link
+# (token lookup + minute-usage accounting) lives on app/routers/sdk.py.
+
+
+def _demo_link_to_out(link) -> CallFlowDemoLinkOut:
+    out = CallFlowDemoLinkOut.model_validate(link)
+    out.share_url = call_flow_demo_link_service.build_share_url(link.token)
+    return out
+
+
+@router.post(
+    "/{flow_id}/demo-links",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CallFlowDemoLinkOut,
+)
+def create_demo_link(
+    flow_id: uuid.UUID,
+    body: CallFlowDemoLinkCreate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+):
+    tid = _workspace_id(principal)
+    created_by_user_id = principal.id if isinstance(principal, User) else None
+    link = call_flow_demo_link_service.create_demo_link(
+        db, tid, flow_id, body, created_by_user_id
+    )
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tid,
+        action="call_flow.demo_link_created",
+        resource_type="call_flow_demo_link",
+        resource_id=link.id,
+        new_value=body.model_dump(exclude_none=True),
+        actor_user_id=created_by_user_id,
+    )
+    return _demo_link_to_out(link)
+
+
+@router.get("/{flow_id}/demo-links", response_model=CallFlowDemoLinkListResponse)
+def list_demo_links(
+    flow_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+):
+    tid = _workspace_id(principal)
+    links = call_flow_demo_link_service.list_demo_links(db, tid, flow_id)
+    return CallFlowDemoLinkListResponse(
+        data=[_demo_link_to_out(link) for link in links]
+    )
+
+
+@router.patch("/demo-links/{link_id}", response_model=CallFlowDemoLinkOut)
+def update_demo_link(
+    link_id: uuid.UUID,
+    body: CallFlowDemoLinkUpdate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+):
+    tid = _workspace_id(principal)
+    link = call_flow_demo_link_service.update_demo_link(db, tid, link_id, body)
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tid,
+        action="call_flow.demo_link_updated",
+        resource_type="call_flow_demo_link",
+        resource_id=link_id,
+        new_value=body.model_dump(exclude_unset=True),
+        actor_user_id=principal.id if isinstance(principal, User) else None,
+    )
+    return _demo_link_to_out(link)
+
+
+@router.delete(
+    "/demo-links/{link_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def delete_demo_link(
+    link_id: uuid.UUID,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_config_or_api_key),
+    db: Session = Depends(get_db),
+):
+    tid = _workspace_id(principal)
+    call_flow_demo_link_service.delete_demo_link(db, tid, link_id)
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tid,
+        action="call_flow.demo_link_deleted",
+        resource_type="call_flow_demo_link",
+        resource_id=link_id,
+        actor_user_id=principal.id if isinstance(principal, User) else None,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/app/routers/sdk.py
+++ b/app/routers/sdk.py
@@ -1,23 +1,36 @@
 """Public (unauthenticated) Web SDK endpoints.
 
-POST /api/v1/sdk/public-call-token is the only route in the app that takes
-no API key and no JWT — see _SKIP_PREFIXES in app/middleware/api_key_middleware.py.
-Security is enforced inside the handler instead of via credentials:
+POST /api/v1/sdk/public-call-token and POST /api/v1/sdk/demo/{token}/call-token
+are the only routes in the app that take no API key and no JWT — see
+_SKIP_PREFIXES in app/middleware/api_key_middleware.py.
+
+public-call-token security is enforced inside the handler instead of via
+credentials:
   1. The target call flow must have public_access=True.
   2. The request's Origin header must match an allowed_domains entry for
      the workspace that owns the flow (or be localhost in development).
 IP-based rate limiting (20/min) is enforced by RateLimitMiddleware before
 the request reaches this handler — see _PUBLIC_TOKEN_POST_PATHS there.
+
+demo/{token}/call-token is deliberately origin-unrestricted (no AllowedDomain
+check) — access is controlled purely by possession of the opaque demo-link
+token, its expiry/active flag, and its usage budgets. See
+app/models/call_flow_demo_link.py for the full security rationale. It shares
+the same CORS reflection, auth-skip, and rate-limit treatment as
+public-call-token (see PublicSdkCorsMiddleware, _SKIP_PREFIXES, and
+_PUBLIC_TOKEN_POST_PATHS respectively) since it is equally unauthenticated.
 """
 from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
@@ -26,7 +39,12 @@ from app.core.error_responses import build_api_error_payload
 from app.core.logger import logger
 from app.core.origin import is_localhost_origin, normalize_origin
 from app.models.allowed_domain import AllowedDomain
+from app.models.agent import Agent
 from app.models.call_flow import CallFlow
+from app.models.call_flow_demo_link import CallFlowDemoLink
+from app.models.call_flow_demo_link_visitor_usage import CallFlowDemoLinkVisitorUsage
+from app.models.user import user_tenant_association
+from app.services.call_session_service import call_session_service
 
 router = APIRouter()
 
@@ -138,5 +156,215 @@ def public_call_token(
         "livekit_token": token,
         "room_name": room_name,
         "flow_id": str(flow.id),
+        "expires_at": expires_at.isoformat(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Demo link — shareable, origin-unrestricted call token
+# ---------------------------------------------------------------------------
+
+
+class DemoCallTokenRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # Opaque client-generated identifier the caller is expected to persist
+    # (e.g. localStorage) and resend on every call so per-visitor minute
+    # limits can be enforced across sessions. Not a FK to `user` — there is
+    # no account behind an anonymous demo-link visitor.
+    visitor_id: str = Field(min_length=1, max_length=255)
+
+
+def _demo_error(request: Request, code: int, message: str, error_code: str) -> JSONResponse:
+    return _error(request, code, message, error_code)
+
+
+@router.post("/demo/{token}/call-token")
+async def demo_call_token(
+    token: str,
+    body: DemoCallTokenRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    ip = _client_ip(request)
+
+    demo_link = db.execute(
+        select(CallFlowDemoLink).where(CallFlowDemoLink.token == token)
+    ).scalar_one_or_none()
+
+    if demo_link is None:
+        logger.info("Demo call token request: link not found ip=%s", ip)
+        return _demo_error(request, 404, "Demo link not found", "demo_link_not_found")
+
+    if not demo_link.is_active:
+        logger.info("Demo call token denied (inactive) demo_link_id=%s ip=%s", demo_link.id, ip)
+        return _demo_error(request, 403, "This demo link is no longer active.", "demo_link_inactive")
+
+    if demo_link.expires_at is not None:
+        expires_at = demo_link.expires_at
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        if expires_at < datetime.now(timezone.utc):
+            logger.info("Demo call token denied (expired) demo_link_id=%s ip=%s", demo_link.id, ip)
+            return _demo_error(request, 410, "This demo link has expired.", "demo_link_expired")
+
+    flow = db.execute(
+        select(CallFlow).where(
+            CallFlow.id == demo_link.call_flow_id,
+            CallFlow.is_deleted == False,  # noqa: E712
+            CallFlow.status == "active",
+        )
+    ).scalar_one_or_none()
+
+    if flow is None:
+        logger.info(
+            "Demo call token denied (call flow unavailable) demo_link_id=%s ip=%s",
+            demo_link.id, ip,
+        )
+        return _demo_error(
+            request, 403, "This demo link's call flow is no longer available.", "call_flow_unavailable"
+        )
+
+    agent = db.execute(
+        select(Agent).where(
+            Agent.id == flow.agent_id,
+            Agent.is_deleted == False,  # noqa: E712
+        )
+    ).scalar_one_or_none()
+
+    if agent is None:
+        logger.info(
+            "Demo call token denied (agent unavailable) demo_link_id=%s agent_id=%s ip=%s",
+            demo_link.id, flow.agent_id, ip,
+        )
+        return _demo_error(
+            request, 403, "This demo link's agent is no longer available.", "agent_unavailable"
+        )
+
+    if demo_link.total_budget_minutes is not None and demo_link.total_minutes_used >= demo_link.total_budget_minutes:
+        logger.info("Demo call token denied (budget exhausted) demo_link_id=%s ip=%s", demo_link.id, ip)
+        return _demo_error(
+            request, 403, "This demo link has used up its total call budget.", "demo_link_budget_exceeded"
+        )
+
+    visitor_id = body.visitor_id.strip()
+    if not visitor_id:
+        return _demo_error(request, 400, "visitor_id is required", "visitor_id_required")
+
+    visitor_usage = db.execute(
+        select(CallFlowDemoLinkVisitorUsage).where(
+            CallFlowDemoLinkVisitorUsage.demo_link_id == demo_link.id,
+            CallFlowDemoLinkVisitorUsage.visitor_id == visitor_id,
+        )
+    ).scalar_one_or_none()
+
+    if visitor_usage is None:
+        visitor_usage = CallFlowDemoLinkVisitorUsage(
+            demo_link_id=demo_link.id,
+            visitor_id=visitor_id,
+            minutes_used=Decimal("0"),
+        )
+        db.add(visitor_usage)
+        try:
+            db.commit()
+        except IntegrityError:
+            # Two concurrent first-time requests for the same visitor_id —
+            # the other request's insert won the unique constraint
+            # (demo_link_id, visitor_id); fetch the row it created instead.
+            db.rollback()
+            visitor_usage = db.execute(
+                select(CallFlowDemoLinkVisitorUsage).where(
+                    CallFlowDemoLinkVisitorUsage.demo_link_id == demo_link.id,
+                    CallFlowDemoLinkVisitorUsage.visitor_id == visitor_id,
+                )
+            ).scalar_one()
+        else:
+            db.refresh(visitor_usage)
+
+    if (
+        demo_link.per_user_limit_minutes is not None
+        and visitor_usage.minutes_used >= demo_link.per_user_limit_minutes
+    ):
+        logger.info(
+            "Demo call token denied (visitor limit) demo_link_id=%s visitor_id=%s ip=%s",
+            demo_link.id, visitor_id, ip,
+        )
+        return _demo_error(
+            request,
+            403,
+            "You have used up your allotted call time for this demo link.",
+            "demo_link_visitor_limit_exceeded",
+        )
+
+    from app.services.livekit_service import livekit_service
+
+    # CallSession.user_id is a NOT NULL FK to `user.id` — there is no real
+    # user behind an anonymous demo-link visitor, so follow the same
+    # convention already used for inbound Twilio calls (voice.py:
+    # user_id=inbound_agent.created_by): attribute the session to whoever
+    # created the underlying agent (fetched above). Fall back to the demo
+    # link's own creator if the agent has no creator on record.
+    owner_user_id = agent.created_by or demo_link.created_by_user_id
+    if owner_user_id is None:
+        # Last resort: every tenant/workspace has exactly one creator
+        # (RBAC's is_creator flag), so this should always resolve even
+        # when the agent/link have no recorded creator (e.g. API-key
+        # originated).
+        owner_user_id = db.execute(
+            select(user_tenant_association.c.user_id).where(
+                user_tenant_association.c.tenant_id == demo_link.tenant_id,
+                user_tenant_association.c.is_creator == True,  # noqa: E712
+            )
+        ).scalar_one_or_none()
+    if owner_user_id is None:
+        logger.warning(
+            "Demo call token denied (no owning user) demo_link_id=%s agent_id=%s ip=%s",
+            demo_link.id, flow.agent_id, ip,
+        )
+        return _demo_error(
+            request, 500, "This demo link is not configured correctly.", "demo_link_misconfigured"
+        )
+
+    # Room naming follows the platform-wide convention documented in
+    # livekit_service.py ("room_{call_session.id}") rather than
+    # public-call-token's unlinked room_{uuid4()} — this lets the demo-link
+    # session show up in v2 active-calls/insights and, more importantly,
+    # gives the end-of-call hook in CallSessionService.update_call_session_status
+    # a CallSession row to finalize duration/minute-accounting against.
+    call_session = call_session_service.create_call_session(
+        db=db,
+        user_id=owner_user_id,
+        agent_id=flow.agent_id,
+        tenant_id=demo_link.tenant_id,
+        call_type="web",
+        assistant_phone_number="web_agent",
+        customer_phone_number="browser_demo_link",
+    )
+    call_session.call_flow_id = flow.id
+    call_session.call_metadata = {
+        **(call_session.call_metadata or {}),
+        "demo_link": {
+            "demo_link_id": str(demo_link.id),
+            "visitor_id": visitor_id,
+        },
+    }
+    db.commit()
+
+    room_name = f"room_{call_session.id}"
+    lk_token = livekit_service.generate_caller_token(room_name)
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=settings.LIVEKIT_TOKEN_TTL)
+
+    logger.info(
+        "Demo call token issued demo_link_id=%s call_session_id=%s room=%s ip=%s",
+        demo_link.id, call_session.id, room_name, ip,
+    )
+
+    return {
+        "livekit_token": lk_token,
+        "room_name": room_name,
+        "flow_id": str(flow.id),
+        "agent_id": str(flow.agent_id),
+        "call_session_id": str(call_session.id),
+        "demo_link_name": demo_link.name,
         "expires_at": expires_at.isoformat(),
     }

--- a/app/schemas/call_flow_demo_link.py
+++ b/app/schemas/call_flow_demo_link.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CallFlowDemoLinkCreate(BaseModel):
+    """Request body for ``POST /api/v1/call-flows/{flow_id}/demo-links``."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    name: str | None = Field(None, max_length=255)
+    expires_at: datetime | None = Field(None, alias="expiresAt")
+    per_user_limit_minutes: Decimal | None = Field(None, alias="perUserLimitMinutes", gt=0)
+    total_budget_minutes: Decimal | None = Field(None, alias="totalBudgetMinutes", gt=0)
+
+
+class CallFlowDemoLinkUpdate(BaseModel):
+    """Request body for ``PATCH /api/v1/call-flows/demo-links/{link_id}``."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    name: str | None = Field(None, max_length=255)
+    expires_at: datetime | None = Field(None, alias="expiresAt")
+    per_user_limit_minutes: Decimal | None = Field(None, alias="perUserLimitMinutes", gt=0)
+    total_budget_minutes: Decimal | None = Field(None, alias="totalBudgetMinutes", gt=0)
+    is_active: bool | None = Field(None, alias="isActive")
+
+
+class CallFlowDemoLinkOut(BaseModel):
+    """Response shape for a demo link, including the derived shareable URL."""
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: uuid.UUID
+    call_flow_id: uuid.UUID = Field(..., serialization_alias="callFlowId")
+    name: str | None = None
+    token: str
+    share_url: str | None = Field(None, serialization_alias="shareUrl")
+    is_active: bool = Field(..., serialization_alias="isActive")
+    expires_at: datetime | None = Field(None, serialization_alias="expiresAt")
+    per_user_limit_minutes: Decimal | None = Field(None, serialization_alias="perUserLimitMinutes")
+    total_budget_minutes: Decimal | None = Field(None, serialization_alias="totalBudgetMinutes")
+    total_minutes_used: Decimal = Field(..., serialization_alias="totalMinutesUsed")
+    created_by_user_id: uuid.UUID | None = Field(None, serialization_alias="createdByUserId")
+    created_at: datetime = Field(..., serialization_alias="createdAt")
+    updated_at: datetime | None = Field(None, serialization_alias="updatedAt")
+
+
+class CallFlowDemoLinkListResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    data: list[CallFlowDemoLinkOut]

--- a/app/services/call_flow_demo_link_service.py
+++ b/app/services/call_flow_demo_link_service.py
@@ -1,0 +1,135 @@
+"""Tenant-facing CRUD for shareable call-flow demo links.
+
+Public consumption of a demo link (token lookup, minute-usage tracking) is a
+separate, unauthenticated surface built elsewhere (app/routers/sdk.py) — this
+service only covers the authenticated tenant-owner management API.
+"""
+from __future__ import annotations
+
+import secrets
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.models.call_flow import CallFlow
+from app.models.call_flow_demo_link import CallFlowDemoLink
+from app.schemas.call_flow_demo_link import (
+    CallFlowDemoLinkCreate,
+    CallFlowDemoLinkUpdate,
+)
+
+_TOKEN_BYTES = 32
+
+
+class CallFlowDemoLinkService:
+    # ── Internal helpers ──────────────────────────────────────────────────
+
+    def _get_flow_or_404(
+        self, db: Session, flow_id: uuid.UUID, tenant_id: uuid.UUID
+    ) -> CallFlow:
+        flow = db.execute(
+            select(CallFlow).where(
+                CallFlow.id == flow_id,
+                CallFlow.tenant_id == tenant_id,
+                CallFlow.is_deleted == False,  # noqa: E712
+            )
+        ).scalar_one_or_none()
+        if flow is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Call flow {flow_id} not found",
+            )
+        return flow
+
+    def _get_link_or_404(
+        self, db: Session, link_id: uuid.UUID, tenant_id: uuid.UUID
+    ) -> CallFlowDemoLink:
+        link = db.execute(
+            select(CallFlowDemoLink).where(
+                CallFlowDemoLink.id == link_id,
+                CallFlowDemoLink.tenant_id == tenant_id,
+            )
+        ).scalar_one_or_none()
+        if link is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Demo link {link_id} not found",
+            )
+        return link
+
+    def build_share_url(self, token: str) -> str | None:
+        base = (settings.FRONTEND_URL or "").rstrip("/")
+        if not base:
+            return None
+        return f"{base}/demo/{token}"
+
+    # ── Public API ────────────────────────────────────────────────────────
+
+    def create_demo_link(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        flow_id: uuid.UUID,
+        body: CallFlowDemoLinkCreate,
+        created_by_user_id: uuid.UUID | None,
+    ) -> CallFlowDemoLink:
+        self._get_flow_or_404(db, flow_id, tenant_id)
+
+        link = CallFlowDemoLink(
+            tenant_id=tenant_id,
+            call_flow_id=flow_id,
+            name=body.name,
+            token=secrets.token_urlsafe(_TOKEN_BYTES),
+            expires_at=body.expires_at,
+            per_user_limit_minutes=body.per_user_limit_minutes,
+            total_budget_minutes=body.total_budget_minutes,
+            created_by_user_id=created_by_user_id,
+        )
+        db.add(link)
+        db.commit()
+        db.refresh(link)
+        return link
+
+    def list_demo_links(
+        self, db: Session, tenant_id: uuid.UUID, flow_id: uuid.UUID
+    ) -> list[CallFlowDemoLink]:
+        self._get_flow_or_404(db, flow_id, tenant_id)
+        rows = db.execute(
+            select(CallFlowDemoLink)
+            .where(
+                CallFlowDemoLink.call_flow_id == flow_id,
+                CallFlowDemoLink.tenant_id == tenant_id,
+            )
+            .order_by(CallFlowDemoLink.created_at.desc())
+        ).scalars().all()
+        return list(rows)
+
+    def update_demo_link(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        link_id: uuid.UUID,
+        body: CallFlowDemoLinkUpdate,
+    ) -> CallFlowDemoLink:
+        link = self._get_link_or_404(db, link_id, tenant_id)
+
+        updates = body.model_dump(exclude_unset=True)
+        for field, value in updates.items():
+            setattr(link, field, value)
+
+        db.commit()
+        db.refresh(link)
+        return link
+
+    def delete_demo_link(
+        self, db: Session, tenant_id: uuid.UUID, link_id: uuid.UUID
+    ) -> None:
+        link = self._get_link_or_404(db, link_id, tenant_id)
+        db.delete(link)
+        db.commit()
+
+
+call_flow_demo_link_service = CallFlowDemoLinkService()

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -10,6 +10,7 @@ from app.schemas.call_log import CallLogCreate
 from typing import List, Dict, Any
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 import asyncio
 from app.core.logger import logger
 from app.services.inbound_call_crm_sync_service import (
@@ -141,6 +142,80 @@ class CallSessionService:
         
         return call_session
     
+    def _record_demo_link_usage(self, db: Session, call_session: CallSession) -> None:
+        """
+        Credit a finished call's duration against its originating demo link's
+        total_minutes_used and the visitor's per-visitor minutes_used, if the
+        session was created via the public demo-link flow.
+
+        No-op for every other call session (call_metadata missing the
+        "demo_link" key, which is the overwhelming majority of calls).
+
+        KNOWN LIMITATION (accepted, not missing logic — do not "fix" by
+        adding more accounting here): this method is only ever reached via
+        this class's own update_call_session_status(), and nothing in the
+        codebase currently calls that for a call_type="web" / demo-link
+        CallSession — there is no LiveKit room_finished webhook receiver and
+        no public "call ended" beacon a browser client can hit. Twilio calls
+        reach update_call_session_status() via call_control_mixin.py /
+        voice_webhook_service.py; the browser-only demo-link path
+        (app/routers/sdk.py::demo_call_token) has no equivalent trigger yet.
+        This is a pre-existing gap shared with the public-call-token widget
+        flow, deliberately scoped out of the demo-link feature (see
+        01 Architecture/Voice Pipeline.md in the docs vault). Practical
+        effect: CallFlowDemoLink.total_minutes_used and
+        CallFlowDemoLinkVisitorUsage.minutes_used are checked at
+        token-issuance time but do not currently decrement from real call
+        activity in production. Closing this requires a call-end signal
+        (e.g. a public beacon endpoint or a LiveKit webhook receiver) that
+        affects both flows together — track as separate follow-up work.
+        """
+        metadata = call_session.call_metadata or {}
+        demo_meta = metadata.get("demo_link") if isinstance(metadata, dict) else None
+        if not isinstance(demo_meta, dict):
+            return
+
+        demo_link_id = demo_meta.get("demo_link_id")
+        visitor_id = demo_meta.get("visitor_id")
+        if not demo_link_id or not visitor_id or not call_session.duration:
+            return
+
+        from app.models.call_flow_demo_link import CallFlowDemoLink
+        from app.models.call_flow_demo_link_visitor_usage import CallFlowDemoLinkVisitorUsage
+
+        try:
+            demo_link_uuid = uuid.UUID(str(demo_link_id))
+        except ValueError:
+            logger.warning(
+                "Demo link usage accounting: malformed demo_link_id=%r session=%s",
+                demo_link_id, call_session.id,
+            )
+            return
+
+        minutes = Decimal(call_session.duration) / Decimal(60)
+
+        demo_link = db.query(CallFlowDemoLink).filter(CallFlowDemoLink.id == demo_link_uuid).first()
+        if demo_link is None:
+            return
+        demo_link.total_minutes_used = (demo_link.total_minutes_used or Decimal("0")) + minutes
+
+        visitor_usage = (
+            db.query(CallFlowDemoLinkVisitorUsage)
+            .filter(
+                CallFlowDemoLinkVisitorUsage.demo_link_id == demo_link_uuid,
+                CallFlowDemoLinkVisitorUsage.visitor_id == str(visitor_id),
+            )
+            .first()
+        )
+        if visitor_usage is not None:
+            visitor_usage.minutes_used = (visitor_usage.minutes_used or Decimal("0")) + minutes
+
+        db.commit()
+        logger.info(
+            "Demo link usage recorded demo_link_id=%s visitor_id=%s session=%s minutes=%s",
+            demo_link_id, visitor_id, call_session.id, minutes,
+        )
+
     def _create_call_log_for_session(self, db: Session, call_session: CallSession) -> CallLog:
         """Create a call log entry for a call session"""
         # Generate a shortened call ID for display (like in Vapi dashboard)
@@ -258,13 +333,28 @@ class CallSessionService:
                     if call_session.start_time:
                         duration = (call_session.end_time - call_session.start_time).total_seconds()
                         call_session.duration = int(duration)
-                
+
                 db.commit()
                 db.refresh(call_session)
 
                 self._update_call_log_for_session(
                     db, call_session, ended_reason, success_evaluation, cost, transferred
                 )
+
+                # Demo link minute accounting: a call session created via
+                # POST /api/v1/sdk/demo/{token}/call-token stashes
+                # {"demo_link_id", "visitor_id"} under call_metadata["demo_link"]
+                # (see app/routers/sdk.py::demo_call_token). On terminal status
+                # with a computed duration, credit that duration against the
+                # link's total budget and the visitor's per-user budget.
+                if status in ("completed", "failed", "busy", "no_answer") and call_session.duration:
+                    try:
+                        self._record_demo_link_usage(db, call_session)
+                    except Exception as demo_exc:  # pragma: no cover
+                        logger.warning(
+                            "Demo link usage accounting failed (non-critical) session=%s: %s",
+                            session_id, demo_exc,
+                        )
 
                 if (
                     (call_session.call_type or "").lower() == "inbound"

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1617,6 +1617,128 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/call-flows/{flow_id}/demo-links:
+    post:
+      tags:
+      - Call Flows
+      summary: Create Demo Link
+      operationId: create_demo_link_api_v1_call_flows__flow_id__demo_links_post
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallFlowDemoLinkCreate'
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallFlowDemoLinkOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - Call Flows
+      summary: List Demo Links
+      operationId: list_demo_links_api_v1_call_flows__flow_id__demo_links_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallFlowDemoLinkListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/call-flows/demo-links/{link_id}:
+    patch:
+      tags:
+      - Call Flows
+      summary: Update Demo Link
+      operationId: update_demo_link_api_v1_call_flows_demo_links__link_id__patch
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: link_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Link Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallFlowDemoLinkUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallFlowDemoLinkOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Call Flows
+      summary: Delete Demo Link
+      operationId: delete_demo_link_api_v1_call_flows_demo_links__link_id__delete
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: link_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Link Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/folders/:
     get:
       tags:
@@ -4666,6 +4788,37 @@ paths:
             schema:
               $ref: '#/components/schemas/PublicCallTokenRequest'
         required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/sdk/demo/{token}/call-token:
+    post:
+      tags:
+      - Web SDK — Public
+      summary: Demo Call Token
+      operationId: demo_call_token_api_v1_sdk_demo__token__call_token_post
+      parameters:
+      - name: token
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DemoCallTokenRequest'
       responses:
         '200':
           description: Successful Response
@@ -11587,6 +11740,141 @@ components:
       - direction
       - agentId
       title: CallFlowCreate
+    CallFlowDemoLinkCreate:
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        perUserLimitMinutes:
+          anyOf:
+          - type: number
+            exclusiveMinimum: 0.0
+          - type: string
+            pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          - type: 'null'
+          title: Peruserlimitminutes
+        totalBudgetMinutes:
+          anyOf:
+          - type: number
+            exclusiveMinimum: 0.0
+          - type: string
+            pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          - type: 'null'
+          title: Totalbudgetminutes
+      additionalProperties: false
+      type: object
+      title: CallFlowDemoLinkCreate
+      description: Request body for ``POST /api/v1/call-flows/{flow_id}/demo-links``.
+    CallFlowDemoLinkListResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/CallFlowDemoLinkOut'
+          type: array
+          title: Data
+      type: object
+      required:
+      - data
+      title: CallFlowDemoLinkListResponse
+    CallFlowDemoLinkOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        callFlowId:
+          type: string
+          format: uuid
+          title: Callflowid
+        name:
+          type: string
+          nullable: true
+        token:
+          type: string
+          title: Token
+        shareUrl:
+          type: string
+          nullable: true
+        isActive:
+          type: boolean
+          title: Isactive
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        perUserLimitMinutes:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          nullable: true
+        totalBudgetMinutes:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          nullable: true
+        totalMinutesUsed:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Totalminutesused
+        createdByUserId:
+          type: string
+          format: uuid
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          title: Createdat
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - id
+      - callFlowId
+      - token
+      - isActive
+      - totalMinutesUsed
+      - createdAt
+      title: CallFlowDemoLinkOut
+      description: Response shape for a demo link, including the derived shareable
+        URL.
+    CallFlowDemoLinkUpdate:
+      properties:
+        name:
+          type: string
+          maxLength: 255
+          nullable: true
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+        perUserLimitMinutes:
+          anyOf:
+          - type: number
+            exclusiveMinimum: 0.0
+          - type: string
+            pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          - type: 'null'
+          title: Peruserlimitminutes
+        totalBudgetMinutes:
+          anyOf:
+          - type: number
+            exclusiveMinimum: 0.0
+          - type: string
+            pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          - type: 'null'
+          title: Totalbudgetminutes
+        isActive:
+          type: boolean
+          nullable: true
+      additionalProperties: false
+      type: object
+      title: CallFlowDemoLinkUpdate
+      description: Request body for ``PATCH /api/v1/call-flows/demo-links/{link_id}``.
     CallFlowSettingsUpdate:
       properties:
         public_access:
@@ -12668,6 +12956,18 @@ components:
       - board_id
       - board_url
       title: DeleteBoardItemsResponse
+    DemoCallTokenRequest:
+      properties:
+        visitor_id:
+          type: string
+          maxLength: 255
+          minLength: 1
+          title: Visitor Id
+      additionalProperties: false
+      type: object
+      required:
+      - visitor_id
+      title: DemoCallTokenRequest
     DirectionEnum:
       type: string
       enum:

--- a/docs/rbac-matrix.md
+++ b/docs/rbac-matrix.md
@@ -143,6 +143,10 @@ their pre-existing `require_tenant` / legacy-alias gating, listed in the
 | PUT | `/api/v1/call-flows/{id}/settings` (public_access toggle) | `admin` | API-key principals rejected (pre-existing) |
 | DELETE | `/api/v1/call-flows/{id}` | `config_only` | also accepts API-key principals |
 | PUT | `/api/v1/call-flows/{id}/knowledge-bases` | `admin` | API-key principals rejected (pre-existing) |
+| POST | `/api/v1/call-flows/{flow_id}/demo-links` | `config_only` | also accepts API-key principals; creates a shareable, origin-unrestricted demo link |
+| GET | `/api/v1/call-flows/{flow_id}/demo-links` | `config_only` | also accepts API-key principals; token is a bearer-style credential, so gated above `read_only` |
+| PATCH | `/api/v1/call-flows/demo-links/{link_id}` | `config_only` | also accepts API-key principals |
+| DELETE | `/api/v1/call-flows/demo-links/{link_id}` | `config_only` | also accepts API-key principals; hard delete, cascades to visitor usage rows |
 
 ### Knowledge base — `app/routers/knowledge_base.py`
 

--- a/tests/api/test_call_flow_demo_links.py
+++ b/tests/api/test_call_flow_demo_links.py
@@ -1,0 +1,543 @@
+"""Integration tests for tenant-facing demo-link CRUD:
+
+POST/GET   /api/v1/call-flows/{flow_id}/demo-links
+PATCH      /api/v1/call-flows/demo-links/{link_id}
+DELETE     /api/v1/call-flows/demo-links/{link_id}
+
+Mirrors the auth-mocking pattern from tests/api/test_call_flows.py.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.workspace import Workspace
+from app.middleware.api_key_middleware import _attach_workspace_context
+from app.core.request_auth import AUTH_METHOD_JWT
+from app.models.agent import Agent
+from app.models.call_flow import CallFlow
+from app.models.call_flow_demo_link import CallFlowDemoLink
+from app.models.call_flow_demo_link_visitor_usage import CallFlowDemoLinkVisitorUsage
+from app.models.role import Role
+from app.models.tenant import Tenant
+from app.models.user import User, user_tenant_association
+
+_API_KEY = "test-demolinks-key"
+
+
+# ─────────────────────────────────────────────────────────────── helpers ──
+
+
+def _payload_for(tenant: Tenant) -> dict:
+    return {
+        "api_key_id": str(uuid.uuid4()),
+        "tenant_id": str(tenant.id),
+        "key_is_active": True,
+        "workspace": {
+            "id": str(tenant.id),
+            "name": tenant.name,
+            "schema_name": tenant.schema_name,
+            "status": "active",
+            "credits": 0.0,
+            "stripe_customer_id": None,
+            "stripe_subscription_id": None,
+        },
+    }
+
+
+def _headers(tenant: Tenant) -> dict:
+    return {"x-api-key": _API_KEY, "x-workspace-id": str(tenant.id)}
+
+
+def _make_jwt_user(db, tenant_id: uuid.UUID, role_name: str) -> User:
+    role = db.query(Role).filter(Role.name == role_name).first()
+    if role is None:
+        role = Role(name=role_name, description=role_name)
+        db.add(role)
+        db.commit()
+        db.refresh(role)
+
+    user = User(
+        email=f"{role_name}-{uuid.uuid4().hex[:8]}@example.com",
+        first_name=role_name.title(),
+        last_name="User",
+        hashed_password="",
+        current_tenant_id=tenant_id,
+    )
+    db.add(user)
+    db.flush()
+    db.execute(
+        user_tenant_association.insert().values(
+            user_id=user.id, tenant_id=tenant_id, role_id=role.id, is_creator=False
+        )
+    )
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@contextmanager
+def _jwt_auth_ctx(workspace: Workspace, user_id: uuid.UUID):
+    async def _jwt_auth(request):
+        _attach_workspace_context(
+            request, workspace=workspace, auth_method=AUTH_METHOD_JWT, user_id=user_id,
+        )
+        return True
+
+    with patch(
+        "app.middleware.api_key_middleware._try_jwt_auth", side_effect=_jwt_auth
+    ):
+        yield
+
+
+# ─────────────────────────────────────────────────────────────── fixtures ──
+
+
+@pytest.fixture
+def auth_tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"DemoLinkWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"demo_link_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def other_tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"OtherWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"other_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def test_agent(db, auth_tenant: Tenant) -> Agent:
+    a = Agent(
+        tenant_id=auth_tenant.id,
+        name="Demo Link Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def test_flow(db, auth_tenant: Tenant, test_agent: Agent) -> CallFlow:
+    flow = CallFlow(
+        tenant_id=auth_tenant.id,
+        agent_id=test_agent.id,
+        name="Demo Link Flow",
+        direction="inbound",
+    )
+    db.add(flow)
+    db.commit()
+    db.refresh(flow)
+    return flow
+
+
+@pytest.fixture
+def other_flow(db, other_tenant: Tenant) -> CallFlow:
+    other_agent = Agent(
+        tenant_id=other_tenant.id,
+        name="Other Tenant Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(other_agent)
+    db.commit()
+    db.refresh(other_agent)
+
+    flow = CallFlow(
+        tenant_id=other_tenant.id,
+        agent_id=other_agent.id,
+        name="Other Tenant Flow",
+        direction="inbound",
+    )
+    db.add(flow)
+    db.commit()
+    db.refresh(flow)
+    return flow
+
+
+@pytest.fixture
+def authed_client(client: TestClient, auth_tenant: Tenant):
+    payload = _payload_for(auth_tenant)
+
+    async def _resolve(_key_hash, _workspace_id):
+        return payload
+
+    with patch(
+        "app.middleware.api_key_middleware._resolve_api_key",
+        side_effect=_resolve,
+    ):
+        yield client
+
+
+# ──────────────────────────────────────────────────────────────── tests ──
+
+
+@pytest.mark.usefixtures("db")
+class TestCreateDemoLink:
+    def test_create_happy_path_returns_token_and_share_url(
+        self, authed_client, auth_tenant, test_flow
+    ):
+        resp = authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "My Demo Link"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["name"] == "My Demo Link"
+        assert body["callFlowId"] == str(test_flow.id)
+        assert body["token"]
+        # shareUrl is derived server-side from settings.FRONTEND_URL + token
+        assert "shareUrl" in body
+        assert body["isActive"] is True
+        assert float(body["totalMinutesUsed"]) == 0
+
+    def test_client_supplied_token_is_rejected(
+        self, authed_client, auth_tenant, test_flow
+    ):
+        """CallFlowDemoLinkCreate uses extra='forbid' — a 'token' field in the
+        body must be rejected outright, not silently ignored."""
+        resp = authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "Hack", "token": "attacker-supplied-token"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400, resp.text
+
+    def test_created_by_user_id_set_for_jwt_user(
+        self, authed_client, auth_tenant, test_flow, db
+    ):
+        admin = _make_jwt_user(db, auth_tenant.id, "admin")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, admin.id):
+            resp = authed_client.post(
+                f"/api/v1/call-flows/{test_flow.id}/demo-links",
+                json={"name": "JWT Created Link"},
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["createdByUserId"] == str(admin.id)
+
+    def test_created_by_user_id_null_for_api_key_principal(
+        self, authed_client, auth_tenant, test_flow
+    ):
+        resp = authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "API Key Created Link"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["createdByUserId"] is None
+
+    def test_create_cross_tenant_flow_returns_404(
+        self, authed_client, auth_tenant, other_flow
+    ):
+        resp = authed_client.post(
+            f"/api/v1/call-flows/{other_flow.id}/demo-links",
+            json={"name": "Cross Tenant"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.usefixtures("db")
+class TestListDemoLinks:
+    def test_list_is_tenant_and_flow_scoped(
+        self, authed_client, auth_tenant, test_flow, test_agent, db
+    ):
+        authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "Link A"},
+            headers=_headers(auth_tenant),
+        )
+        authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "Link B"},
+            headers=_headers(auth_tenant),
+        )
+
+        # A second flow (same tenant) with its own demo link must not appear
+        other_flow_same_tenant = CallFlow(
+            tenant_id=auth_tenant.id,
+            agent_id=test_agent.id,
+            name="Second Flow",
+            direction="inbound",
+        )
+        db.add(other_flow_same_tenant)
+        db.commit()
+        db.refresh(other_flow_same_tenant)
+        authed_client.post(
+            f"/api/v1/call-flows/{other_flow_same_tenant.id}/demo-links",
+            json={"name": "Unrelated Link"},
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.get(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        names = {item["name"] for item in resp.json()["data"]}
+        assert names == {"Link A", "Link B"}
+
+    def test_list_cross_tenant_flow_returns_404(
+        self, authed_client, auth_tenant, other_flow
+    ):
+        resp = authed_client.get(
+            f"/api/v1/call-flows/{other_flow.id}/demo-links",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.usefixtures("db")
+class TestUpdateDemoLink:
+    def _create_link(self, authed_client, auth_tenant, flow, **overrides) -> dict:
+        body = {"name": "Original Name"}
+        body.update(overrides)
+        resp = authed_client.post(
+            f"/api/v1/call-flows/{flow.id}/demo-links",
+            json=body,
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 201, resp.text
+        return resp.json()
+
+    def test_patch_name_only(self, authed_client, auth_tenant, test_flow):
+        link = self._create_link(authed_client, auth_tenant, test_flow)
+        resp = authed_client.patch(
+            f"/api/v1/call-flows/demo-links/{link['id']}",
+            json={"name": "New Name"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["name"] == "New Name"
+        assert body["isActive"] is True
+
+    def test_patch_is_active_toggle(self, authed_client, auth_tenant, test_flow):
+        link = self._create_link(authed_client, auth_tenant, test_flow)
+        resp = authed_client.patch(
+            f"/api/v1/call-flows/demo-links/{link['id']}",
+            json={"isActive": False},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["isActive"] is False
+
+        resp = authed_client.patch(
+            f"/api/v1/call-flows/demo-links/{link['id']}",
+            json={"isActive": True},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["isActive"] is True
+
+    def test_patch_expires_at(self, authed_client, auth_tenant, test_flow):
+        link = self._create_link(authed_client, auth_tenant, test_flow)
+        resp = authed_client.patch(
+            f"/api/v1/call-flows/demo-links/{link['id']}",
+            json={"expiresAt": "2099-01-01T00:00:00Z"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["expiresAt"].startswith("2099-01-01")
+
+    def test_patch_per_user_limit_minutes(self, authed_client, auth_tenant, test_flow):
+        link = self._create_link(authed_client, auth_tenant, test_flow)
+        resp = authed_client.patch(
+            f"/api/v1/call-flows/demo-links/{link['id']}",
+            json={"perUserLimitMinutes": 5},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        assert float(resp.json()["perUserLimitMinutes"]) == 5.0
+
+    def test_patch_total_budget_minutes(self, authed_client, auth_tenant, test_flow):
+        link = self._create_link(authed_client, auth_tenant, test_flow)
+        resp = authed_client.patch(
+            f"/api/v1/call-flows/demo-links/{link['id']}",
+            json={"totalBudgetMinutes": 100},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        assert float(resp.json()["totalBudgetMinutes"]) == 100.0
+
+    def test_patch_cross_tenant_link_returns_404(
+        self, authed_client, auth_tenant, other_flow, db
+    ):
+        other_link = CallFlowDemoLink(
+            tenant_id=other_flow.tenant_id,
+            call_flow_id=other_flow.id,
+            token=uuid.uuid4().hex,
+        )
+        db.add(other_link)
+        db.commit()
+        db.refresh(other_link)
+
+        resp = authed_client.patch(
+            f"/api/v1/call-flows/demo-links/{other_link.id}",
+            json={"name": "Hijack"},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.usefixtures("db")
+class TestDeleteDemoLink:
+    def test_delete_hard_deletes_row(self, authed_client, auth_tenant, test_flow, db):
+        created = authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "To Delete"},
+            headers=_headers(auth_tenant),
+        ).json()
+        link_id = uuid.UUID(created["id"])
+
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/demo-links/{link_id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 204, resp.text
+
+        row = db.query(CallFlowDemoLink).filter(CallFlowDemoLink.id == link_id).first()
+        assert row is None
+
+    def test_delete_cascades_visitor_usage(self, authed_client, auth_tenant, test_flow, db):
+        created = authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "With Usage"},
+            headers=_headers(auth_tenant),
+        ).json()
+        link_id = uuid.UUID(created["id"])
+
+        usage = CallFlowDemoLinkVisitorUsage(
+            demo_link_id=link_id,
+            visitor_id="visitor-abc",
+        )
+        db.add(usage)
+        db.commit()
+        db.refresh(usage)
+        usage_id = usage.id
+
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/demo-links/{link_id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 204, resp.text
+
+        remaining = (
+            db.query(CallFlowDemoLinkVisitorUsage)
+            .filter(CallFlowDemoLinkVisitorUsage.id == usage_id)
+            .first()
+        )
+        assert remaining is None
+
+    def test_delete_cross_tenant_link_returns_404(
+        self, authed_client, auth_tenant, other_flow, db
+    ):
+        other_link = CallFlowDemoLink(
+            tenant_id=other_flow.tenant_id,
+            call_flow_id=other_flow.id,
+            token=uuid.uuid4().hex,
+        )
+        db.add(other_link)
+        db.commit()
+        db.refresh(other_link)
+
+        resp = authed_client.delete(
+            f"/api/v1/call-flows/demo-links/{other_link.id}",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404, resp.text
+
+
+@pytest.mark.usefixtures("db")
+class TestDemoLinkRbac:
+    """require_config_or_api_key gates all four endpoints — read_only (below
+    config tier) must be rejected on every one; API-key principals bypass
+    role checks entirely (covered by the happy-path tests above)."""
+
+    def test_read_only_forbidden_on_create(self, authed_client, auth_tenant, test_flow, db):
+        reader = _make_jwt_user(db, auth_tenant.id, "read_only")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, reader.id):
+            resp = authed_client.post(
+                f"/api/v1/call-flows/{test_flow.id}/demo-links",
+                json={"name": "Should Fail"},
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    def test_read_only_forbidden_on_list(self, authed_client, auth_tenant, test_flow, db):
+        reader = _make_jwt_user(db, auth_tenant.id, "read_only")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, reader.id):
+            resp = authed_client.get(
+                f"/api/v1/call-flows/{test_flow.id}/demo-links",
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    def test_read_only_forbidden_on_patch(self, authed_client, auth_tenant, test_flow, db):
+        link = authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "Target"},
+            headers=_headers(auth_tenant),
+        ).json()
+
+        reader = _make_jwt_user(db, auth_tenant.id, "read_only")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, reader.id):
+            resp = authed_client.patch(
+                f"/api/v1/call-flows/demo-links/{link['id']}",
+                json={"name": "Should Fail"},
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 403, resp.text
+
+    def test_read_only_forbidden_on_delete(self, authed_client, auth_tenant, test_flow, db):
+        link = authed_client.post(
+            f"/api/v1/call-flows/{test_flow.id}/demo-links",
+            json={"name": "Target"},
+            headers=_headers(auth_tenant),
+        ).json()
+
+        reader = _make_jwt_user(db, auth_tenant.id, "read_only")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, reader.id):
+            resp = authed_client.delete(
+                f"/api/v1/call-flows/demo-links/{link['id']}",
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 403, resp.text

--- a/tests/api/test_sdk_demo_link.py
+++ b/tests/api/test_sdk_demo_link.py
@@ -1,0 +1,300 @@
+"""Integration tests for the unauthenticated POST /api/v1/sdk/demo/{token}/call-token.
+
+No x-api-key / x-workspace-id / Authorization headers are ever sent here.
+Unlike public-call-token, this endpoint is deliberately origin-unrestricted —
+access is controlled purely by possession of the opaque demo-link token plus
+its active/expiry/usage-budget fields. See app/routers/sdk.py and
+app/models/call_flow_demo_link.py for the security rationale.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.models.agent import Agent
+from app.models.call_flow import CallFlow
+from app.models.call_flow_demo_link import CallFlowDemoLink
+from app.models.call_flow_demo_link_visitor_usage import CallFlowDemoLinkVisitorUsage
+from app.models.call_session import CallSession
+from app.models.tenant import Tenant
+from app.models.user import User
+
+
+@pytest.fixture
+def tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"DemoSdkWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"demo_sdk_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def creator_user(db) -> User:
+    # Every real tenant/agent has an owning user; CallSession.user_id is a
+    # NOT NULL FK, so a demo-link call session needs one to attribute to.
+    u = User(
+        first_name="Demo",
+        last_name="Creator",
+        email=f"demo-creator-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="not-a-real-hash",
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def agent(db, tenant: Tenant, creator_user: User) -> Agent:
+    a = Agent(
+        tenant_id=tenant.id,
+        name="Demo SDK Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+        created_by=creator_user.id,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, tenant: Tenant, agent: Agent) -> CallFlow:
+    f = CallFlow(
+        tenant_id=tenant.id,
+        agent_id=agent.id,
+        name="Demo SDK Flow",
+        direction="inbound",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+def _make_link(db, tenant: Tenant, flow: CallFlow, **overrides) -> CallFlowDemoLink:
+    kwargs = dict(
+        tenant_id=tenant.id,
+        call_flow_id=flow.id,
+        name="Demo Link",
+        token=uuid.uuid4().hex,
+        is_active=True,
+    )
+    kwargs.update(overrides)
+    link = CallFlowDemoLink(**kwargs)
+    db.add(link)
+    db.commit()
+    db.refresh(link)
+    return link
+
+
+@pytest.fixture
+def demo_link(db, tenant: Tenant, flow: CallFlow) -> CallFlowDemoLink:
+    return _make_link(db, tenant, flow)
+
+
+@pytest.fixture
+def mock_livekit():
+    mock = MagicMock()
+    mock.generate_caller_token = MagicMock(return_value="signed.demo.jwt")
+    with patch("app.services.livekit_service.livekit_service", mock):
+        yield mock
+
+
+def _body(visitor_id: str = "visitor-1") -> dict:
+    return {"visitor_id": visitor_id}
+
+
+@pytest.mark.usefixtures("db")
+class TestDemoCallToken:
+    def test_happy_path_no_limits(self, client: TestClient, db, tenant, flow, demo_link, mock_livekit):
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-happy"),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["livekit_token"] == "signed.demo.jwt"
+        assert body["room_name"].startswith("room_")
+        assert body["flow_id"] == str(flow.id)
+        assert body["agent_id"] == str(flow.agent_id)
+        assert "call_session_id" in body
+        mock_livekit.generate_caller_token.assert_called_once()
+
+        # A CallSession row was created and tagged with demo_link metadata
+        session = (
+            db.query(CallSession)
+            .filter(CallSession.id == uuid.UUID(body["call_session_id"]))
+            .first()
+        )
+        assert session is not None
+        assert session.call_type == "web"
+        assert session.call_metadata["demo_link"]["demo_link_id"] == str(demo_link.id)
+        assert session.call_metadata["demo_link"]["visitor_id"] == "visitor-happy"
+
+    def test_unknown_token_returns_404(self, client: TestClient, mock_livekit):
+        resp = client.post(
+            "/api/v1/sdk/demo/does-not-exist/call-token",
+            json=_body(),
+        )
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["error"]["code"] == "demo_link_not_found"
+
+    def test_inactive_link_returns_403(self, client: TestClient, db, tenant, flow, mock_livekit):
+        link = _make_link(db, tenant, flow, is_active=False)
+        resp = client.post(
+            f"/api/v1/sdk/demo/{link.token}/call-token",
+            json=_body(),
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "demo_link_inactive"
+
+    def test_expired_link_returns_410(self, client: TestClient, db, tenant, flow, mock_livekit):
+        link = _make_link(
+            db, tenant, flow,
+            expires_at=datetime.now(timezone.utc) - timedelta(days=1),
+        )
+        resp = client.post(
+            f"/api/v1/sdk/demo/{link.token}/call-token",
+            json=_body(),
+        )
+        assert resp.status_code == 410, resp.text
+        assert resp.json()["error"]["code"] == "demo_link_expired"
+
+    def test_deleted_parent_flow_returns_403(self, client: TestClient, db, tenant, flow, demo_link, mock_livekit):
+        flow.is_deleted = True
+        db.add(flow)
+        db.commit()
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body(),
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "call_flow_unavailable"
+
+    def test_inactive_parent_flow_returns_403(self, client: TestClient, db, tenant, flow, demo_link, mock_livekit):
+        flow.status = "inactive"
+        db.add(flow)
+        db.commit()
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body(),
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "call_flow_unavailable"
+
+    def test_deleted_agent_returns_403(self, client: TestClient, db, tenant, agent, flow, demo_link, mock_livekit):
+        agent.is_deleted = True
+        db.add(agent)
+        db.commit()
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body(),
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "agent_unavailable"
+
+    def test_total_budget_exceeded_returns_403(self, client: TestClient, db, tenant, flow, mock_livekit):
+        link = _make_link(
+            db, tenant, flow,
+            total_budget_minutes=Decimal("10"),
+            total_minutes_used=Decimal("10"),
+        )
+        resp = client.post(
+            f"/api/v1/sdk/demo/{link.token}/call-token",
+            json=_body(),
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "demo_link_budget_exceeded"
+
+    def test_per_visitor_limit_exceeded_returns_403(
+        self, client: TestClient, db, tenant, flow, mock_livekit
+    ):
+        link = _make_link(db, tenant, flow, per_user_limit_minutes=Decimal("5"))
+        usage = CallFlowDemoLinkVisitorUsage(
+            demo_link_id=link.id,
+            visitor_id="visitor-capped",
+            minutes_used=Decimal("5"),
+        )
+        db.add(usage)
+        db.commit()
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{link.token}/call-token",
+            json=_body("visitor-capped"),
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "demo_link_visitor_limit_exceeded"
+
+    def test_first_time_visitor_usage_row_created(
+        self, client: TestClient, db, tenant, flow, demo_link, mock_livekit
+    ):
+        assert (
+            db.query(CallFlowDemoLinkVisitorUsage)
+            .filter(
+                CallFlowDemoLinkVisitorUsage.demo_link_id == demo_link.id,
+                CallFlowDemoLinkVisitorUsage.visitor_id == "brand-new-visitor",
+            )
+            .first()
+            is None
+        )
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("brand-new-visitor"),
+        )
+        assert resp.status_code == 200, resp.text
+
+        usage = (
+            db.query(CallFlowDemoLinkVisitorUsage)
+            .filter(
+                CallFlowDemoLinkVisitorUsage.demo_link_id == demo_link.id,
+                CallFlowDemoLinkVisitorUsage.visitor_id == "brand-new-visitor",
+            )
+            .first()
+        )
+        assert usage is not None
+        assert float(usage.minutes_used) == 0
+
+    def test_origin_is_not_enforced(self, client: TestClient, demo_link, mock_livekit):
+        """Unlike public-call-token, no AllowedDomain/Origin check gates this
+        endpoint — any Origin (or none) must be allowed through."""
+        resp_no_origin = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-no-origin"),
+        )
+        assert resp_no_origin.status_code == 200, resp_no_origin.text
+
+        resp_evil_origin = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-evil-origin"),
+            headers={"Origin": "https://totally-unrelated-and-unwhitelisted.example.com"},
+        )
+        assert resp_evil_origin.status_code == 200, resp_evil_origin.text
+
+    def test_reachable_without_any_auth_headers(self, client: TestClient, demo_link, mock_livekit):
+        """No x-api-key, x-workspace-id, or Authorization header is sent —
+        confirms the auth-bypass middleware change covers this path."""
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-no-auth"),
+        )
+        assert resp.status_code == 200, resp.text
+        assert "livekit_token" in resp.json()

--- a/tests/services/test_call_session_demo_link_usage.py
+++ b/tests/services/test_call_session_demo_link_usage.py
@@ -1,0 +1,279 @@
+"""Unit tests for the demo-link minute-accounting hook wired into
+CallSessionService.update_call_session_status() / _record_demo_link_usage().
+
+See app/routers/sdk.py::demo_call_token for how call_metadata["demo_link"]
+gets stashed on a CallSession created via the public demo-link flow.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+
+from app.models.agent import Agent
+from app.models.call_flow_demo_link import CallFlowDemoLink
+from app.models.call_flow_demo_link_visitor_usage import CallFlowDemoLinkVisitorUsage
+from app.models.call_session import CallSession
+from app.models.tenant import Tenant
+from app.models.user import User
+from app.services.call_session_service import call_session_service
+
+
+@contextmanager
+def _naive_utcnow_patch():
+    """Work around a SQLite-only testing artifact: SQLAlchemy's
+    DateTime(timezone=True) column does not round-trip tzinfo through SQLite
+    (unlike the real Postgres column), so a CallSession reloaded from the test
+    DB always has a naive start_time. update_call_session_status() then computes
+    ``datetime.now(timezone.utc) - call_session.start_time``, which raises
+    "can't subtract offset-naive and offset-aware datetimes" purely because of
+    this SQLite limitation -- never against the real Postgres schema. Patch
+    datetime.now(tz) inside call_session_service to also return a naive value
+    so the real duration-calculation code path can still be exercised here.
+    """
+    real_datetime = datetime
+
+    class _NaiveNow(real_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return real_datetime.utcnow()
+
+    with patch("app.services.call_session_service.datetime", _NaiveNow):
+        yield
+
+
+@pytest.fixture
+def tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"DemoUsageWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"demo_usage_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def agent(db, tenant: Tenant) -> Agent:
+    a = Agent(
+        tenant_id=tenant.id,
+        name="Demo Usage Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def cs_user(db, tenant: Tenant) -> User:
+    u = User(
+        email=f"cs-user-{uuid.uuid4().hex[:8]}@example.com",
+        first_name="CS",
+        last_name="User",
+        hashed_password="",
+        current_tenant_id=tenant.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def demo_link(db, tenant: Tenant, agent: Agent) -> CallFlowDemoLink:
+    from app.models.call_flow import CallFlow
+
+    flow = CallFlow(
+        tenant_id=tenant.id,
+        agent_id=agent.id,
+        name="Usage Flow",
+        direction="inbound",
+    )
+    db.add(flow)
+    db.commit()
+    db.refresh(flow)
+
+    link = CallFlowDemoLink(
+        tenant_id=tenant.id,
+        call_flow_id=flow.id,
+        token=uuid.uuid4().hex,
+        total_minutes_used=Decimal("0"),
+    )
+    db.add(link)
+    db.commit()
+    db.refresh(link)
+    return link
+
+
+def _make_session(
+    db, tenant: Tenant, agent: Agent, user: User, *, call_metadata: dict | None, minutes_ago: int = 5
+) -> CallSession:
+    session = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=tenant.id,
+        status="active",
+        call_type="web",
+        start_time=datetime.now(timezone.utc) - timedelta(minutes=minutes_ago),
+        call_metadata=call_metadata,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
+
+
+@pytest.mark.usefixtures("db")
+class TestRecordDemoLinkUsage:
+    def test_completed_call_credits_link_and_visitor_minutes(
+        self, db, tenant, agent, cs_user, demo_link
+    ):
+        visitor_usage = CallFlowDemoLinkVisitorUsage(
+            demo_link_id=demo_link.id,
+            visitor_id="visitor-usage-1",
+            minutes_used=Decimal("0"),
+        )
+        db.add(visitor_usage)
+        db.commit()
+
+        session = _make_session(
+            db, tenant, agent, cs_user,
+            call_metadata={
+                "demo_link": {
+                    "demo_link_id": str(demo_link.id),
+                    "visitor_id": "visitor-usage-1",
+                }
+            },
+            minutes_ago=5,
+        )
+
+        with _naive_utcnow_patch():
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+        assert updated is not None
+        assert updated.duration is not None
+        expected_minutes = Decimal(updated.duration) / Decimal(60)
+
+        db.refresh(demo_link)
+        db.refresh(visitor_usage)
+        assert demo_link.total_minutes_used == expected_minutes
+        assert visitor_usage.minutes_used == expected_minutes
+
+    def test_no_demo_link_key_is_noop(self, db, tenant, agent, cs_user):
+        """call_metadata has no 'demo_link' key — the overwhelming majority
+        of calls. Must not raise and must not touch any demo-link tables."""
+        session = _make_session(
+            db, tenant, agent, cs_user,
+            call_metadata={"some_other_key": "value"},
+        )
+
+        with _naive_utcnow_patch():
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+        assert updated is not None
+        assert updated.status == "completed"
+
+    def test_null_call_metadata_is_noop(self, db, tenant, agent, cs_user):
+        session = _make_session(db, tenant, agent, cs_user, call_metadata=None)
+
+        with _naive_utcnow_patch():
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+        assert updated is not None
+        assert updated.status == "completed"
+
+    def test_demo_link_pointing_at_deleted_row_fails_open(
+        self, db, tenant, agent, cs_user
+    ):
+        """demo_link_id references a row that no longer exists (e.g. the demo
+        link was deleted between call start and call end). Must not raise and
+        must not block the rest of update_call_session_status."""
+        nonexistent_id = str(uuid.uuid4())
+        session = _make_session(
+            db, tenant, agent, cs_user,
+            call_metadata={
+                "demo_link": {
+                    "demo_link_id": nonexistent_id,
+                    "visitor_id": "visitor-orphaned",
+                }
+            },
+        )
+
+        with _naive_utcnow_patch():
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+        assert updated is not None
+        assert updated.status == "completed"
+        assert updated.duration is not None
+
+    def test_lookup_exception_fails_open_and_does_not_block_status_update(
+        self, db, tenant, agent, cs_user, demo_link
+    ):
+        """Simulate an unexpected failure inside _record_demo_link_usage
+        (e.g. a DB error during the demo-link lookup). The outer try/except
+        in update_call_session_status must swallow it, log, and still return
+        the updated call session."""
+        session = _make_session(
+            db, tenant, agent, cs_user,
+            call_metadata={
+                "demo_link": {
+                    "demo_link_id": str(demo_link.id),
+                    "visitor_id": "visitor-boom",
+                }
+            },
+        )
+
+        with _naive_utcnow_patch(), patch.object(
+            call_session_service,
+            "_record_demo_link_usage",
+            side_effect=RuntimeError("simulated demo-link lookup failure"),
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        assert updated.duration is not None
+
+        # Demo link itself must be untouched since accounting never ran
+        db.refresh(demo_link)
+        assert demo_link.total_minutes_used == Decimal("0")
+
+    def test_missing_duration_skips_accounting(self, db, tenant, agent, cs_user, demo_link):
+        """No duration computed on the call session — accounting must not run
+        and must not raise. Exercised directly against _record_demo_link_usage
+        since CallSession.start_time is NOT NULL, so a real "no duration" row
+        can't be persisted end-to-end via update_call_session_status."""
+        session = _make_session(
+            db, tenant, agent, cs_user,
+            call_metadata={
+                "demo_link": {
+                    "demo_link_id": str(demo_link.id),
+                    "visitor_id": "visitor-no-duration",
+                }
+            },
+        )
+        session.duration = None
+
+        call_session_service._record_demo_link_usage(db, session)
+        assert session.duration is None
+
+        db.refresh(demo_link)
+        assert demo_link.total_minutes_used == Decimal("0")


### PR DESCRIPTION
## Summary
- New shareable, origin-unrestricted public link per call flow: anyone with the link can talk to the agent live in-browser via LiveKit, no Twilio involved.
- Tenant-facing CRUD (`app/routers/call_flows.py`, gated `require_config_or_api_key`): create/list/patch/delete demo links, with optional name, expiry, per-visitor minute limit, and total budget minutes.
- Public unauthenticated token-issuance endpoint (`POST /api/v1/sdk/demo/{token}/call-token`, `app/routers/sdk.py`): validates link existence/active/expiry, parent call flow status (`active`, not deleted), parent agent existence (not deleted), and budget/limit checks before issuing a LiveKit token — no domain/origin allowlist, by design.
- New tables `CallFlowDemoLink` / `CallFlowDemoLinkVisitorUsage` (migration `c35f4e3d5e3f`).
- Minute-accounting hook wired into `CallSessionService.update_call_session_status()` (`_record_demo_link_usage`), but documented as not yet triggered in production for browser-only calls — this backend has no LiveKit call-end signal yet, a pre-existing gap shared with the existing `public-call-token` widget flow. Explicit TODO comments on the affected model columns and service method.
- Fixed along the way: a NOT NULL FK crash (`CallSession.user_id`) that would have failed every real request, a duplicate-index bug that broke schema creation, a sync/async bug that would 500 every real request, demo-link tokens leaking into access logs (now redacted), and a race condition on concurrent first-time visitor inserts.
- `docs/rbac-matrix.md` and `docs/api/openapi.yaml` updated; local Obsidian vault docs updated (not part of this repo).

## Test plan
- [x] `pytest tests/api/test_sdk_demo_link.py tests/api/test_call_flow_demo_links.py tests/services/test_call_session_demo_link_usage.py tests/api/test_call_flows.py tests/api/test_public_call_token.py tests/middleware/` — 165 passed, 1 skipped
- [x] `ruff check` clean on all touched/new files
- [x] Manual end-to-end voice test via a throwaway QA harness (create link → public token → join LiveKit room → talk to agent) — not part of this repo
- [ ] Reviewer: confirm `FRONTEND_URL`-derived `share_url` path shape (`/demo/{token}`) against the actual frontend route once it exists

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>