### PR TITLE
feat: make the agent actually join browser-only demo-link LiveKit calls

### DIFF
--- a/app/models/call_flow_demo_link.py
+++ b/app/models/call_flow_demo_link.py
@@ -36,12 +36,10 @@ class CallFlowDemoLink(Base):
 
     per_user_limit_minutes = Column(Numeric, nullable=True)
     total_budget_minutes = Column(Numeric, nullable=True)
-    # TODO(known limitation, not missing logic): incremented by
-    # CallSessionService._record_demo_link_usage(), but nothing in
-    # production currently calls update_call_session_status() for a
-    # browser-only demo-link CallSession (no LiveKit call-end signal
-    # exists yet — see that method's docstring). Checked at token-issuance
-    # time; does not yet decrement from real call activity.
+    # Incremented by CallSessionService._record_demo_link_usage(), called
+    # from update_call_session_status() when app.voice.livekit_browser_call_handler
+    # .run_livekit_browser_call() finalizes a demo-link CallSession as the
+    # LiveKit room disconnects — this does decrement from real call activity.
     total_minutes_used = Column(Numeric, nullable=False, default=0, server_default="0")
 
     created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("user.id"), nullable=True)

--- a/app/models/call_flow_demo_link_visitor_usage.py
+++ b/app/models/call_flow_demo_link_visitor_usage.py
@@ -27,9 +27,8 @@ class CallFlowDemoLinkVisitorUsage(Base):
     )
     visitor_id = Column(String, nullable=False, index=True)
 
-    # TODO(known limitation, not missing logic): see the matching comment
-    # on CallFlowDemoLink.total_minutes_used — same accepted gap, same
-    # accounting hook, currently untriggered in production.
+    # See the matching comment on CallFlowDemoLink.total_minutes_used — same
+    # accounting hook, now triggered by run_livekit_browser_call() at call end.
     minutes_used = Column(Numeric, nullable=False, default=0, server_default="0")
 
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/app/routers/sdk.py
+++ b/app/routers/sdk.py
@@ -359,6 +359,19 @@ async def demo_call_token(
         demo_link.id, call_session.id, room_name, ip,
     )
 
+    # Spawn the agent's join/conversation loop as a detached background task —
+    # never awaited here, so the HTTP response returns immediately regardless
+    # of how long the call takes. All failures (agent-join, STT/TTS wiring,
+    # LiveKit connectivity) are caught and logged inside
+    # run_livekit_browser_call itself so this never becomes an unhandled task
+    # exception. spawn_browser_call keeps a strong reference to the task for
+    # its whole lifetime — asyncio.Task is only weakly held by the event
+    # loop, and this task can run for the entire duration of a live call.
+    # See app/voice/livekit_browser_call_handler.py.
+    from app.voice.livekit_browser_call_handler import spawn_browser_call
+
+    spawn_browser_call(call_session.id)
+
     return {
         "livekit_token": lk_token,
         "room_name": room_name,

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -151,24 +151,21 @@ class CallSessionService:
         No-op for every other call session (call_metadata missing the
         "demo_link" key, which is the overwhelming majority of calls).
 
-        KNOWN LIMITATION (accepted, not missing logic — do not "fix" by
-        adding more accounting here): this method is only ever reached via
-        this class's own update_call_session_status(), and nothing in the
-        codebase currently calls that for a call_type="web" / demo-link
-        CallSession — there is no LiveKit room_finished webhook receiver and
-        no public "call ended" beacon a browser client can hit. Twilio calls
-        reach update_call_session_status() via call_control_mixin.py /
-        voice_webhook_service.py; the browser-only demo-link path
-        (app/routers/sdk.py::demo_call_token) has no equivalent trigger yet.
-        This is a pre-existing gap shared with the public-call-token widget
-        flow, deliberately scoped out of the demo-link feature (see
-        01 Architecture/Voice Pipeline.md in the docs vault). Practical
-        effect: CallFlowDemoLink.total_minutes_used and
-        CallFlowDemoLinkVisitorUsage.minutes_used are checked at
-        token-issuance time but do not currently decrement from real call
-        activity in production. Closing this requires a call-end signal
-        (e.g. a public beacon endpoint or a LiveKit webhook receiver) that
-        affects both flows together — track as separate follow-up work.
+        RESOLVED for the demo-link flow specifically: run_livekit_browser_call()
+        (app/voice/livekit_browser_call_handler.py), spawned as a background
+        task from app/routers/sdk.py::demo_call_token, now calls this class's
+        update_call_session_status() with status="completed" once the LiveKit
+        room disconnects or the caller leaves — so this method is reached and
+        CallFlowDemoLink.total_minutes_used / CallFlowDemoLinkVisitorUsage.
+        minutes_used do decrement from real call activity for demo-link
+        sessions now.
+
+        STILL OPEN (deliberately out of scope here): the public-call-token
+        widget flow (app/routers/sdk.py::public_call_token) has no equivalent
+        call-end signal — it doesn't even create a CallSession row, so this
+        method never applies to it regardless. That gap is unrelated to demo
+        links (public-call-token has no minute-budget accounting at all) and
+        is tracked separately.
         """
         metadata = call_session.call_metadata or {}
         demo_meta = metadata.get("demo_link") if isinstance(metadata, dict) else None
@@ -347,6 +344,9 @@ class CallSessionService:
                 # (see app/routers/sdk.py::demo_call_token). On terminal status
                 # with a computed duration, credit that duration against the
                 # link's total budget and the visitor's per-user budget.
+                is_demo_link_call = isinstance(call_session.call_metadata, dict) and isinstance(
+                    call_session.call_metadata.get("demo_link"), dict
+                )
                 if status in ("completed", "failed", "busy", "no_answer") and call_session.duration:
                     try:
                         self._record_demo_link_usage(db, call_session)
@@ -369,7 +369,10 @@ class CallSessionService:
                 # HubSpot post-call write-back: create a Call engagement with the
                 # transcript summary once the call has actually completed. Fire-and-forget
                 # (fail open) — see app/services/hubspot_service.py::schedule_hubspot_writeback.
-                if status == "completed":
+                # Skipped for anonymous demo-link calls (customer_phone_number is a
+                # placeholder, not a real contact — would just be wasted API calls,
+                # or worse, a false match onto a real customer's CRM record).
+                if status == "completed" and not is_demo_link_call:
                     try:
                         from app.services.hubspot_service import (
                             schedule_hubspot_writeback,
@@ -386,7 +389,8 @@ class CallSessionService:
                 # Salesforce post-call write-back: create a Task (Activity) with the
                 # transcript summary once the call has actually completed. Fire-and-forget
                 # (fail open) — see app/services/salesforce_service.py::schedule_salesforce_writeback.
-                if status == "completed":
+                # Skipped for anonymous demo-link calls — see HubSpot block above for why.
+                if status == "completed" and not is_demo_link_call:
                     try:
                         from app.services.salesforce_service import (
                             schedule_salesforce_writeback,
@@ -405,7 +409,8 @@ class CallSessionService:
                 # transcript summary once the call has actually completed. Enqueued
                 # as an ARQ background job (fail open) — see
                 # app/services/ghl_service.py::schedule_ghl_writeback.
-                if status == "completed":
+                # Skipped for anonymous demo-link calls — see HubSpot block above for why.
+                if status == "completed" and not is_demo_link_call:
                     try:
                         from app.services.ghl_service import (
                             schedule_ghl_writeback,

--- a/app/services/kb_ingestion_service.py
+++ b/app/services/kb_ingestion_service.py
@@ -212,7 +212,6 @@ async def run_file_ingestion(
                 kb_id=kb_file.kb_id,
                 file_id=file_id,
                 content=chunk_content,
-                # Store as JSON string for the TEXT column; Postgres sees it as vector-compatible string
                 embedding=embedding,
                 chunk_metadata={"chunk_index": i, "source": "file", "filename": kb_file.original_filename},
             )

--- a/app/services/livekit_service.py
+++ b/app/services/livekit_service.py
@@ -146,17 +146,25 @@ class RoomService:
     # Token generation
     # ------------------------------------------------------------------
 
-    def generate_agent_token(self, room_name: str) -> str:
+    def generate_agent_token(self, room_name: str, identity: str | None = None) -> str:
         """
         Return a signed JWT granting agent-{room_name} join access to the room.
         TTL = LIVEKIT_TOKEN_TTL seconds (default 3600).
         Never logged — callers must treat the return value as a secret.
+
+        `identity` defaults to "agent-{room_name}" (existing behaviour). Pass
+        an explicit override when a second, distinct agent-side participant
+        needs to join the same room concurrently (e.g. a dedicated TTS-out
+        publisher alongside the default audio-in subscriber identity — see
+        app/voice/livekit_browser_call_handler.py) — LiveKit disconnects the
+        older session on a duplicate-identity reconnect, so those two
+        connections must not share an identity.
         """
         from livekit.api import AccessToken, VideoGrants
 
         self._validate_room_name(room_name)
         _, api_key, api_secret = self._get_credentials()
-        identity = f"agent-{room_name}"
+        identity = identity or f"agent-{room_name}"
         token = (
             AccessToken(api_key=api_key, api_secret=api_secret)
             .with_identity(identity)

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -222,13 +222,29 @@ class RagService:
                     logger.error("Embedding failed for chunk %d: %s", idx, e, exc_info=True)
                     raise
 
+                if not isinstance(embedding, list):
+                    raise TypeError(
+                        f"embedding for chunk {idx} must be a list[float], got {type(embedding)}"
+                    )
+                if not all(isinstance(x, (float, int)) for x in embedding):
+                    raise TypeError(
+                        f"embedding for chunk {idx} must contain only float/int values"
+                    )
+
+                logger.debug(
+                    "kbchunk insert: embedding type=%s len=%d first5=%s",
+                    type(embedding).__name__,
+                    len(embedding),
+                    embedding[:5],
+                )
+
                 chunk_rows.append(
                     KbChunk(
                         id=uuid.uuid4(),
                         kb_id=kb.id,
                         file_id=None,
                         content=chunk_content,
-                        embedding=json.dumps(embedding),
+                        embedding=embedding,
                         chunk_metadata={
                             "chunk_index": idx,
                             "document_id": str(document_id),

--- a/app/voice/audio_transcoder.py
+++ b/app/voice/audio_transcoder.py
@@ -9,10 +9,15 @@ from __future__ import annotations
 
 import asyncio
 import shutil
+import time
 
 from app.core.logger import logger
 
 _FFMPEG_OUTPUT_FORMAT = "s16le"
+# Minimum gap between ffmpeg (re)start attempts once one has failed, so a
+# sustained outage (binary missing, fork/exec exhaustion) doesn't retry on
+# every ~20ms frame and pile onto whatever resource pressure caused it.
+_RESTART_BACKOFF_SECONDS = 1.0
 
 
 class LiveKitAudioProcessor:
@@ -31,6 +36,11 @@ class LiveKitAudioProcessor:
         self._ffmpeg_input_rate: int | None = None
         self._ffmpeg_input_channels: int | None = None
         self._first_frame_logged = False
+        # Rate-limits the "ffmpeg (re)start failed" error to once per outage
+        # (rather than once per dropped frame) so a sustained failure doesn't
+        # flood the logs while still being fully visible.
+        self._ffmpeg_start_failed_logged = False
+        self._last_restart_failure: float | None = None
 
     async def process_frame(
         self,
@@ -56,9 +66,20 @@ class LiveKitAudioProcessor:
             sample_rate == self._output_sample_rate
             and num_channels == self._output_channels
         ):
+            logger.debug(
+                "[LiveKitAudioProcessor] after resampler: passthrough bytes=%s (already %sHz/%sch)",
+                len(raw_bytes), self._output_sample_rate, self._output_channels,
+            )
             return raw_bytes
 
-        return await self._ffmpeg_convert(raw_bytes, sample_rate, num_channels)
+        out = await self._ffmpeg_convert(raw_bytes, sample_rate, num_channels)
+        logger.debug(
+            "[LiveKitAudioProcessor] after resampler: in_bytes=%s out_bytes=%s "
+            "(%sHz/%sch → %sHz/%sch)",
+            len(raw_bytes), len(out), sample_rate, num_channels,
+            self._output_sample_rate, self._output_channels,
+        )
+        return out
 
     async def _ffmpeg_convert(
         self,
@@ -72,7 +93,38 @@ class LiveKitAudioProcessor:
             or self._ffmpeg_input_rate != sample_rate
             or self._ffmpeg_input_channels != num_channels
         ):
-            await self._restart_ffmpeg(sample_rate, num_channels)
+            now = time.monotonic()
+            if (
+                self._last_restart_failure is not None
+                and now - self._last_restart_failure < _RESTART_BACKOFF_SECONDS
+            ):
+                # Still within backoff from the last failed (re)start attempt —
+                # drop this frame without retrying, so a sustained outage
+                # doesn't re-attempt subprocess creation on every ~20ms frame.
+                return b""
+            try:
+                await self._restart_ffmpeg(sample_rate, num_channels)
+            except Exception as exc:
+                # A single frame's ffmpeg-(re)start failure (e.g. binary missing
+                # from PATH in this environment, transient fork/exec error) must
+                # not kill the whole LiveKitAudioSubscriber loop for the rest of
+                # the call — that would silently end STT ingestion for the
+                # entire conversation after only the frames processed so far.
+                # Log once loudly, drop this frame, and let a later frame retry
+                # (subject to the backoff above).
+                if not self._ffmpeg_start_failed_logged:
+                    logger.error(
+                        "[LiveKitAudioProcessor] ffmpeg (re)start failed — "
+                        "dropping frames until it recovers: %s",
+                        exc,
+                        exc_info=True,
+                    )
+                    self._ffmpeg_start_failed_logged = True
+                self._last_restart_failure = now
+                return b""
+            else:
+                self._ffmpeg_start_failed_logged = False
+                self._last_restart_failure = None
 
         proc = self._ffmpeg_process
         if proc is None or proc.stdin is None or proc.stdout is None:
@@ -85,12 +137,40 @@ class LiveKitAudioProcessor:
             return out or b""
         except (BrokenPipeError, ConnectionResetError) as exc:
             logger.warning("[LiveKitAudioProcessor] ffmpeg pipe broken: %s", exc)
+            await self._reset_after_failure()
             return b""
         except asyncio.TimeoutError:
+            logger.warning(
+                "[LiveKitAudioProcessor] ffmpeg read timed out — process likely stuck, resetting"
+            )
+            await self._reset_after_failure()
             return b""
         except Exception as exc:
             logger.warning("[LiveKitAudioProcessor] ffmpeg convert error: %s", exc)
+            await self._reset_after_failure()
             return b""
+
+    async def _reset_after_failure(self) -> None:
+        """Clear the (dead/stuck) ffmpeg process so the next frame re-enters
+        the restart path instead of repeatedly hitting the same broken proc
+        for the rest of the call, and reap the old process in the background
+        so a merely-stuck (not dead) proc doesn't leak as an orphan."""
+        stale_proc = self._ffmpeg_process
+        self._ffmpeg_process = None
+        self._ffmpeg_input_rate = None
+        self._ffmpeg_input_channels = None
+        self._last_restart_failure = time.monotonic()
+        if stale_proc is not None:
+            asyncio.create_task(self._kill_stale_process(stale_proc))
+
+    @staticmethod
+    async def _kill_stale_process(proc: asyncio.subprocess.Process) -> None:
+        try:
+            if proc.returncode is None:
+                proc.kill()
+            await asyncio.wait_for(proc.wait(), timeout=3.0)
+        except Exception as exc:
+            logger.debug("[LiveKitAudioProcessor] failed to reap stale ffmpeg process: %s", exc)
 
     async def _restart_ffmpeg(self, sample_rate: int, num_channels: int) -> None:
         await self.close()

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -703,6 +703,10 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 f"🧠 Calling LLM ({llm_service.__class__.__name__ if hasattr(llm_service, '__class__') else 'Service'}) "
                 f"for response to: '{user_text[:20]}...'"
             )
+            logger.debug(
+                "[LLM] request sent: provider=%s model=%s user_text_len=%s",
+                llm_runtime.provider_slug, model_name, len(user_text or ""),
+            )
 
             async def try_stream(service, model: str, api_key_override: str | None = None) -> str:
                 nonlocal chunk_counter
@@ -871,6 +875,10 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
             final_text = ""
             try:
                 final_text = await try_stream(llm_service, model_name, api_key_override=api_key)
+                logger.debug(
+                    "[LLM] response received: chars=%s chunks_queued=%s",
+                    len(final_text or ""), chunk_counter,
+                )
             except Exception as e:
                 logger.error(f"LLM streaming failed: {e}", exc_info=True)
 

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -192,10 +192,15 @@ class ConversationOrchestrator:
         try:
             # 👋 HANDLE AUTO-GREETING - Skip LLM, use pre-defined greeting
             if is_greeting:
-                # Get greeting from agent or use default
-                if self._h.agent and hasattr(self._h.agent, "first_message") and self._h.agent.first_message:
-                    greeting_text = self._h.agent.first_message
-                else:
+                # Get greeting from agent or use default. Prefer greeting_message
+                # (current field) over the legacy first_message, matching the
+                # Twilio path's convention (BidirectionalStreamHandler.generate_and_stream_response).
+                greeting_text = None
+                if self._h.agent:
+                    greeting_text = (getattr(self._h.agent, "greeting_message", None) or "").strip() or None
+                    if not greeting_text:
+                        greeting_text = (getattr(self._h.agent, "first_message", None) or "").strip() or None
+                if not greeting_text:
                     greeting_text = "hello how are you"
 
                 # Add greeting to transcript

--- a/app/voice/livekit_audio_subscriber.py
+++ b/app/voice/livekit_audio_subscriber.py
@@ -37,6 +37,7 @@ class LiveKitAudioSubscriber:
         self._output_sample_rate = output_sample_rate
         self._stop_event = asyncio.Event()
         self._processor: LiveKitAudioProcessor | None = None
+        self._vad_note_logged = False
 
     async def run(self) -> None:
         """Connect to LiveKit room, subscribe to caller audio, feed STT."""
@@ -107,6 +108,21 @@ class LiveKitAudioSubscriber:
             if audio_stream is None or self._processor is None:
                 return
 
+            if not self._vad_note_logged:
+                # No local VAD/silence gate exists on this path — every decoded
+                # frame is forwarded to STT (Deepgram/Google) unconditionally;
+                # turn-taking ("speech started/stopped") is entirely delegated
+                # to the STT provider's own server-side endpointing
+                # (speech_final / UtteranceEnd for Deepgram, is_final for
+                # Google). Logged once so a future "conversation never
+                # starts" investigation doesn't waste time looking for an
+                # app-side VAD gate that was never here.
+                logger.debug(
+                    "[LiveKitAudioSubscriber] VAD decision: no local VAD gate — "
+                    "all frames forwarded, turn-taking is provider-side endpointing"
+                )
+                self._vad_note_logged = True
+
             async for audio_frame_event in audio_stream:
                 if self._stop_event.is_set():
                     break
@@ -119,12 +135,27 @@ class LiveKitAudioSubscriber:
                 sample_rate = int(getattr(frame, "sample_rate", 48000) or 48000)
                 num_channels = int(getattr(frame, "num_channels", 1) or 1)
 
-                pcm_bytes = await self._processor.process_frame(
-                    raw_bytes,
-                    sample_rate=sample_rate,
-                    num_channels=num_channels,
-                )
+                try:
+                    pcm_bytes = await self._processor.process_frame(
+                        raw_bytes,
+                        sample_rate=sample_rate,
+                        num_channels=num_channels,
+                    )
+                except Exception as exc:
+                    # A single frame's processing failure must never abort the
+                    # whole subscription loop — that would silently end STT
+                    # ingestion for the rest of the call after only the frames
+                    # seen so far. Drop this frame and keep listening.
+                    logger.error(
+                        "[LiveKitAudioSubscriber] frame processing error "
+                        "(dropping this frame, continuing): %s", exc, exc_info=True,
+                    )
+                    continue
+
                 if pcm_bytes:
+                    logger.debug(
+                        "[LiveKitAudioSubscriber] STT send: bytes=%s", len(pcm_bytes)
+                    )
                     await self._stt_pipeline.feed_audio_chunk(pcm_bytes)
 
         except asyncio.CancelledError:

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -1,0 +1,779 @@
+"""
+LiveKitBrowserCallHandler — browser-only (no Twilio) LiveKit voice agent.
+
+Powers the "Share Demo Link" feature: a visitor gets a LiveKit token from
+POST /api/v1/sdk/demo/{token}/call-token (app/routers/sdk.py::demo_call_token)
+and joins a LiveKit room directly from the browser (WebRTC mic in / speaker
+out — no phone, no Twilio Media Streams).
+
+This module is what makes the agent actually join that room and hold a real
+conversation. It is a *parallel* implementation to
+app/routers/bidirectional_stream.py::BidirectionalStreamHandler — it does not
+modify, subclass, or import from that file. It exists because the Twilio
+handler's audio I/O is fundamentally MULAW-over-WebSocket while this path is
+LiveKit-native PCM-over-WebRTC.
+
+Reused unmodified:
+  - app.voice.stt_pipeline.SttPipeline            (provider-agnostic STT)
+  - app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber (caller audio in)
+  - app.voice.voice_orchestrator.VoiceOrchestrator (TTS pipeline ownership +
+    unified shutdown — see _run_livekit_browser_call for exactly how it's
+    wired up without going through its Twilio-specific on_audio_chunk())
+  - app.voice.tts_pipeline.TtsPipeline             (parallel TTS synthesis)
+  - app.voice.conversation_orchestrator.ConversationOrchestrator (prompt
+    building incl. call-flow prompt override, KB/RAG context retrieval, CRM
+    read-only context blocks, LLM streaming — the actual "brain" of the call)
+
+New in this module:
+  - LiveKitBrowserCallHandler: implements exactly the handler surface that
+    VoiceOrchestrator / TtsPipeline / ConversationOrchestrator expect (see
+    each class's docstring for the attributes/methods they access on
+    `self._h` / `self._handler`), so those three classes run completely
+    unmodified against a LiveKit room instead of a Twilio WebSocket.
+  - _LiveKitAgentAudioPublisher: publishes synthesized speech into the room
+    as an outgoing WebRTC audio track.
+  - run_livekit_browser_call(): the background task entrypoint called from
+    demo_call_token.
+
+Out of scope for this path (stubbed, never crashes):
+  - Booking/Calendly, CRM write-back, transfer routing — see
+    _update_booking_memory_from_user_turn / _end_call_after_agent_request /
+    _transfer_after_agent_request below.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import struct
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.services.bidirectional_stream_service import generate_mulaw_tts
+from app.services.transcript_service import transcript_service
+from app.utils.audio_utils import MULAW_FRAME_BYTES, ulaw_to_linear_sample
+from app.utils.ssml_utils import strip_ssml_tags
+from app.voice.conversation_orchestrator import ConversationOrchestrator, VOICE_TUNABLES
+
+# ── Design decision: agent TTS-out audio format ─────────────────────────────
+# We publish mu-law 8kHz audio converted to LINEAR16 PCM, not native
+# provider PCM (e.g. ElevenLabs `pcm_16000`). This lets _prefetch_tts_audio
+# below call the *exact same* generate_mulaw_tts() helper the Twilio path
+# already uses for its non-streaming fallback/greeting turns — zero new
+# per-provider (Google/ElevenLabs/Rime) synthesis code — and reuses the same
+# ulaw_to_linear_sample() conversion LiveKitTwilioPublisher already uses for
+# caller-audio mirroring in app/voice/livekit_twilio_bridge.py. Trade-off:
+# 8kHz "phone quality" instead of wideband 16/24kHz, and whole-chunk
+# synthesis instead of true incremental provider streaming — both acceptable
+# for a demo/preview experience; TtsPipeline still pipelines chunk-by-chunk
+# at LLM sentence-flush boundaries so perceived latency is reasonable.
+_AGENT_AUDIO_SAMPLE_RATE = 8000
+
+# STT-in is always fed via LiveKitAudioSubscriber (LiveKit PCM), never
+# Twilio MULAW, regardless of which STT provider the agent is configured
+# for — so we force LINEAR16 here rather than trusting resolve_stt_runtime's
+# defaults (which assume Twilio MULAW 8kHz for Deepgram, the platform-wide
+# default provider). Provider/model/language selection is still fully
+# respected; only the wire format is overridden.
+_STT_INPUT_SAMPLE_RATE = 16000
+_STT_INPUT_ENCODING = "LINEAR16"
+
+_GREETING_DELAY_SEC = 0.6
+_TURN_TIMEOUT_SEC = 25.0
+
+# asyncio.Task objects are only weakly referenced by the event loop (see the
+# asyncio docs' explicit warning) — a fire-and-forget asyncio.create_task()
+# with no other reference is eligible for GC at any point. For a short burst
+# of work that's usually academic; here it would mean a live, minutes-long
+# voice conversation silently going dead mid-call with no error surfaced
+# anywhere. Mirrors VoiceOrchestrator._pending_final_tasks' pattern.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
+def _track(task: asyncio.Task) -> asyncio.Task:
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_BACKGROUND_TASKS.discard)
+    return task
+
+
+def spawn_browser_call(call_session_id: uuid.UUID) -> asyncio.Task:
+    """Fire-and-forget entrypoint for callers (e.g. app.routers.sdk) — keeps
+    a strong reference to the task for its whole lifetime, unlike a bare
+    asyncio.create_task() call at the call site."""
+    return _track(asyncio.create_task(run_livekit_browser_call(call_session_id)))
+
+
+class _LiveKitAgentAudioPublisher:
+    """
+    Publishes synthesized agent speech into a LiveKit room as its own
+    'agent-tts-<room>' participant — deliberately a *different* identity
+    from the 'agent-<room>' identity LiveKitAudioSubscriber connects with
+    for caller-audio-in, so both can hold simultaneous connections to the
+    same room (LiveKit reconnecting with a duplicate identity would kick the
+    older session).
+
+    Connect/publish pattern mirrors app.voice.livekit_twilio_bridge's
+    LiveKitTwilioPublisher (kept as a separate, new class here instead of
+    reusing that one directly, since that file backs the live Twilio
+    recording-mirror path and is not in this task's touch list).
+    """
+
+    def __init__(self, room_name: str) -> None:
+        self._room_name = room_name
+        self._room: Any = None
+        self._source: Any = None
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    async def connect(self) -> bool:
+        if not settings.LIVEKIT_ENABLED:
+            return False
+        try:
+            from livekit import rtc
+        except ImportError:
+            logger.error("[LiveKitBrowserCall] livekit package not available")
+            return False
+
+        try:
+            from app.services.livekit_service import livekit_service, _http_to_ws_url
+
+            livekit_service._validate_room_name(self._room_name)
+            url, _, _ = livekit_service._get_credentials()
+            ws_url = _http_to_ws_url(url)
+            token = livekit_service.generate_agent_token(
+                self._room_name, identity=f"agent-tts-{self._room_name}"
+            )
+
+            self._room = rtc.Room()
+            await self._room.connect(ws_url, token)
+
+            self._source = rtc.AudioSource(_AGENT_AUDIO_SAMPLE_RATE, 1)
+            track = rtc.LocalAudioTrack.create_audio_track("agent-tts-audio", self._source)
+            options = rtc.TrackPublishOptions()
+            options.source = rtc.TrackSource.SOURCE_MICROPHONE
+            await self._room.local_participant.publish_track(track, options)
+
+            self._connected = True
+            logger.info(
+                "[LiveKitBrowserCall] agent TTS-out track published room=%s",
+                self._room_name,
+            )
+            return True
+        except Exception as exc:
+            logger.error(
+                "[LiveKitBrowserCall] TTS publisher connect failed room=%s: %s",
+                self._room_name,
+                exc,
+                exc_info=True,
+            )
+            await self.disconnect()
+            return False
+
+    async def publish_mulaw(self, mulaw_bytes: bytes, cancel: asyncio.Event | None = None) -> None:
+        """Push mu-law bytes into the outgoing track, converting to PCM16 per frame."""
+        if not self._connected or not self._source or not mulaw_bytes:
+            return
+        try:
+            from livekit import rtc
+        except ImportError:
+            return
+
+        try:
+            offset = 0
+            total = len(mulaw_bytes)
+            while offset < total:
+                if cancel is not None and cancel.is_set():
+                    try:
+                        self._source.clear_queue()
+                    except Exception:  # noqa: S110 - best-effort barge-in abort
+                        pass
+                    return
+
+                chunk = mulaw_bytes[offset : offset + MULAW_FRAME_BYTES]
+                offset += MULAW_FRAME_BYTES
+                if len(chunk) < MULAW_FRAME_BYTES:
+                    chunk = chunk + bytes([0xFF]) * (MULAW_FRAME_BYTES - len(chunk))
+
+                samples = [ulaw_to_linear_sample(b) for b in chunk]
+                pcm = struct.pack(f"<{len(samples)}h", *samples)
+                frame = rtc.AudioFrame.create(_AGENT_AUDIO_SAMPLE_RATE, 1, len(samples))
+                frame.data[:] = pcm
+                await self._source.capture_frame(frame)
+        except Exception as exc:
+            logger.debug("[LiveKitBrowserCall] publish_mulaw failed: %s", exc)
+
+    async def disconnect(self) -> None:
+        self._connected = False
+        if self._room is not None:
+            try:
+                await self._room.disconnect()
+            except Exception as exc:
+                logger.debug("[LiveKitBrowserCall] room disconnect failed: %s", exc)
+        self._room = None
+        self._source = None
+
+
+class LiveKitBrowserCallHandler:
+    """
+    Transport adapter: implements exactly the attribute/method surface that
+    VoiceOrchestrator, TtsPipeline, and ConversationOrchestrator need on
+    their `handler` so those classes can be constructed against this object
+    unmodified. See the module docstring above and each of those classes'
+    own docstrings for the authoritative list.
+
+    Deliberately written generally enough (no assumption baked in that this
+    call came from the demo-link flow specifically — only that it is a
+    LiveKit browser call bound to a real CallSession/Agent) that it could
+    back the public-call-token widget flow too without modification, once
+    that path gets its own lifecycle wiring (out of scope here — see
+    run_livekit_browser_call's docstring).
+    """
+
+    # Same tunables ConversationOrchestrator reads off the handler for TTS
+    # chunk flushing — mirrors BidirectionalStreamHandler's class attributes.
+    TTS_FLUSH_MIN_WORDS = VOICE_TUNABLES.tts_flush_min_words
+    TTS_FLUSH_MAX_WORDS = VOICE_TUNABLES.tts_flush_max_words
+
+    def __init__(self, db, call_session, agent, call_flow=None) -> None:
+        self.db = db
+        self.call_session = call_session
+        self.agent = agent
+        self.call_flow = call_flow
+        self.call_session_id = str(call_session.id)
+        self.agent_id = str(agent.id) if agent else None
+
+        # Twilio-only naming (`streamSid`). Nothing in this path sends Twilio
+        # media-stream frames, but VoiceOrchestrator reads this attribute for
+        # logging in a couple of places, so it must exist and never crash.
+        self.stream_sid: str | None = f"livekit_{self.call_session_id}"
+
+        # ── TTS state (read by TtsPipeline / ConversationOrchestrator) ──────
+        self.is_speaking = False
+        self._is_tts_playing = False
+        self._tts_cancel = asyncio.Event()
+        self._tts_lock = asyncio.Lock()
+        self._tts_worker_task = None  # set by VoiceOrchestrator
+        self._tts_pipeline = None  # set by VoiceOrchestrator
+        self._prev_tts_tail = b""
+        # No Twilio jitter buffer exists on this path — treat as always
+        # primed so TtsPipeline/ConversationOrchestrator never wait on it.
+        self._twilio_buffer_primed = True
+        self._elevenlabs_prev_tts_text = ""
+        self._use_ssml = True
+
+        self._llm_response_task: asyncio.Task | None = None
+        self._turn_response_started = False
+
+        # ── Barge-in / interim tunables — same defaults BidirectionalStreamHandler
+        # uses, so behaviour matches the phone experience as closely as possible.
+        self._enable_interim_llm: bool = bool(getattr(settings, "VOICE_ENABLE_INTERIM_LLM", False))
+        self._min_interim_words: int = max(1, int(getattr(settings, "VOICE_MIN_INTERIM_WORDS", 4) or 4))
+        self._min_interim_confidence: float = float(
+            getattr(settings, "VOICE_MIN_INTERIM_CONFIDENCE", 0.52) or 0.52
+        )
+        self._min_interim_interval_sec: float = VOICE_TUNABLES.stt_interim_interval_ms / 1000.0
+        self._barge_in_min_conf: float = float(getattr(settings, "VOICE_BARGE_IN_MIN_CONFIDENCE", 0.26) or 0.26)
+        self._barge_in_min_conf_1w: float = float(
+            getattr(settings, "VOICE_BARGE_IN_MIN_CONFIDENCE_1W", 0.52) or 0.52
+        )
+        self._barge_in_min_words: int = max(1, int(getattr(settings, "VOICE_BARGE_IN_MIN_WORDS", 2) or 2))
+        # Pickup-detection tunables: unused by this path (LiveKit rooms have no
+        # Twilio ringing/system-message phase to skip) but VoiceOrchestrator's
+        # __init__ reads them off the handler unconditionally.
+        self._min_audio_level_threshold: int = int(getattr(settings, "VOICE_MIN_AUDIO_RMS_FOR_PICKUP", 70) or 70)
+        self._audio_samples_needed: int = max(4, int(getattr(settings, "VOICE_PICKUP_SAMPLE_WINDOW", 6) or 6))
+        self._audio_non_silent_needed: int = self._audio_samples_needed
+
+        self._stop_event = asyncio.Event()
+
+        self._conversation = ConversationOrchestrator(self)
+
+        # Wired up by run_livekit_browser_call() once connected.
+        self._agent_publisher: _LiveKitAgentAudioPublisher | None = None
+
+    # ── Transcript ────────────────────────────────────────────────────────
+
+    async def _add_to_transcript(
+        self,
+        role: str,
+        message: str,
+        message_type: str = "speech",
+        confidence: float | None = None,
+        message_metadata: dict | None = None,
+        defer_post_write: bool = False,
+    ) -> None:
+        """
+        Persist a transcript line. Cross-turn state lives entirely in
+        `callsession` / `transcript_message` (never in memory) — mirrors
+        app.voice.call_control_mixin.CallControlMixin._add_to_transcript's
+        core DB write, without that mixin's Twilio-adjacent dedupe/contact-
+        intake side effects (booking/CRM intake sync is out of scope here).
+        """
+        if not self.call_session:
+            return
+        try:
+            clean_message = strip_ssml_tags(message)
+            hipaa_enabled = bool(getattr(self.call_flow, "hipaa_compliance", False)) if self.call_flow else False
+
+            added = await transcript_service.add_and_broadcast_message(
+                db=self.db,
+                call_session_id=self.call_session.id,
+                role=role,
+                message=clean_message,
+                message_type=message_type,
+                agent_id=self.agent.id if self.agent else None,
+                user_id=self.call_session.user_id,
+                confidence=confidence,
+                metadata=message_metadata,
+                hipaa_enabled=hipaa_enabled,
+            )
+            if added is None:
+                return
+
+            if not defer_post_write:
+                conversation = transcript_service.get_conversation_array(self.db, self.call_session.id)
+                self.call_session.call_transcript = conversation
+                self.db.commit()
+
+            try:
+                self.db.refresh(self.call_session)
+            except Exception as exc:
+                logger.debug(
+                    "[LiveKitBrowserCall] failed to refresh call_session %s: %s",
+                    self.call_session.id, exc,
+                )
+        except Exception as exc:
+            logger.error("[LiveKitBrowserCall] _add_to_transcript failed: %s", exc, exc_info=True)
+
+    # ── Out-of-scope side effects — clean stubs, never crash ────────────────
+
+    def _update_booking_memory_from_user_turn(self, transcript: str) -> None:
+        """Booking is out of scope for the browser demo path — no-op."""
+        return
+
+    async def _end_call_after_agent_request(self) -> None:
+        """
+        Twilio path hangs up when the LLM emits [END_CALL]. The browser demo
+        path intentionally keeps the conversation open instead — there is no
+        "hang up the phone" equivalent for a WebRTC tab the visitor controls,
+        and ending the LiveKit room out from under an active browser tab
+        would be a worse experience than the agent saying goodbye and the
+        conversation simply continuing if the visitor speaks again.
+        """
+        logger.warning(
+            "[LiveKitBrowserCall] agent requested end-call (call_session_id=%s) — "
+            "not supported on the browser demo path yet, continuing the call",
+            self.call_session_id,
+        )
+
+    async def _transfer_after_agent_request(self) -> None:
+        """Call transfer has no meaning for a browser-only room — no-op, log only."""
+        logger.warning(
+            "[LiveKitBrowserCall] agent requested transfer (call_session_id=%s) — "
+            "not supported on the browser demo path yet, continuing the call",
+            self.call_session_id,
+        )
+
+    # ── STT → turn handling (wired as SttPipeline on_interim/on_final) ─────
+
+    async def _maybe_process_interim(self, transcript: str, confidence: float) -> None:
+        """
+        Barge-in only. LiveKit rooms have their own echo cancellation and the
+        default platform setting (VOICE_ENABLE_INTERIM_LLM=False) means the
+        Twilio path doesn't start early LLM generation on interims either —
+        so this mirrors that default behaviour rather than reimplementing the
+        early-LLM path's seed/regeneration bookkeeping.
+        """
+        try:
+            if not self._is_tts_playing or not transcript:
+                return
+            text = transcript.strip()
+            if not text:
+                return
+            word_count = len(text.split())
+            if word_count < self._barge_in_min_words:
+                return
+            min_conf = self._barge_in_min_conf_1w if word_count < 2 else self._barge_in_min_conf
+            if confidence < min_conf:
+                return
+            logger.info(
+                "[LiveKitBrowserCall] barge-in: words=%d conf=%.2f text=%r",
+                word_count, confidence, text[:40],
+            )
+            await self._cancel_inflight_llm_response()
+        except Exception as exc:
+            logger.error("[LiveKitBrowserCall] _maybe_process_interim error: %s", exc, exc_info=True)
+
+    async def _cancel_inflight_llm_response(self) -> None:
+        task = self._llm_response_task
+        self._llm_response_task = None
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as exc:
+                logger.debug("[LiveKitBrowserCall] cancelled turn raised: %s", exc)
+        if self._tts_pipeline:
+            await self._tts_pipeline.cancel_current_and_clear_queue()
+
+    async def _process_transcript(self, transcript: str, confidence: float) -> None:
+        """STT final callback (wired via VoiceOrchestrator._on_final)."""
+        try:
+            text = (transcript or "").strip()
+            if not text:
+                return
+
+            if self._is_tts_playing:
+                logger.info("[LiveKitBrowserCall] barge-in (final): %r", text[:40])
+                await self._cancel_inflight_llm_response()
+
+            await self._add_to_transcript("client", text, "speech", confidence)
+            self._update_booking_memory_from_user_turn(text)
+            await self._complete_llm_turn_after_stt_final(text, confidence)
+        except Exception as exc:
+            logger.error("[LiveKitBrowserCall] _process_transcript error: %s", exc, exc_info=True)
+
+    async def _complete_llm_turn_after_stt_final(self, transcript: str, confidence: float) -> None:
+        self._tts_cancel.clear()
+
+        async def _run() -> None:
+            try:
+                await self.generate_and_stream_response(transcript, confidence, is_greeting=False)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error("[LiveKitBrowserCall] turn generation failed: %s", exc, exc_info=True)
+
+        task = asyncio.create_task(_run())
+        self._llm_response_task = task
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=_TURN_TIMEOUT_SEC)
+        except asyncio.TimeoutError:
+            logger.error("[LiveKitBrowserCall] turn timed out after %.0fs", _TURN_TIMEOUT_SEC)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if self._llm_response_task is task:
+                self._llm_response_task = None
+
+    async def generate_and_stream_response(
+        self, user_text: str, confidence: float, is_greeting: bool = False
+    ) -> None:
+        """Delegates to ConversationOrchestrator — the reused LLM/RAG/prompt pipeline."""
+        await self._conversation.generate_and_stream_response(user_text, confidence, is_greeting=is_greeting)
+
+    def _schedule_recreate_stt_for_email_collection(self, agent_text: str) -> None:
+        """
+        Twilio-only Deepgram endpointing upgrade for spelled-out email
+        collection. Browser STT input already runs at a fixed LINEAR16
+        16kHz configuration for this path (see module docstring) — no-op.
+        """
+        return
+
+    # ── TTS synthesis + LiveKit-native playback ─────────────────────────────
+
+    async def _prefetch_tts_audio(self, task: dict) -> bytes | None:
+        """Synthesize a TTS chunk to raw mu-law bytes (see module docstring for format rationale)."""
+        text = (task.get("text") or "").strip()
+        if not text or self._tts_cancel.is_set():
+            return None
+        use_ssml = bool(task.get("use_ssml", False))
+        try:
+            lang = self.agent.language if self.agent and self.agent.language else "en"
+            voice = self.agent.voice_type if self.agent and self.agent.voice_type else "female"
+            audio_bytes = await generate_mulaw_tts(
+                text=text,
+                lang=lang,
+                voice=voice,
+                use_chirp3_hd=True,
+                speaking_rate=1.0,
+                use_ssml=use_ssml,
+                add_office_bg=False,
+                agent=self.agent,
+                db=self.db,
+            )
+            return audio_bytes or None
+        except Exception as exc:
+            logger.warning("[LiveKitBrowserCall] TTS synthesis failed for %r: %s", text[:30], exc)
+            return None
+
+    async def _stream_tts_chunk(
+        self,
+        text: str,
+        use_ssml: bool = False,
+        is_final: bool = False,
+        prefetched_bytes: Any = None,
+    ) -> None:
+        """Publish one TTS chunk's audio into the LiveKit room (TtsPipeline's audio sink)."""
+        if not text or not text.strip() or self._tts_cancel.is_set():
+            return
+
+        publisher = self._agent_publisher
+        if publisher is None or not publisher.connected:
+            logger.warning(
+                "[LiveKitBrowserCall] no agent audio publisher connected — dropping TTS chunk"
+            )
+            return
+
+        async with self._tts_lock:
+            self.is_speaking = True
+            try:
+                mulaw_bytes = prefetched_bytes if isinstance(prefetched_bytes, (bytes, bytearray)) else None
+                if mulaw_bytes is None:
+                    mulaw_bytes = await self._prefetch_tts_audio({"text": text, "use_ssml": use_ssml})
+                if not mulaw_bytes or self._tts_cancel.is_set():
+                    return
+
+                self._is_tts_playing = True
+                await publisher.publish_mulaw(mulaw_bytes, cancel=self._tts_cancel)
+            finally:
+                self.is_speaking = False
+                self._is_tts_playing = False
+                if is_final:
+                    self._prev_tts_tail = b""
+
+    async def _full_shutdown(self) -> None:
+        """Idempotent call-end signal for the main run loop (mirrors BidirectionalStreamHandler's)."""
+        self._stop_event.set()
+
+
+def _forced_browser_stt_runtime(resolved: Any) -> Any:
+    """Override wire format to LINEAR16/16kHz — see module docstring."""
+    return dataclasses.replace(
+        resolved,
+        sample_rate_hz=_STT_INPUT_SAMPLE_RATE,
+        encoding=_STT_INPUT_ENCODING,
+    )
+
+
+async def _load_browser_call_context(db, call_session_id: uuid.UUID):
+    """Load CallSession + Agent + CallFlow — mirrors BidirectionalStreamHandler._load_session_data."""
+    from app.models.call_flow import CallFlow
+    from app.services.agent_service import agent_service
+    from app.services.call_session_service import call_session_service
+
+    call_session = call_session_service.get_call_session_by_id(db, call_session_id)
+    if call_session is None:
+        return None, None, None
+
+    agent = None
+    if call_session.agent_id:
+        agent = agent_service.get_agent_by_id(db, call_session.agent_id, call_session.tenant_id)
+        if agent is not None:
+            agent_service.ensure_agent_prompt_ingested(db, agent)
+
+    call_flow = None
+    if call_session.call_flow_id:
+        call_flow = (
+            db.query(CallFlow)
+            .filter(CallFlow.id == call_session.call_flow_id, CallFlow.is_deleted == False)  # noqa: E712
+            .first()
+        )
+
+    return call_session, agent, call_flow
+
+
+async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
+    """
+    Background task entrypoint: joins the LiveKit room for `call_session_id`
+    as the agent, greets the caller, and holds the conversation until the
+    caller disconnects or the room connection drops.
+
+    Called (fire-and-forget) from app.routers.sdk::demo_call_token right
+    after the CallSession row + caller LiveKit token are created — never
+    call this synchronously from a request handler.
+
+    Not currently wired into public-call-token (the embedded-widget flow) —
+    out of scope for this task. LiveKitBrowserCallHandler itself has no
+    demo-link-specific assumptions baked in, so reusing it there later is
+    just a matter of adding the same background-task call at that call
+    site; this function's CallSession-loading approach would need a small
+    twin (public-call-token's flow doesn't create a CallSession row today).
+    """
+    if not settings.LIVEKIT_ENABLED:
+        logger.info("[LiveKitBrowserCall] LIVEKIT_ENABLED=false — agent will not join room=%s", call_session_id)
+        return
+
+    from app.db.session import SessionLocal
+
+    db = SessionLocal()
+    handler: LiveKitBrowserCallHandler | None = None
+    voice_orchestrator = None
+    stt_pipeline = None
+    audio_subscriber = None
+    audio_subscriber_task: asyncio.Task | None = None
+    publisher: _LiveKitAgentAudioPublisher | None = None
+    room_name = f"room_{call_session_id}"
+    call_session = None
+    # Distinguishes "the agent actually joined and the conversation ran" from
+    # "we aborted before ever connecting" — the two early-return paths below
+    # (missing agent, TTS publisher connect failure) must not be finalized as
+    # a successful "completed" call: that would both mislabel a zero-content
+    # attempt in dashboards/analytics and (via update_call_session_status)
+    # trigger CRM write-back scheduling for a call nothing ever happened on.
+    agent_joined = False
+
+    try:
+        call_session, agent, call_flow = await _load_browser_call_context(db, call_session_id)
+        if call_session is None:
+            logger.error("[LiveKitBrowserCall] call_session %s not found — aborting agent join", call_session_id)
+            return
+        if agent is None:
+            logger.error(
+                "[LiveKitBrowserCall] agent not found for call_session=%s — aborting agent join",
+                call_session_id,
+            )
+            return
+
+        handler = LiveKitBrowserCallHandler(db=db, call_session=call_session, agent=agent, call_flow=call_flow)
+
+        # VoiceOrchestrator is constructed unmodified purely for the parts of
+        # its public surface that don't require Twilio MULAW frames: it
+        # creates + owns TtsPipeline (writes handler._tts_pipeline /
+        # _tts_worker_task) and provides a single unified shutdown() that
+        # cancels any in-flight LLM turn, drains TtsPipeline, and closes
+        # whatever SttPipeline is registered on it. Its on_audio_chunk()
+        # (Twilio MULAW pickup-detection + lazy Deepgram-session creation)
+        # is intentionally never called here — this path always has a
+        # connected LiveKit room as its only audio source, so SttPipeline is
+        # created directly below and its callbacks are wired to
+        # VoiceOrchestrator's own _on_interim/_on_final (the exact same
+        # callables it would have wired itself inside on_audio_chunk).
+        from app.voice.voice_orchestrator import VoiceOrchestrator
+
+        voice_orchestrator = VoiceOrchestrator(handler)
+
+        # ── Connect agent audio-out (TTS) ───────────────────────────────────
+        publisher = _LiveKitAgentAudioPublisher(room_name)
+        connected = await publisher.connect()
+        if not connected:
+            logger.error("[LiveKitBrowserCall] failed to connect TTS publisher room=%s", room_name)
+            return
+        handler._agent_publisher = publisher
+
+        # Detect the caller leaving / our own connection dropping via the
+        # publisher's room object (the one connection we own directly here).
+        def _on_participant_disconnected(participant) -> None:
+            identity = (getattr(participant, "identity", "") or "").lower()
+            if "caller" in identity:
+                logger.info("[LiveKitBrowserCall] caller left room=%s — ending call", room_name)
+                _track(asyncio.create_task(handler._full_shutdown()))
+
+        def _on_room_disconnected(*_args) -> None:
+            logger.info("[LiveKitBrowserCall] room connection dropped room=%s", room_name)
+            _track(asyncio.create_task(handler._full_shutdown()))
+
+        if publisher._room is not None:
+            publisher._room.on("participant_disconnected", _on_participant_disconnected)
+            publisher._room.on("disconnected", _on_room_disconnected)
+
+        # ── Resolve + start STT ─────────────────────────────────────────────
+        from app.core.agent_runtime import resolve_stt_runtime
+
+        flow_lang = None
+        if call_flow and isinstance(call_flow.settings, dict):
+            raw = call_flow.settings.get("sttLanguageCode") or call_flow.settings.get("stt_language_code")
+            if isinstance(raw, str) and raw.strip():
+                flow_lang = raw.strip()
+
+        resolved_stt = _forced_browser_stt_runtime(
+            resolve_stt_runtime(agent, flow_language_code=flow_lang, db=db)
+        )
+
+        from app.voice.stt_pipeline import SttPipeline
+
+        stt_pipeline = SttPipeline.from_runtime_config(
+            resolved=resolved_stt,
+            on_interim=voice_orchestrator._on_interim,
+            on_final=voice_orchestrator._on_final,
+            call_session_id=handler.call_session_id,
+            agent_id=handler.agent_id,
+            event_bus=voice_orchestrator.stt_event_bus,
+        )
+        # Register onto VoiceOrchestrator so its shutdown() closes this
+        # session too (it only closes a pipeline it knows about).
+        voice_orchestrator._stt_pipeline = stt_pipeline
+        voice_orchestrator._stt_active = True
+
+        from app.voice.livekit_audio_subscriber import LiveKitAudioSubscriber
+
+        audio_subscriber = LiveKitAudioSubscriber(
+            room_name=room_name,
+            stt_pipeline=stt_pipeline,
+            output_sample_rate=_STT_INPUT_SAMPLE_RATE,
+        )
+        audio_subscriber_task = asyncio.create_task(audio_subscriber.run())
+
+        # From here on, the agent has actually joined and audio is flowing —
+        # a subsequent failure/disconnect is a real (if possibly short) call,
+        # not an aborted-before-connecting attempt.
+        agent_joined = True
+
+        # ── Mark call live + greet ───────────────────────────────────────────
+        call_session.status = "in-progress"
+        if not call_session.start_time:
+            call_session.start_time = datetime.now(timezone.utc)
+        db.commit()
+
+        await asyncio.sleep(_GREETING_DELAY_SEC)
+        if not handler._stop_event.is_set():
+            await handler.generate_and_stream_response("", 1.0, is_greeting=True)
+
+        # ── Hold the call until the caller/room disconnects ─────────────────
+        await handler._stop_event.wait()
+
+    except Exception as exc:
+        logger.error(
+            "[LiveKitBrowserCall] agent-join/conversation loop failed room=%s: %s",
+            room_name, exc, exc_info=True,
+        )
+    finally:
+        try:
+            if voice_orchestrator is not None:
+                await voice_orchestrator.shutdown()
+        except Exception as exc:
+            logger.debug("[LiveKitBrowserCall] voice_orchestrator shutdown failed: %s", exc)
+
+        if audio_subscriber is not None:
+            try:
+                await audio_subscriber.stop()
+            except Exception as exc:
+                logger.debug("[LiveKitBrowserCall] audio subscriber stop failed: %s", exc)
+        if audio_subscriber_task is not None and not audio_subscriber_task.done():
+            audio_subscriber_task.cancel()
+            try:
+                await audio_subscriber_task
+            except (asyncio.CancelledError, Exception):  # noqa: S110 - expected from cancelling above
+                pass
+
+        if publisher is not None:
+            try:
+                await publisher.disconnect()
+            except Exception as exc:
+                logger.debug("[LiveKitBrowserCall] publisher disconnect failed: %s", exc)
+
+        if call_session is not None:
+            try:
+                from app.services.call_session_service import call_session_service
+
+                if agent_joined:
+                    call_session_service.update_call_session_status(db, call_session_id, "completed")
+                else:
+                    call_session_service.update_call_session_status(
+                        db, call_session_id, "failed", ended_reason="agent_join_failed"
+                    )
+            except Exception as exc:
+                logger.warning(
+                    "[LiveKitBrowserCall] failed to finalize call_session=%s status: %s",
+                    call_session_id, exc,
+                )
+
+        db.close()
+        logger.info("[LiveKitBrowserCall] call ended room=%s", room_name)

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -532,6 +532,10 @@ class LiveKitBrowserCallHandler:
                     return
 
                 self._is_tts_playing = True
+                logger.debug(
+                    "[LiveKitBrowserCall] LiveKit playback: publishing %d mu-law bytes "
+                    "(call_session_id=%s)", len(mulaw_bytes), self.call_session_id,
+                )
                 await publisher.publish_mulaw(mulaw_bytes, cancel=self._tts_cancel)
             finally:
                 self.is_speaking = False

--- a/app/voice/stt_pipeline.py
+++ b/app/voice/stt_pipeline.py
@@ -235,6 +235,11 @@ class SttPipeline:
                         self._last_final_norm_mono = now_mono
 
                     is_silence = self._is_silence()
+                    logger.debug(
+                        "[STT] final transcript received: %r confidence=%.2f "
+                        "(call_session_id=%s)",
+                        transcript[:80], confidence, self._call_session_id,
+                    )
                     await self._event_bus.emit(
                         SttFinalEvent(
                             transcript=transcript,
@@ -244,6 +249,11 @@ class SttPipeline:
                     )
                     await self._on_final(transcript, confidence)
                 else:
+                    logger.debug(
+                        "[STT] partial transcript received: %r confidence=%.2f "
+                        "(call_session_id=%s)",
+                        transcript[:80], confidence, self._call_session_id,
+                    )
                     await self._event_bus.emit(
                         SttInterimEvent(transcript=transcript, confidence=confidence)
                     )
@@ -260,7 +270,16 @@ class SttPipeline:
         self._last_audio_mono = time.monotonic()
         await self._ensure_session()
         if self._stt_session:
+            logger.debug(
+                "[STT] send: bytes=%s provider=%s (call_session_id=%s)",
+                len(audio_data), self._provider_slug, self._call_session_id,
+            )
             self._stt_session.push_audio(audio_data)
+        else:
+            logger.debug(
+                "[STT] send skipped — no session available (provider=%s, call_session_id=%s)",
+                self._provider_slug, self._call_session_id,
+            )
 
     async def recreate_with_endpointing(self, endpointing_ms: int) -> None:
         """Reopen Deepgram session with a new endpointing value (email collection).

--- a/app/voice/tts_pipeline.py
+++ b/app/voice/tts_pipeline.py
@@ -444,6 +444,9 @@ class TtsPipeline:
                 async with self._synthesis_semaphore:
                     if self.cancel_event.is_set():
                         return
+                    logger.debug(
+                        "[TTS] generation started chunk %d '%.25s'", chunk_id, text
+                    )
                     try:
                         audio_bytes = await self._handler._prefetch_tts_audio(task)  # type: ignore[attr-defined]
                     except asyncio.CancelledError:

--- a/tests/api/test_sdk_demo_link.py
+++ b/tests/api/test_sdk_demo_link.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -112,6 +112,24 @@ def mock_livekit():
     mock = MagicMock()
     mock.generate_caller_token = MagicMock(return_value="signed.demo.jwt")
     with patch("app.services.livekit_service.livekit_service", mock):
+        yield mock
+
+
+@pytest.fixture(autouse=True)
+def mock_agent_join():
+    """
+    demo_call_token now fires a detached background task
+    (run_livekit_browser_call) that joins the LiveKit room as the agent —
+    see app/voice/livekit_browser_call_handler.py. Autoused so every existing
+    test in this file keeps exercising only the synchronous token-issuance
+    path (no real DB session / LiveKit network connection from a background
+    task racing the test's own teardown). Dedicated coverage for the
+    scheduling itself lives in TestDemoCallTokenAgentJoin below.
+    """
+    with patch(
+        "app.voice.livekit_browser_call_handler.run_livekit_browser_call",
+        new_callable=AsyncMock,
+    ) as mock:
         yield mock
 
 
@@ -298,3 +316,45 @@ class TestDemoCallToken:
         )
         assert resp.status_code == 200, resp.text
         assert "livekit_token" in resp.json()
+
+
+@pytest.mark.usefixtures("db")
+class TestDemoCallTokenAgentJoin:
+    """
+    demo_call_token spawns a detached background task
+    (run_livekit_browser_call) so the AI agent actually joins the LiveKit
+    room and talks back. See app/voice/livekit_browser_call_handler.py.
+    """
+
+    def test_agent_join_scheduled_with_new_call_session_id(
+        self, client: TestClient, db, tenant, flow, demo_link, mock_livekit, mock_agent_join
+    ):
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-agent-join"),
+        )
+        assert resp.status_code == 200, resp.text
+        call_session_id = uuid.UUID(resp.json()["call_session_id"])
+
+        # The endpoint must return before/without waiting on the background
+        # task — asserting on call args here (rather than a return value)
+        # confirms the response body didn't depend on it completing.
+        mock_agent_join.assert_called_once_with(call_session_id)
+
+    def test_response_not_blocked_by_slow_agent_join(
+        self, client: TestClient, db, tenant, flow, demo_link, mock_livekit, mock_agent_join
+    ):
+        """Even if the agent-join coroutine would take a long time, the HTTP
+        response must not wait on it — demo_call_token only creates the task."""
+        import asyncio as _asyncio
+
+        async def _slow(*_args, **_kwargs):
+            await _asyncio.sleep(30)
+
+        mock_agent_join.side_effect = _slow
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-slow-join"),
+        )
+        assert resp.status_code == 200, resp.text

--- a/tests/services/test_call_session_demo_link_usage.py
+++ b/tests/services/test_call_session_demo_link_usage.py
@@ -277,3 +277,57 @@ class TestRecordDemoLinkUsage:
 
         db.refresh(demo_link)
         assert demo_link.total_minutes_used == Decimal("0")
+
+    def test_completed_demo_link_call_skips_crm_writeback(self, db, tenant, agent, cs_user, demo_link):
+        """
+        A demo-link CallSession has an anonymous customer_phone_number
+        placeholder, not a real contact — CRM write-back scheduling must be
+        skipped entirely for it, even when the tenant has HubSpot/Salesforce/
+        GHL connected, rather than relying on the placeholder phone number
+        being unmatchable as an implicit safety net.
+        """
+        session = _make_session(
+            db, tenant, agent, cs_user,
+            call_metadata={
+                "demo_link": {
+                    "demo_link_id": str(demo_link.id),
+                    "visitor_id": "visitor-crm-skip",
+                }
+            },
+            minutes_ago=5,
+        )
+
+        with _naive_utcnow_patch(), \
+             patch("app.services.hubspot_service.tenant_has_hubspot_connected", return_value=True) as mock_hs_conn, \
+             patch("app.services.hubspot_service.schedule_hubspot_writeback") as mock_hs_sched, \
+             patch("app.services.salesforce_service.tenant_has_salesforce_connected", return_value=True) as mock_sf_conn, \
+             patch("app.services.salesforce_service.schedule_salesforce_writeback") as mock_sf_sched, \
+             patch("app.services.ghl_service.tenant_has_ghl_connected", return_value=True) as mock_ghl_conn, \
+             patch("app.services.ghl_service.schedule_ghl_writeback") as mock_ghl_sched:
+            call_session_service.update_call_session_status(db, session.id, "completed")
+
+        mock_hs_conn.assert_not_called()
+        mock_hs_sched.assert_not_called()
+        mock_sf_conn.assert_not_called()
+        mock_sf_sched.assert_not_called()
+        mock_ghl_conn.assert_not_called()
+        mock_ghl_sched.assert_not_called()
+
+    def test_completed_non_demo_link_call_still_triggers_crm_writeback(self, db, tenant, agent, cs_user):
+        """Sanity check the skip is scoped to demo-link calls only — an
+        ordinary completed call must still trigger CRM write-back scheduling
+        when the tenant has an integration connected."""
+        session = _make_session(
+            db, tenant, agent, cs_user,
+            call_metadata=None,
+            minutes_ago=5,
+        )
+
+        with _naive_utcnow_patch(), \
+             patch("app.services.hubspot_service.tenant_has_hubspot_connected", return_value=True), \
+             patch("app.services.hubspot_service.schedule_hubspot_writeback") as mock_hs_sched, \
+             patch("app.services.salesforce_service.tenant_has_salesforce_connected", return_value=False), \
+             patch("app.services.ghl_service.tenant_has_ghl_connected", return_value=False):
+            call_session_service.update_call_session_status(db, session.id, "completed")
+
+        mock_hs_sched.assert_called_once_with(session.id)

--- a/tests/services/test_rag_service_ingestion.py
+++ b/tests/services/test_rag_service_ingestion.py
@@ -1,0 +1,96 @@
+"""
+Regression tests for RagService.ingest_document embedding serialization.
+
+Bug: KbChunk.embedding was being assigned a JSON-stringified vector
+(`json.dumps(embedding)`) instead of a raw list[float]. pgvector's
+Vector._to_db() (invoked by SQLAlchemy's bind_processor at INSERT time)
+cannot parse a stringified vector and raises:
+
+    ValueError: could not convert string to float: '[-0.023..., 0.014..., ...]'
+
+These tests reproduce the failure at the point of stringification (without
+needing a live Postgres+pgvector instance) and confirm the fix restores a
+raw list[float] on the ORM object before it ever reaches the DB driver.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from pgvector.utils import Vector
+
+from app.services.rag_service import RagService
+
+
+FAKE_EMBEDDING = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+
+def _embedding_func(text: str):
+    return FAKE_EMBEDDING
+
+
+def _make_fake_db():
+    db = MagicMock()
+    db.add_all = MagicMock()
+    db.commit = MagicMock()
+    db.rollback = MagicMock()
+    return db
+
+
+def test_ingest_document_attaches_raw_list_embedding(monkeypatch):
+    """
+    RagService.ingest_document must attach embedding as a raw list[float]
+    to KbChunk.embedding, not a JSON-stringified blob. A stringified value
+    passes SQLAlchemy's ORM layer fine but blows up at INSERT time inside
+    pgvector's bind_processor (see companion test below) -- so the
+    assertion here is the actual root-cause guard.
+    """
+    service = RagService()
+    db = _make_fake_db()
+
+    fake_kb = MagicMock()
+    fake_kb.id = uuid.uuid4()
+    monkeypatch.setattr(service, "_get_or_create_auto_kb", lambda db, tenant_id: fake_kb)
+    monkeypatch.setattr(service, "_delete_chunks_by_meta_source_ref", lambda *a, **kw: None)
+
+    tenant_id = uuid.uuid4()
+    service.ingest_document(
+        tenant_id=tenant_id,
+        agent_id=None,
+        title="Doc",
+        source_type="text",
+        source_ref="ref-1",
+        full_text="Some short text to embed for the knowledge base.",
+        embedding_func=_embedding_func,
+        db_session=db,
+    )
+
+    assert db.add_all.called
+    chunk_rows = db.add_all.call_args[0][0]
+    assert len(chunk_rows) >= 1
+    chunk = chunk_rows[0]
+
+    assert isinstance(chunk.embedding, list), (
+        f"expected embedding to be a raw list[float], got {type(chunk.embedding)}: "
+        f"{chunk.embedding!r}"
+    )
+    assert all(isinstance(x, (float, int)) for x in chunk.embedding)
+    assert len(chunk.embedding) == len(FAKE_EMBEDDING)
+
+    # Simulate exactly what pgvector's bind_processor does at INSERT time --
+    # this must not raise.
+    Vector._to_db(chunk.embedding, dim=len(FAKE_EMBEDDING))
+
+
+def test_stringified_embedding_reproduces_insert_time_valueerror():
+    """
+    Pins down the exact production failure mode: feeding a JSON-stringified
+    embedding (what the buggy code produced) through pgvector's Vector._to_db
+    raises `ValueError: could not convert string to float`, matching the
+    reported traceback.
+    """
+    stringified = json.dumps(FAKE_EMBEDDING)
+    with pytest.raises(ValueError, match="could not convert string to float"):
+        Vector._to_db(stringified, dim=len(FAKE_EMBEDDING))

--- a/tests/voice/test_livekit_audio_subscriber.py
+++ b/tests/voice/test_livekit_audio_subscriber.py
@@ -1,0 +1,240 @@
+"""
+Unit tests for the LiveKit caller-audio → STT ingestion path
+(app/voice/audio_transcoder.py + app/voice/livekit_audio_subscriber.py).
+
+Regression coverage for a production stall: the browser-based LiveKit
+agent-join path (app/voice/livekit_browser_call_handler.py) reuses this
+subscriber/resampler unmodified from the older Twilio+Google-STT LiveKit
+bridge, but neither file had any test coverage before this change — the
+resample→STT-feed handoff was only ever exercised with every LiveKit/STT
+boundary mocked out (see test_livekit_browser_call_handler.py), so a defect
+in the real per-frame processing chain was invisible to CI.
+
+Bug: a single frame's ffmpeg (re)start failure (binary missing from PATH,
+transient fork/exec error, etc.) raised out of
+LiveKitAudioProcessor._ffmpeg_convert() uncaught, which propagated out of
+LiveKitAudioSubscriber._subscribe_and_transcode()'s per-frame processing
+call. Since that call sat directly inside the `async for audio_frame_event
+in audio_stream:` loop with no per-frame try/except, the exception unwound
+the entire loop (caught only by the outer broad `except Exception` around
+the whole subscribe/transcode call), permanently ending STT ingestion for
+the rest of the call after the very first frame that hit the failure —
+matching the reported symptom exactly: "first frame received and logged,
+then nothing else happens."
+
+Fix: (1) LiveKitAudioProcessor._ffmpeg_convert now catches restart failures
+per-frame and returns b"" (dropping just that frame) instead of raising;
+(2) LiveKitAudioSubscriber's per-frame loop additionally wraps
+processor.process_frame() in a try/except so any other unexpected
+per-frame error also can't kill the whole subscription.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.voice.audio_transcoder import LiveKitAudioProcessor
+from app.voice.livekit_audio_subscriber import LiveKitAudioSubscriber
+
+# A single browser-side LiveKit audio frame as reported in production:
+# 48kHz mono, 960 bytes (480 samples * 2 bytes/sample = 10ms @ 48kHz).
+_FRAME_48K_MONO = bytes(range(256)) * 3 + bytes(192)  # 960 bytes of non-zero data
+assert len(_FRAME_48K_MONO) == 960
+
+
+class _FakeAudioFrame:
+    def __init__(self, data: bytes, sample_rate: int = 48000, num_channels: int = 1):
+        self.data = data
+        self.sample_rate = sample_rate
+        self.num_channels = num_channels
+
+
+class _FakeAudioFrameEvent:
+    def __init__(self, frame: _FakeAudioFrame):
+        self.frame = frame
+
+
+class _FakeAudioStream:
+    """Minimal async-iterable stand-in for livekit.rtc.AudioStream."""
+
+    def __init__(self, frames: list[_FakeAudioFrame]):
+        self._frames = frames
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for f in self._frames:
+            yield _FakeAudioFrameEvent(f)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LiveKitAudioProcessor: ffmpeg-restart failure must not raise out of
+# process_frame — it should degrade to "drop this frame" and recover once
+# ffmpeg becomes available again.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestLiveKitAudioProcessorResilience:
+    @pytest.mark.asyncio
+    async def test_ffmpeg_restart_failure_does_not_raise(self):
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+
+        with patch.object(
+            processor, "_restart_ffmpeg", new=AsyncMock(side_effect=RuntimeError("ffmpeg not found in PATH"))
+        ):
+            # Must return empty bytes, not propagate the RuntimeError.
+            out = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+
+        assert out == b""
+
+    @pytest.mark.asyncio
+    async def test_recovers_once_ffmpeg_becomes_available(self):
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+
+        fake_proc = MagicMock()
+        fake_proc.stdin = MagicMock()
+        fake_proc.stdin.write = MagicMock()
+        fake_proc.stdin.drain = AsyncMock()
+        fake_proc.stdout = MagicMock()
+        fake_proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
+
+        async def _fail_then_succeed(sample_rate, num_channels):
+            processor._ffmpeg_process = fake_proc
+            processor._ffmpeg_input_rate = sample_rate
+            processor._ffmpeg_input_channels = num_channels
+
+        with patch.object(
+            processor, "_restart_ffmpeg", new=AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            out1 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+        assert out1 == b""
+
+        # Simulate the restart backoff window having elapsed (the processor
+        # rate-limits retry *attempts*, not just log lines, so a real caller
+        # waits out this same window before the next successful restart).
+        processor._last_restart_failure = None
+
+        with patch.object(processor, "_restart_ffmpeg", new=_fail_then_succeed):
+            out2 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+        assert out2 != b""
+
+    @pytest.mark.asyncio
+    async def test_mid_call_ffmpeg_death_self_heals_on_next_frame(self):
+        """
+        A second instance of the same production symptom: ffmpeg starts fine
+        for frame 1, then the process dies (broken pipe) partway through the
+        call. Before the fix, self._ffmpeg_process was never cleared on this
+        path, so every subsequent frame kept hitting the same dead process
+        forever — permanent silence for the rest of the call, exactly like
+        the original bug, just triggered by a mid-call crash instead of a
+        failed start. After the fix, the dead process must be cleared so the
+        next frame re-enters _restart_ffmpeg and recovers.
+        """
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+
+        dead_proc = MagicMock()
+        dead_proc.stdin = MagicMock()
+        dead_proc.stdin.write = MagicMock(side_effect=BrokenPipeError("pipe closed"))
+        dead_proc.stdout = MagicMock()
+        dead_proc.returncode = None
+        dead_proc.wait = AsyncMock(return_value=None)
+        dead_proc.kill = MagicMock()
+
+        processor._ffmpeg_process = dead_proc
+        processor._ffmpeg_input_rate = 48000
+        processor._ffmpeg_input_channels = 1
+
+        out1 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+        assert out1 == b""
+        # The dead process reference must be cleared, not left in place.
+        assert processor._ffmpeg_process is None
+
+        # Simulate the restart backoff window having elapsed.
+        processor._last_restart_failure = None
+
+        healthy_proc = MagicMock()
+        healthy_proc.stdin = MagicMock()
+        healthy_proc.stdin.write = MagicMock()
+        healthy_proc.stdin.drain = AsyncMock()
+        healthy_proc.stdout = MagicMock()
+        healthy_proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
+
+        async def _restart(sample_rate, num_channels):
+            processor._ffmpeg_process = healthy_proc
+            processor._ffmpeg_input_rate = sample_rate
+            processor._ffmpeg_input_channels = num_channels
+
+        with patch.object(processor, "_restart_ffmpeg", new=_restart):
+            out2 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+
+        # Recovers on the very next frame instead of being stuck on the dead
+        # process for the rest of the call.
+        assert out2 != b""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LiveKitAudioSubscriber: a single bad frame must not abort ingestion for the
+# rest of the call — this is the exact regression scenario from production.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestLiveKitAudioSubscriberFrameLoop:
+    @pytest.mark.asyncio
+    async def test_run_loop_survives_processing_error_end_to_end(self):
+        """
+        Full _subscribe_and_transcode() path (not just the extracted loop
+        body): first frame's process_frame() raises, second frame succeeds —
+        asserts SttPipeline.feed_audio_chunk (the "STT send" stage) is still
+        called for the surviving frame, i.e. the subscription loop is not
+        aborted by the first frame's error.
+        """
+        stt_pipeline = MagicMock()
+        stt_pipeline.feed_audio_chunk = AsyncMock()
+
+        subscriber = LiveKitAudioSubscriber(
+            room_name="room_test", stt_pipeline=stt_pipeline, output_sample_rate=16000
+        )
+
+        frames = [_FakeAudioFrame(_FRAME_48K_MONO), _FakeAudioFrame(_FRAME_48K_MONO)]
+        audio_stream = _FakeAudioStream(frames)
+
+        fake_room = MagicMock()
+        fake_room.connect = AsyncMock()
+        fake_room.disconnect = AsyncMock()
+        fake_room.on = MagicMock()
+
+        fake_rtc = MagicMock()
+        fake_rtc.Room = MagicMock(return_value=fake_room)
+        fake_rtc.TrackKind.KIND_AUDIO = "audio"
+        fake_rtc.AudioStream = MagicMock(return_value=audio_stream)
+
+        fake_processor = MagicMock()
+        fake_processor.process_frame = AsyncMock(
+            side_effect=[RuntimeError("ffmpeg not found in PATH"), b"\x01\x02" * 50]
+        )
+        subscriber._processor = fake_processor
+
+        fake_track = MagicMock()
+        fake_track.kind = "audio"
+        fake_track.sid = "TR_test"
+        fake_participant = MagicMock()
+        fake_participant.identity = "caller-room_test"
+
+        async def _connect_and_fire_track_subscribed(*_args, **_kwargs):
+            # Simulate LiveKit firing track_subscribed right after connect.
+            for call in fake_room.on.call_args_list:
+                if call.args and call.args[0] == "track_subscribed":
+                    handler = call.args[1]
+                    handler(fake_track, MagicMock(), fake_participant)
+                    return
+
+        fake_room.connect.side_effect = _connect_and_fire_track_subscribed
+
+        with patch("app.core.config.settings.LIVEKIT_ENABLED", True), \
+             patch.dict("sys.modules", {"livekit": MagicMock(rtc=fake_rtc)}):
+            await asyncio.wait_for(
+                subscriber._subscribe_and_transcode("ws://fake", "fake-token"), timeout=5.0
+            )
+
+        stt_pipeline.feed_audio_chunk.assert_awaited_once()

--- a/tests/voice/test_livekit_browser_call_handler.py
+++ b/tests/voice/test_livekit_browser_call_handler.py
@@ -1,0 +1,602 @@
+"""
+Unit tests for the browser-only (no Twilio) LiveKit voice agent path.
+
+See app/voice/livekit_browser_call_handler.py — powers the "Share Demo Link"
+feature (POST /api/v1/sdk/demo/{token}/call-token). These tests exercise the
+new adapter/handler and lifecycle-wiring logic without a live LiveKit server
+or real audio (not feasible in a unit test) — see
+tests/api/test_sdk_demo_link.py::TestDemoCallTokenAgentJoin for the HTTP-level
+scheduling coverage.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.agent_runtime import ResolvedSttRuntime
+from app.voice.livekit_browser_call_handler import (
+    LiveKitBrowserCallHandler,
+    _LiveKitAgentAudioPublisher,
+    _forced_browser_stt_runtime,
+    run_livekit_browser_call,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _base_handler() -> LiveKitBrowserCallHandler:
+    db = MagicMock()
+    call_session = MagicMock()
+    call_session.id = uuid.uuid4()
+    call_session.user_id = uuid.uuid4()
+    call_session.tenant_id = uuid.uuid4()
+    call_session.call_metadata = {}
+    call_session.call_transcript = []
+
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "Demo Agent"
+    agent.language = "en"
+    agent.voice_type = "female"
+    agent.greeting_message = "Hi, thanks for trying the demo!"
+    agent.first_message = None
+
+    return LiveKitBrowserCallHandler(db=db, call_session=call_session, agent=agent, call_flow=None)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Construction / attribute-surface wiring
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestHandlerConstruction:
+    def test_constructs_against_voice_orchestrator_and_tts_pipeline_unmodified(self):
+        """
+        The whole point of this handler is that VoiceOrchestrator / TtsPipeline
+        construct against it with zero modification to those classes.
+        """
+        from app.voice.voice_orchestrator import VoiceOrchestrator
+        from app.voice.tts_pipeline import TtsPipeline
+
+        h = _base_handler()
+        vo = VoiceOrchestrator(h)
+
+        assert h._tts_pipeline is not None
+        assert isinstance(h._tts_pipeline, TtsPipeline)
+        assert vo.tts_pipeline is h._tts_pipeline
+
+    def test_conversation_orchestrator_attached(self):
+        from app.voice.conversation_orchestrator import ConversationOrchestrator
+
+        h = _base_handler()
+        assert isinstance(h._conversation, ConversationOrchestrator)
+        assert h._conversation._h is h
+
+    def test_stream_sid_never_none_and_never_crashes_consumers(self):
+        h = _base_handler()
+        assert h.stream_sid is not None
+        assert h.call_session_id in h.stream_sid
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Out-of-scope stubs — must never crash, never actually act
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestOutOfScopeStubs:
+    def test_update_booking_memory_is_a_noop(self):
+        h = _base_handler()
+        assert h._update_booking_memory_from_user_turn("book me for 3pm") is None
+
+    @pytest.mark.asyncio
+    async def test_end_call_after_agent_request_does_not_raise_or_set_stop(self):
+        h = _base_handler()
+        await h._end_call_after_agent_request()
+        assert not h._stop_event.is_set()
+
+    @pytest.mark.asyncio
+    async def test_transfer_after_agent_request_does_not_raise(self):
+        h = _base_handler()
+        await h._transfer_after_agent_request()
+
+    def test_schedule_recreate_stt_for_email_collection_is_a_noop(self):
+        h = _base_handler()
+        assert h._schedule_recreate_stt_for_email_collection("please spell your email") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Barge-in / turn handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestTurnHandling:
+    @pytest.mark.asyncio
+    async def test_interim_ignored_when_tts_not_playing(self):
+        h = _base_handler()
+        h._is_tts_playing = False
+        h._cancel_inflight_llm_response = AsyncMock()
+        await h._maybe_process_interim("stop that", 0.9)
+        h._cancel_inflight_llm_response.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_interim_barge_in_cancels_when_confident_and_playing(self):
+        h = _base_handler()
+        h._is_tts_playing = True
+        h._cancel_inflight_llm_response = AsyncMock()
+        await h._maybe_process_interim("please stop now", 0.9)
+        h._cancel_inflight_llm_response.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_interim_barge_in_rejects_low_confidence_filler(self):
+        h = _base_handler()
+        h._is_tts_playing = True
+        h._cancel_inflight_llm_response = AsyncMock()
+        await h._maybe_process_interim("um", 0.05)
+        h._cancel_inflight_llm_response.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_transcript_persists_and_triggers_turn(self):
+        h = _base_handler()
+        h._add_to_transcript = AsyncMock()
+        h._complete_llm_turn_after_stt_final = AsyncMock()
+
+        await h._process_transcript("what are your hours", 0.8)
+
+        h._add_to_transcript.assert_awaited_once_with(
+            "client", "what are your hours", "speech", 0.8
+        )
+        h._complete_llm_turn_after_stt_final.assert_awaited_once_with(
+            "what are your hours", 0.8
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_transcript_ignores_empty_text(self):
+        h = _base_handler()
+        h._add_to_transcript = AsyncMock()
+        await h._process_transcript("   ", 0.9)
+        h._add_to_transcript.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_complete_llm_turn_delegates_to_conversation_orchestrator(self):
+        h = _base_handler()
+        h._conversation.generate_and_stream_response = AsyncMock()
+
+        await h._complete_llm_turn_after_stt_final("hello", 0.9)
+
+        h._conversation.generate_and_stream_response.assert_awaited_once_with(
+            "hello", 0.9, is_greeting=False
+        )
+        assert h._llm_response_task is None  # cleared after completion
+
+    @pytest.mark.asyncio
+    async def test_generate_and_stream_response_delegates(self):
+        h = _base_handler()
+        h._conversation.generate_and_stream_response = AsyncMock()
+        await h.generate_and_stream_response("hi", 1.0, is_greeting=True)
+        h._conversation.generate_and_stream_response.assert_awaited_once_with(
+            "hi", 1.0, is_greeting=True
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TTS synthesis + playback
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestTtsSynthesisAndPlayback:
+    @pytest.mark.asyncio
+    async def test_prefetch_tts_audio_uses_generate_mulaw_tts(self):
+        h = _base_handler()
+        with patch(
+            "app.voice.livekit_browser_call_handler.generate_mulaw_tts",
+            new=AsyncMock(return_value=b"\xff" * 160),
+        ) as mock_gen:
+            audio = await h._prefetch_tts_audio({"text": "Hello there", "use_ssml": False})
+        assert audio == b"\xff" * 160
+        mock_gen.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_prefetch_tts_audio_returns_none_for_empty_text(self):
+        h = _base_handler()
+        assert await h._prefetch_tts_audio({"text": "  "}) is None
+
+    @pytest.mark.asyncio
+    async def test_stream_tts_chunk_drops_when_no_publisher(self):
+        h = _base_handler()
+        h._agent_publisher = None
+        await h._stream_tts_chunk("hello", is_final=True)
+        assert h.is_speaking is False
+        assert h._is_tts_playing is False
+
+    @pytest.mark.asyncio
+    async def test_stream_tts_chunk_publishes_prefetched_bytes(self):
+        h = _base_handler()
+        publisher = MagicMock()
+        publisher.connected = True
+        publisher.publish_mulaw = AsyncMock()
+        h._agent_publisher = publisher
+
+        await h._stream_tts_chunk("hello", is_final=True, prefetched_bytes=b"\xff" * 160)
+
+        publisher.publish_mulaw.assert_awaited_once()
+        args, kwargs = publisher.publish_mulaw.call_args
+        assert args[0] == b"\xff" * 160
+        assert h.is_speaking is False  # reset in finally
+        assert h._is_tts_playing is False
+
+    @pytest.mark.asyncio
+    async def test_stream_tts_chunk_synthesizes_when_not_prefetched(self):
+        h = _base_handler()
+        publisher = MagicMock()
+        publisher.connected = True
+        publisher.publish_mulaw = AsyncMock()
+        h._agent_publisher = publisher
+
+        with patch(
+            "app.voice.livekit_browser_call_handler.generate_mulaw_tts",
+            new=AsyncMock(return_value=b"\xff" * 160),
+        ):
+            await h._stream_tts_chunk("hello there", is_final=False)
+
+        publisher.publish_mulaw.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stream_tts_chunk_respects_cancel(self):
+        h = _base_handler()
+        h._tts_cancel.set()
+        publisher = MagicMock()
+        publisher.connected = True
+        publisher.publish_mulaw = AsyncMock()
+        h._agent_publisher = publisher
+
+        await h._stream_tts_chunk("hello", prefetched_bytes=b"\xff" * 160)
+
+        publisher.publish_mulaw.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Transcript persistence
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAddToTranscript:
+    @pytest.mark.asyncio
+    async def test_no_call_session_is_a_noop(self):
+        h = _base_handler()
+        h.call_session = None
+        # Should not raise even though db/transcript_service would fail if called.
+        await h._add_to_transcript("agent", "hello")
+
+    @pytest.mark.asyncio
+    async def test_persists_via_transcript_service(self):
+        h = _base_handler()
+        added = MagicMock()
+        with patch(
+            "app.voice.livekit_browser_call_handler.transcript_service"
+        ) as mock_ts:
+            mock_ts.add_and_broadcast_message = AsyncMock(return_value=added)
+            mock_ts.get_conversation_array = MagicMock(return_value=[{"role": "agent"}])
+            await h._add_to_transcript("agent", "Hello there", "greeting")
+
+        mock_ts.add_and_broadcast_message.assert_awaited_once()
+        call_kwargs = mock_ts.add_and_broadcast_message.call_args.kwargs
+        assert call_kwargs["role"] == "agent"
+        assert call_kwargs["message"] == "Hello there"
+        assert call_kwargs["message_type"] == "greeting"
+        assert call_kwargs["call_session_id"] == h.call_session.id
+        # Non-deferred write commits the denormalized transcript array.
+        h.db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_deferred_write_skips_denormalized_commit(self):
+        h = _base_handler()
+        with patch(
+            "app.voice.livekit_browser_call_handler.transcript_service"
+        ) as mock_ts:
+            mock_ts.add_and_broadcast_message = AsyncMock(return_value=MagicMock())
+            await h._add_to_transcript("client", "hi", "speech", defer_post_write=True)
+
+        h.db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_swallows_persistence_errors(self):
+        h = _base_handler()
+        with patch(
+            "app.voice.livekit_browser_call_handler.transcript_service"
+        ) as mock_ts:
+            mock_ts.add_and_broadcast_message = AsyncMock(side_effect=RuntimeError("db down"))
+            # Must not raise.
+            await h._add_to_transcript("client", "hi")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STT runtime override
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_forced_browser_stt_runtime_overrides_wire_format_only():
+    resolved = ResolvedSttRuntime(
+        provider_slug="deepgram",
+        model_id="nova-3",
+        language_code="en",
+        sample_rate_hz=8000,
+        encoding="MULAW",
+        silence_threshold_ms=1500,
+        api_config={"foo": "bar"},
+    )
+    forced = _forced_browser_stt_runtime(resolved)
+
+    assert forced.sample_rate_hz == 16000
+    assert forced.encoding == "LINEAR16"
+    # Everything else (provider/model/language/api_config) is preserved.
+    assert forced.provider_slug == "deepgram"
+    assert forced.model_id == "nova-3"
+    assert forced.language_code == "en"
+    assert forced.api_config == {"foo": "bar"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _LiveKitAgentAudioPublisher
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestLiveKitAgentAudioPublisher:
+    @pytest.mark.asyncio
+    async def test_connect_returns_false_when_livekit_disabled(self):
+        publisher = _LiveKitAgentAudioPublisher("room_" + str(uuid.uuid4()))
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings:
+            mock_settings.LIVEKIT_ENABLED = False
+            connected = await publisher.connect()
+        assert connected is False
+        assert publisher.connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_uses_distinct_identity_from_audio_subscriber(self):
+        room_name = f"room_{uuid.uuid4()}"
+        publisher = _LiveKitAgentAudioPublisher(room_name)
+
+        mock_rtc = MagicMock()
+        mock_room_instance = MagicMock()
+        mock_room_instance.connect = AsyncMock()
+        mock_room_instance.local_participant.publish_track = AsyncMock()
+        mock_rtc.Room.return_value = mock_room_instance
+
+        mock_livekit_service = MagicMock()
+        mock_livekit_service.generate_agent_token.return_value = "jwt.token"
+        mock_livekit_service._get_credentials.return_value = ("https://lk.example.com", "k", "s")
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch.dict("sys.modules", {"livekit": MagicMock(rtc=mock_rtc)}), \
+             patch("app.services.livekit_service.livekit_service", mock_livekit_service):
+            mock_settings.LIVEKIT_ENABLED = True
+            connected = await publisher.connect()
+
+        assert connected is True
+        assert publisher.connected is True
+        mock_livekit_service.generate_agent_token.assert_called_once_with(
+            room_name, identity=f"agent-tts-{room_name}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_mulaw_noop_when_not_connected(self):
+        publisher = _LiveKitAgentAudioPublisher("room_x")
+        # Should return immediately without raising or touching self._source.
+        await publisher.publish_mulaw(b"\xff" * 160)
+
+    @pytest.mark.asyncio
+    async def test_publish_mulaw_stops_on_cancel(self):
+        publisher = _LiveKitAgentAudioPublisher("room_x")
+        publisher._connected = True
+        mock_source = MagicMock()
+        mock_source.capture_frame = AsyncMock()
+        mock_source.clear_queue = MagicMock()
+        publisher._source = mock_source
+
+        cancel = asyncio.Event()
+        cancel.set()
+
+        mock_rtc = MagicMock()
+        mock_rtc.AudioFrame.create.return_value = MagicMock(data=bytearray(320))
+
+        with patch.dict("sys.modules", {"livekit": MagicMock(rtc=mock_rtc)}):
+            await publisher.publish_mulaw(b"\xff" * 320, cancel=cancel)
+
+        mock_source.capture_frame.assert_not_called()
+        mock_source.clear_queue.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run_livekit_browser_call — full lifecycle wiring (fully mocked)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestRunLiveKitBrowserCall:
+    @pytest.mark.asyncio
+    async def test_noop_when_livekit_disabled(self):
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings:
+            mock_settings.LIVEKIT_ENABLED = False
+            # Must return immediately without touching the DB at all.
+            await run_livekit_browser_call(uuid.uuid4())
+
+    @pytest.mark.asyncio
+    async def test_aborts_cleanly_when_call_session_missing(self):
+        call_session_id = uuid.uuid4()
+        mock_db = MagicMock()
+        mock_db.close = MagicMock()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(None, None, None)),
+             ), \
+             patch("app.services.call_session_service.call_session_service") as mock_svc:
+            mock_settings.LIVEKIT_ENABLED = True
+            await run_livekit_browser_call(call_session_id)
+
+        # No terminal-status update should fire for a call session that was
+        # never found — nothing to finalize.
+        mock_svc.update_call_session_status.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_finalizes_as_failed_not_completed(self):
+        """
+        A loaded call_session but no agent must NOT be finalized as
+        "completed" — no audio/conversation ever happened. Also matters
+        because update_call_session_status(status="completed") fires
+        CRM write-back scheduling; a "failed" status doesn't.
+        """
+        call_session_id = uuid.uuid4()
+        call_session = MagicMock()
+        call_session.id = call_session_id
+        mock_db = MagicMock()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, None, None)),
+             ), \
+             patch("app.services.call_session_service.call_session_service") as mock_svc:
+            mock_settings.LIVEKIT_ENABLED = True
+            await run_livekit_browser_call(call_session_id)
+
+        mock_svc.update_call_session_status.assert_called_once_with(
+            mock_db, call_session_id, "failed", ended_reason="agent_join_failed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_publisher_connect_failure_finalizes_as_failed_not_completed(self):
+        """Same as above, but the abort happens after the agent is loaded —
+        TTS publisher never connects, so no greeting/conversation happened."""
+        call_session_id = uuid.uuid4()
+        call_session = MagicMock()
+        call_session.id = call_session_id
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+
+        mock_db = MagicMock()
+        publisher_instance = MagicMock()
+        publisher_instance.connect = AsyncMock(return_value=False)
+        publisher_instance.disconnect = AsyncMock()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch("app.voice.voice_orchestrator.VoiceOrchestrator", return_value=MagicMock(shutdown=AsyncMock())), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 return_value=publisher_instance,
+             ), \
+             patch("app.services.call_session_service.call_session_service") as mock_svc:
+            mock_settings.LIVEKIT_ENABLED = True
+            await run_livekit_browser_call(call_session_id)
+
+        publisher_instance.connect.assert_awaited_once()
+        mock_svc.update_call_session_status.assert_called_once_with(
+            mock_db, call_session_id, "failed", ended_reason="agent_join_failed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_full_happy_path_greets_and_finalizes_on_disconnect(self):
+        """
+        Full lifecycle with every LiveKit/DB boundary mocked: connects the
+        TTS publisher, wires STT, greets, waits for the (immediately-set)
+        stop event, then tears everything down and marks the call completed.
+        """
+        call_session_id = uuid.uuid4()
+        call_session = MagicMock()
+        call_session.id = call_session_id
+        call_session.call_flow_id = None
+        call_session.call_metadata = {}
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.stt_provider_slug = None
+        agent.stt_model_id = None
+
+        mock_db = MagicMock()
+
+        publisher_instance = MagicMock()
+        publisher_instance.connect = AsyncMock(return_value=True)
+        publisher_instance.disconnect = AsyncMock()
+        publisher_instance._room = MagicMock()
+
+        mock_subscriber_instance = MagicMock()
+        mock_subscriber_instance.run = AsyncMock()
+        mock_subscriber_instance.stop = AsyncMock()
+
+        mock_vo_instance = MagicMock()
+        mock_vo_instance.shutdown = AsyncMock()
+        mock_vo_instance.stt_event_bus = MagicMock()
+        mock_vo_instance._on_interim = AsyncMock()
+        mock_vo_instance._on_final = AsyncMock()
+
+        async def _immediately_stop_and_greet(self, *_args, **_kwargs):
+            # Simulate handler.generate_and_stream_response for the greeting,
+            # then let the run loop fall through by setting the stop event
+            # (as if the caller disconnected right after the greeting).
+            self._stop_event.set()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch("app.voice.voice_orchestrator.VoiceOrchestrator", return_value=mock_vo_instance), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 return_value=publisher_instance,
+             ), \
+             patch("app.core.agent_runtime.resolve_stt_runtime") as mock_resolve_stt, \
+             patch("app.voice.stt_pipeline.SttPipeline.from_runtime_config", return_value=MagicMock()), \
+             patch(
+                 "app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber",
+                 return_value=mock_subscriber_instance,
+             ), \
+             patch("app.services.call_session_service.call_session_service") as mock_svc, \
+             patch.object(
+                 LiveKitBrowserCallHandler,
+                 "generate_and_stream_response",
+                 new=_immediately_stop_and_greet,
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            mock_resolve_stt.return_value = ResolvedSttRuntime(
+                provider_slug="deepgram",
+                model_id="nova-3",
+                language_code="en",
+                sample_rate_hz=8000,
+                encoding="MULAW",
+                silence_threshold_ms=1500,
+                api_config={},
+            )
+
+            await asyncio.wait_for(run_livekit_browser_call(call_session_id), timeout=5.0)
+
+        publisher_instance.connect.assert_awaited_once()
+        publisher_instance.disconnect.assert_awaited_once()
+        mock_vo_instance.shutdown.assert_awaited_once()
+        mock_svc.update_call_session_status.assert_called_once_with(
+            mock_db, call_session_id, "completed"
+        )
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_join_failure_is_caught_not_raised(self):
+        """An exception anywhere in the join/conversation loop must never
+        propagate out as an unhandled background-task exception."""
+        call_session_id = uuid.uuid4()
+        mock_db = MagicMock()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(side_effect=RuntimeError("DB exploded")),
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            # Must not raise.
+            await run_livekit_browser_call(call_session_id)
+
+        mock_db.close.assert_called_once()


### PR DESCRIPTION
## Summary
Follow-up to #169 (already merged). That PR let a browser visitor get a LiveKit token via the demo-link public endpoint, but nothing made the AI agent itself join the room — visitors would connect alone. This adds the missing piece:

- New `app/voice/livekit_browser_call_handler.py`: a parallel, LiveKit-native STT→LLM(+RAG)→TTS conversation loop for browser-only (no Twilio) calls. Reuses `SttPipeline`, `LiveKitAudioSubscriber`, `VoiceOrchestrator`, `TtsPipeline`, and `ConversationOrchestrator` **unmodified** — no changes to the Twilio-path production classes. `LiveKitBrowserCallHandler` implements exactly the attribute/method surface those classes expect from their `handler`.
- New `_LiveKitAgentAudioPublisher`: publishes synthesized TTS speech into the room as an outgoing WebRTC track (mu-law 8kHz, reusing the existing `generate_mulaw_tts` helper — see module docstring for the format trade-off rationale).
- `demo_call_token` (`app/routers/sdk.py`) now spawns this conversation loop as a tracked background task (`spawn_browser_call`) right after issuing the caller's token — never blocks the HTTP response.
- In scope: live conversation using the call flow's real prompt and RAG/knowledge-base context. Out of scope (clean no-op stubs, never crash): booking/Calendly, CRM write-back, transfer routing — deferred to a later phase per product decision.
- `generate_agent_token()` gained an optional `identity` kwarg so the audio-in subscriber and the new audio-out publisher can hold simultaneous distinct connections to the same room.

### Code-review fixes included in this PR
- CRM write-back (HubSpot/Salesforce/GHL) is now explicitly skipped for demo-link calls, rather than relying on the placeholder `customer_phone_number` being unmatchable as an implicit safety net.
- Early agent-join aborts (missing agent, TTS publisher connect failure) now finalize the call session as `"failed"` (with `ended_reason="agent_join_failed"`), not `"completed"` — avoids mislabeling zero-content attempts and avoids triggering CRM write-back for calls where nothing happened.
- The long-lived background conversation task is now held by a tracked-task registry (mirrors `VoiceOrchestrator._pending_final_tasks`) — `asyncio.Task` is only weakly referenced by the event loop, and this task can run for the full duration of a live call.
- Closed the previously-documented demo-link minute-accounting gap: `run_livekit_browser_call()` now calls `update_call_session_status(..., "completed")` on room/caller disconnect, so `CallFlowDemoLink.total_minutes_used` / `CallFlowDemoLinkVisitorUsage.minutes_used` actually decrement from real call activity. (The equivalent gap on the `public-call-token` widget flow remains open and unrelated — that endpoint doesn't create a `CallSession` at all.)

## Test plan
- [x] 33 new unit tests in `tests/voice/test_livekit_browser_call_handler.py` (construction wiring, stubs, barge-in/turn handling, TTS synthesis/playback, transcript persistence, publisher byte-conversion, full lifecycle incl. both new "failed" finalization paths)
- [x] New/updated tests in `tests/api/test_sdk_demo_link.py` (background task scheduling, response not blocked) and `tests/services/test_call_session_demo_link_usage.py` (CRM write-back skip for demo-link calls, confirmed still fires for ordinary calls)
- [x] Full repo suite: 1819+ passed, 0 failed — zero regressions on the Twilio call path (verified independently, not just via the implementing agent's own report)
- [x] `ruff check` clean on all touched/new files
- [ ] End-to-end manual voice test is currently blocked on an unrelated LiveKit-server-side credential investigation (401 invalid authorization token) — tracked separately, not caused by this PR's code (JWT signing/claims verified correct and self-consistent)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>