### PR TITLE
fix: browser demo call TTS silence and STT track-wait timeout

### DIFF
--- a/app/services/bidirectional_stream_service.py
+++ b/app/services/bidirectional_stream_service.py
@@ -3,6 +3,8 @@ Service functions for bidirectional streaming.
 Handles TTS generation and TwiML building.
 """
 
+import asyncio
+import functools
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -132,10 +134,20 @@ async def generate_mulaw_tts(
             settings_json.setdefault("output_format", "ulaw_8000")
             adapter = get_tts_adapter(provider_slug)
             logger.info(f"🎤 Generating fresh MULAW TTS ('{text[:30]}...') [provider={provider_slug}]")
-            audio_content = adapter.synthesize(
-                text=tts_text,
-                voice_external_id=external_voice_id,
-                settings_json=settings_json,
+            # adapter.synthesize() is a blocking sync call (network round-trip
+            # for Rime/ElevenLabs, or a bridged asyncio.run() for Rime's async
+            # backend) — this function is awaited directly on the caller's
+            # event loop (e.g. LiveKitBrowserCallHandler on the main loop), so
+            # calling it inline would freeze that loop for every other
+            # concurrent call sharing it. Offload to a worker thread instead.
+            audio_content = await asyncio.get_running_loop().run_in_executor(
+                None,
+                functools.partial(
+                    adapter.synthesize,
+                    text=tts_text,
+                    voice_external_id=external_voice_id,
+                    settings_json=settings_json,
+                ),
             )
 
         if add_office_bg:

--- a/app/utils/tts_adapter.py
+++ b/app/utils/tts_adapter.py
@@ -337,16 +337,38 @@ class RimeTTSAdapter(BaseTTSProviderAdapter):
         speed_alpha = self._user_speed_to_speed_alpha(cfg.get("speed", 1.0), model_id)
         speaker = voice_external_id or self._DEFAULT_VOICE
         from app.services.rime_tts_service import rime_tts_service
-        return asyncio.get_event_loop().run_until_complete(
-            rime_tts_service.synthesize(
-                text=text,
-                speaker=speaker,
-                model_id=model_id,
-                speed_alpha=speed_alpha,
-                sample_rate=8000,
-                audio_format="mulaw",
-            )
+
+        coro = rime_tts_service.synthesize(
+            text=text,
+            speaker=speaker,
+            model_id=model_id,
+            speed_alpha=speed_alpha,
+            sample_rate=8000,
+            audio_format="mulaw",
         )
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No loop running on the calling thread — safe to drive the
+            # coroutine to completion directly.
+            return asyncio.run(coro)
+
+        # A loop IS already running on this thread. asyncio.run() /
+        # run_until_complete() would raise "This event loop is already
+        # running" in that case, so hand the coroutine to a dedicated
+        # one-off thread with its own fresh event loop instead. In practice
+        # this branch should no longer trigger for generate_mulaw_tts()'s
+        # call site — that caller now offloads adapter.synthesize() to a
+        # worker thread via run_in_executor() (see
+        # bidirectional_stream_service.py) specifically so this blocking
+        # call never runs on the main event loop's thread; this remains as
+        # a defensive fallback for any other/future caller invoked directly
+        # from an async context.
+        import concurrent.futures
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            return executor.submit(asyncio.run, coro).result()
 
     async def async_stream_synthesize(
         self,

--- a/app/voice/livekit_audio_subscriber.py
+++ b/app/voice/livekit_audio_subscriber.py
@@ -38,6 +38,12 @@ class LiveKitAudioSubscriber:
         self._stop_event = asyncio.Event()
         self._processor: LiveKitAudioProcessor | None = None
         self._vad_note_logged = False
+        # Rate-limits the "still waiting for caller audio track" warning to
+        # once (the first 30s timeout) rather than once per retry, so a
+        # sustained wait (slow mic permission grant, ICE/TURN negotiation on
+        # a restrictive network, etc.) doesn't flood the logs while still
+        # being fully visible the first time it happens.
+        self._caller_track_wait_timeout_logged = False
 
     async def run(self) -> None:
         """Connect to LiveKit room, subscribe to caller audio, feed STT."""
@@ -65,6 +71,81 @@ class LiveKitAudioSubscriber:
             await self._subscribe_and_transcode(ws_url, agent_token)
         self._processor = None
 
+    async def _wait_for_caller_track(
+        self,
+        caller_track_found: asyncio.Event,
+        room_disconnected: asyncio.Event,
+    ) -> bool:
+        """
+        Wait for the caller's audio track to be subscribed, for the effective
+        lifetime of the call — not just a single 30s window.
+
+        A live web-demo call can run for minutes (bounded only by the caller
+        hanging up or an explicit end-call), and the browser side may take
+        longer than 30s to actually publish its mic track on a first-time
+        visit (mic permission prompt, restrictive-network ICE/TURN
+        negotiation, etc.). Giving up permanently after one timeout silently
+        kills STT ingestion for the rest of the call. Instead, loop the wait
+        indefinitely, exiting only when the track is found, the caller
+        explicitly requests stop (``self._stop_event``), or the room itself
+        disconnects.
+
+        Returns True if the caller track was found, False otherwise (in
+        which case the caller should not proceed to consume audio_stream).
+        """
+        stop_task = asyncio.ensure_future(self._stop_event.wait())
+        disconnect_task = asyncio.ensure_future(room_disconnected.wait())
+        track_task = asyncio.ensure_future(caller_track_found.wait())
+
+        try:
+            while True:
+                done, _pending = await asyncio.wait(
+                    {stop_task, disconnect_task, track_task},
+                    timeout=30.0,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if track_task in done:
+                    return True
+
+                if stop_task in done:
+                    logger.info(
+                        "[LiveKitAudioSubscriber] stop requested while waiting "
+                        "for caller audio track room=%s", self._room_name,
+                    )
+                    return False
+
+                if disconnect_task in done:
+                    logger.warning(
+                        "[LiveKitAudioSubscriber] room disconnected while "
+                        "waiting for caller audio track room=%s", self._room_name,
+                    )
+                    return False
+
+                # 30s elapsed with none of the above — keep waiting, but
+                # don't spam the logs on every subsequent retry.
+                if not self._caller_track_wait_timeout_logged:
+                    logger.warning(
+                        "[LiveKitAudioSubscriber] still waiting for caller "
+                        "audio track after 30s (room=%s) — continuing to "
+                        "wait for the rest of the call instead of "
+                        "disconnecting; further waits logged at debug level",
+                        self._room_name,
+                    )
+                    self._caller_track_wait_timeout_logged = True
+                else:
+                    logger.debug(
+                        "[LiveKitAudioSubscriber] still waiting for caller "
+                        "audio track (room=%s)", self._room_name,
+                    )
+        finally:
+            for task in (stop_task, disconnect_task, track_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(
+                stop_task, disconnect_task, track_task, return_exceptions=True
+            )
+
     async def _subscribe_and_transcode(self, ws_url: str, token: str) -> None:
         try:
             from livekit import rtc
@@ -75,6 +156,7 @@ class LiveKitAudioSubscriber:
         room = rtc.Room()
         audio_stream: Any | None = None
         caller_track_found = asyncio.Event()
+        room_disconnected = asyncio.Event()
 
         def on_track_subscribed(track, publication, participant):
             nonlocal audio_stream
@@ -89,7 +171,11 @@ class LiveKitAudioSubscriber:
                 audio_stream = rtc.AudioStream(track)
                 caller_track_found.set()
 
+        def on_room_disconnected(*_args):
+            room_disconnected.set()
+
         room.on("track_subscribed", on_track_subscribed)
+        room.on("disconnected", on_room_disconnected)
 
         try:
             await room.connect(ws_url, token)
@@ -97,12 +183,9 @@ class LiveKitAudioSubscriber:
                 "[LiveKitAudioSubscriber] connected to room=%s", self._room_name
             )
 
-            try:
-                await asyncio.wait_for(caller_track_found.wait(), timeout=30.0)
-            except asyncio.TimeoutError:
-                logger.warning(
-                    "[LiveKitAudioSubscriber] timed out waiting for caller audio track"
-                )
+            if not await self._wait_for_caller_track(
+                caller_track_found, room_disconnected
+            ):
                 return
 
             if audio_stream is None or self._processor is None:

--- a/tests/voice/test_livekit_audio_subscriber.py
+++ b/tests/voice/test_livekit_audio_subscriber.py
@@ -238,3 +238,191 @@ class TestLiveKitAudioSubscriberFrameLoop:
             )
 
         stt_pipeline.feed_audio_chunk.assert_awaited_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LiveKitAudioSubscriber: caller audio track arriving after the first 30s
+# window must not be treated as a permanent failure — regression coverage for
+# a production stall where the subscriber gave up and disconnected after
+# exactly one 30s timeout, permanently killing STT ingestion for the rest of
+# a call that continued for minutes afterward.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestLiveKitAudioSubscriberCallerTrackWaitLoop:
+    @pytest.mark.asyncio
+    async def test_stop_requested_shortly_after_start_ends_wait_promptly(self):
+        """
+        stop_event set shortly after start, before the track is ever found —
+        must return False promptly rather than blocking for the full 30s
+        internal timeout window.
+        """
+        subscriber = LiveKitAudioSubscriber(
+            room_name="room_test", stt_pipeline=MagicMock(), output_sample_rate=16000
+        )
+        caller_track_found = asyncio.Event()
+        room_disconnected = asyncio.Event()
+
+        async def _stop_soon():
+            await asyncio.sleep(0.05)
+            subscriber._stop_event.set()
+
+        stopper = asyncio.create_task(_stop_soon())
+        result = await asyncio.wait_for(
+            subscriber._wait_for_caller_track(caller_track_found, room_disconnected),
+            timeout=5.0,
+        )
+        await stopper
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_caller_track_arriving_after_first_timeout_window_is_not_lost(self):
+        """
+        Core regression: the caller's track is NOT found within the first
+        30s window, but arrives shortly after. Before the fix, the subscriber
+        gave up permanently on the first timeout and disconnected — STT would
+        never see this track no matter how long the call continued. After
+        the fix, the wait loop keeps waiting (bounded by asyncio.wait's
+        internal 30s timeout, looped) and must pick the track up as soon as
+        it's set, without ever disconnecting.
+        """
+        subscriber = LiveKitAudioSubscriber(
+            room_name="room_test", stt_pipeline=MagicMock(), output_sample_rate=16000
+        )
+        caller_track_found = asyncio.Event()
+        room_disconnected = asyncio.Event()
+
+        # Patch the loop's internal 30s timeout down to something fast so the
+        # test doesn't actually wait 30 real seconds to exercise a second
+        # iteration of the retry loop.
+        async def _set_track_after_delay():
+            await asyncio.sleep(0.2)
+            caller_track_found.set()
+
+        setter = asyncio.create_task(_set_track_after_delay())
+
+        _real_asyncio_wait = asyncio.wait
+
+        with patch("asyncio.wait") as _wrapped:
+            # Force the internal per-iteration timeout way down so a single
+            # "timeout" retry cycle happens well before the track is set at
+            # t=0.2s, proving the loop survives at least one timeout without
+            # giving up.
+            async def _wait_with_short_timeout(tasks, timeout=None, return_when=None):
+                return await _real_asyncio_wait(tasks, timeout=0.05, return_when=return_when)
+
+            _wrapped.side_effect = _wait_with_short_timeout
+
+            result = await asyncio.wait_for(
+                subscriber._wait_for_caller_track(caller_track_found, room_disconnected),
+                timeout=5.0,
+            )
+
+        await setter
+        assert result is True
+        # Must not have given up: no stop/disconnect should have been needed.
+        assert not subscriber._stop_event.is_set()
+        assert not room_disconnected.is_set()
+        # The rate-limited timeout warning must have fired at least once,
+        # proving the loop actually looped through a timeout before success.
+        assert subscriber._caller_track_wait_timeout_logged is True
+
+    @pytest.mark.asyncio
+    async def test_stop_event_ends_the_wait_without_disconnect_flag(self):
+        subscriber = LiveKitAudioSubscriber(
+            room_name="room_test", stt_pipeline=MagicMock(), output_sample_rate=16000
+        )
+        caller_track_found = asyncio.Event()
+        room_disconnected = asyncio.Event()
+        subscriber._stop_event.set()
+
+        result = await asyncio.wait_for(
+            subscriber._wait_for_caller_track(caller_track_found, room_disconnected),
+            timeout=2.0,
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_room_disconnected_ends_the_wait(self):
+        subscriber = LiveKitAudioSubscriber(
+            room_name="room_test", stt_pipeline=MagicMock(), output_sample_rate=16000
+        )
+        caller_track_found = asyncio.Event()
+        room_disconnected = asyncio.Event()
+        room_disconnected.set()
+
+        result = await asyncio.wait_for(
+            subscriber._wait_for_caller_track(caller_track_found, room_disconnected),
+            timeout=2.0,
+        )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_full_subscribe_loop_survives_late_caller_track_end_to_end(self):
+        """
+        Full _subscribe_and_transcode() path: caller track arrives late (after
+        the on_track_subscribed callback fires from a delayed simulated
+        LiveKit event), and STT ingestion must still proceed — the room must
+        not have been disconnected in between.
+        """
+        stt_pipeline = MagicMock()
+        stt_pipeline.feed_audio_chunk = AsyncMock()
+
+        subscriber = LiveKitAudioSubscriber(
+            room_name="room_test", stt_pipeline=stt_pipeline, output_sample_rate=16000
+        )
+
+        frames = [_FakeAudioFrame(_FRAME_48K_MONO)]
+        audio_stream = _FakeAudioStream(frames)
+
+        fake_room = MagicMock()
+        fake_room.connect = AsyncMock()
+        fake_room.disconnect = AsyncMock()
+        fake_room.on = MagicMock()
+
+        fake_rtc = MagicMock()
+        fake_rtc.Room = MagicMock(return_value=fake_room)
+        fake_rtc.TrackKind.KIND_AUDIO = "audio"
+        fake_rtc.AudioStream = MagicMock(return_value=audio_stream)
+
+        fake_processor = MagicMock()
+        fake_processor.process_frame = AsyncMock(return_value=b"\x01\x02" * 50)
+        subscriber._processor = fake_processor
+
+        fake_track = MagicMock()
+        fake_track.kind = "audio"
+        fake_track.sid = "TR_test"
+        fake_participant = MagicMock()
+        fake_participant.identity = "caller-room_test"
+
+        async def _connect_and_fire_track_subscribed_late(*_args, **_kwargs):
+            async def _fire_late():
+                await asyncio.sleep(0.15)
+                for call in fake_room.on.call_args_list:
+                    if call.args and call.args[0] == "track_subscribed":
+                        handler = call.args[1]
+                        handler(fake_track, MagicMock(), fake_participant)
+                        return
+
+            asyncio.create_task(_fire_late())
+
+        fake_room.connect.side_effect = _connect_and_fire_track_subscribed_late
+
+        _real_asyncio_wait = asyncio.wait
+
+        with patch("app.core.config.settings.LIVEKIT_ENABLED", True), \
+             patch.dict("sys.modules", {"livekit": MagicMock(rtc=fake_rtc)}), \
+             patch("asyncio.wait") as _wrapped:
+
+            async def _wait_with_short_timeout(tasks, timeout=None, return_when=None):
+                return await _real_asyncio_wait(tasks, timeout=0.05, return_when=return_when)
+
+            _wrapped.side_effect = _wait_with_short_timeout
+
+            await asyncio.wait_for(
+                subscriber._subscribe_and_transcode("ws://fake", "fake-token"), timeout=5.0
+            )
+
+        stt_pipeline.feed_audio_chunk.assert_awaited_once()
+        # disconnect() is called once at the very end via the outer `finally`,
+        # not prematurely after the (survived) first timeout.
+        fake_room.disconnect.assert_awaited_once()

--- a/tests/voice/test_rime_tts_and_barge_in.py
+++ b/tests/voice/test_rime_tts_and_barge_in.py
@@ -301,6 +301,162 @@ class TestRimeTTSAdapter:
         )
 
 
+class TestRimeSyncSynthesizeEventLoopBridge:
+    """
+    Regression: RimeTTSAdapter.synthesize() (the sync BaseTTSProviderAdapter
+    contract) is invoked from generate_mulaw_tts() (an `async def`) via
+    LiveKitBrowserCallHandler._prefetch_tts_audio() — i.e. from a thread that
+    already has a running event loop. The old implementation bridged
+    sync→async with `asyncio.get_event_loop().run_until_complete(...)`, which
+    raises `RuntimeError: This event loop is already running` whenever a loop
+    is already running on the calling thread — exactly this call path.
+    Caller heard nothing (TTS synthesis always failed).
+
+    Fix: detect a running loop and, if present, execute the coroutine on a
+    dedicated one-off thread with its own fresh event loop instead of trying
+    to reuse the calling thread's loop.
+    """
+
+    def test_synthesize_from_within_running_event_loop_does_not_raise(self):
+        from app.utils.tts_adapter import RimeTTSAdapter
+
+        adapter = RimeTTSAdapter()
+
+        async def _fake_service_synthesize(**kwargs):
+            return b"\xff" * 320
+
+        async def _run():
+            with patch(
+                "app.services.rime_tts_service.rime_tts_service.synthesize",
+                side_effect=_fake_service_synthesize,
+            ):
+                # Called directly from a coroutine running on this thread's
+                # event loop — this is the exact scenario that previously
+                # raised "This event loop is already running".
+                return adapter.synthesize(
+                    text="Hello there",
+                    voice_external_id="mistv2_Wildflower",
+                    settings_json={"speed": 1.0},
+                )
+
+        result = asyncio.run(_run())
+        assert result == b"\xff" * 320
+
+    def test_synthesize_without_running_event_loop_still_works(self):
+        """The plain-sync-caller path (no loop on this thread) must keep working."""
+        from app.utils.tts_adapter import RimeTTSAdapter
+
+        adapter = RimeTTSAdapter()
+
+        async def _fake_service_synthesize(**kwargs):
+            return b"\xab" * 160
+
+        with patch(
+            "app.services.rime_tts_service.rime_tts_service.synthesize",
+            side_effect=_fake_service_synthesize,
+        ):
+            result = adapter.synthesize(
+                text="Hello there",
+                voice_external_id="mistv2_Wildflower",
+                settings_json={"speed": 1.0},
+            )
+
+        assert result == b"\xab" * 160
+
+    @pytest.mark.asyncio
+    async def test_generate_mulaw_tts_does_not_block_sibling_task_on_the_loop(self):
+        """
+        The bridge fix in RimeTTSAdapter.synthesize() only stops the crash —
+        by itself it still blocks the calling event-loop thread for the full
+        Rime call (via Future.result()), starving every other concurrent
+        call on that loop (STT frame delivery, other calls' TTS, etc). The
+        actual fix for that is in generate_mulaw_tts() (bidirectional_stream_
+        service.py), which now offloads adapter.synthesize() to a worker
+        thread via run_in_executor() *before* it ever reaches
+        RimeTTSAdapter.synthesize() — so the main loop stays free while a
+        slow Rime call is in flight. This test proves that end-to-end via
+        the real generate_mulaw_tts() call, not just the adapter in
+        isolation.
+        """
+        from app.services.bidirectional_stream_service import generate_mulaw_tts
+
+        agent = MagicMock()
+        agent.tts_voice = None
+        agent.tts_settings_json = {"speed": 1.0}
+
+        async def _slow_fake_service_synthesize(**kwargs):
+            # Simulate the ~real Rime HTTP round trip latency.
+            await asyncio.sleep(0.3)
+            return b"\xff" * 320
+
+        tick_count = 0
+
+        async def _ticker():
+            nonlocal tick_count
+            while True:
+                await asyncio.sleep(0.01)
+                tick_count += 1
+
+        with patch(
+            "app.services.rime_tts_service.rime_tts_service.synthesize",
+            side_effect=_slow_fake_service_synthesize,
+        ), patch(
+            "app.services.bidirectional_stream_service._resolve_tts_provider_slug",
+            return_value="rime",
+        ), patch(
+            "app.services.bidirectional_stream_service.resolve_tts_runtime",
+        ) as mock_resolve_runtime, patch(
+            "app.services.bidirectional_stream_service.audio_cache", {}
+        ):
+            mock_resolve_runtime.return_value = MagicMock(
+                voice_external_id="mistv2_Wildflower", settings_json={"speed": 1.0}
+            )
+
+            ticker_task = asyncio.create_task(_ticker())
+            try:
+                result = await generate_mulaw_tts(
+                    text="Hello there, this is a test utterance",
+                    agent=agent,
+                )
+            finally:
+                ticker_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await ticker_task
+
+        assert result == b"\xff" * 320
+        # While the ~300ms Rime call was "in flight", a sibling task ticking
+        # every 10ms must have kept making progress — if the main loop had
+        # been blocked synchronously for that duration, tick_count would be
+        # ~0 instead of ~20+.
+        assert tick_count >= 10, (
+            f"expected sibling task to keep progressing during TTS synth, "
+            f"got only {tick_count} ticks — event loop was blocked"
+        )
+
+    def test_synthesize_from_running_loop_propagates_service_errors(self):
+        """Errors from the underlying async service must still surface, not be swallowed."""
+        from app.utils.tts_adapter import RimeTTSAdapter
+
+        adapter = RimeTTSAdapter()
+
+        async def _fake_service_synthesize(**kwargs):
+            raise RuntimeError("Rime upstream error")
+
+        async def _run():
+            with patch(
+                "app.services.rime_tts_service.rime_tts_service.synthesize",
+                side_effect=_fake_service_synthesize,
+            ):
+                adapter.synthesize(
+                    text="Hello there",
+                    voice_external_id="mistv2_Wildflower",
+                    settings_json={"speed": 1.0},
+                )
+
+        with pytest.raises(RuntimeError, match="Rime upstream error"):
+            asyncio.run(_run())
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 2. agent_runtime — 'rime' adapter resolution
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixed Rime TTS synthesis crashing with `RuntimeError: This event loop is already running` on the browser LiveKit demo-call path (`RimeTTSAdapter.synthesize()` was bridging sync→async onto an already-running loop). Also moved the whole non-Google TTS synthesize call in `generate_mulaw_tts()` onto a worker thread so a slow TTS call no longer blocks every other concurrent call sharing the event loop.
- Fixed `LiveKitAudioSubscriber` permanently giving up after a single 30s wait for the caller's browser mic track, which silently killed STT ingestion for the rest of a live call if the track published even slightly late (mic permission prompts, ICE/TURN negotiation delays). It now keeps waiting, bounded by stop-event or room disconnect, with rate-limited logging instead of a silent one-shot timeout.
- Verified against Rime's official API docs that no sync SDK exists and the endpoint is streaming-only, confirming the fix belongs in our own adapter bridging code, not the Rime service wrapper.

## Test plan
- [x] New regression tests reproduce both bugs against pre-fix code and pass post-fix (`tests/voice/test_rime_tts_and_barge_in.py`, `tests/voice/test_livekit_audio_subscriber.py`)
- [x] New test confirms the TTS fix doesn't block sibling tasks on the event loop during a slow synth call
- [x] Full `tests/voice/` + `tests/services/test_tts_architecture.py` suite passes (235 tests)
- [x] `ruff check` clean on all changed files
- [ ] Manual verification on a real browser demo-link call (agent voice audible, caller speech transcribed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)