### PR TITLE
fix: ffmpeg timeout respawn loop and silent TTS publish failures

### DIFF
--- a/app/voice/audio_transcoder.py
+++ b/app/voice/audio_transcoder.py
@@ -18,6 +18,14 @@ _FFMPEG_OUTPUT_FORMAT = "s16le"
 # sustained outage (binary missing, fork/exec exhaustion) doesn't retry on
 # every ~20ms frame and pile onto whatever resource pressure caused it.
 _RESTART_BACKOFF_SECONDS = 1.0
+# A single stdout-read timeout is normal/expected — a freshly (re)started
+# ffmpeg process needs a moment to initialize and buffer enough input before
+# it flushes its first output block, especially under container CPU
+# contention, and each caller-audio frame is only ~10-20ms of PCM. Only treat
+# it as "the process is actually stuck" (and reset it) after this many
+# *consecutive* timeouts, so we don't kill-and-respawn ffmpeg before it ever
+# gets a chance to reach steady state.
+_MAX_CONSECUTIVE_READ_TIMEOUTS = 15
 
 
 class LiveKitAudioProcessor:
@@ -41,6 +49,7 @@ class LiveKitAudioProcessor:
         # flood the logs while still being fully visible.
         self._ffmpeg_start_failed_logged = False
         self._last_restart_failure: float | None = None
+        self._consecutive_read_timeouts = 0
 
     async def process_frame(
         self,
@@ -134,19 +143,33 @@ class LiveKitAudioProcessor:
             proc.stdin.write(pcm)
             await proc.stdin.drain()
             out = await asyncio.wait_for(proc.stdout.read(65536), timeout=0.5)
+            self._consecutive_read_timeouts = 0
             return out or b""
         except (BrokenPipeError, ConnectionResetError) as exc:
             logger.warning("[LiveKitAudioProcessor] ffmpeg pipe broken: %s", exc)
+            self._consecutive_read_timeouts = 0
             await self._reset_after_failure()
             return b""
         except asyncio.TimeoutError:
-            logger.warning(
-                "[LiveKitAudioProcessor] ffmpeg read timed out — process likely stuck, resetting"
-            )
-            await self._reset_after_failure()
+            # A single (or occasional) timeout is normal — the process just
+            # hasn't buffered enough input yet to flush output for this
+            # frame; drop this frame only, keep the same process running so
+            # it can reach steady state. Only reset once enough consecutive
+            # timeouts have piled up to indicate the process is genuinely
+            # stuck rather than merely warming up / catching up.
+            self._consecutive_read_timeouts += 1
+            if self._consecutive_read_timeouts >= _MAX_CONSECUTIVE_READ_TIMEOUTS:
+                logger.warning(
+                    "[LiveKitAudioProcessor] ffmpeg read timed out %d times in a "
+                    "row — process likely stuck, resetting",
+                    self._consecutive_read_timeouts,
+                )
+                self._consecutive_read_timeouts = 0
+                await self._reset_after_failure()
             return b""
         except Exception as exc:
             logger.warning("[LiveKitAudioProcessor] ffmpeg convert error: %s", exc)
+            self._consecutive_read_timeouts = 0
             await self._reset_after_failure()
             return b""
 

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -125,6 +125,13 @@ class _LiveKitAgentAudioPublisher:
         self._room: Any = None
         self._source: Any = None
         self._connected = False
+        # Rate-limits the "publish failed" warning to once per outage (rather
+        # than once per ~20ms frame) so a sustained failure doesn't flood the
+        # logs while still being visible at all — previously this was a bare
+        # DEBUG log, so a capture_frame() failure meant TTS could be reported
+        # as synthesized/queued successfully while zero audio ever reached
+        # the browser, with no trace of why in normal logs.
+        self._publish_failed_logged = False
 
     @property
     def connected(self) -> bool:
@@ -204,8 +211,14 @@ class _LiveKitAgentAudioPublisher:
                 frame = rtc.AudioFrame.create(_AGENT_AUDIO_SAMPLE_RATE, 1, len(samples))
                 frame.data[:] = pcm
                 await self._source.capture_frame(frame)
+                self._publish_failed_logged = False
         except Exception as exc:
-            logger.debug("[LiveKitBrowserCall] publish_mulaw failed: %s", exc)
+            if not self._publish_failed_logged:
+                logger.warning(
+                    "[LiveKitBrowserCall] publish_mulaw failed room=%s: %s",
+                    self._room_name, exc, exc_info=True,
+                )
+                self._publish_failed_logged = True
 
     async def disconnect(self) -> None:
         self._connected = False

--- a/tests/voice/test_livekit_audio_subscriber.py
+++ b/tests/voice/test_livekit_audio_subscriber.py
@@ -173,6 +173,70 @@ class TestLiveKitAudioProcessorResilience:
         # process for the rest of the call.
         assert out2 != b""
 
+    @pytest.mark.asyncio
+    async def test_occasional_read_timeout_does_not_reset_ffmpeg(self):
+        """
+        Regression: a single (or occasional) stdout-read timeout is a normal
+        condition for a live/freshly-started ffmpeg process that hasn't
+        buffered enough input yet to flush output for a tiny 10-20ms frame —
+        it is NOT evidence the process is dead. A prior fix incorrectly
+        treated every timeout the same as a broken pipe / dead process and
+        reset (killed + forced a respawn) on every single one — which meant
+        ffmpeg was killed before it ever got a chance to reach steady state,
+        producing an infinite respawn loop where caller audio was NEVER
+        successfully converted (observed in production: "ffmpeg read timed
+        out — process likely stuck, resetting" logged continuously, every
+        ~1.5s, for the whole call). A timeout must leave the same process in
+        place so it can catch up on a later frame.
+        """
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+
+        proc = MagicMock()
+        proc.stdin = MagicMock()
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
+        proc.stdout = MagicMock()
+        proc.stdout.read = AsyncMock(side_effect=asyncio.TimeoutError())
+
+        processor._ffmpeg_process = proc
+        processor._ffmpeg_input_rate = 48000
+        processor._ffmpeg_input_channels = 1
+
+        for _ in range(5):
+            out = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+            assert out == b""
+
+        # After several (but not too many) consecutive timeouts, the SAME
+        # process must still be in place — not reset/killed.
+        assert processor._ffmpeg_process is proc
+
+    @pytest.mark.asyncio
+    async def test_sustained_read_timeouts_eventually_reset_ffmpeg(self):
+        """A process that never recovers across many consecutive timeouts is
+        genuinely stuck and must still eventually self-heal."""
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+
+        proc = MagicMock()
+        proc.stdin = MagicMock()
+        proc.stdin.write = MagicMock()
+        proc.stdin.drain = AsyncMock()
+        proc.stdout = MagicMock()
+        proc.stdout.read = AsyncMock(side_effect=asyncio.TimeoutError())
+        proc.returncode = None
+        proc.wait = AsyncMock(return_value=None)
+        proc.kill = MagicMock()
+
+        processor._ffmpeg_process = proc
+        processor._ffmpeg_input_rate = 48000
+        processor._ffmpeg_input_channels = 1
+
+        from app.voice.audio_transcoder import _MAX_CONSECUTIVE_READ_TIMEOUTS
+
+        for _ in range(_MAX_CONSECUTIVE_READ_TIMEOUTS):
+            await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+
+        assert processor._ffmpeg_process is None
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # LiveKitAudioSubscriber: a single bad frame must not abort ingestion for the

--- a/tests/voice/test_livekit_browser_call_handler.py
+++ b/tests/voice/test_livekit_browser_call_handler.py
@@ -11,6 +11,7 @@ scheduling coverage.
 from __future__ import annotations
 
 import asyncio
+import logging
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -401,6 +402,33 @@ class TestLiveKitAgentAudioPublisher:
 
         mock_source.capture_frame.assert_not_called()
         mock_source.clear_queue.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_publish_mulaw_failure_is_logged_at_warning_not_swallowed(self, caplog):
+        """
+        Regression: capture_frame() failures were previously caught and
+        logged only at DEBUG — invisible in normal/production logs. This
+        meant TTS synthesis could succeed and be reported as "turn
+        complete" while the actual publish to the browser silently failed
+        with zero audible output and zero trace of why. Must now be visible
+        at WARNING.
+        """
+        publisher = _LiveKitAgentAudioPublisher("room_x")
+        publisher._connected = True
+        mock_source = MagicMock()
+        mock_source.capture_frame = AsyncMock(side_effect=RuntimeError("source closed"))
+        publisher._source = mock_source
+
+        mock_rtc = MagicMock()
+        mock_rtc.AudioFrame.create.return_value = MagicMock(data=bytearray(320))
+
+        with patch.dict("sys.modules", {"livekit": MagicMock(rtc=mock_rtc)}), \
+             caplog.at_level(logging.WARNING, logger="tgs_agent"):
+            await publisher.publish_mulaw(b"\xff" * 320)
+
+        assert any(
+            "publish_mulaw failed" in record.message for record in caplog.records
+        ), "expected a WARNING-level log for the swallowed publish failure"
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- The earlier self-heal fix (PR #172) treated a plain ffmpeg stdout-read timeout the same as a genuinely dead process and reset (killed + respawned) ffmpeg on every single one. A read timeout on a freshly (re)started process converting a tiny 10-20ms frame is normal — it just hasn't buffered enough input yet, especially under container CPU pressure. This meant every respawned process hit the same cold-start timeout again, forever — observed in production as a continuous "ffmpeg read timed out — resetting" loop every ~1.5s for the whole call, with caller audio never once successfully converted (STT received nothing). Now only resets after several consecutive timeouts (real evidence of being stuck), while still resetting immediately on broken pipe/connection errors.
- `_LiveKitAgentAudioPublisher.publish_mulaw()` caught any `capture_frame()` failure and logged it only at DEBUG — invisible in normal logs. This meant a TTS chunk could be synthesized and reported as "turn complete" while the actual publish to the browser silently failed with zero audible output and zero trace of why. Bumped to a rate-limited WARNING with `exc_info` so a real publish failure is visible instead of silent.

## Test plan
- [x] New regression tests: occasional timeouts don't reset ffmpeg, sustained timeouts still self-heal, publish failures are now logged at WARNING
- [x] Confirmed the ffmpeg test fails against the pre-fix code and passes post-fix
- [x] Full `tests/voice/` suite passes (228 tests)
- [x] `ruff check` clean on all changed files
- [ ] Manual verification on a real browser demo-link call (no more respawn-loop logging, greeting audio audible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)