### PR TITLE
fix: Rime event-loop reuse, AudioFrame publish, audit log, stray STT session

### DIFF
--- a/app/services/audit_service.py
+++ b/app/services/audit_service.py
@@ -7,6 +7,7 @@ abort a business operation.
 """
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
@@ -16,6 +17,19 @@ from sqlalchemy.orm import Session
 from app.core.logger import logger
 from app.core.request_auth import AUTH_METHOD_API_KEY, get_auth_method
 from app.models.audit_log import AuditLog
+
+
+def _json_safe(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Coerce a dict into something the plain JSON column can actually store.
+
+    Callers commonly pass Pydantic .model_dump() output, which keeps native
+    Python objects (datetime, UUID, Decimal, ...) rather than JSON-primitive
+    values. AuditLog.old_value/new_value are plain `JSON` columns with no
+    custom serializer, so those objects raise TypeError at flush time.
+    """
+    if value is None:
+        return None
+    return json.loads(json.dumps(value, default=str))
 
 
 def _extract_ip(request: Request) -> str | None:
@@ -63,8 +77,8 @@ def log_audit_event(
             action=action,
             resource_type=resource_type,
             resource_id=resource_id,
-            old_value=old_value,
-            new_value=new_value,
+            old_value=_json_safe(old_value),
+            new_value=_json_safe(new_value),
             ip_address=ip,
             user_agent=user_agent,
         )

--- a/app/services/rime_tts_service.py
+++ b/app/services/rime_tts_service.py
@@ -16,6 +16,7 @@ Rime mistv2 supports:
 """
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import AsyncIterator
 
@@ -38,18 +39,39 @@ class RimeTtsService:
     """Thin async wrapper around the Rime TTS HTTP streaming endpoint."""
 
     def __init__(self) -> None:
-        # Client is created lazily (no event loop at module import time).
-        self._client: httpx.AsyncClient | None = None
+        # httpx.AsyncClient's connection pool (httpcore/anyio) is bound to
+        # whichever asyncio event loop was running when the client's
+        # sockets were opened — it is NOT safe to reuse a single client
+        # across different loops (a stale pooled connection tries to
+        # call_soon() on its original loop when closed/reused, raising
+        # "RuntimeError: Event loop is closed" if that loop already ended).
+        #
+        # This service is called from two distinct execution contexts that
+        # each have their own long-lived loop for the life of the process:
+        #   - the live Twilio/LiveKit streaming path (stream_text_to_speech
+        #     awaited directly on the app's main event loop)
+        #   - RimeTTSAdapter.synthesize()'s sync-bridge path, which now runs
+        #     all its coroutines on one dedicated background loop (see
+        #     app/utils/tts_adapter.py::_get_rime_sync_bridge_loop) instead
+        #     of spinning up/tearing down a fresh loop per call.
+        # Keying the cached client by the *running loop* means each of those
+        # stable loops gets its own client, created once and reused for that
+        # loop's whole lifetime — never shared across loops.
+        self._clients: dict[int, httpx.AsyncClient] = {}
         # Resolve once at construction so a missing key fails before any live call.
         self._api_key = get_rime_api_key()
 
     def _get_client(self) -> httpx.AsyncClient:
-        if self._client is None or self._client.is_closed:
-            self._client = httpx.AsyncClient(
+        loop = asyncio.get_running_loop()
+        key = id(loop)
+        client = self._clients.get(key)
+        if client is None or client.is_closed:
+            client = httpx.AsyncClient(
                 timeout=httpx.Timeout(connect=3.0, read=30.0, write=10.0, pool=5.0),
                 http2=False,
             )
-        return self._client
+            self._clients[key] = client
+        return client
 
     # ------------------------------------------------------------------
     # Public API
@@ -152,8 +174,17 @@ class RimeTtsService:
         return b"".join(chunks)
 
     async def close(self) -> None:
-        if self._client and not self._client.is_closed:
-            await self._client.aclose()
+        """Close whichever client is bound to the *currently running* loop.
+
+        Only the caller's own loop-scoped client can be safely closed from
+        here — closing a client bound to a different (possibly already
+        stopped) loop would itself risk the same "Event loop is closed"
+        failure this file exists to avoid.
+        """
+        loop = asyncio.get_running_loop()
+        client = self._clients.pop(id(loop), None)
+        if client and not client.is_closed:
+            await client.aclose()
 
 
 rime_tts_service = RimeTtsService()

--- a/app/utils/tts_adapter.py
+++ b/app/utils/tts_adapter.py
@@ -1,12 +1,88 @@
 from __future__ import annotations
 
+import asyncio
+import threading
 from abc import ABC, abstractmethod
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Coroutine
 
 from app.core.secret_manager import get_rime_api_key
 from app.models.tts_provider import TTSProvider
 from app.services.elevenlabs_service import elevenlabs_service
 from app.services.google_tts_service import google_tts_service
+
+
+class _RimeSyncEventLoopBridge:
+    """Runs Rime's async HTTP calls on a single, persistent background event
+    loop so synchronous callers (RimeTTSAdapter.synthesize(), invoked from a
+    worker thread via run_in_executor()) can drive them without spinning up
+    and tearing down a fresh event loop on every call.
+
+    Why this exists: rime_tts_service caches an httpx.AsyncClient for
+    connection pooling, and an httpx.AsyncClient's connection pool is bound
+    to whichever event loop was running when its sockets were opened. Doing
+    `asyncio.run(coro)` per call — one fresh loop created and destroyed each
+    time — meant a second call could reuse a pooled connection still bound
+    to the *first* call's already-closed loop, raising
+    "RuntimeError: Event loop is closed" deep inside httpx/httpcore/anyio's
+    connection teardown.
+
+    A dedicated loop, started once and reused for the process's lifetime,
+    keeps the cached client bound to exactly one stable loop for its whole
+    life — matching httpx's actual threading/loop contract. This is chosen
+    over "don't cache the client" because Rime is on the hot TTS-latency
+    path and repeated TLS handshakes per call would add real latency; a
+    single background thread is a small, one-time cost.
+
+    This bridge is used *only* for the sync-bridge path
+    (RimeTTSAdapter.synthesize()). The live streaming path
+    (async_stream_synthesize / stream_synthesize, called from
+    app/voice/tts_stream_mixin.py) is already correctly awaited directly on
+    the caller's own real running loop and must keep working exactly as
+    before — it does not go through this bridge at all.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._start_lock = threading.Lock()
+
+    def _ensure_started(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is not None:
+            return loop
+        with self._start_lock:
+            if self._loop is not None:
+                return self._loop
+
+            ready = threading.Event()
+            state: dict[str, asyncio.AbstractEventLoop] = {}
+
+            def _run_forever() -> None:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                state["loop"] = loop
+                ready.set()
+                loop.run_forever()
+
+            thread = threading.Thread(
+                target=_run_forever,
+                name="rime-tts-sync-bridge",
+                daemon=True,
+            )
+            thread.start()
+            ready.wait()
+            self._loop = state["loop"]
+            return self._loop
+
+    def run(self, coro: "Coroutine[Any, Any, bytes]") -> bytes:
+        """Schedule `coro` on the dedicated bridge loop and block the
+        calling thread until it completes. Safe to call from any thread,
+        regardless of whether that thread has its own running event loop."""
+        loop = self._ensure_started()
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return future.result()
+
+
+_rime_sync_bridge = _RimeSyncEventLoopBridge()
 
 
 class BaseTTSProviderAdapter(ABC):
@@ -331,7 +407,6 @@ class RimeTTSAdapter(BaseTTSProviderAdapter):
         voice_external_id: str,
         settings_json: dict[str, Any] | None = None,
     ) -> bytes:
-        import asyncio
         cfg = dict(settings_json or {})
         model_id = cfg.get("model_id", self._DEFAULT_MODEL)
         speed_alpha = self._user_speed_to_speed_alpha(cfg.get("speed", 1.0), model_id)
@@ -347,28 +422,14 @@ class RimeTTSAdapter(BaseTTSProviderAdapter):
             audio_format="mulaw",
         )
 
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            # No loop running on the calling thread — safe to drive the
-            # coroutine to completion directly.
-            return asyncio.run(coro)
-
-        # A loop IS already running on this thread. asyncio.run() /
-        # run_until_complete() would raise "This event loop is already
-        # running" in that case, so hand the coroutine to a dedicated
-        # one-off thread with its own fresh event loop instead. In practice
-        # this branch should no longer trigger for generate_mulaw_tts()'s
-        # call site — that caller now offloads adapter.synthesize() to a
-        # worker thread via run_in_executor() (see
-        # bidirectional_stream_service.py) specifically so this blocking
-        # call never runs on the main event loop's thread; this remains as
-        # a defensive fallback for any other/future caller invoked directly
-        # from an async context.
-        import concurrent.futures
-
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-            return executor.submit(asyncio.run, coro).result()
+        # Drive the coroutine on a single persistent background event loop
+        # (see _RimeSyncEventLoopBridge above) instead of asyncio.run()'s
+        # per-call fresh-loop-then-teardown, which corrupted rime_tts_service's
+        # cached httpx.AsyncClient across calls ("Event loop is closed").
+        # Safe to call regardless of whether the calling thread already has
+        # its own running loop — run_coroutine_threadsafe only needs the
+        # target (bridge) loop to be running, not the caller's thread.
+        return _rime_sync_bridge.run(coro)
 
     async def async_stream_synthesize(
         self,

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -209,7 +209,14 @@ class _LiveKitAgentAudioPublisher:
                 samples = [ulaw_to_linear_sample(b) for b in chunk]
                 pcm = struct.pack(f"<{len(samples)}h", *samples)
                 frame = rtc.AudioFrame.create(_AGENT_AUDIO_SAMPLE_RATE, 1, len(samples))
-                frame.data[:] = pcm
+                # frame.data is a memoryview already cast to int16 ("h")
+                # format (see livekit.rtc.AudioFrame.data); assigning a plain
+                # `bytes` object (format "B") straight into it raises
+                # "ValueError: memoryview assignment: lvalue and rvalue have
+                # different structures" even though the byte lengths match.
+                # Cast the destination view to bytes format first so both
+                # sides agree on structure.
+                frame.data.cast("B")[:] = pcm
                 await self._source.capture_frame(frame)
                 self._publish_failed_logged = False
         except Exception as exc:

--- a/app/voice/livekit_twilio_bridge.py
+++ b/app/voice/livekit_twilio_bridge.py
@@ -113,7 +113,17 @@ class LiveKitTwilioPublisher:
                 frame = rtc.AudioFrame.create(
                     _TWILIO_SAMPLE_RATE, 1, len(samples)
                 )
-                frame.data[:] = pcm
+                # frame.data is a memoryview already cast to int16 ("h")
+                # format (see livekit.rtc.AudioFrame.data); assigning a
+                # plain `bytes` object (format "B") straight into it raises
+                # "ValueError: memoryview assignment: lvalue and rvalue have
+                # different structures" even though the byte lengths match.
+                # Cast the destination view to bytes format first so both
+                # sides agree on structure. (Same bug as, and same fix as,
+                # _LiveKitAgentAudioPublisher.publish_mulaw in
+                # livekit_browser_call_handler.py — previously silently
+                # swallowed here via the debug-level log below.)
+                frame.data.cast("B")[:] = pcm
                 await self._source.capture_frame(frame)
         except Exception as exc:
             logger.debug("[LiveKitBridge] publish_mulaw: %s", exc)

--- a/app/voice/stt_pipeline.py
+++ b/app/voice/stt_pipeline.py
@@ -75,6 +75,14 @@ class SttPipeline:
 
         self._stt_session = None
         self._reader_task: asyncio.Task | None = None
+        # Set by aclose() — once the pipeline has been deliberately shut down,
+        # a trailing/late-arriving audio chunk (e.g. an ffmpeg buffer flush
+        # racing the call's own shutdown sequence) must not lazily reopen a
+        # brand-new STT session that can never receive further audio and
+        # will just time out and error minutes later. Reset by
+        # recreate_with_endpointing(), which intentionally closes then
+        # expects the next feed_audio_chunk() to reopen a fresh session.
+        self._closed = False
 
         # Normalized-final dedup — catches re-endpoints within window
         self._last_final_norm_key: str = ""
@@ -267,6 +275,12 @@ class SttPipeline:
         """Feed raw audio bytes (MULAW or LINEAR16) into the streaming session."""
         if not audio_data:
             return
+        if self._closed:
+            logger.debug(
+                "[STT] send skipped — pipeline already closed, not reopening "
+                "(call_session_id=%s)", self._call_session_id,
+            )
+            return
         self._last_audio_mono = time.monotonic()
         await self._ensure_session()
         if self._stt_session:
@@ -299,6 +313,7 @@ class SttPipeline:
         if want == self._effective_endpointing_ms() and self._stt_session is not None:
             return
         await self.aclose()
+        self._closed = False  # aclose() marks closed; this call reopens deliberately
         self._endpointing_ms = want
         self._stt_session = None
         self._reader_task = None
@@ -318,6 +333,7 @@ class SttPipeline:
 
     async def aclose(self) -> None:
         """Graceful shutdown: signal finish then wait up to 5s for reader."""
+        self._closed = True
         self.finish_session()
         if self._reader_task and not self._reader_task.done():
             try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,21 @@ _RUN_GOOGLE_STT_INTEGRATION = os.environ.get(
 ).lower() in ("1", "true", "yes")
 
 if not _RUN_GOOGLE_STT_INTEGRATION:
+    # Force-load livekit's rtc extension (and, transitively, the real
+    # google.protobuf submodules it needs — descriptor, descriptor_pool,
+    # symbol_database, etc.) *before* stubbing out the `google` namespace
+    # below. Those protobuf submodules are an unrelated real dependency
+    # (used by livekit/grpc, not Google Cloud/GenAI), but once `google`
+    # itself is replaced with a bare MagicMock (no `__path__`), any *new*
+    # `from google.protobuf import ...` fails with "'google' is not a
+    # package". Pre-importing here caches the real submodules in
+    # sys.modules so later imports hit that cache directly instead of
+    # resolving through the mocked parent package.
+    try:
+        import livekit.rtc  # noqa: F401
+    except ImportError:
+        pass
+
     sys.modules["google"] = MagicMock()
     sys.modules["google.genai"] = MagicMock()
     sys.modules["google.oauth2"] = MagicMock()

--- a/tests/services/test_audit_service.py
+++ b/tests/services/test_audit_service.py
@@ -1,0 +1,92 @@
+"""
+Regression: log_audit_event() silently failed (caught, logged at WARNING,
+rolled back) whenever old_value/new_value contained a datetime, UUID, or
+other non-JSON-primitive value — e.g. a raw Pydantic .model_dump() dict, as
+every call site in app/routers/call_flows.py passes. AuditLog.old_value/
+new_value are plain `JSON` columns with no custom serializer, so
+`TypeError: Object of type datetime is not JSON serializable` was raised at
+flush time and swallowed, silently dropping the audit trail entry while the
+underlying business operation (e.g. demo link creation) still succeeded.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from app.services.audit_service import log_audit_event
+
+
+def _fake_request() -> MagicMock:
+    request = MagicMock()
+    request.headers = {"x-forwarded-for": "", "user-agent": "pytest"}
+    request.client = MagicMock(host="127.0.0.1")
+    request.state = MagicMock(api_key_prefix=None)
+    return request
+
+
+def test_log_audit_event_with_datetime_in_new_value_does_not_fail():
+    db = MagicMock()
+    request = _fake_request()
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=uuid.uuid4(),
+        action="call_flow.demo_link_created",
+        resource_type="call_flow_demo_link",
+        resource_id=uuid.uuid4(),
+        new_value={
+            "name": "demo",
+            "expires_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        },
+    )
+
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    db.rollback.assert_not_called()
+
+    entry = db.add.call_args[0][0]
+    assert entry.new_value["name"] == "demo"
+    assert entry.new_value["expires_at"] == "2026-01-01 00:00:00+00:00"
+
+
+def test_log_audit_event_with_uuid_and_decimal_in_old_value_does_not_fail():
+    db = MagicMock()
+    request = _fake_request()
+
+    some_id = uuid.uuid4()
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=uuid.uuid4(),
+        action="call_flow.demo_link_updated",
+        resource_type="call_flow_demo_link",
+        old_value={"linked_id": some_id, "budget": Decimal("12.50")},
+    )
+
+    db.add.assert_called_once()
+    db.commit.assert_called_once()
+    db.rollback.assert_not_called()
+
+    entry = db.add.call_args[0][0]
+    assert entry.old_value["linked_id"] == str(some_id)
+    assert entry.old_value["budget"] == "12.50"
+
+
+def test_log_audit_event_with_none_values_is_a_noop_passthrough():
+    db = MagicMock()
+    request = _fake_request()
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=uuid.uuid4(),
+        action="call_flow.demo_link_deleted",
+        resource_type="call_flow_demo_link",
+    )
+
+    entry = db.add.call_args[0][0]
+    assert entry.old_value is None
+    assert entry.new_value is None

--- a/tests/services/test_stt_regressions.py
+++ b/tests/services/test_stt_regressions.py
@@ -59,6 +59,66 @@ def test_stt_pipeline_exits_reader_loop_on_done(monkeypatch):
     assert seen["final"] == 0
 
 
+def test_feed_audio_chunk_after_aclose_does_not_reopen_session(monkeypatch):
+    """
+    Regression: a trailing/late-arriving audio chunk (e.g. an ffmpeg buffer
+    flush racing the call's own shutdown sequence) fed to an already-closed
+    SttPipeline used to lazily reopen a brand-new provider session via
+    _ensure_session() — a session that could never receive further audio
+    (the call had already ended and the LiveKit room had disconnected) and
+    would just sit there until it timed out and errored minutes later
+    (observed in production: "Deepgram did not receive audio data ... within
+    the timeout window", ~12s after a call had already ended cleanly).
+    aclose() must mark the pipeline closed so a subsequent feed_audio_chunk()
+    is a no-op instead of opening a new session.
+    """
+    sessions_created = {"count": 0}
+
+    class FakeSession:
+        async def start(self):
+            return None
+
+        async def get_result(self):
+            await asyncio.sleep(1)
+            return {}
+
+        def push_audio(self, _):
+            return None
+
+        def finish(self):
+            return None
+
+    def _create_session(**_):
+        sessions_created["count"] += 1
+        return FakeSession()
+
+    from app.services import deepgram_stt_service as dg_module
+
+    monkeypatch.setattr(
+        dg_module.deepgram_stt_service, "create_streaming_session", _create_session
+    )
+
+    async def on_interim(_, __):
+        return None
+
+    async def on_final(_, __):
+        return None
+
+    async def _run():
+        pipeline = SttPipeline(language_code="en-US", on_interim=on_interim, on_final=on_final)
+        await pipeline.feed_audio_chunk(b"\x00\x01")
+        assert sessions_created["count"] == 1
+
+        await pipeline.aclose()
+
+        # A trailing chunk arriving after shutdown must not reopen a session.
+        await pipeline.feed_audio_chunk(b"\x00\x01")
+        assert sessions_created["count"] == 1
+        assert pipeline._stt_session is None
+
+    asyncio.run(_run())
+
+
 def test_bidirectional_disconnect_triggers_finish_session(monkeypatch):
     close_state = {"closed": False, "finished": 0}
 

--- a/tests/voice/test_livekit_twilio_bridge.py
+++ b/tests/voice/test_livekit_twilio_bridge.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import uuid
+from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 
 
 def test_build_livekit_stream_ws_url():
@@ -34,3 +36,29 @@ def test_call_session_id_from_invalid_room_name():
 
     assert _call_session_id_from_room("not-a-room") is None
     assert _call_session_id_from_room("room_not-a-uuid") is None
+
+
+@pytest.mark.asyncio
+async def test_publish_mulaw_writes_pcm_into_int16_frame_without_raising():
+    """Regression test for the same memoryview-format bug fixed in
+    _LiveKitAgentAudioPublisher.publish_mulaw (livekit_browser_call_handler.py):
+    rtc.AudioFrame.data is a memoryview already cast to int16 ("h") format,
+    so assigning a plain `bytes` object (format "B") into it raises
+    "ValueError: memoryview assignment: lvalue and rvalue have different
+    structures" unless the destination view is first cast to "B". Uses the
+    real installed livekit.rtc.AudioFrame (not a mock)."""
+    from app.utils.audio_utils import MULAW_FRAME_BYTES
+    from app.voice.livekit_twilio_bridge import LiveKitTwilioPublisher
+
+    publisher = LiveKitTwilioPublisher.__new__(LiveKitTwilioPublisher)
+    publisher._connected = True
+    publisher._source = MagicMock()
+    publisher._source.capture_frame = AsyncMock()
+
+    mulaw_bytes = bytes([0xFF]) * MULAW_FRAME_BYTES
+
+    await publisher.publish_mulaw(mulaw_bytes)
+
+    publisher._source.capture_frame.assert_awaited_once()
+    frame_arg = publisher._source.capture_frame.call_args[0][0]
+    assert bytes(frame_arg.data.cast("B")) != bytes(len(frame_arg.data.cast("B")))

--- a/tests/voice/test_rime_eventloop_and_publish_mulaw.py
+++ b/tests/voice/test_rime_eventloop_and_publish_mulaw.py
@@ -1,0 +1,188 @@
+"""
+Regression tests for two production bugs that made browser LiveKit demo
+calls (and, for bug 2, potentially the Twilio bridge path too) go silent:
+
+1. Rime TTS sync-bridge path crashes with "RuntimeError: Event loop is
+   closed" because RimeTtsService (a module-level singleton) caches a single
+   httpx.AsyncClient across calls, while RimeTTSAdapter.synthesize()'s
+   no-running-loop fallback drives each call through a brand new
+   asyncio.run() — which creates *and tears down* a fresh event loop every
+   time. httpx/httpcore's connection pool keeps idle keep-alive connections
+   bound to whichever loop was running when they were created; reusing the
+   client on a second asyncio.run() loop touches the (now-closed) first
+   loop and raises "Event loop is closed".
+
+2. _LiveKitAgentAudioPublisher.publish_mulaw() (livekit_browser_call_handler.py)
+   assigns raw `bytes` (buffer format 'B') into `frame.data[:]`, but
+   `rtc.AudioFrame.data` is a memoryview already cast to format 'h'
+   (int16) — see venv/lib/python3.12/site-packages/livekit/rtc/audio_frame.py.
+   Assigning a differently-formatted buffer into a memoryview slice raises
+   "ValueError: memoryview assignment: lvalue and rvalue have different
+   structures", even though both sides have the same total byte length.
+"""
+from __future__ import annotations
+
+import asyncio
+import http.server
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bug 1: Rime httpx.AsyncClient reused across asyncio.run() loops
+# ─────────────────────────────────────────────────────────────────────────────
+
+class _KeepAliveHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal HTTP/1.1 keep-alive server standing in for the real Rime API.
+
+    A real TCP connection (not a MockTransport) is required to reproduce the
+    bug: httpcore's connection pool only touches the anyio/asyncio transport
+    objects bound to the loop that created them when actually closing/reusing
+    a socket-backed connection.
+    """
+
+    protocol_version = "HTTP/1.1"
+
+    def do_POST(self):
+        # Must fully drain the request body before responding, otherwise the
+        # leftover bytes corrupt request framing on the next request reusing
+        # this same keep-alive connection.
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length:
+            self.rfile.read(content_length)
+
+        body = b"\xff" * 160
+        self.send_response(200)
+        self.send_header("Content-Type", "audio/x-mulaw")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args, **kwargs):  # noqa: D401 - silence test server logs
+        pass
+
+
+@pytest.fixture
+def local_rime_server():
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _KeepAliveHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://{server.server_address[0]}:{server.server_address[1]}/"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+
+def _drive_two_sequential_asyncio_run_calls(base_url: str):
+    """Mimics production: two worker-thread invocations of
+    RimeTTSAdapter.synthesize()'s asyncio.run(coro) fallback, both hitting
+    the *same* RimeTtsService singleton (and therefore the same cached
+    httpx.AsyncClient)."""
+    import app.services.rime_tts_service as rime_mod
+
+    service = rime_mod.RimeTtsService.__new__(rime_mod.RimeTtsService)
+    service._clients = {}
+    service._api_key = "test-key"
+
+    with patch.object(rime_mod, "_RIME_TTS_URL", base_url):
+        async def _one_call():
+            chunks = []
+            async for chunk in service.stream_text_to_speech(text="hello there"):
+                chunks.append(chunk)
+            return chunks
+
+        asyncio.run(_one_call())  # loop #1: creates + caches the client, then closes
+        return asyncio.run(_one_call())  # loop #2: reuses the cached client
+
+
+class TestRimeClientEventLoopSafety:
+    def test_shared_client_survives_across_asyncio_run_calls(self, local_rime_server):
+        """After the fix, a second asyncio.run() call reusing the singleton's
+        client must succeed instead of raising 'Event loop is closed'."""
+        chunks = _drive_two_sequential_asyncio_run_calls(local_rime_server)
+        assert b"".join(chunks) == b"\xff" * 160
+
+    def test_rime_tts_adapter_synthesize_survives_two_worker_thread_calls(
+        self, local_rime_server
+    ):
+        """End-to-end through the real call path exercised in production:
+        RimeTTSAdapter.synthesize() invoked twice back-to-back off the main
+        thread (as run_in_executor does), sharing the module-level
+        rime_tts_service singleton."""
+        import concurrent.futures
+
+        import app.services.rime_tts_service as rime_mod
+        from app.utils.tts_adapter import RimeTTSAdapter
+
+        # Reset the real singleton's cached clients so this test starts clean
+        # regardless of test ordering.
+        rime_mod.rime_tts_service._clients = {}
+
+        with patch.object(rime_mod, "_RIME_TTS_URL", local_rime_server), patch.object(
+            rime_mod.rime_tts_service, "_api_key", "test-key"
+        ):
+            adapter = RimeTTSAdapter.__new__(RimeTTSAdapter)
+
+            def _call():
+                return adapter.synthesize(
+                    text="hello there",
+                    voice_external_id="mistv2_Wildflower",
+                    settings_json={"speed": 1.0},
+                )
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                first = pool.submit(_call).result()
+                second = pool.submit(_call).result()
+
+        assert first == b"\xff" * 160
+        assert second == b"\xff" * 160
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bug 2: publish_mulaw() memoryview format mismatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestPublishMulawBufferFormat:
+    @pytest.mark.asyncio
+    async def test_publish_mulaw_writes_pcm_into_int16_frame_without_raising(self, caplog):
+        """Reproduces the exact production traceback: rtc.AudioFrame.data is
+        a memoryview already cast to format 'h' (int16); assigning a plain
+        `bytes` object (format 'B') into it must not raise
+        'memoryview assignment: lvalue and rvalue have different structures'.
+
+        Uses the real installed `livekit.rtc.AudioFrame` (not a mock) so the
+        test fails against the buggy code for the same reason production
+        did, and passes once publish_mulaw() writes through a same-format
+        view. publish_mulaw() catches and only logs exceptions (never
+        re-raises), so the regression is asserted via: (a) capture_frame
+        actually got called with real audio data, and (b) no
+        "publish_mulaw failed" warning was logged.
+        """
+        from app.voice.livekit_browser_call_handler import _LiveKitAgentAudioPublisher
+
+        publisher = _LiveKitAgentAudioPublisher("room-1")
+        publisher._connected = True
+        publisher._source = MagicMock()
+        publisher._source.capture_frame = AsyncMock()
+
+        # One full MULAW_FRAME_BYTES chunk of silence bytes.
+        from app.utils.audio_utils import MULAW_FRAME_BYTES
+
+        mulaw_bytes = bytes([0xFF]) * MULAW_FRAME_BYTES
+
+        # No mocking of `livekit.rtc` here — we want the real AudioFrame
+        # buffer-protocol behavior to be exercised.
+        with caplog.at_level("WARNING"):
+            await publisher.publish_mulaw(mulaw_bytes)
+
+        assert not any(
+            "publish_mulaw failed" in record.message for record in caplog.records
+        )
+        publisher._source.capture_frame.assert_awaited_once()
+        frame_arg = publisher._source.capture_frame.call_args[0][0]
+        # frame.data must contain the converted PCM16 samples, not be left
+        # empty/zeroed because the assignment silently failed.
+        assert bytes(frame_arg.data.cast("B")) != bytes(len(frame_arg.data.cast("B")))

--- a/tests/voice/test_rime_tts_and_barge_in.py
+++ b/tests/voice/test_rime_tts_and_barge_in.py
@@ -284,7 +284,7 @@ class TestRimeTTSAdapter:
         mock_client.stream.side_effect = _fake_stream_call
 
         svc = RimeTtsService()
-        svc._client = mock_client
+        svc._get_client = lambda: mock_client
 
         with patch("app.core.secret_manager.get_rime_api_key", return_value="test-key"):
             async def _run():
@@ -926,7 +926,7 @@ class TestRimeTtsService:
         mock_client = MagicMock()
         mock_client.is_closed = False
         mock_client.stream.return_value = _FakeStream()
-        svc._client = mock_client
+        svc._get_client = lambda: mock_client
 
         with patch("app.core.secret_manager.get_rime_api_key", return_value="test-key"):
 


### PR DESCRIPTION
## Summary

Users could not hear the agent on browser LiveKit demo calls. Two root causes, plus two smaller issues found while live-monitoring server logs:

- **Rime TTS "Event loop is closed"**: `RimeTtsService` cached a single `httpx.AsyncClient` across calls, but the sync bridge in `RimeTTSAdapter.synthesize()` ran each call via `asyncio.run()`, creating and destroying a fresh event loop every time. Reusing the cached client across those throwaway loops corrupted it once a stale connection bound to an already-closed loop was touched. Fixed with a single persistent background thread running one dedicated event loop for the process's lifetime, plus per-loop client caching as defense in depth.
- **`publish_mulaw()` memoryview crash**: wrote raw bytes directly into `livekit.rtc.AudioFrame.data`, which is always an int16-typed memoryview, raising `ValueError: memoryview assignment: lvalue and rvalue have different structures` on every publish. Fixed with `.cast("B")` before assignment. Found and fixed the identical latent bug in `livekit_twilio_bridge.py`'s `LiveKitTwilioPublisher` (the live Twilio call-recording mirror), which had been silently failing there since that feature shipped.
- **Audit log silently drops entries**: `log_audit_event()` raised (and silently swallowed) `TypeError` whenever `old_value`/`new_value` contained a `datetime`, `UUID`, or `Decimal` — e.g. any call site passing a raw Pydantic `.model_dump()` dict, as every call in `call_flows.py` does. Now JSON-safe-serializes both fields centrally so no caller needs to worry about it.
- **Stray post-shutdown STT session**: `SttPipeline.feed_audio_chunk()` lazily reopened a brand-new provider session for a trailing chunk arriving after `aclose()` (e.g. an ffmpeg buffer flush racing the call's own shutdown), opening a session that could never receive further audio and errored ~12s later with a misleading timeout. `aclose()` now marks the pipeline closed so a late feed is a no-op.

## Test plan
- [x] New/updated regression tests for all 4 fixes, each confirmed to fail against pre-fix code and pass post-fix
- [x] Full `tests/voice/` + STT + audit suites pass (239 tests)
- [x] Full `tests/api/` suite passes (917 tests)
- [x] `ruff check` clean on all changed files
- [ ] Manual verification on a real browser demo-link call (agent voice audible, clean shutdown with no stray STT errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)