### PR TITLE
Browser call recording gate, workspace RBAC, call-flow analytics, folder move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ Multi-tenant SaaS Voice Agent Backend. Tenants configure AI voice agents that ha
 
 ## Common Commands
 
+Activate the project's own venv first — `source venv/bin/activate` — the system `python3` does not have this repo's dependencies installed.
+
 ```bash
 # Dev server
 uvicorn app.main:app --reload
@@ -242,6 +244,19 @@ LiveKit audio → LiveKitAudioSubscriber
 ```
 
 Mixins (`BookingMixin`, `CallControlMixin`, `TtsStreamMixin`) are composed into orchestrator classes. State shared across turns is persisted in `callsession` + `transcript_message` tables — never held in memory across requests.
+
+**Two call transports share this pipeline, with two separate handler implementations:**
+
+| | `app/routers/bidirectional_stream.py`'s `BidirectionalStreamHandler` | `app/voice/livekit_browser_call_handler.py`'s `LiveKitBrowserCallHandler` |
+|---|---|---|
+| Transport | Twilio Media Streams (MULAW over WebSocket) | Browser WebRTC via LiveKit ("Share Demo Link" feature, `POST /api/v1/sdk/demo/{token}/call-token`) |
+| STT / LLM orchestration | `SttPipeline`, `ConversationOrchestrator`, `TtsPipeline` — **reused unmodified** by both handlers | same |
+| TTS synthesis-to-publish | `TtsStreamMixin._prefetch_tts_audio`/`_stream_tts_chunk` — true incremental provider streaming (`adapter.async_stream_synthesize()`), audio reaches the caller within ~100-300ms | Its own `_prefetch_tts_audio`/`_publish_mulaw_stream` — mirrors the same true-streaming approach as of the browser/Twilio parity work |
+| Call recording | `_start_livekit_recording()` creates a **separate mirror LiveKit room** + duplicate caller/agent publishers purely for egress, since a Twilio call has no native LiveKit room | `_start_browser_call_recording()` starts egress directly on the call's **own existing** room — no mirror room needed |
+
+Both handlers are deliberately parallel, not shared via inheritance (per `livekit_browser_call_handler.py`'s own module docstring) — when changing STT/LLM/TTS-scheduling behavior, changes to the shared classes apply to both transports automatically; transport-specific behavior (recording, barge-in publish mechanics, greeting/audio format) must be changed in each handler separately.
+
+Browser-call recording is gated by `recording_config_service.get_recording_enabled_for_call()`, which resolves via phone-number lookup for Twilio calls but short-circuits to `VOICE_BROWSER_DEMO_RECORDING_ENABLED` (env var, default off) for `call_type == "web"` — there is no per-tenant/agent recording toggle in the schema yet for browser calls.
 
 ### Smart Callback Scheduler
 

--- a/app/api/api_v1/endpoints/workspace.py
+++ b/app/api/api_v1/endpoints/workspace.py
@@ -1,6 +1,8 @@
 """Workspace (tenant) management endpoints — API-key authenticated.
 
-Every endpoint requires a valid API key resolved by :class:`ApiKeyMiddleware`.
+Every endpoint requires a valid API key resolved by :class:`ApiKeyMiddleware`,
+**except** ``PUT /name``, which additionally accepts a JWT user with at least
+``config_only`` rank in the workspace (see ``require_config_or_api_key``).
 Endpoints addressing a specific workspace return ``403`` if the authenticated
 workspace id does not match the URL/target workspace.
 """
@@ -13,12 +15,18 @@ from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, get_workspace_api_key, require_config
-from app.core.request_auth import get_workspace_from_request
+from app.api.deps import (
+    get_db,
+    get_workspace_api_key,
+    require_config,
+    require_config_or_api_key,
+)
+from app.core.request_auth import ApiKeyPrincipal, get_workspace_from_request
 from app.core.config import settings
 from app.core.logger import logger
 from app.core.workspace import Workspace
 from app.models.tenant import Tenant
+from app.models.user import User
 from app.repositories.workspace_repository import WorkspaceRepository
 from app.schemas.base import SuccessResponse
 from app.schemas.integration import MakeSecretResponse, N8nSecretResponse
@@ -57,6 +65,10 @@ _DB_ERROR = HTTPException(
     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
     detail="Database error",
 )
+
+
+def _workspace_id(principal: User | ApiKeyPrincipal) -> uuid.UUID:
+    return principal.current_tenant_id
 
 
 def _ensure_same_workspace(target: uuid.UUID, authed: uuid.UUID) -> None:
@@ -111,6 +123,17 @@ async def _parse_update_name_body(request: Request) -> WorkspaceUpdateName:
     status_code=status.HTTP_201_CREATED,
     summary="Create a new workspace",
     responses={**_COMMON_ERROR_RESPONSES, 201: {"description": "Workspace created — flat body: {id, name, createdAt}"}},
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": WorkspaceCreate.model_json_schema(),
+                    "example": {"name": "Acme Corp"},
+                }
+            },
+        }
+    },
 )
 def create_workspace(
     request: Request,
@@ -189,17 +212,29 @@ def get_workspace_by_id(
     response_model_by_alias=True,
     summary="Update the authenticated workspace's name",
     responses=_COMMON_ERROR_RESPONSES,
+    openapi_extra={
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": WorkspaceUpdateName.model_json_schema(),
+                    "example": {"name": "Acme Corp"},
+                }
+            },
+        }
+    },
 )
 def update_workspace_name(
     request: Request,
     payload: WorkspaceUpdateName = Depends(_parse_update_name_body),
-    authed: Workspace = Depends(get_workspace_api_key),
+    principal: User | ApiKeyPrincipal = Depends(require_config_or_api_key),
     repo: WorkspaceRepository = Depends(_repository),
     db: Session = Depends(get_db),
 ):
     """Update the name of the authenticated workspace. 409 on duplicate name."""
+    workspace_id = _workspace_id(principal)
     try:
-        tenant = repo.find_by_id(authed.id)
+        tenant = repo.find_by_id(workspace_id)
         if tenant is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -230,10 +265,11 @@ def update_workspace_name(
     log_audit_event(
         db,
         request=request,
-        tenant_id=authed.id,
+        tenant_id=workspace_id,
+        actor_user_id=principal.id if isinstance(principal, User) else None,
         action="workspace.updated",
         resource_type="workspace",
-        resource_id=authed.id,
+        resource_id=workspace_id,
         old_value={"name": old_name},
         new_value={"name": payload.name},
     )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -537,6 +537,13 @@ class Settings(BaseSettings):
     VOICE_TTS_FLUSH_MAX_WORDS: int = 6
     # If no sentence boundary yet, flush after this many seconds (once min words met).
     VOICE_TTS_TIME_FLUSH_SEC: float = 0.10
+    # Browser "Share Demo Link" calls (app.voice.livekit_browser_call_handler) have no
+    # Twilio phone number, so recording_config_service.get_recording_enabled_for_call's
+    # NumberConfiguration lookup can never resolve for them (assistant_phone_number is
+    # the literal string "web_agent"). There is currently no per-tenant/agent/call-flow
+    # recording toggle independent of a phone number — this is a process-wide interim
+    # default until that's added via a proper schema change (flag for db-migration).
+    VOICE_BROWSER_DEMO_RECORDING_ENABLED: bool = False
     # Keep a short (but non-zero) guard after pickup so ringback artifacts are skipped
     # without delaying real user speech by multiple seconds.
     VOICE_POST_PICKUP_STT_GRACE_SEC: float = 0.35

--- a/app/routers/folders.py
+++ b/app/routers/folders.py
@@ -8,7 +8,12 @@ from sqlalchemy.orm import Session
 from app.api.deps import get_db, require_tenant
 from app.core.request_auth import ApiKeyPrincipal
 from app.models.user import User
-from app.schemas.folder import AddFlowToFolderRequest, FolderCreate, FolderUpdate
+from app.schemas.folder import (
+    AddFlowToFolderRequest,
+    FolderCreate,
+    FolderUpdate,
+    MoveFlowRequest,
+)
 from app.services.folder_service import folder_service
 
 router = APIRouter()
@@ -45,7 +50,9 @@ def update_folder(
     return folder_service.update_folder(db, folder_id, _workspace_id(principal), body)
 
 
-@router.delete("/{folder_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response)
+@router.delete(
+    "/{folder_id}", status_code=status.HTTP_204_NO_CONTENT, response_class=Response
+)
 def delete_folder(
     folder_id: uuid.UUID,
     principal: User | ApiKeyPrincipal = Depends(require_tenant),
@@ -91,3 +98,16 @@ def remove_flow_from_folder(
         db, folder_id, _workspace_id(principal), flow_id
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.put("/{folder_id}/flows/{flow_id}/move", status_code=status.HTTP_200_OK)
+def move_flow_to_folder(
+    folder_id: uuid.UUID,
+    flow_id: uuid.UUID,
+    body: MoveFlowRequest,
+    principal: User | ApiKeyPrincipal = Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    return folder_service.move_flow_to_folder(
+        db, folder_id, body.target_folder_id, _workspace_id(principal), flow_id
+    )

--- a/app/schemas/folder.py
+++ b/app/schemas/folder.py
@@ -37,6 +37,12 @@ class AddFlowToFolderRequest(BaseModel):
     flow_id: uuid.UUID = Field(..., alias="flowId")
 
 
+class MoveFlowRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    target_folder_id: uuid.UUID = Field(..., alias="targetFolderId")
+
+
 class FolderListResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -15,6 +15,7 @@ from app.models.call_session import CallSession
 from app.models.prompt_version import PromptVersion
 from app.repositories.call_flow_repository import CallFlowRepository
 from app.repositories.prompt_version_repository import PromptVersionRepository
+from app.services.call_history_service import call_history_service
 from app.schemas.agent import agent_to_out
 from app.schemas.ab_testing import (
     AbResultsResponse,
@@ -299,6 +300,10 @@ class CallFlowService:
         repo = CallFlowRepository(db)
         rows, total = repo.find_by_workspace(tenant_id, page=page, limit=limit)
         folder_ids_map = repo.find_folder_ids_map([f.id for f in rows])
+        # Tenant-wide across every call flow/agent — NOT scoped to this page's
+        # flows or affected by pagination. Callers must not assume it reflects
+        # only the `data` rows returned above.
+        metrics = call_history_service.get_metrics(db, tenant_id)
         return {
             "data": [
                 self.flow_to_list_item(f, folder_ids_map.get(f.id, [])) for f in rows
@@ -306,6 +311,11 @@ class CallFlowService:
             "total": total,
             "page": page,
             "pageSize": limit,
+            "analytics": {
+                "totalCalls": metrics.total_calls,
+                "successRatePercent": metrics.success_rate_percent,
+                "averageDurationSeconds": metrics.avg_duration_seconds,
+            },
         }
 
     def update_flow(

--- a/app/services/folder_service.py
+++ b/app/services/folder_service.py
@@ -1,4 +1,5 @@
 """Folder service — organise call flows into tenant-scoped folders."""
+
 from __future__ import annotations
 
 import uuid
@@ -119,6 +120,60 @@ class FolderService:
 
         repo.remove_flow(link)
         db.commit()
+
+    def move_flow_to_folder(
+        self,
+        db: Session,
+        source_folder_id: uuid.UUID,
+        target_folder_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        flow_id: uuid.UUID,
+    ) -> dict:
+        """Move a flow from ``source_folder_id`` to ``target_folder_id``.
+
+        A flow can belong to multiple folders simultaneously, but "move"
+        means: remove it from the source folder and ensure it's linked to
+        the target folder — skipping duplicate-link creation if it's
+        already in the target.
+        """
+        self._get_folder_or_404(db, source_folder_id, tenant_id)
+        self._get_folder_or_404(db, target_folder_id, tenant_id)
+
+        if source_folder_id == target_folder_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="source and target folder must differ",
+            )
+
+        cf_repo = CallFlowRepository(db)
+        flow = cf_repo.find_by_id(flow_id, tenant_id=tenant_id)
+        if flow is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Call flow {flow_id} not found in workspace",
+            )
+
+        repo = FolderRepository(db)
+        source_link = repo.find_folder_flow(source_folder_id, flow_id)
+        if source_link is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Call flow {flow_id} is not in folder {source_folder_id}",
+            )
+
+        repo.remove_flow(source_link)
+
+        target_link = repo.find_folder_flow(target_folder_id, flow_id)
+        if target_link is None:
+            repo.add_flow(target_folder_id, flow_id)
+
+        db.commit()
+
+        return {
+            "flowId": str(flow_id),
+            "sourceFolderId": str(source_folder_id),
+            "targetFolderId": str(target_folder_id),
+        }
 
     def list_flows_in_folder(
         self, db: Session, folder_id: uuid.UUID, tenant_id: uuid.UUID

--- a/app/services/recording_config_service.py
+++ b/app/services/recording_config_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.logger import logger
 from app.models.call_session import CallSession
 from app.models.phone_number import NumberConfiguration, PhoneNumber
@@ -18,15 +19,27 @@ from app.models.phone_number import NumberConfiguration, PhoneNumber
 
 def get_recording_enabled_for_call(db: Session, call_session: CallSession) -> bool:
     """
-    Return True if recording is enabled for the phone number on this call.
+    Return True if recording is enabled for this call.
 
-    Resolution order:
+    Twilio calls (inbound/outbound) resolution order:
     1. call_session.assistant_phone_number (set on outbound and inbound calls)
     2. call_session.to_number (fallback for inbound — the number the caller dialled)
     3. call_session.from_number (last resort for outbound)
-
     Returns False if no NumberConfiguration is found (safe default).
+
+    Browser "Share Demo Link" calls (app.voice.livekit_browser_call_handler,
+    call_session.call_type == "web") have no Twilio phone number at all —
+    assistant_phone_number is the literal sentinel "web_agent" (see
+    app.routers.sdk::demo_call_token), which would never match a real
+    NumberConfiguration row. There is currently no per-tenant/agent/call-flow
+    recording toggle for this path, so it's gated on a single process-wide
+    flag (VOICE_BROWSER_DEMO_RECORDING_ENABLED, default False) instead — an
+    interim default until a proper per-tenant/agent config field is added via
+    a schema change (flag for db-migration).
     """
+    if (call_session.call_type or "").lower() == "web":
+        return bool(settings.VOICE_BROWSER_DEMO_RECORDING_ENABLED)
+
     phone_number_str = _resolve_phone_number(call_session)
     if not phone_number_str:
         return False

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -182,7 +182,16 @@ class _LiveKitAgentAudioPublisher:
             return False
 
     async def publish_mulaw(self, mulaw_bytes: bytes, cancel: asyncio.Event | None = None) -> None:
-        """Push mu-law bytes into the outgoing track, converting to PCM16 per frame."""
+        """
+        Push mu-law bytes into the outgoing track, converting to PCM16 per frame.
+
+        Callable with an arbitrary-length buffer (legacy/whole-utterance
+        callers) or with a single already-frame-aligned MULAW_FRAME_BYTES
+        chunk (the incremental streaming path in
+        LiveKitBrowserCallHandler._publish_mulaw_stream) — either way, any
+        final partial frame is padded with mu-law silence (0xFF) rather than
+        dropped.
+        """
         if not self._connected or not self._source or not mulaw_bytes:
             return
         try:
@@ -498,31 +507,207 @@ class LiveKitBrowserCallHandler:
         return
 
     # ── TTS synthesis + LiveKit-native playback ─────────────────────────────
+    #
+    # _prefetch_tts_audio / _stream_tts_chunk below mirror
+    # TtsStreamMixin._prefetch_tts_audio / _stream_tts_chunk
+    # (app/voice/tts_stream_mixin.py) so this path gets the provider's *true*
+    # incremental streaming API (Rime/ElevenLabs async_stream_synthesize,
+    # Google's stream_text_to_speech) instead of buffering a whole
+    # utterance's mu-law bytes via generate_mulaw_tts() before publishing
+    # anything — the first audio now reaches the LiveKit room as soon as the
+    # provider emits its first chunk, matching the Twilio path's latency
+    # characteristics. generate_mulaw_tts() is kept imported only as a last-
+    # resort fallback for providers/paths that expose neither streaming API.
 
-    async def _prefetch_tts_audio(self, task: dict) -> bytes | None:
-        """Synthesize a TTS chunk to raw mu-law bytes (see module docstring for format rationale)."""
+    async def _prefetch_tts_audio(self, task: dict) -> Any:
+        """
+        Resolve the TTS provider's real streaming API for this chunk and
+        return an async iterator of raw mu-law byte fragments as they're
+        generated (or None on empty text / cancellation / unresolvable
+        provider). Never buffers the whole utterance itself — TtsPipeline
+        awaits this to get the iterator object, then _stream_tts_chunk
+        below actually drains it while publishing incrementally.
+        """
         text = (task.get("text") or "").strip()
         if not text or self._tts_cancel.is_set():
             return None
         use_ssml = bool(task.get("use_ssml", False))
+
         try:
+            from app.core.agent_runtime import resolve_tts_runtime
+            from app.services.google_tts_service import google_tts_service
+            from app.utils.eleven_tts_text import prepare_tts_text_for_provider
+            from app.utils.tts_adapter import get_tts_adapter
+
             lang = self.agent.language if self.agent and self.agent.language else "en"
             voice = self.agent.voice_type if self.agent and self.agent.voice_type else "female"
-            audio_bytes = await generate_mulaw_tts(
-                text=text,
-                lang=lang,
-                voice=voice,
-                use_chirp3_hd=True,
+            tts_runtime = resolve_tts_runtime(self.agent, db=self.db)
+            tts_provider_slug = tts_runtime.adapter_slug
+
+            streaming_text = strip_ssml_tags(text) if use_ssml or text.lstrip().startswith("<speak>") else text
+            streaming_text = prepare_tts_text_for_provider(streaming_text, tts_provider_slug)
+            if not streaming_text or not streaming_text.strip():
+                return None
+
+            if tts_provider_slug and tts_provider_slug not in ("google", ""):
+                external_voice_id = tts_runtime.voice_external_id
+                if not external_voice_id:
+                    tts_voice = getattr(self.agent, "tts_voice", None) if self.agent else None
+                    external_voice_id = getattr(tts_voice, "external_voice_id", None)
+                if not external_voice_id and tts_provider_slug == "rime":
+                    external_voice_id = "mistv2_Wildflower"
+                if not external_voice_id:
+                    logger.warning(
+                        "[LiveKitBrowserCall] TTS voice not configured for streaming provider=%s",
+                        tts_provider_slug,
+                    )
+                    return None
+
+                adapter = get_tts_adapter(tts_provider_slug)
+                provider_settings = dict(tts_runtime.settings_json)
+                if tts_provider_slug == "elevenlabs":
+                    provider_settings.setdefault("output_format", "ulaw_8000")
+                    previous_text = (self._elevenlabs_prev_tts_text or "").strip()
+                    if previous_text:
+                        provider_settings["previous_text"] = previous_text[-500:]
+                elif tts_provider_slug == "rime":
+                    # Rime uses async_stream_synthesize — no output_format key needed
+                    # (mulaw 8 kHz is the default in RimeTTSAdapter).
+                    pass
+                else:
+                    provider_settings.setdefault("output_format", "ulaw_8000")
+
+                # Prefer true async streaming for providers that support it (Rime, ElevenLabs).
+                if hasattr(adapter, "async_stream_synthesize"):
+                    _cancel_ref = self._tts_cancel
+
+                    async def _async_provider_iter(
+                        _adapter=adapter,
+                        _text=streaming_text,
+                        _vid=external_voice_id,
+                        _cfg=provider_settings,
+                        _cancel=_cancel_ref,
+                    ):
+                        async for chunk in _adapter.async_stream_synthesize(
+                            text=_text,
+                            voice_external_id=_vid,
+                            settings_json=_cfg,
+                        ):
+                            if _cancel.is_set():
+                                break
+                            if chunk:
+                                yield chunk
+
+                    return _async_provider_iter()
+
+                sync_iter = adapter.stream_synthesize(
+                    text=streaming_text,
+                    voice_external_id=external_voice_id,
+                    settings_json=provider_settings,
+                )
+
+                async def _async_iter_from_sync(sync_source):
+                    iterator = iter(sync_source)
+                    sentinel = object()
+                    while True:
+                        if self._tts_cancel.is_set():
+                            break
+                        chunk = await asyncio.to_thread(next, iterator, sentinel)
+                        if chunk is sentinel:
+                            break
+                        if chunk:
+                            yield chunk
+
+                return _async_iter_from_sync(sync_iter)
+
+            # Google (or unresolved provider): native async streaming API.
+            tts_voice = getattr(self.agent, "tts_voice", None) if self.agent else None
+            google_voice_name = getattr(tts_voice, "external_voice_id", None)
+            audio_iter = google_tts_service.stream_text_to_speech(
+                text=streaming_text,
+                language=lang,
+                voice_type=voice,
                 speaking_rate=1.0,
-                use_ssml=use_ssml,
-                add_office_bg=False,
-                agent=self.agent,
-                db=self.db,
+                output_format="mulaw",
+                use_chirp3_hd=True,
+                sample_rate_hz=_AGENT_AUDIO_SAMPLE_RATE,
+                voice_name_override=google_voice_name,
             )
-            return audio_bytes or None
+
+            async def _checked_async_iter(source_iter):
+                async for chunk in source_iter:
+                    if self._tts_cancel.is_set():
+                        break
+                    if chunk:
+                        yield chunk
+
+            return _checked_async_iter(audio_iter)
         except Exception as exc:
-            logger.warning("[LiveKitBrowserCall] TTS synthesis failed for %r: %s", text[:30], exc)
-            return None
+            logger.warning(
+                "[LiveKitBrowserCall] TTS streaming setup failed for %r: %s — "
+                "falling back to whole-utterance synthesis", text[:30], exc,
+            )
+            if self._tts_cancel.is_set():
+                return None
+            try:
+                lang = self.agent.language if self.agent and self.agent.language else "en"
+                voice = self.agent.voice_type if self.agent and self.agent.voice_type else "female"
+                return await generate_mulaw_tts(
+                    text=text,
+                    lang=lang,
+                    voice=voice,
+                    use_chirp3_hd=True,
+                    speaking_rate=1.0,
+                    use_ssml=use_ssml,
+                    add_office_bg=False,
+                    agent=self.agent,
+                    db=self.db,
+                ) or None
+            except Exception as fallback_exc:
+                logger.warning(
+                    "[LiveKitBrowserCall] TTS fallback synthesis also failed for %r: %s",
+                    text[:30], fallback_exc,
+                )
+                return None
+
+    async def _publish_mulaw_stream(
+        self,
+        publisher: "_LiveKitAgentAudioPublisher",
+        audio_iter: Any,
+        cancel: asyncio.Event,
+    ) -> None:
+        """
+        Drain an async iterator of provider mu-law fragments and publish each
+        full MULAW_FRAME_BYTES frame into the LiveKit room as soon as it's
+        assembled — mirrors TtsStreamMixin._stream_tts_chunk's
+        stream_mulaw_from_audio_iter, but targets publisher.publish_mulaw()
+        instead of the Twilio WebSocket. Frames are aligned across provider
+        chunk boundaries (buffered, not padded per-chunk) so an arbitrary
+        provider fragment size never introduces mid-utterance silence
+        padding — only the final remainder gets padded.
+        """
+        byte_buf = bytearray()
+        async for chunk_bytes in audio_iter:
+            if cancel.is_set():
+                return
+            if not chunk_bytes:
+                continue
+            byte_buf.extend(chunk_bytes)
+            while len(byte_buf) >= MULAW_FRAME_BYTES:
+                frame = bytes(byte_buf[:MULAW_FRAME_BYTES])
+                del byte_buf[:MULAW_FRAME_BYTES]
+                await publisher.publish_mulaw(frame, cancel=cancel)
+                if cancel.is_set():
+                    return
+
+        if cancel.is_set():
+            return
+
+        if byte_buf:
+            pad = MULAW_FRAME_BYTES - (len(byte_buf) % MULAW_FRAME_BYTES)
+            if pad != MULAW_FRAME_BYTES:
+                byte_buf.extend(bytes([0xFF]) * pad)
+            await publisher.publish_mulaw(bytes(byte_buf), cancel=cancel)
 
     async def _stream_tts_chunk(
         self,
@@ -545,18 +730,43 @@ class LiveKitBrowserCallHandler:
         async with self._tts_lock:
             self.is_speaking = True
             try:
-                mulaw_bytes = prefetched_bytes if isinstance(prefetched_bytes, (bytes, bytearray)) else None
-                if mulaw_bytes is None:
-                    mulaw_bytes = await self._prefetch_tts_audio({"text": text, "use_ssml": use_ssml})
-                if not mulaw_bytes or self._tts_cancel.is_set():
+                source = prefetched_bytes
+                if source is None:
+                    source = await self._prefetch_tts_audio({"text": text, "use_ssml": use_ssml})
+                if source is None or self._tts_cancel.is_set():
                     return
 
                 self._is_tts_playing = True
-                logger.debug(
-                    "[LiveKitBrowserCall] LiveKit playback: publishing %d mu-law bytes "
-                    "(call_session_id=%s)", len(mulaw_bytes), self.call_session_id,
-                )
-                await publisher.publish_mulaw(mulaw_bytes, cancel=self._tts_cancel)
+
+                if hasattr(source, "__aiter__"):
+                    logger.debug(
+                        "[LiveKitBrowserCall] LiveKit playback: streaming TTS chunk "
+                        "incrementally (call_session_id=%s)", self.call_session_id,
+                    )
+                    await self._publish_mulaw_stream(publisher, source, self._tts_cancel)
+
+                    # Mirrors TtsStreamMixin._stream_tts_chunk: record the text
+                    # just streamed as ElevenLabs "previous_text" context for the
+                    # next chunk's prosody continuity, once streaming completes
+                    # (not at prefetch time — that runs concurrently with the
+                    # prior chunk still playing and would race the ordering).
+                    if not self._tts_cancel.is_set():
+                        try:
+                            from app.core.agent_runtime import resolve_tts_runtime
+
+                            if resolve_tts_runtime(self.agent, db=self.db).adapter_slug == "elevenlabs":
+                                self._elevenlabs_prev_tts_text = text.strip()[-500:]
+                        except Exception:  # noqa: S110 - best-effort continuity hint only
+                            pass
+                elif isinstance(source, (bytes, bytearray)) and source:
+                    # Defensive fallback: _prefetch_tts_audio always returns an
+                    # async iterator or None above, but keep this path so a
+                    # caller passing raw bytes directly (e.g. tests) still works.
+                    logger.debug(
+                        "[LiveKitBrowserCall] LiveKit playback: publishing %d mu-law bytes "
+                        "(call_session_id=%s)", len(source), self.call_session_id,
+                    )
+                    await publisher.publish_mulaw(source, cancel=self._tts_cancel)
             finally:
                 self.is_speaking = False
                 self._is_tts_playing = False
@@ -575,6 +785,82 @@ def _forced_browser_stt_runtime(resolved: Any) -> Any:
         sample_rate_hz=_STT_INPUT_SAMPLE_RATE,
         encoding=_STT_INPUT_ENCODING,
     )
+
+
+async def _start_browser_call_recording(db, call_session) -> str | None:
+    """
+    Start a room-composite egress on the call's own native LiveKit room
+    (room_{call_session.id} — already created for the caller/agent by
+    demo_call_token / _LiveKitAgentAudioPublisher.connect(), unlike the
+    Twilio path which has to stand up a *separate* mirror room + duplicate
+    publishers purely for recording since a plain Twilio call has no
+    native LiveKit room of its own).
+
+    Fail-open: any error here must never abort or degrade the actual call —
+    same convention as BidirectionalStreamHandler._start_livekit_recording.
+    Returns the egress_id on success, None otherwise (including when
+    recording is disabled for this call).
+    """
+    from app.services.recording_config_service import get_recording_enabled_for_call
+
+    try:
+        if not get_recording_enabled_for_call(db, call_session):
+            return None
+
+        from app.services.livekit_recording_service import livekit_recording_service
+        from app.services.s3_recording_service import build_s3_key
+
+        gcs_path = build_s3_key(
+            workspace_id=call_session.tenant_id,
+            call_id=call_session.id,
+            end_time=call_session.end_time,
+        )
+        egress_id = await livekit_recording_service.start_room_recording(
+            call_id=call_session.id,
+            workspace_id=call_session.tenant_id,
+            gcs_path=gcs_path,
+        )
+        if not egress_id:
+            return None
+
+        meta = dict(call_session.call_metadata or {})
+        # Same shape Twilio's _start_livekit_recording stores under
+        # call_metadata["recording"] — call_recording_upload_service reads
+        # exactly these two keys (egress_id, gcs_path) and needs no changes
+        # to pick up browser-call recordings.
+        meta["recording"] = {"egress_id": egress_id, "gcs_path": gcs_path}
+        call_session.call_metadata = meta
+        db.commit()
+        logger.info(
+            "[LiveKitBrowserCall] recording started: session=%s egress_id=%s",
+            call_session.id, egress_id,
+        )
+        return egress_id
+    except Exception as exc:
+        logger.warning(
+            "[LiveKitBrowserCall] could not start recording for session %s: %s",
+            call_session.id, exc,
+        )
+        return None
+
+
+async def _stop_browser_call_recording(call_session_id: uuid.UUID, egress_id: str | None) -> None:
+    """Stop the egress (if one was started) then schedule the S3 upload/finalize job."""
+    if not egress_id:
+        return
+    try:
+        from app.services.livekit_recording_service import livekit_recording_service
+
+        await livekit_recording_service.stop_room_recording(egress_id)
+    except Exception as exc:
+        logger.debug("[LiveKitBrowserCall] recording stop failed: %s", exc)
+
+    try:
+        from app.services.call_recording_upload_service import schedule_recording_upload
+
+        schedule_recording_upload(call_session_id)
+    except Exception as exc:
+        logger.debug("[LiveKitBrowserCall] schedule_recording_upload failed: %s", exc)
 
 
 async def _load_browser_call_context(db, call_session_id: uuid.UUID):
@@ -643,6 +929,7 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
     # attempt in dashboards/analytics and (via update_call_session_status)
     # trigger CRM write-back scheduling for a call nothing ever happened on.
     agent_joined = False
+    recording_egress_id: str | None = None
 
     try:
         call_session, agent, call_flow = await _load_browser_call_context(db, call_session_id)
@@ -681,6 +968,9 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
             logger.error("[LiveKitBrowserCall] failed to connect TTS publisher room=%s", room_name)
             return
         handler._agent_publisher = publisher
+
+        # ── Recording (fail-open — never aborts/degrades the call) ──────────
+        recording_egress_id = await _start_browser_call_recording(db, call_session)
 
         # Detect the caller leaving / our own connection dropping via the
         # publisher's room object (the one connection we own directly here).
@@ -764,6 +1054,13 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
                 await voice_orchestrator.shutdown()
         except Exception as exc:
             logger.debug("[LiveKitBrowserCall] voice_orchestrator shutdown failed: %s", exc)
+
+        # ── Recording teardown (mirrors Twilio's _full_shutdown ordering:
+        # stop the egress, then schedule the async S3 finalize/upload job) ──
+        try:
+            await _stop_browser_call_recording(call_session_id, recording_egress_id)
+        except Exception as exc:
+            logger.debug("[LiveKitBrowserCall] recording teardown failed: %s", exc)
 
         if audio_subscriber is not None:
             try:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -772,6 +772,27 @@ paths:
       description: Create a new workspace. Name must be unique among active workspaces
         (3–50 chars).
       operationId: create_workspace_api_v1_workspace_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 50
+                  minLength: 3
+                  title: Name
+                  examples:
+                  - Acme Corp
+              additionalProperties: false
+              type: object
+              required:
+              - name
+              title: WorkspaceCreate
+              description: Request body for ``POST /api/v1/workspace``.
+            example:
+              name: Acme Corp
+        required: true
       responses:
         '201':
           description: 'Workspace created — flat body: {id, name, createdAt}'
@@ -875,6 +896,27 @@ paths:
       description: Update the name of the authenticated workspace. 409 on duplicate
         name.
       operationId: update_workspace_name_api_v1_workspace_name_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  maxLength: 50
+                  minLength: 3
+                  title: Name
+                  examples:
+                  - Acme Corp
+              additionalProperties: false
+              type: object
+              required:
+              - name
+              title: WorkspaceUpdateName
+              description: Request body for ``PUT /api/v1/workspace/name``.
+            example:
+              name: Acme Corp
+        required: true
       responses:
         '200':
           description: Successful Response
@@ -1923,6 +1965,47 @@ paths:
       responses:
         '204':
           description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/folders/{folder_id}/flows/{flow_id}/move:
+    put:
+      tags:
+      - Folders
+      summary: Move Flow To Folder
+      operationId: move_flow_to_folder_api_v1_folders__folder_id__flows__flow_id__move_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: folder_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Folder Id
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MoveFlowRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
         '422':
           description: Validation Error
           content:
@@ -14649,6 +14732,17 @@ components:
       type: object
       title: ModelUpdate
       description: Schema for updating a model
+    MoveFlowRequest:
+      properties:
+        targetFolderId:
+          type: string
+          format: uuid
+          title: Targetfolderid
+      additionalProperties: false
+      type: object
+      required:
+      - targetFolderId
+      title: MoveFlowRequest
     N8nSecretResponse:
       properties:
         secret:

--- a/docs/rbac-matrix.md
+++ b/docs/rbac-matrix.md
@@ -171,6 +171,12 @@ their pre-existing `require_tenant` / legacy-alias gating, listed in the
 
 All 5 endpoints (create/list/get/update/delete): `admin`.
 
+### Workspace name update — `app/api/api_v1/endpoints/workspace.py`
+
+| Method | Path | Min role | Notes |
+|---|---|---|---|
+| PUT | `/api/v1/workspace/name` | `config_only` | also accepts API-key principals; the one endpoint in this router (otherwise API-key-only) that accepts a JWT user |
+
 ### Web SDK domain whitelist — `app/api/api_v1/endpoints/allowed_domains.py`
 
 | Method | Path | Min role | Notes |

--- a/tests/api/test_call_flows.py
+++ b/tests/api/test_call_flows.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import uuid
 from contextlib import contextmanager
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -149,6 +150,41 @@ def _create_body(agent_id: uuid.UUID, **overrides) -> dict:
     }
     body.update(overrides)
     return body
+
+
+def _make_call_session(
+    db,
+    *,
+    tenant: Tenant,
+    agent: Agent,
+    status: str = "completed",
+    duration: int | None = None,
+    call_flow_id: uuid.UUID | None = None,
+) -> CallSession:
+    """Directly inserts a CallSession row for analytics-aggregation tests."""
+    user = User(
+        email=f"cs-user-{uuid.uuid4().hex[:8]}@example.com",
+        first_name="CS",
+        last_name="User",
+        hashed_password="",
+        current_tenant_id=tenant.id,
+    )
+    db.add(user)
+    db.flush()
+
+    session = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=tenant.id,
+        call_flow_id=call_flow_id,
+        status=status,
+        duration=duration,
+        start_time=datetime.utcnow(),
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+    return session
 
 
 # ──────────────────────────────────────────────────────────────── tests ──
@@ -611,6 +647,183 @@ class TestListCallFlows:
             assert "agent" in item
             assert item["agent"]["name"] == test_agent.name
             assert item["folderIds"] == []
+
+
+@pytest.mark.usefixtures("db")
+class TestListCallFlowsAnalytics:
+    def test_analytics_key_present_with_expected_fields(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, name="Analytics Flow"),
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.get(
+            "/api/v1/call-flows",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "analytics" in body
+        analytics = body["analytics"]
+        assert set(analytics.keys()) == {
+            "totalCalls",
+            "successRatePercent",
+            "averageDurationSeconds",
+        }
+
+    def test_analytics_zero_calls_returns_null_rate_and_duration(
+        self, authed_client, auth_tenant, test_agent
+    ):
+        authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, name="No Calls Flow"),
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.get(
+            "/api/v1/call-flows",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        analytics = resp.json()["analytics"]
+        assert analytics["totalCalls"] == 0
+        assert analytics["successRatePercent"] is None
+        assert analytics["averageDurationSeconds"] is None
+
+    def test_analytics_aggregates_across_flows_and_agents(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        # NOTE: `agent` has a single-row-per-tenant unique index in this test
+        # DB (sqlite doesn't honour the Postgres-only partial-index predicate
+        # on `uq_agent_single_follow_up_per_tenant`), so a second Agent per
+        # tenant can't be created here. Both flows below use the same
+        # `test_agent` — analytics is tenant-wide (not flow-scoped) so this
+        # still exercises aggregation across multiple call flows.
+        flow_1 = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, name="Flow One"),
+            headers=_headers(auth_tenant),
+        ).json()
+        flow_2 = authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, name="Flow Two"),
+            headers=_headers(auth_tenant),
+        ).json()
+
+        # 4 total calls: 2 completed (durations 100, 200), 1 failed (duration 300),
+        # 1 no_answer (no duration set).
+        _make_call_session(
+            db,
+            tenant=auth_tenant,
+            agent=test_agent,
+            status="completed",
+            duration=100,
+            call_flow_id=uuid.UUID(flow_1["id"]),
+        )
+        _make_call_session(
+            db,
+            tenant=auth_tenant,
+            agent=test_agent,
+            status="completed",
+            duration=200,
+            call_flow_id=uuid.UUID(flow_2["id"]),
+        )
+        _make_call_session(
+            db,
+            tenant=auth_tenant,
+            agent=test_agent,
+            status="failed",
+            duration=300,
+            call_flow_id=uuid.UUID(flow_2["id"]),
+        )
+        _make_call_session(
+            db,
+            tenant=auth_tenant,
+            agent=test_agent,
+            status="no_answer",
+            duration=None,
+            call_flow_id=uuid.UUID(flow_1["id"]),
+        )
+
+        resp = authed_client.get(
+            "/api/v1/call-flows",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        analytics = resp.json()["analytics"]
+        assert analytics["totalCalls"] == 4
+        # 2 completed / 4 total = 50%
+        assert analytics["successRatePercent"] == 50.0
+        # avg(100, 200, 300) = 200 — the no_answer row has no duration and is excluded
+        assert analytics["averageDurationSeconds"] == 200.0
+
+    def test_analytics_is_tenant_isolated(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        other_tenant = Tenant(
+            name=f"OtherFlowWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"other_flow_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        other_agent = Agent(
+            tenant_id=other_tenant.id,
+            name="Other Tenant Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-z",
+            tts_language="en",
+        )
+        db.add(other_agent)
+        db.commit()
+        db.refresh(other_agent)
+
+        # Tenant A: 1 completed call, duration 100.
+        authed_client.post(
+            "/api/v1/call-flows",
+            json=_create_body(test_agent.id, name="Tenant A Flow"),
+            headers=_headers(auth_tenant),
+        )
+        _make_call_session(
+            db,
+            tenant=auth_tenant,
+            agent=test_agent,
+            status="completed",
+            duration=100,
+        )
+
+        # Tenant B: several calls with very different numbers — must not leak
+        # into tenant A's analytics.
+        for status, duration in [
+            ("completed", 10),
+            ("completed", 20),
+            ("failed", 999),
+            ("no_answer", None),
+        ]:
+            _make_call_session(
+                db,
+                tenant=other_tenant,
+                agent=other_agent,
+                status=status,
+                duration=duration,
+            )
+
+        resp = authed_client.get(
+            "/api/v1/call-flows",
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        analytics = resp.json()["analytics"]
+        assert analytics["totalCalls"] == 1
+        assert analytics["successRatePercent"] == 100.0
+        assert analytics["averageDurationSeconds"] == 100.0
 
 
 @pytest.mark.usefixtures("db")

--- a/tests/api/test_folders.py
+++ b/tests/api/test_folders.py
@@ -469,3 +469,310 @@ class TestRemoveFlowFromFolder:
             headers=_headers(auth_tenant),
         )
         assert resp.status_code == 400
+
+
+@pytest.mark.usefixtures("db")
+class TestMoveFlowToFolder:
+    def _link(self, db, folder_id: uuid.UUID, flow_id: uuid.UUID) -> None:
+        db.add(FolderFlow(folder_id=folder_id, flow_id=flow_id))
+        db.commit()
+
+    def test_move_flow_success(self, authed_client, auth_tenant, test_agent, db):
+        folder_a = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Move Source"},
+            headers=_headers(auth_tenant),
+        ).json()
+        folder_b = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Move Target"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Move Flow")
+        authed_client.post(
+            f"/api/v1/folders/{folder_a['id']}/flows",
+            json={"flowId": str(flow.id)},
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.put(
+            f"/api/v1/folders/{folder_a['id']}/flows/{flow.id}/move",
+            json={"targetFolderId": folder_b["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["flowId"] == str(flow.id)
+        assert body["sourceFolderId"] == folder_a["id"]
+        assert body["targetFolderId"] == folder_b["id"]
+
+        # No longer in source
+        source_flows = authed_client.get(
+            f"/api/v1/folders/{folder_a['id']}/flows",
+            headers=_headers(auth_tenant),
+        ).json()
+        assert source_flows["total"] == 0
+
+        # Now in target
+        target_flows = authed_client.get(
+            f"/api/v1/folders/{folder_b['id']}/flows",
+            headers=_headers(auth_tenant),
+        ).json()
+        assert target_flows["total"] == 1
+        assert target_flows["data"][0]["id"] == str(flow.id)
+
+    def test_move_flow_same_folder_returns_400(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        folder = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Same Folder"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Same Folder Flow")
+        authed_client.post(
+            f"/api/v1/folders/{folder['id']}/flows",
+            json={"flowId": str(flow.id)},
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.put(
+            f"/api/v1/folders/{folder['id']}/flows/{flow.id}/move",
+            json={"targetFolderId": folder["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 400
+
+    def test_move_flow_unknown_source_folder_returns_404(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        folder_b = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Target Only"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Orphan Flow")
+
+        resp = authed_client.put(
+            f"/api/v1/folders/{uuid.uuid4()}/flows/{flow.id}/move",
+            json={"targetFolderId": folder_b["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_move_flow_unknown_target_folder_returns_404(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        folder_a = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Source Only"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Source Flow")
+        authed_client.post(
+            f"/api/v1/folders/{folder_a['id']}/flows",
+            json={"flowId": str(flow.id)},
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.put(
+            f"/api/v1/folders/{folder_a['id']}/flows/{flow.id}/move",
+            json={"targetFolderId": str(uuid.uuid4())},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_move_unknown_flow_returns_404(self, authed_client, auth_tenant):
+        folder_a = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Move Src Unknown Flow"},
+            headers=_headers(auth_tenant),
+        ).json()
+        folder_b = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Move Tgt Unknown Flow"},
+            headers=_headers(auth_tenant),
+        ).json()
+
+        resp = authed_client.put(
+            f"/api/v1/folders/{folder_a['id']}/flows/{uuid.uuid4()}/move",
+            json={"targetFolderId": folder_b["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_move_flow_not_in_source_folder_returns_404(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        folder_a = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Not Linked Source"},
+            headers=_headers(auth_tenant),
+        ).json()
+        folder_b = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Not Linked Target"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Not Linked Flow")
+
+        resp = authed_client.put(
+            f"/api/v1/folders/{folder_a['id']}/flows/{flow.id}/move",
+            json={"targetFolderId": folder_b["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+    def test_move_flow_already_in_target_dedupes(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        folder_a = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Dedup Source"},
+            headers=_headers(auth_tenant),
+        ).json()
+        folder_b = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Dedup Target"},
+            headers=_headers(auth_tenant),
+        ).json()
+        flow = _make_flow(db, auth_tenant, test_agent, "Dedup Flow")
+
+        # Flow already linked to both source and target
+        authed_client.post(
+            f"/api/v1/folders/{folder_a['id']}/flows",
+            json={"flowId": str(flow.id)},
+            headers=_headers(auth_tenant),
+        )
+        authed_client.post(
+            f"/api/v1/folders/{folder_b['id']}/flows",
+            json={"flowId": str(flow.id)},
+            headers=_headers(auth_tenant),
+        )
+
+        resp = authed_client.put(
+            f"/api/v1/folders/{folder_a['id']}/flows/{flow.id}/move",
+            json={"targetFolderId": folder_b["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 200, resp.text
+
+        # No duplicate row in target, and source link removed
+        target_links = (
+            db.query(FolderFlow)
+            .filter(
+                FolderFlow.folder_id == uuid.UUID(folder_b["id"]),
+                FolderFlow.flow_id == flow.id,
+            )
+            .count()
+        )
+        assert target_links == 1
+
+        source_link = (
+            db.query(FolderFlow)
+            .filter(
+                FolderFlow.folder_id == uuid.UUID(folder_a["id"]),
+                FolderFlow.flow_id == flow.id,
+            )
+            .first()
+        )
+        assert source_link is None
+
+        target_flows = authed_client.get(
+            f"/api/v1/folders/{folder_b['id']}/flows",
+            headers=_headers(auth_tenant),
+        ).json()
+        assert target_flows["total"] == 1
+
+    def test_move_flow_cross_tenant_returns_404(
+        self, authed_client, auth_tenant, test_agent, db
+    ):
+        """A tenant must not be able to move a flow using folder/flow ids
+        belonging to a different tenant — every combination should 404."""
+        other_tenant = Tenant(
+            name=f"OtherWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"other_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        other_agent = Agent(
+            tenant_id=other_tenant.id,
+            name="Other Tenant Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-y",
+            tts_language="en",
+        )
+        db.add(other_agent)
+        db.commit()
+        db.refresh(other_agent)
+
+        # Folders/flow owned by the "other" tenant, created directly via DB
+        # (no authed client available for them in this test).
+        other_folder_a = Folder(tenant_id=other_tenant.id, name="Other Source")
+        other_folder_b = Folder(tenant_id=other_tenant.id, name="Other Target")
+        db.add_all([other_folder_a, other_folder_b])
+        db.commit()
+        db.refresh(other_folder_a)
+        db.refresh(other_folder_b)
+
+        other_flow = _make_flow(db, other_tenant, other_agent, "Other Tenant Flow")
+        self._link(db, other_folder_a.id, other_flow.id)
+
+        # Our own tenant's folders/flow for cross-combinations
+        own_folder = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Own Folder"},
+            headers=_headers(auth_tenant),
+        ).json()
+        own_folder_2 = authed_client.post(
+            "/api/v1/folders",
+            json={"name": "Own Folder Target"},
+            headers=_headers(auth_tenant),
+        ).json()
+        own_flow = _make_flow(db, auth_tenant, test_agent, "Own Flow")
+        authed_client.post(
+            f"/api/v1/folders/{own_folder['id']}/flows",
+            json={"flowId": str(own_flow.id)},
+            headers=_headers(auth_tenant),
+        )
+
+        # 1. Source folder belongs to other tenant -> 404
+        resp = authed_client.put(
+            f"/api/v1/folders/{other_folder_a.id}/flows/{own_flow.id}/move",
+            json={"targetFolderId": own_folder["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+        # 2. Target folder belongs to other tenant -> 404
+        resp = authed_client.put(
+            f"/api/v1/folders/{own_folder['id']}/flows/{own_flow.id}/move",
+            json={"targetFolderId": str(other_folder_b.id)},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+        # 3. Flow belongs to other tenant -> 404
+        resp = authed_client.put(
+            f"/api/v1/folders/{own_folder['id']}/flows/{other_flow.id}/move",
+            json={"targetFolderId": own_folder_2["id"]},
+            headers=_headers(auth_tenant),
+        )
+        assert resp.status_code == 404
+
+        # Sanity: the other tenant's flow is still linked to its own folder,
+        # untouched by any of the failed attempts above.
+        still_linked = (
+            db.query(FolderFlow)
+            .filter(
+                FolderFlow.folder_id == other_folder_a.id,
+                FolderFlow.flow_id == other_flow.id,
+            )
+            .first()
+        )
+        assert still_linked is not None

--- a/tests/api/test_workspace_endpoints.py
+++ b/tests/api/test_workspace_endpoints.py
@@ -7,6 +7,7 @@ The middleware is bypassed for protected routes by mocking
 from __future__ import annotations
 
 import uuid
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -15,7 +16,10 @@ from fastapi.testclient import TestClient
 from app.core.request_auth import AUTH_METHOD_JWT
 from app.core.workspace import Workspace
 from app.middleware.api_key_middleware import _attach_workspace_context
+from app.models.audit_log import AuditLog
+from app.models.role import Role
 from app.models.tenant import Tenant
+from app.models.user import User, user_tenant_association
 _API_KEY = "test-workspace-key"
 
 
@@ -65,6 +69,51 @@ def authed_client(client: TestClient, auth_tenant: Tenant):
         side_effect=_resolve,
     ):
         yield client
+
+
+def _make_jwt_user(db, tenant_id: uuid.UUID, role_name: str) -> User:
+    role = db.query(Role).filter(Role.name == role_name).first()
+    if role is None:
+        role = Role(name=role_name, description=role_name)
+        db.add(role)
+        db.commit()
+        db.refresh(role)
+
+    user = User(
+        email=f"{role_name}-{uuid.uuid4().hex[:8]}@example.com",
+        first_name=role_name.title(),
+        last_name="User",
+        hashed_password="",
+        current_tenant_id=tenant_id,
+    )
+    db.add(user)
+    db.flush()
+    db.execute(
+        user_tenant_association.insert().values(
+            user_id=user.id, tenant_id=tenant_id, role_id=role.id, is_creator=False
+        )
+    )
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+@contextmanager
+def _jwt_auth_ctx(workspace: Workspace, user_id: uuid.UUID):
+    """Patch the JWT auth branch to attach the given workspace/user — bypasses
+    real token verification while still exercising the real DB-backed role
+    check inside require_config_or_api_key."""
+
+    async def _jwt_auth(request):
+        _attach_workspace_context(
+            request, workspace=workspace, auth_method=AUTH_METHOD_JWT, user_id=user_id,
+        )
+        return True
+
+    with patch(
+        "app.middleware.api_key_middleware._try_jwt_auth", side_effect=_jwt_auth
+    ):
+        yield
 
 
 @pytest.mark.usefixtures("db")
@@ -210,6 +259,48 @@ class TestUpdateWorkspaceName:
             headers=_headers(auth_tenant),
         )
         assert resp.status_code == 400
+
+    @pytest.mark.parametrize("role_name", ["admin", "manager", "config_only"])
+    def test_jwt_at_least_config_only_can_update(self, client, db, auth_tenant, role_name):
+        new_name = f"JwtRenamed-{role_name}-{uuid.uuid4().hex[:6]}"
+        user = _make_jwt_user(db, auth_tenant.id, role_name)
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, user.id):
+            resp = client.put(
+                "/api/v1/workspace/name",
+                json={"name": new_name},
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["data"]["name"] == new_name
+
+        db.refresh(auth_tenant)
+        assert auth_tenant.name == new_name
+
+        audit_row = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.tenant_id == auth_tenant.id,
+                AuditLog.action == "workspace.updated",
+            )
+            .order_by(AuditLog.timestamp.desc())
+            .first()
+        )
+        assert audit_row is not None
+        assert audit_row.user_id == user.id
+
+    def test_jwt_read_only_forbidden(self, client, db, auth_tenant):
+        user = _make_jwt_user(db, auth_tenant.id, "read_only")
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, user.id):
+            resp = client.put(
+                "/api/v1/workspace/name",
+                json={"name": f"ShouldFail-{uuid.uuid4().hex[:6]}"},
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 403, resp.text
 
 
 @pytest.mark.usefixtures("db")

--- a/tests/voice/test_livekit_browser_call_handler.py
+++ b/tests/voice/test_livekit_browser_call_handler.py
@@ -22,6 +22,8 @@ from app.voice.livekit_browser_call_handler import (
     LiveKitBrowserCallHandler,
     _LiveKitAgentAudioPublisher,
     _forced_browser_stt_runtime,
+    _start_browser_call_recording,
+    _stop_browser_call_recording,
     run_livekit_browser_call,
 )
 
@@ -185,22 +187,72 @@ class TestTurnHandling:
 # TTS synthesis + playback
 # ─────────────────────────────────────────────────────────────────────────────
 
-class TestTtsSynthesisAndPlayback:
-    @pytest.mark.asyncio
-    async def test_prefetch_tts_audio_uses_generate_mulaw_tts(self):
-        h = _base_handler()
-        with patch(
-            "app.voice.livekit_browser_call_handler.generate_mulaw_tts",
-            new=AsyncMock(return_value=b"\xff" * 160),
-        ) as mock_gen:
-            audio = await h._prefetch_tts_audio({"text": "Hello there", "use_ssml": False})
-        assert audio == b"\xff" * 160
-        mock_gen.assert_awaited_once()
+def _fake_tts_runtime(adapter_slug: str, voice_external_id: str | None = "voice-1"):
+    from app.core.agent_runtime import ResolvedTtsRuntime
 
+    return ResolvedTtsRuntime(
+        adapter_slug=adapter_slug,
+        voice_external_id=voice_external_id,
+        language="en",
+        settings_json={},
+        used_ticket_tts=False,
+    )
+
+
+class TestTtsSynthesisAndPlayback:
     @pytest.mark.asyncio
     async def test_prefetch_tts_audio_returns_none_for_empty_text(self):
         h = _base_handler()
         assert await h._prefetch_tts_audio({"text": "  "}) is None
+
+    @pytest.mark.asyncio
+    async def test_prefetch_tts_audio_uses_true_streaming_api_not_generate_mulaw_tts(self):
+        """
+        The main functional fix: _prefetch_tts_audio must resolve the
+        provider's real streaming API (async_stream_synthesize) and return
+        an async iterator — never buffer the whole utterance via
+        generate_mulaw_tts() first (that was the pre-fix behavior).
+        """
+        h = _base_handler()
+
+        async def fake_stream(**kwargs):
+            yield b"\x01" * 80
+            yield b"\x02" * 80
+
+        mock_adapter = MagicMock()
+        mock_adapter.async_stream_synthesize = fake_stream
+
+        with patch(
+            "app.core.agent_runtime.resolve_tts_runtime",
+            return_value=_fake_tts_runtime("rime"),
+        ), patch(
+            "app.utils.tts_adapter.get_tts_adapter", return_value=mock_adapter
+        ), patch(
+            "app.voice.livekit_browser_call_handler.generate_mulaw_tts",
+            new=AsyncMock(side_effect=AssertionError("must not buffer via generate_mulaw_tts")),
+        ):
+            result = await h._prefetch_tts_audio({"text": "Hello there"})
+
+        assert hasattr(result, "__aiter__"), "expected an async iterator, not a whole-blob bytes object"
+        chunks = [c async for c in result]
+        assert chunks == [b"\x01" * 80, b"\x02" * 80]
+
+    @pytest.mark.asyncio
+    async def test_prefetch_tts_audio_falls_back_to_generate_mulaw_tts_on_setup_failure(self):
+        """If provider streaming setup itself raises, fall back to whole-utterance synthesis
+        rather than dropping the chunk entirely."""
+        h = _base_handler()
+        with patch(
+            "app.core.agent_runtime.resolve_tts_runtime",
+            side_effect=RuntimeError("boom"),
+        ), patch(
+            "app.voice.livekit_browser_call_handler.generate_mulaw_tts",
+            new=AsyncMock(return_value=b"\xff" * 160),
+        ) as mock_gen:
+            audio = await h._prefetch_tts_audio({"text": "Hello there"})
+
+        assert audio == b"\xff" * 160
+        mock_gen.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_stream_tts_chunk_drops_when_no_publisher(self):
@@ -227,6 +279,49 @@ class TestTtsSynthesisAndPlayback:
         assert h._is_tts_playing is False
 
     @pytest.mark.asyncio
+    async def test_stream_tts_chunk_publishes_incrementally_as_provider_chunks_arrive(self):
+        """
+        Regression test for the main functional gap: when prefetched_bytes is
+        a true streaming async iterator (the TtsPipeline flow), each provider
+        chunk must be published to the room as it arrives — not buffered
+        until the whole utterance's audio has finished generating.
+        """
+        h = _base_handler()
+        publisher = MagicMock()
+        publisher.connected = True
+        publish_calls: list[bytes] = []
+
+        async def _record_publish(data: bytes, cancel=None):
+            publish_calls.append(bytes(data))
+
+        publisher.publish_mulaw = AsyncMock(side_effect=_record_publish)
+        h._agent_publisher = publisher
+
+        produced: list[int] = []
+
+        async def fake_provider_iter():
+            # Two full frames' worth of provider audio, produced one at a time —
+            # if the implementation buffered until StopAsyncIteration, we'd only
+            # ever see a single publish_mulaw call at the very end.
+            from app.utils.audio_utils import MULAW_FRAME_BYTES
+
+            for i in range(2):
+                produced.append(i)
+                yield bytes([i]) * MULAW_FRAME_BYTES
+
+        with patch("app.core.agent_runtime.resolve_tts_runtime", return_value=_fake_tts_runtime("rime")):
+            await h._stream_tts_chunk(
+                "hello there friend", is_final=True, prefetched_bytes=fake_provider_iter()
+            )
+
+        assert publisher.publish_mulaw.await_count >= 2, (
+            "expected multiple incremental publish_mulaw calls, not one whole-blob call"
+        )
+        from app.utils.audio_utils import MULAW_FRAME_BYTES
+        assert publish_calls[0] == bytes([0]) * MULAW_FRAME_BYTES
+        assert publish_calls[1] == bytes([1]) * MULAW_FRAME_BYTES
+
+    @pytest.mark.asyncio
     async def test_stream_tts_chunk_synthesizes_when_not_prefetched(self):
         h = _base_handler()
         publisher = MagicMock()
@@ -234,13 +329,19 @@ class TestTtsSynthesisAndPlayback:
         publisher.publish_mulaw = AsyncMock()
         h._agent_publisher = publisher
 
+        async def fake_stream(**kwargs):
+            yield b"\xff" * 160
+
+        mock_adapter = MagicMock()
+        mock_adapter.async_stream_synthesize = fake_stream
+
         with patch(
-            "app.voice.livekit_browser_call_handler.generate_mulaw_tts",
-            new=AsyncMock(return_value=b"\xff" * 160),
-        ):
+            "app.core.agent_runtime.resolve_tts_runtime",
+            return_value=_fake_tts_runtime("rime"),
+        ), patch("app.utils.tts_adapter.get_tts_adapter", return_value=mock_adapter):
             await h._stream_tts_chunk("hello there", is_final=False)
 
-        publisher.publish_mulaw.assert_awaited_once()
+        publisher.publish_mulaw.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_stream_tts_chunk_respects_cancel(self):
@@ -584,6 +685,14 @@ class TestRunLiveKitBrowserCall:
                  return_value=mock_subscriber_instance,
              ), \
              patch("app.services.call_session_service.call_session_service") as mock_svc, \
+             patch(
+                 "app.voice.livekit_browser_call_handler._start_browser_call_recording",
+                 new=AsyncMock(return_value=None),
+             ) as mock_start_rec, \
+             patch(
+                 "app.voice.livekit_browser_call_handler._stop_browser_call_recording",
+                 new=AsyncMock(),
+             ) as mock_stop_rec, \
              patch.object(
                  LiveKitBrowserCallHandler,
                  "generate_and_stream_response",
@@ -609,6 +718,10 @@ class TestRunLiveKitBrowserCall:
             mock_db, call_session_id, "completed"
         )
         mock_db.close.assert_called_once()
+        # Recording is gated (start attempted, teardown always runs even when
+        # nothing was actually started — mirrors Twilio's fail-open convention).
+        mock_start_rec.assert_awaited_once_with(mock_db, call_session)
+        mock_stop_rec.assert_awaited_once_with(call_session_id, None)
 
     @pytest.mark.asyncio
     async def test_agent_join_failure_is_caught_not_raised(self):
@@ -628,3 +741,182 @@ class TestRunLiveKitBrowserCall:
             await run_livekit_browser_call(call_session_id)
 
         mock_db.close.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Browser-call recording (room-composite egress on the call's own native room)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestBrowserCallRecording:
+    def _call_session(self):
+        call_session = MagicMock()
+        call_session.id = uuid.uuid4()
+        call_session.tenant_id = uuid.uuid4()
+        call_session.end_time = None
+        call_session.call_metadata = {}
+        call_session.call_type = "web"
+        return call_session
+
+    @pytest.mark.asyncio
+    async def test_start_recording_skips_when_disabled(self):
+        """Gate: get_recording_enabled_for_call() returning False must skip
+        entirely — no egress call, no metadata write, no commit."""
+        call_session = self._call_session()
+        db = MagicMock()
+
+        with patch(
+            "app.services.recording_config_service.get_recording_enabled_for_call",
+            return_value=False,
+        ), patch(
+            "app.services.livekit_recording_service.livekit_recording_service"
+        ) as mock_svc:
+            egress_id = await _start_browser_call_recording(db, call_session)
+
+        assert egress_id is None
+        mock_svc.start_room_recording.assert_not_called()
+        db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_recording_writes_call_metadata_shape_matching_twilio(self):
+        """
+        call_metadata["recording"] must be {"egress_id":..., "gcs_path":...} —
+        the exact shape call_recording_upload_service._get_recording_meta reads,
+        so no changes are needed there to pick up browser-call recordings.
+        """
+        call_session = self._call_session()
+        db = MagicMock()
+
+        with patch(
+            "app.services.recording_config_service.get_recording_enabled_for_call",
+            return_value=True,
+        ), patch(
+            "app.services.livekit_recording_service.livekit_recording_service"
+        ) as mock_rec_svc, patch(
+            "app.services.s3_recording_service.build_s3_key", return_value="path/to/recording.opus"
+        ):
+            mock_rec_svc.start_room_recording = AsyncMock(return_value="EG_123")
+            egress_id = await _start_browser_call_recording(db, call_session)
+
+        assert egress_id == "EG_123"
+        assert call_session.call_metadata["recording"] == {
+            "egress_id": "EG_123",
+            "gcs_path": "path/to/recording.opus",
+        }
+        db.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_start_recording_is_fail_open_on_egress_error(self):
+        """A recording-start failure must never raise — the call must proceed
+        unaffected (fail-open, same convention as Twilio's _start_livekit_recording)."""
+        call_session = self._call_session()
+        db = MagicMock()
+
+        with patch(
+            "app.services.recording_config_service.get_recording_enabled_for_call",
+            return_value=True,
+        ), patch(
+            "app.services.livekit_recording_service.livekit_recording_service"
+        ) as mock_rec_svc:
+            mock_rec_svc.start_room_recording = AsyncMock(side_effect=RuntimeError("egress API down"))
+            egress_id = await _start_browser_call_recording(db, call_session)
+
+        assert egress_id is None
+        db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_recording_noop_when_no_egress_id(self):
+        with patch(
+            "app.services.livekit_recording_service.livekit_recording_service"
+        ) as mock_rec_svc, patch(
+            "app.services.call_recording_upload_service.schedule_recording_upload"
+        ) as mock_schedule:
+            await _stop_browser_call_recording(uuid.uuid4(), None)
+
+        mock_rec_svc.stop_room_recording.assert_not_called()
+        mock_schedule.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stop_recording_stops_egress_then_schedules_upload(self):
+        call_session_id = uuid.uuid4()
+
+        with patch(
+            "app.services.livekit_recording_service.livekit_recording_service"
+        ) as mock_rec_svc, patch(
+            "app.services.call_recording_upload_service.schedule_recording_upload"
+        ) as mock_schedule:
+            mock_rec_svc.stop_room_recording = AsyncMock(return_value=True)
+            await _stop_browser_call_recording(call_session_id, "EG_123")
+
+        mock_rec_svc.stop_room_recording.assert_awaited_once_with("EG_123")
+        mock_schedule.assert_called_once_with(call_session_id)
+
+    @pytest.mark.asyncio
+    async def test_stop_recording_still_schedules_upload_when_egress_stop_fails(self):
+        """Fail-open: even if stop_room_recording() raises, still schedule the
+        upload job — LiveKit may already be tearing down the egress on its own."""
+        call_session_id = uuid.uuid4()
+
+        with patch(
+            "app.services.livekit_recording_service.livekit_recording_service"
+        ) as mock_rec_svc, patch(
+            "app.services.call_recording_upload_service.schedule_recording_upload"
+        ) as mock_schedule:
+            mock_rec_svc.stop_room_recording = AsyncMock(side_effect=RuntimeError("boom"))
+            await _stop_browser_call_recording(call_session_id, "EG_123")
+
+        mock_schedule.assert_called_once_with(call_session_id)
+
+
+class TestGetRecordingEnabledForCallBrowserGating:
+    """
+    get_recording_enabled_for_call's phone-number lookup can never resolve
+    for browser demo calls (assistant_phone_number is the literal sentinel
+    "web_agent", not a real Twilio number) — call_type == "web" now
+    short-circuits to a dedicated process-wide flag instead of falling
+    through to the NumberConfiguration/PhoneNumber join, which would always
+    return False for these calls.
+    """
+
+    def test_web_call_type_short_circuits_to_flag_when_enabled(self):
+        from app.services.recording_config_service import get_recording_enabled_for_call
+
+        call_session = MagicMock()
+        call_session.call_type = "web"
+        db = MagicMock()
+
+        with patch(
+            "app.services.recording_config_service.settings"
+        ) as mock_settings:
+            mock_settings.VOICE_BROWSER_DEMO_RECORDING_ENABLED = True
+            assert get_recording_enabled_for_call(db, call_session) is True
+
+        db.execute.assert_not_called()
+
+    def test_web_call_type_short_circuits_to_flag_when_disabled_by_default(self):
+        from app.services.recording_config_service import get_recording_enabled_for_call
+
+        call_session = MagicMock()
+        call_session.call_type = "web"
+        db = MagicMock()
+
+        with patch(
+            "app.services.recording_config_service.settings"
+        ) as mock_settings:
+            mock_settings.VOICE_BROWSER_DEMO_RECORDING_ENABLED = False
+            assert get_recording_enabled_for_call(db, call_session) is False
+
+        db.execute.assert_not_called()
+
+    def test_non_web_call_type_still_uses_phone_number_lookup(self):
+        """Twilio calls must be entirely unaffected by the new branch."""
+        from app.services.recording_config_service import get_recording_enabled_for_call
+
+        call_session = MagicMock()
+        call_session.call_type = "inbound"
+        call_session.assistant_phone_number = "+15551234567"
+        call_session.tenant_id = uuid.uuid4()
+        db = MagicMock()
+        db.execute.return_value.scalar_one_or_none.return_value = None
+
+        assert get_recording_enabled_for_call(db, call_session) is False
+        db.execute.assert_called_once()


### PR DESCRIPTION
## Summary

**Browser/Twilio call parity work (recording gate, RBAC, docs):**
- Add `VOICE_BROWSER_DEMO_RECORDING_ENABLED` as an interim process-wide recording toggle for browser "Share Demo Link" calls, since those calls have no phone number to key a per-tenant `NumberConfiguration` lookup off of.
- Wire `livekit_browser_call_handler.py`'s recording path through `recording_config_service` accordingly, with expanded test coverage.
- Allow `PUT /api/v1/workspace/name` to accept a JWT `config_only`+ user (not just API-key principals), with audit-log actor attribution and matching `docs/rbac-matrix.md` documentation.
- Document the browser-vs-Twilio call transport parity architecture in `CLAUDE.md`.

**Call-flow analytics:**
- `GET /api/v1/call-flows/` now returns a tenant-wide `analytics` summary (`totalCalls`, `successRatePercent`, `averageDurationSeconds`) alongside the paginated flow list — reuses the existing `call_history_service.get_metrics` (same metric definitions as `GET /call-history/metrics`), scoped by tenant, one extra indexed aggregate query, not paginated (reflects all flows/agents in the tenant regardless of `page`/`pageSize`).

**Move call flow between folders:**
- New `PUT /api/v1/folders/{folder_id}/flows/{flow_id}/move` (body: `{"targetFolderId": "<uuid>"}`) to move a call flow from its current (source) folder to another. Validates source/target folders and the flow all belong to the authenticated tenant; 400 if source == target; 404 if the flow isn't currently in the source folder; handles the case where the flow is already also linked to the target folder (no duplicate link, no `IntegrityError`); atomic single-commit remove+add.

**Swagger/OpenAPI fix:**
- `POST /api/v1/workspace` and `PUT /api/v1/workspace/name` were showing no request body field in Swagger UI because the body was parsed via a `Depends()` (for custom 400 error messages) rather than a declared Pydantic body param, so FastAPI never emitted a `requestBody` schema. Fixed via `openapi_extra` — documentation only, no runtime behavior change. `docs/api/openapi.yaml` regenerated to match.

## Test plan
- [x] `pytest tests/api/test_call_flows.py -v` — 45 passed (incl. 4 new analytics tests)
- [x] `pytest tests/api/test_folders.py -v` — 24 passed (incl. 8 new move-endpoint tests)
- [x] `pytest tests/api/test_workspace_endpoints.py -v` — passes with new RBAC test coverage
- [x] `pytest tests/voice/test_livekit_browser_call_handler.py -v` — passes with new recording-gate coverage
- [x] `pytest tests/test_openapi_contract.py -v` — 29 passed, spec matches generated schema
- [x] `ruff check` / `black` clean on all touched files
- [x] Code review pass completed on the analytics and folder-move changes (no blocking findings; one pre-existing RBAC-tiering gap noted on the folders router, out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)