### PR TITLE
fix: stale recording test after browser-demo recording default flip

### DIFF
--- a/app/services/recording_config_service.py
+++ b/app/services/recording_config_service.py
@@ -33,7 +33,7 @@ def get_recording_enabled_for_call(db: Session, call_session: CallSession) -> bo
     app.routers.sdk::demo_call_token), which would never match a real
     NumberConfiguration row. There is currently no per-tenant/agent/call-flow
     recording toggle for this path, so it's gated on a single process-wide
-    flag (VOICE_BROWSER_DEMO_RECORDING_ENABLED, default False) instead — an
+    flag (VOICE_BROWSER_DEMO_RECORDING_ENABLED, default True) instead — an
     interim default until a proper per-tenant/agent config field is added via
     a schema change (flag for db-migration).
     """

--- a/tests/api/test_call_recordings.py
+++ b/tests/api/test_call_recordings.py
@@ -224,7 +224,12 @@ class TestGetRecordingEnabledForCall:
         db.delete(session)
         db.commit()
 
-    def test_no_phone_number_returns_false(self, db, rec_tenant, rec_agent):
+    def test_web_call_follows_browser_demo_recording_flag(self, db, rec_tenant, rec_agent):
+        """Web (browser demo) calls have no phone number to resolve a
+        NumberConfiguration from, so they're gated on the process-wide
+        VOICE_BROWSER_DEMO_RECORDING_ENABLED flag instead — assert both
+        directions rather than hardcoding one, since the flag's own default
+        is expected to change independently of this test's intent."""
         session = CallSession(
             user_id=uuid.uuid4(),
             agent_id=rec_agent.id,
@@ -237,8 +242,17 @@ class TestGetRecordingEnabledForCall:
         db.commit()
         db.refresh(session)
 
-        result = get_recording_enabled_for_call(db, session)
-        assert result is False
+        with patch(
+            "app.services.recording_config_service.settings.VOICE_BROWSER_DEMO_RECORDING_ENABLED",
+            True,
+        ):
+            assert get_recording_enabled_for_call(db, session) is True
+
+        with patch(
+            "app.services.recording_config_service.settings.VOICE_BROWSER_DEMO_RECORDING_ENABLED",
+            False,
+        ):
+            assert get_recording_enabled_for_call(db, session) is False
 
         db.delete(session)
         db.commit()


### PR DESCRIPTION
## Summary
- `dev`'s `25e71af` ("enable voice browser demo recording by default") flipped `VOICE_BROWSER_DEMO_RECORDING_ENABLED`'s default from `False` to `True`, but `tests/api/test_call_recordings.py::TestGetRecordingEnabledForCall::test_no_phone_number_returns_false` was still hardcoded to expect the old `False` default — full suite was red on `dev` as a result.
- Rewrote that test (`test_web_call_follows_browser_demo_recording_flag`) to explicitly patch the flag both `True` and `False` and assert both directions, instead of asserting on whatever the global config default happens to be — so it can't silently go stale again next time the default changes.
- Fixed the now-inaccurate "default False" docstring note in `recording_config_service.get_recording_enabled_for_call`.

No production behavior changes — test-only fix plus a doc-comment correction.

## Test plan
- [x] `pytest tests/api/test_call_recordings.py -v` — 14 passed
- [x] `pytest tests/ -q` (full suite) — **1876 passed, 65 skipped, 0 failed**
- [x] `ruff check` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)