### PR TITLE
Allow JWT admin to call DELETE /api/v1/workspace/{workspace_id}

### DIFF
--- a/app/api/api_v1/endpoints/workspace.py
+++ b/app/api/api_v1/endpoints/workspace.py
@@ -1,8 +1,10 @@
 """Workspace (tenant) management endpoints — API-key authenticated.
 
 Every endpoint requires a valid API key resolved by :class:`ApiKeyMiddleware`,
-**except** ``PUT /name``, which additionally accepts a JWT user with at least
-``config_only`` rank in the workspace (see ``require_config_or_api_key``).
+**except** ``PUT /name`` and ``DELETE /{workspace_id}``, which additionally
+accept a JWT user with at least ``config_only`` (for ``PUT /name``) or
+``admin`` (for ``DELETE /{workspace_id}``) rank in the workspace (see
+``require_config_or_api_key`` / ``require_admin_or_api_key``).
 Endpoints addressing a specific workspace return ``403`` if the authenticated
 workspace id does not match the URL/target workspace.
 """
@@ -18,6 +20,7 @@ from sqlalchemy.orm import Session
 from app.api.deps import (
     get_db,
     get_workspace_api_key,
+    require_admin_or_api_key,
     require_config,
     require_config_or_api_key,
 )
@@ -385,11 +388,12 @@ def generate_n8n_integration_secret(
 def soft_delete_workspace(
     workspace_id: uuid.UUID,
     request: Request,
-    authed: Workspace = Depends(get_workspace_api_key),
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
     repo: WorkspaceRepository = Depends(_repository),
     db: Session = Depends(get_db),
 ):
-    _ensure_same_workspace(workspace_id, authed.id)
+    tenant_id = _workspace_id(principal)
+    _ensure_same_workspace(workspace_id, tenant_id)
 
     try:
         tenant = repo.find_by_id(workspace_id)
@@ -409,7 +413,8 @@ def soft_delete_workspace(
     log_audit_event(
         db,
         request=request,
-        tenant_id=authed.id,
+        tenant_id=tenant_id,
+        actor_user_id=principal.id if isinstance(principal, User) else None,
         action="workspace.deleted",
         resource_type="workspace",
         resource_id=workspace_id,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -858,6 +858,7 @@ paths:
       - Workspace
       summary: Soft delete a workspace
       operationId: soft_delete_workspace_api_v1_workspace__workspace_id__delete
+      security: *id001
       parameters:
       - name: workspace_id
         in: path
@@ -887,7 +888,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-      security: *id001
   /api/v1/workspace/name:
     put:
       tags:

--- a/docs/rbac-matrix.md
+++ b/docs/rbac-matrix.md
@@ -171,11 +171,14 @@ their pre-existing `require_tenant` / legacy-alias gating, listed in the
 
 All 5 endpoints (create/list/get/update/delete): `admin`.
 
-### Workspace name update — `app/api/api_v1/endpoints/workspace.py`
+### Workspace name update / delete — `app/api/api_v1/endpoints/workspace.py`
 
 | Method | Path | Min role | Notes |
 |---|---|---|---|
-| PUT | `/api/v1/workspace/name` | `config_only` | also accepts API-key principals; the one endpoint in this router (otherwise API-key-only) that accepts a JWT user |
+| PUT | `/api/v1/workspace/name` | `config_only` | also accepts API-key principals |
+| DELETE | `/api/v1/workspace/{workspace_id}` | `admin` | also accepts API-key principals |
+
+The rest of this router (`POST /`, `GET /{workspace_id}`, `POST /settings/make-secret`, `POST /settings/n8n-secret`) remains API-key-only.
 
 ### Web SDK domain whitelist — `app/api/api_v1/endpoints/allowed_domains.py`
 

--- a/tests/api/test_workspace_endpoints.py
+++ b/tests/api/test_workspace_endpoints.py
@@ -345,6 +345,56 @@ class TestDeleteWorkspace:
             )
             assert follow_up.status_code == 404
 
+    def test_jwt_admin_can_delete(self, client, db):
+        t = Tenant(
+            name=f"DelMeJwt-{uuid.uuid4().hex[:8]}",
+            schema_name=f"del_me_jwt_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(t)
+        db.commit()
+        db.refresh(t)
+
+        user = _make_jwt_user(db, t.id, "admin")
+        workspace = Workspace.from_tenant(t)
+
+        with _jwt_auth_ctx(workspace, user.id):
+            resp = client.delete(
+                f"/api/v1/workspace/{t.id}",
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 204, resp.text
+
+        db.refresh(t)
+        assert t.deleted_at is not None
+
+        audit_row = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.tenant_id == t.id,
+                AuditLog.action == "workspace.deleted",
+            )
+            .order_by(AuditLog.timestamp.desc())
+            .first()
+        )
+        assert audit_row is not None
+        assert audit_row.user_id == user.id
+
+    @pytest.mark.parametrize("role_name", ["manager", "config_only", "read_only"])
+    def test_jwt_below_admin_forbidden_to_delete(self, client, db, auth_tenant, role_name):
+        user = _make_jwt_user(db, auth_tenant.id, role_name)
+        workspace = Workspace.from_tenant(auth_tenant)
+
+        with _jwt_auth_ctx(workspace, user.id):
+            resp = client.delete(
+                f"/api/v1/workspace/{auth_tenant.id}",
+                headers={"Authorization": "Bearer test-token"},
+            )
+        assert resp.status_code == 403, resp.text
+
+        db.refresh(auth_tenant)
+        assert auth_tenant.deleted_at is None
+
 
 @pytest.mark.usefixtures("db")
 class TestWorkspaceAuth:


### PR DESCRIPTION
## Summary
- `DELETE /api/v1/workspace/{workspace_id}` was API-key-only. It now also accepts a JWT-authenticated `admin`-role user, matching the dual-auth pattern `PUT /api/v1/workspace/name` already uses (`require_config_or_api_key`) — here via `require_admin_or_api_key`, since deleting a workspace is a destructive action and deserves the highest role floor.
- API-key authentication is unaffected — fully backward compatible.
- Audit log (`workspace.deleted`) now records `actor_user_id` when the caller is a JWT user (previously always `None` since only API-key auth was possible).
- Can now be tested from Swagger via the "Authorize" dialog using a JWT Bearer token, not just `x-api-key`/`x-workspace-id`.

## Test plan
- [x] `pytest tests/api/test_workspace_endpoints.py -v` — 25 passed, including 2 new tests: admin JWT can delete (204, audit row has `user_id`), and manager/config_only/read_only JWT get 403 (parametrized).
- [x] Existing API-key-path delete tests unchanged and still passing.
- [x] `ruff check` clean.
- [x] `docs/rbac-matrix.md` and `docs/api/openapi.yaml` updated/regenerated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)