### PR TITLE
fix: deleted workspace still appears in my-tenants / profile

### DIFF
--- a/app/api/api_v1/endpoints/user.py
+++ b/app/api/api_v1/endpoints/user.py
@@ -630,9 +630,10 @@ def get_user_tenants(
     Get all tenants associated with the current user for dropdown selection.
     Returns list of tenants with id and name, plus current tenant id.
     """
-    # Get all tenants for the user
-    user_tenants = user.tenants
-    
+    # Get all tenants for the user, excluding soft-deleted workspaces
+    # (user.tenants is a raw relationship with no deleted_at filter).
+    user_tenants = [tenant for tenant in user.tenants if tenant.deleted_at is None]
+
     # Convert to simple format for dropdown
     tenant_list = [
         {
@@ -818,9 +819,11 @@ def get_user_profile(
         created_at=user.created_at,
         role=role_info,
         current_tenant=user.current_tenant,
-        tenants=user.tenants
+        # Exclude soft-deleted workspaces — user.tenants is a raw
+        # relationship with no deleted_at filter.
+        tenants=[t for t in user.tenants if t.deleted_at is None]
     )
-    
+
     return create_success_response(
         user_profile,
         "User profile retrieved successfully"
@@ -894,9 +897,11 @@ def update_user_profile(
         created_at=current_user.created_at,
         role=role_info,
         current_tenant=current_user.current_tenant,
-        tenants=current_user.tenants
+        # Exclude soft-deleted workspaces — current_user.tenants is a raw
+        # relationship with no deleted_at filter.
+        tenants=[t for t in current_user.tenants if t.deleted_at is None]
     )
-    
+
     return create_success_response(
         user_profile,
         "User profile updated successfully"

--- a/tests/api/test_user_my_tenants_soft_delete.py
+++ b/tests/api/test_user_my_tenants_soft_delete.py
@@ -1,0 +1,124 @@
+"""Regression tests: soft-deleted tenants must never reappear in
+user-tenant-listing responses.
+
+Bug: `DELETE /api/v1/workspace/{workspace_id}` soft-deletes a tenant
+(`Tenant.deleted_at` set) and a second DELETE correctly 404s (proving
+`WorkspaceRepository.find_by_id` filters `deleted_at IS NULL`), but
+`GET /api/v1/users/my-tenants` and `GET/PUT /api/v1/users/profile` read
+`user.tenants` directly — a raw SQLAlchemy relationship with no
+`deleted_at` filter — so the deleted tenant still shows up there.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.security import create_user_token
+from app.models.tenant import Tenant
+from app.models.user import User
+
+
+@pytest.fixture
+def active_tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"Active-{uuid.uuid4().hex[:6]}",
+        schema_name=f"active_{uuid.uuid4().hex[:6]}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def deleted_tenant(db) -> Tenant:
+    t = Tenant(
+        name=f"Deleted-{uuid.uuid4().hex[:6]}",
+        schema_name=f"deleted_{uuid.uuid4().hex[:6]}",
+        status="active",
+        deleted_at=datetime.now(timezone.utc),
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def member_user(db, active_tenant, deleted_tenant) -> User:
+    u = User(
+        email=f"member-{uuid.uuid4().hex[:6]}@example.com",
+        first_name="Member",
+        last_name="User",
+        hashed_password="",
+        current_tenant_id=active_tenant.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+
+    # Associate the user with BOTH tenants (one active, one already
+    # soft-deleted) — mirrors "user was a member before the workspace was
+    # deleted".
+    u.tenants.append(active_tenant)
+    u.tenants.append(deleted_tenant)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _auth_headers(user: User, tenant_id: uuid.UUID) -> dict:
+    token = create_user_token(user_id=user.id, email=user.email, tenant_id=tenant_id)
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestMyTenantsExcludesSoftDeleted:
+    def test_my_tenants_excludes_soft_deleted_tenant(
+        self, client: TestClient, member_user, active_tenant, deleted_tenant
+    ):
+        resp = client.get(
+            "/api/v1/users/my-tenants",
+            headers=_auth_headers(member_user, active_tenant.id),
+        )
+        assert resp.status_code == 200, resp.text
+        tenant_ids = {t["id"] for t in resp.json()["data"]["tenants"]}
+        assert str(active_tenant.id) in tenant_ids
+        assert (
+            str(deleted_tenant.id) not in tenant_ids
+        ), "Soft-deleted tenant must not appear in GET /users/my-tenants"
+
+
+class TestProfileExcludesSoftDeleted:
+    def test_get_profile_excludes_soft_deleted_tenant(
+        self, client: TestClient, member_user, active_tenant, deleted_tenant
+    ):
+        resp = client.get(
+            "/api/v1/users/profile",
+            headers=_auth_headers(member_user, active_tenant.id),
+        )
+        assert resp.status_code == 200, resp.text
+        tenant_ids = {t["id"] for t in resp.json()["data"]["tenants"]}
+        assert str(active_tenant.id) in tenant_ids
+        assert (
+            str(deleted_tenant.id) not in tenant_ids
+        ), "Soft-deleted tenant must not appear in GET /users/profile"
+
+    def test_put_profile_excludes_soft_deleted_tenant(
+        self, client: TestClient, member_user, active_tenant, deleted_tenant
+    ):
+        resp = client.put(
+            "/api/v1/users/profile",
+            json={"first_name": "Updated"},
+            headers=_auth_headers(member_user, active_tenant.id),
+        )
+        assert resp.status_code == 200, resp.text
+        tenant_ids = {t["id"] for t in resp.json()["data"]["tenants"]}
+        assert str(active_tenant.id) in tenant_ids
+        assert (
+            str(deleted_tenant.id) not in tenant_ids
+        ), "Soft-deleted tenant must not appear in PUT /users/profile response"


### PR DESCRIPTION
## Root cause
`GET /api/v1/users/my-tenants` and `GET`/`PUT /api/v1/users/profile` all read a user's workspaces via the raw `user.tenants` SQLAlchemy relationship (`app/models/user.py`), which carries **no `deleted_at` filter**. This differs from `WorkspaceRepository.find_by_id` (used by `GET`/`DELETE /api/v1/workspace/{id}`), which correctly excludes soft-deleted tenants — which is exactly why a second `DELETE` on an already-deleted workspace correctly returns `404`, while the same workspace kept reappearing in `my-tenants`/profile responses.

## Fix
Minimal, filter-only change at the three broken read sites in `app/api/api_v1/endpoints/user.py`:
- `GET /api/v1/users/my-tenants`
- `GET /api/v1/users/profile`
- `PUT /api/v1/users/profile`

Each now filters `tenant.deleted_at is None` before building its response. No schema/relationship change — this repo's existing `deleted_at IS NULL` == active convention is unchanged; the fix just makes these call sites respect it.

## Test plan
- [x] New `tests/api/test_user_my_tenants_soft_delete.py` — a user with one active and one soft-deleted tenant membership; asserts the deleted tenant is excluded from `my-tenants`, `profile`, and `profile`-update responses. All three reproduced the bug before the fix and pass after.
- [x] Full suite: `pytest tests/ -q` — **1883 passed, 65 skipped, 0 failed**.
- [x] `ruff check` clean on touched files.

## Out of scope (flagged for follow-up)
The same unfiltered `user.tenants` pattern also exists in login/token issuance (`user.py`'s `login`/Google-OAuth/`refresh`), tenant switching (`app/routers/tenant.py`), `_attach_tenants` (`app/api/deps/rbac.py`), and the Jira CRM credentials endpoint (`app/routers/scheduled_calls.py`). Left untouched here since fixing those touches auth/session-issuance and a separate CRM subsystem — bigger blast radius than what this ticket reported/reproduced. Recommend a dedicated follow-up pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)