### PR TITLE
fix: decouple ffmpeg write/read in LiveKit audio transcoder to stop STT stall

### DIFF
--- a/app/voice/audio_transcoder.py
+++ b/app/voice/audio_transcoder.py
@@ -4,6 +4,41 @@ LiveKit / telephony audio → LINEAR16 PCM for Google STT.
 LiveKit Python RTC ``AudioStream`` delivers decoded PCM (s16le), not raw Opus.
 Use :class:`LiveKitAudioProcessor` per call: passthrough when already 16 kHz mono,
 otherwise resample via ffmpeg child process (one per call).
+
+Concurrency model (writer/reader decoupling)
+---------------------------------------------
+``process_frame()`` is called once per ~10-20ms LiveKit ``AudioFrame`` from
+``LiveKitAudioSubscriber``'s tight ``async for`` loop. Earlier versions of
+this class wrote each frame to ffmpeg's stdin and then *blocked that same
+call* on ``asyncio.wait_for(proc.stdout.read(...), timeout=0.5)`` before the
+loop could move on to the next frame — i.e. writing frame N+1 was gated on
+reading frame N's output first, serialized inside a single coroutine call.
+Even with prompt output flushing on the ffmpeg side (``-flush_packets 1``,
+see below), this write-then-blocking-read pattern is structurally unsafe:
+any slow/late read (resampler warm-up, transient CPU contention, a stuck
+process before the watchdog below kicks in) directly stalls how fast
+incoming LiveKit frames get drained, which is the real-time hot path feeding
+STT.
+
+To remove that coupling, writing to ffmpeg's stdin and reading its stdout
+now run as two independent background ``asyncio.Task``s (``_writer_loop`` /
+``_reader_loop``) per ffmpeg process, bridged by two bounded
+``asyncio.Queue``s:
+
+  LiveKit frame → process_frame() → _write_queue → _writer_loop → ffmpeg stdin
+  ffmpeg stdout → _reader_loop → _output_queue → process_frame() → caller (STT)
+
+``process_frame()`` itself never blocks on ffmpeg I/O: it enqueues the new
+frame (non-blocking, bounded — see ``_MAX_WRITE_QUEUE_FRAMES``) and drains
+whatever output has already accumulated (non-blocking — see
+``_drain_output_nowait``), so LiveKit frames are consumed at real-time
+cadence regardless of exactly when ffmpeg happens to flush.
+
+Both queues are bounded (not unbounded buffers): if a queue is ever full —
+meaning the pipeline is falling behind — the oldest entry is dropped in
+favor of the newest one, since for a live conversation, fresher audio is more
+valuable than stale backlog, and this bounds memory growth if ffmpeg were to
+stall completely instead of blocking or growing forever.
 """
 from __future__ import annotations
 
@@ -18,14 +53,20 @@ _FFMPEG_OUTPUT_FORMAT = "s16le"
 # sustained outage (binary missing, fork/exec exhaustion) doesn't retry on
 # every ~20ms frame and pile onto whatever resource pressure caused it.
 _RESTART_BACKOFF_SECONDS = 1.0
-# A single stdout-read timeout is normal/expected — a freshly (re)started
-# ffmpeg process needs a moment to initialize and buffer enough input before
-# it flushes its first output block, especially under container CPU
-# contention, and each caller-audio frame is only ~10-20ms of PCM. Only treat
-# it as "the process is actually stuck" (and reset it) after this many
-# *consecutive* timeouts, so we don't kill-and-respawn ffmpeg before it ever
-# gets a chance to reach steady state.
-_MAX_CONSECUTIVE_READ_TIMEOUTS = 15
+# Bounds on the writer-in / reader-out queues bridging process_frame() and
+# the background writer/reader tasks. ~100 frames of ~10-20ms audio is 1-2s
+# of buffered input — enough to absorb brief scheduling jitter without
+# growing unbounded if ffmpeg genuinely stalls. Output chunks are typically
+# much smaller than a whole frame's worth once flushed, so a slightly larger
+# bound is used there.
+_MAX_WRITE_QUEUE_FRAMES = 100
+_MAX_OUTPUT_QUEUE_CHUNKS = 200
+# If no output has arrived from ffmpeg for this long *while frames are still
+# actively being written*, the process is treated as genuinely stuck (not
+# just warming up) and is reset. Replaces the old "N consecutive per-call
+# read timeouts" heuristic, which no longer applies once reads happen on a
+# free-running background task rather than once per process_frame() call.
+_STUCK_RESET_SECONDS = 5.0
 
 
 class LiveKitAudioProcessor:
@@ -49,7 +90,19 @@ class LiveKitAudioProcessor:
         # flood the logs while still being fully visible.
         self._ffmpeg_start_failed_logged = False
         self._last_restart_failure: float | None = None
-        self._consecutive_read_timeouts = 0
+
+        # ── Writer/reader decoupling state ──────────────────────────────────
+        self._restart_lock = asyncio.Lock()
+        self._write_queue: asyncio.Queue | None = None
+        self._output_queue: asyncio.Queue | None = None
+        self._writer_task: asyncio.Task | None = None
+        self._reader_task: asyncio.Task | None = None
+        self._last_output_at: float | None = None
+        self._last_write_at: float | None = None
+        # Rate-limits the backpressure-drop warnings similarly to the ffmpeg
+        # start-failure log above.
+        self._write_backpressure_logged = False
+        self._output_backpressure_logged = False
 
     async def process_frame(
         self,
@@ -57,7 +110,10 @@ class LiveKitAudioProcessor:
         sample_rate: int,
         num_channels: int,
     ) -> bytes:
-        """Return LINEAR16 mono PCM at ``output_sample_rate`` Hz."""
+        """Return LINEAR16 mono PCM at ``output_sample_rate`` Hz.
+
+        Never blocks on ffmpeg subprocess I/O — see module docstring.
+        """
         if not raw_bytes:
             return b""
 
@@ -90,18 +146,227 @@ class LiveKitAudioProcessor:
         )
         return out
 
+    # ── Non-blocking convert: enqueue for the writer task, drain whatever
+    #    the reader task has already produced ───────────────────────────────
+
     async def _ffmpeg_convert(
         self,
         pcm: bytes,
         sample_rate: int,
         num_channels: int,
     ) -> bytes:
-        """Resample / remix via ffmpeg child process (lazy-started, per call)."""
-        if (
-            self._ffmpeg_process is None
-            or self._ffmpeg_input_rate != sample_rate
-            or self._ffmpeg_input_channels != num_channels
-        ):
+        """Resample / remix via a persistent ffmpeg child process whose stdin
+        writes and stdout reads run on independent background tasks (lazy-
+        started, one process per call). This call itself only enqueues
+        ``pcm`` and drains already-available output — it never awaits the
+        subprocess's pipes directly, so a slow/stalled ffmpeg cannot stall
+        the caller's per-frame loop."""
+        started = await self._ensure_running(sample_rate, num_channels)
+        if not started:
+            return b""
+
+        self._enqueue_write(pcm)
+        self._check_watchdog()
+        return self._drain_output_nowait()
+
+    # ── Writer-in / reader-out queue plumbing ───────────────────────────────
+
+    def _enqueue_write(self, pcm: bytes) -> None:
+        queue = self._write_queue
+        if queue is None:
+            return
+        try:
+            queue.put_nowait(pcm)
+        except asyncio.QueueFull:
+            # Falling behind — drop the oldest buffered frame in favor of
+            # this newer one rather than blocking the caller or growing the
+            # queue unbounded. Losing a stale ~10-20ms frame under sustained
+            # backpressure is far less harmful than stalling real-time
+            # ingestion for the whole call.
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                queue.put_nowait(pcm)
+            except asyncio.QueueFull:
+                pass
+            if not self._write_backpressure_logged:
+                logger.warning(
+                    "[LiveKitAudioProcessor] write queue full — dropping oldest "
+                    "buffered frame (ffmpeg falling behind real-time)"
+                )
+                self._write_backpressure_logged = True
+        else:
+            self._write_backpressure_logged = False
+        self._last_write_at = time.monotonic()
+
+    def _push_output_nowait(self, output_queue: asyncio.Queue, data: bytes) -> None:
+        try:
+            output_queue.put_nowait(data)
+        except asyncio.QueueFull:
+            try:
+                output_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
+            try:
+                output_queue.put_nowait(data)
+            except asyncio.QueueFull:
+                pass
+            if not self._output_backpressure_logged:
+                logger.warning(
+                    "[LiveKitAudioProcessor] output queue full — dropping oldest "
+                    "resampled chunk (consumer falling behind)"
+                )
+                self._output_backpressure_logged = True
+        else:
+            self._output_backpressure_logged = False
+        self._last_output_at = time.monotonic()
+
+    def _drain_output_nowait(self) -> bytes:
+        queue = self._output_queue
+        if queue is None:
+            return b""
+        chunks: list[bytes] = []
+        while True:
+            try:
+                chunks.append(queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return b"".join(chunks) if chunks else b""
+
+    def _check_watchdog(self) -> None:
+        """Detect a still-running-but-stuck ffmpeg process: writes are
+        flowing but no output has arrived for a long time. Replaces the old
+        per-call consecutive-timeout counter, which doesn't apply once reads
+        happen on an independent background task."""
+        if self._last_output_at is None or self._last_write_at is None:
+            return
+        now = time.monotonic()
+        if now - self._last_output_at < _STUCK_RESET_SECONDS:
+            return
+        if now - self._last_write_at > _STUCK_RESET_SECONDS:
+            # No recent writes either — this is just an idle gap (e.g. caller
+            # silence), not a stuck process. Nothing to reset.
+            return
+        logger.warning(
+            "[LiveKitAudioProcessor] no ffmpeg output for %.1fs despite active "
+            "writes — process likely stuck, resetting",
+            now - self._last_output_at,
+        )
+        self._mark_broken(now, self._ffmpeg_process)
+
+    # ── Writer / reader background tasks ────────────────────────────────────
+
+    async def _writer_loop(self, proc: asyncio.subprocess.Process, write_queue: asyncio.Queue) -> None:
+        try:
+            while True:
+                pcm = await write_queue.get()
+                if pcm is None:  # shutdown sentinel
+                    return
+                if proc.stdin is None:
+                    return
+                try:
+                    proc.stdin.write(pcm)
+                    await proc.stdin.drain()
+                except (BrokenPipeError, ConnectionResetError) as exc:
+                    logger.warning("[LiveKitAudioProcessor] ffmpeg stdin write failed (pipe broken): %s", exc)
+                    self._mark_broken(time.monotonic(), proc)
+                    return
+                except Exception as exc:
+                    logger.warning("[LiveKitAudioProcessor] ffmpeg stdin write error: %s", exc)
+                    self._mark_broken(time.monotonic(), proc)
+                    return
+        except asyncio.CancelledError:
+            raise
+
+    async def _reader_loop(self, proc: asyncio.subprocess.Process, output_queue: asyncio.Queue) -> None:
+        try:
+            while True:
+                if proc.stdout is None:
+                    return
+                try:
+                    data = await proc.stdout.read(65536)
+                except (BrokenPipeError, ConnectionResetError, ValueError) as exc:
+                    logger.warning("[LiveKitAudioProcessor] ffmpeg stdout read failed: %s", exc)
+                    self._mark_broken(time.monotonic(), proc)
+                    return
+                except Exception as exc:
+                    logger.warning("[LiveKitAudioProcessor] ffmpeg stdout read error: %s", exc)
+                    self._mark_broken(time.monotonic(), proc)
+                    return
+
+                if not data:
+                    # EOF — ffmpeg exited.
+                    logger.warning(
+                        "[LiveKitAudioProcessor] ffmpeg stdout closed (EOF) — "
+                        "process ended, will restart on next frame"
+                    )
+                    self._mark_broken(time.monotonic(), proc)
+                    return
+
+                self._push_output_nowait(output_queue, data)
+                # Defensive cooperative yield: a real subprocess pipe read
+                # naturally cedes control to the event loop whenever no data
+                # is immediately available, but guard against this loop ever
+                # monopolizing the loop (e.g. if the transport ever returns a
+                # burst of already-buffered reads back-to-back) so other
+                # tasks — including this call's own writer task and the
+                # caller's process_frame() drain — always get a turn.
+                await asyncio.sleep(0)
+        except asyncio.CancelledError:
+            raise
+
+    def _mark_broken(self, now: float, stale_proc: asyncio.subprocess.Process | None) -> None:
+        """Fast, non-blocking: called from the writer/reader tasks themselves
+        (or the watchdog) when the process is known to be dead/stuck. Only
+        clears the process reference so the next ``_ensure_running()`` call
+        knows to (re)start — the writer/reader tasks calling this are already
+        returning on their own, so actual task cancellation/join happens
+        later in ``_stop_pipeline_locked`` rather than here (a task can't
+        await-cancel itself)."""
+        if self._ffmpeg_process is stale_proc:
+            self._ffmpeg_process = None
+            self._ffmpeg_input_rate = None
+            self._ffmpeg_input_channels = None
+        self._last_restart_failure = now
+        if stale_proc is not None:
+            asyncio.create_task(self._kill_stale_process(stale_proc))
+
+    @staticmethod
+    async def _kill_stale_process(proc: asyncio.subprocess.Process) -> None:
+        try:
+            if proc.returncode is None:
+                proc.kill()
+            await asyncio.wait_for(proc.wait(), timeout=3.0)
+        except Exception as exc:
+            logger.debug("[LiveKitAudioProcessor] failed to reap stale ffmpeg process: %s", exc)
+
+    # ── Process + task lifecycle ─────────────────────────────────────────────
+
+    async def _ensure_running(self, sample_rate: int, num_channels: int) -> bool:
+        """Ensure an ffmpeg process (+ its writer/reader tasks) matching
+        ``sample_rate``/``num_channels`` is running. Returns False if a
+        (re)start attempt is currently backed off or failed."""
+
+        def _matches() -> bool:
+            return (
+                self._ffmpeg_process is not None
+                and self._ffmpeg_input_rate == sample_rate
+                and self._ffmpeg_input_channels == num_channels
+                and self._writer_task is not None and not self._writer_task.done()
+                and self._reader_task is not None and not self._reader_task.done()
+            )
+
+        if _matches():
+            return True
+
+        async with self._restart_lock:
+            # Re-check inside the lock — another call may have already
+            # completed the (re)start while this one waited for the lock.
+            if _matches():
+                return True
+
             now = time.monotonic()
             if (
                 self._last_restart_failure is not None
@@ -110,7 +375,10 @@ class LiveKitAudioProcessor:
                 # Still within backoff from the last failed (re)start attempt —
                 # drop this frame without retrying, so a sustained outage
                 # doesn't re-attempt subprocess creation on every ~20ms frame.
-                return b""
+                return False
+
+            await self._stop_pipeline_locked()
+
             try:
                 await self._restart_ffmpeg(sample_rate, num_channels)
             except Exception as exc:
@@ -130,73 +398,80 @@ class LiveKitAudioProcessor:
                     )
                     self._ffmpeg_start_failed_logged = True
                 self._last_restart_failure = now
-                return b""
-            else:
-                self._ffmpeg_start_failed_logged = False
-                self._last_restart_failure = None
+                return False
 
-        proc = self._ffmpeg_process
-        if proc is None or proc.stdin is None or proc.stdout is None:
-            return b""
+            self._ffmpeg_start_failed_logged = False
+            self._last_restart_failure = None
 
-        try:
-            proc.stdin.write(pcm)
-            await proc.stdin.drain()
-            out = await asyncio.wait_for(proc.stdout.read(65536), timeout=0.5)
-            self._consecutive_read_timeouts = 0
-            return out or b""
-        except (BrokenPipeError, ConnectionResetError) as exc:
-            logger.warning("[LiveKitAudioProcessor] ffmpeg pipe broken: %s", exc)
-            self._consecutive_read_timeouts = 0
-            await self._reset_after_failure()
-            return b""
-        except asyncio.TimeoutError:
-            # A single (or occasional) timeout is normal — the process just
-            # hasn't buffered enough input yet to flush output for this
-            # frame; drop this frame only, keep the same process running so
-            # it can reach steady state. Only reset once enough consecutive
-            # timeouts have piled up to indicate the process is genuinely
-            # stuck rather than merely warming up / catching up.
-            self._consecutive_read_timeouts += 1
-            if self._consecutive_read_timeouts >= _MAX_CONSECUTIVE_READ_TIMEOUTS:
-                logger.warning(
-                    "[LiveKitAudioProcessor] ffmpeg read timed out %d times in a "
-                    "row — process likely stuck, resetting",
-                    self._consecutive_read_timeouts,
-                )
-                self._consecutive_read_timeouts = 0
-                await self._reset_after_failure()
-            return b""
-        except Exception as exc:
-            logger.warning("[LiveKitAudioProcessor] ffmpeg convert error: %s", exc)
-            self._consecutive_read_timeouts = 0
-            await self._reset_after_failure()
-            return b""
+            proc = self._ffmpeg_process
+            if proc is None or proc.stdin is None or proc.stdout is None:
+                return False
 
-    async def _reset_after_failure(self) -> None:
-        """Clear the (dead/stuck) ffmpeg process so the next frame re-enters
-        the restart path instead of repeatedly hitting the same broken proc
-        for the rest of the call, and reap the old process in the background
-        so a merely-stuck (not dead) proc doesn't leak as an orphan."""
+            write_queue: asyncio.Queue = asyncio.Queue(maxsize=_MAX_WRITE_QUEUE_FRAMES)
+            output_queue: asyncio.Queue = asyncio.Queue(maxsize=_MAX_OUTPUT_QUEUE_CHUNKS)
+            self._write_queue = write_queue
+            self._output_queue = output_queue
+            self._writer_task = asyncio.create_task(self._writer_loop(proc, write_queue))
+            self._reader_task = asyncio.create_task(self._reader_loop(proc, output_queue))
+            self._last_output_at = time.monotonic()
+            self._last_write_at = None
+            return True
+
+    async def _stop_pipeline_locked(self, *, wait_for_kill: bool = False) -> None:
+        """Stop the writer/reader tasks and the ffmpeg process they're bound
+        to. Must be called while holding ``self._restart_lock``.
+
+        By default the final process reap runs as a detached background task
+        so a mid-call restart (``_ensure_running``) never blocks frame
+        processing on ``proc.wait()``. ``close()`` passes
+        ``wait_for_kill=True`` instead, since callers of ``close()`` (e.g.
+        ``LiveKitAudioSubscriber.stop()`` during call/app teardown) rely on
+        the ffmpeg child actually being gone — not just scheduled for
+        killing — by the time ``close()`` returns, to avoid leaking orphaned
+        ffmpeg processes across many concurrent calls."""
+        for task in (self._writer_task, self._reader_task):
+            if task is not None and not task.done():
+                task.cancel()
+        # Also unblock a writer task parked on write_queue.get() so it can
+        # observe cancellation promptly instead of waiting on a queue nobody
+        # will feed again.
+        if self._write_queue is not None:
+            try:
+                self._write_queue.put_nowait(None)
+            except asyncio.QueueFull:
+                pass
+
+        tasks = [t for t in (self._writer_task, self._reader_task) if t is not None]
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._writer_task = None
+        self._reader_task = None
+        self._write_queue = None
+        self._output_queue = None
+        self._last_output_at = None
+        self._last_write_at = None
+
         stale_proc = self._ffmpeg_process
         self._ffmpeg_process = None
         self._ffmpeg_input_rate = None
         self._ffmpeg_input_channels = None
-        self._last_restart_failure = time.monotonic()
-        if stale_proc is not None:
+        if stale_proc is None:
+            return
+
+        try:
+            if stale_proc.stdin and not stale_proc.stdin.is_closing():
+                stale_proc.stdin.close()
+                await asyncio.wait_for(stale_proc.stdin.wait_closed(), timeout=1.0)
+        except Exception as exc:
+            logger.debug("[LiveKitAudioProcessor] failed to close stale ffmpeg stdin: %s", exc)
+        if wait_for_kill:
+            await self._kill_stale_process(stale_proc)
+        else:
             asyncio.create_task(self._kill_stale_process(stale_proc))
 
-    @staticmethod
-    async def _kill_stale_process(proc: asyncio.subprocess.Process) -> None:
-        try:
-            if proc.returncode is None:
-                proc.kill()
-            await asyncio.wait_for(proc.wait(), timeout=3.0)
-        except Exception as exc:
-            logger.debug("[LiveKitAudioProcessor] failed to reap stale ffmpeg process: %s", exc)
-
     async def _restart_ffmpeg(self, sample_rate: int, num_channels: int) -> None:
-        await self.close()
+        """Spawn a fresh ffmpeg process. Caller is responsible for stopping
+        any prior process/tasks first (see ``_stop_pipeline_locked``)."""
         ffmpeg_bin = shutil.which("ffmpeg")
         if not ffmpeg_bin:
             raise RuntimeError(
@@ -253,21 +528,8 @@ class LiveKitAudioProcessor:
         )
 
     async def close(self) -> None:
-        if self._ffmpeg_process is None:
-            return
-        try:
-            if self._ffmpeg_process.stdin and not self._ffmpeg_process.stdin.is_closing():
-                self._ffmpeg_process.stdin.close()
-                await self._ffmpeg_process.stdin.wait_closed()
-        except Exception as exc:
-            logger.debug("Failed to close ffmpeg stdin: %s", exc)
-        try:
-            await asyncio.wait_for(self._ffmpeg_process.wait(), timeout=3.0)
-        except asyncio.TimeoutError:
-            self._ffmpeg_process.kill()
-        self._ffmpeg_process = None
-        self._ffmpeg_input_rate = None
-        self._ffmpeg_input_channels = None
+        async with self._restart_lock:
+            await self._stop_pipeline_locked(wait_for_kill=True)
 
     async def __aenter__(self) -> "LiveKitAudioProcessor":
         return self

--- a/tests/voice/test_livekit_audio_subscriber.py
+++ b/tests/voice/test_livekit_audio_subscriber.py
@@ -31,11 +31,18 @@ per-frame error also can't kill the whole subscription.
 from __future__ import annotations
 
 import asyncio
+import logging
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.voice.audio_transcoder import LiveKitAudioProcessor
+from app.voice.audio_transcoder import (
+    _MAX_OUTPUT_QUEUE_CHUNKS,
+    _MAX_WRITE_QUEUE_FRAMES,
+    _STUCK_RESET_SECONDS,
+    LiveKitAudioProcessor,
+)
 from app.voice.livekit_audio_subscriber import LiveKitAudioSubscriber
 
 # A single browser-side LiveKit audio frame as reported in production:
@@ -70,6 +77,29 @@ class _FakeAudioStream:
             yield _FakeAudioFrameEvent(f)
 
 
+async def _drain_until_nonempty(
+    processor: LiveKitAudioProcessor, frame: bytes, attempts: int = 50
+) -> bytes:
+    """Call process_frame() repeatedly, yielding to the event loop between
+    calls, until the reader background task has produced output to drain.
+
+    process_frame() no longer awaits ffmpeg I/O directly — it only enqueues a
+    write and drains whatever the independent writer/reader tasks have
+    already produced (see the module docstring in
+    app/voice/audio_transcoder.py) — so a single call right after a (re)start
+    can legitimately still see no output yet. This mirrors how a real caller
+    feeding frames on a ~10-20ms cadence would observe output arriving once
+    the background tasks catch up.
+    """
+    out = b""
+    for _ in range(attempts):
+        out = await processor.process_frame(frame, sample_rate=48000, num_channels=1)
+        if out:
+            return out
+        await asyncio.sleep(0.01)
+    return out
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # LiveKitAudioProcessor: ffmpeg-restart failure must not raise out of
 # process_frame — it should degrade to "drop this frame" and recover once
@@ -91,34 +121,46 @@ class TestLiveKitAudioProcessorResilience:
 
     @pytest.mark.asyncio
     async def test_recovers_once_ffmpeg_becomes_available(self):
+        """process_frame() never blocks on ffmpeg I/O directly anymore — a
+        successful (re)start spins up independent writer/reader background
+        tasks, so recovery is observed by polling the non-blocking drain
+        until the reader task has had a chance to run, rather than by a
+        single awaited call."""
         processor = LiveKitAudioProcessor(output_sample_rate=16000)
+        try:
+            fake_proc = MagicMock()
+            fake_proc.stdin = MagicMock()
+            fake_proc.stdin.write = MagicMock()
+            fake_proc.stdin.drain = AsyncMock()
+            fake_proc.stdout = MagicMock()
+            fake_proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
 
-        fake_proc = MagicMock()
-        fake_proc.stdin = MagicMock()
-        fake_proc.stdin.write = MagicMock()
-        fake_proc.stdin.drain = AsyncMock()
-        fake_proc.stdout = MagicMock()
-        fake_proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
+            async def _fail_then_succeed(sample_rate, num_channels):
+                processor._ffmpeg_process = fake_proc
+                processor._ffmpeg_input_rate = sample_rate
+                processor._ffmpeg_input_channels = num_channels
 
-        async def _fail_then_succeed(sample_rate, num_channels):
-            processor._ffmpeg_process = fake_proc
-            processor._ffmpeg_input_rate = sample_rate
-            processor._ffmpeg_input_channels = num_channels
+            with patch.object(
+                processor, "_restart_ffmpeg", new=AsyncMock(side_effect=RuntimeError("boom"))
+            ):
+                out1 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+            assert out1 == b""
 
-        with patch.object(
-            processor, "_restart_ffmpeg", new=AsyncMock(side_effect=RuntimeError("boom"))
-        ):
-            out1 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
-        assert out1 == b""
+            # Simulate the restart backoff window having elapsed (the
+            # processor rate-limits retry *attempts*, not just log lines, so
+            # a real caller waits out this same window before the next
+            # successful restart).
+            processor._last_restart_failure = None
 
-        # Simulate the restart backoff window having elapsed (the processor
-        # rate-limits retry *attempts*, not just log lines, so a real caller
-        # waits out this same window before the next successful restart).
-        processor._last_restart_failure = None
-
-        with patch.object(processor, "_restart_ffmpeg", new=_fail_then_succeed):
-            out2 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
-        assert out2 != b""
+            with patch.object(processor, "_restart_ffmpeg", new=_fail_then_succeed):
+                out2 = await _drain_until_nonempty(processor, _FRAME_48K_MONO)
+            assert out2 != b""
+            # Writer/reader background tasks must actually be up and running
+            # against the newly (re)started process.
+            assert processor._writer_task is not None and not processor._writer_task.done()
+            assert processor._reader_task is not None and not processor._reader_task.done()
+        finally:
+            await processor.close()
 
     @pytest.mark.asyncio
     async def test_mid_call_ffmpeg_death_self_heals_on_next_frame(self):
@@ -131,111 +173,388 @@ class TestLiveKitAudioProcessorResilience:
         the original bug, just triggered by a mid-call crash instead of a
         failed start. After the fix, the dead process must be cleared so the
         next frame re-enters _restart_ffmpeg and recovers.
+
+        The write itself now happens on the background writer task rather
+        than inline in process_frame(), so the broken pipe is observed by the
+        writer task and must be given an event-loop turn to propagate before
+        asserting the process reference was cleared.
         """
         processor = LiveKitAudioProcessor(output_sample_rate=16000)
+        try:
+            proc = MagicMock()
+            proc.stdin = MagicMock()
+            proc.stdin.write = MagicMock()
+            proc.stdin.drain = AsyncMock()
+            proc.stdout = MagicMock()
+            proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
+            proc.returncode = None
+            proc.wait = AsyncMock(return_value=None)
+            proc.kill = MagicMock()
 
-        dead_proc = MagicMock()
-        dead_proc.stdin = MagicMock()
-        dead_proc.stdin.write = MagicMock(side_effect=BrokenPipeError("pipe closed"))
-        dead_proc.stdout = MagicMock()
-        dead_proc.returncode = None
-        dead_proc.wait = AsyncMock(return_value=None)
-        dead_proc.kill = MagicMock()
+            async def _restart_healthy(sample_rate, num_channels):
+                processor._ffmpeg_process = proc
+                processor._ffmpeg_input_rate = sample_rate
+                processor._ffmpeg_input_channels = num_channels
 
-        processor._ffmpeg_process = dead_proc
-        processor._ffmpeg_input_rate = 48000
-        processor._ffmpeg_input_channels = 1
+            with patch.object(processor, "_restart_ffmpeg", new=_restart_healthy):
+                await _drain_until_nonempty(processor, _FRAME_48K_MONO)
+            assert processor._ffmpeg_process is proc
 
-        out1 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
-        assert out1 == b""
-        # The dead process reference must be cleared, not left in place.
-        assert processor._ffmpeg_process is None
+            # Simulate the ffmpeg process dying mid-call: the next stdin
+            # write raises a broken pipe on the writer task.
+            proc.stdin.write = MagicMock(side_effect=BrokenPipeError("pipe closed"))
 
-        # Simulate the restart backoff window having elapsed.
-        processor._last_restart_failure = None
+            await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+            # Give the writer task a turn to observe the broken pipe and
+            # mark the process broken.
+            for _ in range(20):
+                if processor._ffmpeg_process is None:
+                    break
+                await asyncio.sleep(0.01)
 
-        healthy_proc = MagicMock()
-        healthy_proc.stdin = MagicMock()
-        healthy_proc.stdin.write = MagicMock()
-        healthy_proc.stdin.drain = AsyncMock()
-        healthy_proc.stdout = MagicMock()
-        healthy_proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
+            # The dead process reference must be cleared, not left in place.
+            assert processor._ffmpeg_process is None
 
-        async def _restart(sample_rate, num_channels):
-            processor._ffmpeg_process = healthy_proc
-            processor._ffmpeg_input_rate = sample_rate
-            processor._ffmpeg_input_channels = num_channels
+            # Simulate the restart backoff window having elapsed.
+            processor._last_restart_failure = None
 
-        with patch.object(processor, "_restart_ffmpeg", new=_restart):
-            out2 = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
+            healthy_proc = MagicMock()
+            healthy_proc.stdin = MagicMock()
+            healthy_proc.stdin.write = MagicMock()
+            healthy_proc.stdin.drain = AsyncMock()
+            healthy_proc.stdout = MagicMock()
+            healthy_proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
 
-        # Recovers on the very next frame instead of being stuck on the dead
-        # process for the rest of the call.
-        assert out2 != b""
+            async def _restart(sample_rate, num_channels):
+                processor._ffmpeg_process = healthy_proc
+                processor._ffmpeg_input_rate = sample_rate
+                processor._ffmpeg_input_channels = num_channels
+
+            with patch.object(processor, "_restart_ffmpeg", new=_restart):
+                out2 = await _drain_until_nonempty(processor, _FRAME_48K_MONO)
+
+            # Recovers on a subsequent frame instead of being stuck on the
+            # dead process for the rest of the call.
+            assert out2 != b""
+        finally:
+            await processor.close()
 
     @pytest.mark.asyncio
-    async def test_occasional_read_timeout_does_not_reset_ffmpeg(self):
+    async def test_recent_output_gap_does_not_reset_ffmpeg(self):
         """
-        Regression: a single (or occasional) stdout-read timeout is a normal
-        condition for a live/freshly-started ffmpeg process that hasn't
-        buffered enough input yet to flush output for a tiny 10-20ms frame —
-        it is NOT evidence the process is dead. A prior fix incorrectly
-        treated every timeout the same as a broken pipe / dead process and
-        reset (killed + forced a respawn) on every single one — which meant
-        ffmpeg was killed before it ever got a chance to reach steady state,
-        producing an infinite respawn loop where caller audio was NEVER
-        successfully converted (observed in production: "ffmpeg read timed
-        out — process likely stuck, resetting" logged continuously, every
-        ~1.5s, for the whole call). A timeout must leave the same process in
-        place so it can catch up on a later frame.
+        Regression: a short gap since ffmpeg's last stdout flush (e.g.
+        because the caller is mid-utterance and ffmpeg hasn't had a full
+        frame's worth to flush yet) is a normal condition, not evidence the
+        process is dead. This replaces the old per-call "N consecutive read
+        timeouts" heuristic (removed along with the blocking read it used to
+        guard) with the new time-based watchdog: it must only reset a
+        process that has been stuck for >= _STUCK_RESET_SECONDS, not on
+        every check.
         """
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+        try:
+            proc = MagicMock()
+            processor._ffmpeg_process = proc
+            now = time.monotonic()
+            # Output flowing recently, writes actively flowing too — well
+            # under the stuck threshold.
+            processor._last_output_at = now - 0.5
+            processor._last_write_at = now - 0.05
+
+            processor._check_watchdog()
+
+            assert processor._ffmpeg_process is proc
+        finally:
+            await processor.close()
+
+    @pytest.mark.asyncio
+    async def test_sustained_no_output_while_writing_resets_ffmpeg(self):
+        """A process that has stopped producing output for longer than
+        _STUCK_RESET_SECONDS while frames are still actively being written
+        is genuinely stuck and must still eventually self-heal via the
+        watchdog resetting it (clearing the process reference so the next
+        frame re-enters _restart_ffmpeg)."""
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+        try:
+            proc = MagicMock()
+            proc.returncode = None
+            proc.wait = AsyncMock(return_value=None)
+            proc.kill = MagicMock()
+            processor._ffmpeg_process = proc
+            now = time.monotonic()
+            # No output for well over the stuck threshold, but writes are
+            # still flowing recently — this is the "genuinely stuck" case,
+            # not an idle gap.
+            processor._last_output_at = now - (_STUCK_RESET_SECONDS + 1.0)
+            processor._last_write_at = now - 0.05
+
+            processor._check_watchdog()
+            # _mark_broken() schedules an async task to kill/reap the stale
+            # process — give it a turn to run.
+            await asyncio.sleep(0.05)
+
+            assert processor._ffmpeg_process is None
+            proc.kill.assert_called_once()
+        finally:
+            await processor.close()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_reset_with_live_tasks_spins_up_fresh_writer_reader_pair(self):
+        """End-to-end coverage for the watchdog reset: unlike
+        test_sustained_no_output_while_writing_resets_ffmpeg (which drives
+        _check_watchdog() in isolation with no writer/reader tasks running
+        at all), this starts a real writer/reader task pair against a live
+        fake process, forces the "stuck" condition, invokes the watchdog,
+        and then verifies a *subsequent* process_frame() call actually
+        cancels/joins the now-stale tasks and replaces them with a genuinely
+        fresh pair bound to a new process — not just that kill() was called
+        on the raw process mock."""
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+        try:
+            proc = MagicMock()
+            proc.stdin = MagicMock()
+            proc.stdin.write = MagicMock()
+            proc.stdin.drain = AsyncMock()
+            proc.stdin.is_closing = MagicMock(return_value=False)
+            proc.stdin.close = MagicMock()
+            proc.stdin.wait_closed = AsyncMock(return_value=None)
+            proc.stdout = MagicMock()
+            proc.stdout.read = AsyncMock(return_value=b"\x01\x02" * 100)
+            proc.returncode = None
+            proc.wait = AsyncMock(return_value=None)
+            proc.kill = MagicMock()
+
+            async def _restart_healthy(sample_rate, num_channels):
+                processor._ffmpeg_process = proc
+                processor._ffmpeg_input_rate = sample_rate
+                processor._ffmpeg_input_channels = num_channels
+
+            with patch.object(processor, "_restart_ffmpeg", new=_restart_healthy):
+                await _drain_until_nonempty(processor, _FRAME_48K_MONO)
+
+            stale_writer_task = processor._writer_task
+            stale_reader_task = processor._reader_task
+            assert stale_writer_task is not None and not stale_writer_task.done()
+            assert stale_reader_task is not None and not stale_reader_task.done()
+            assert processor._ffmpeg_process is proc
+
+            # Force the "genuinely stuck" state: no output for well over the
+            # threshold while writes are still recent.
+            now = time.monotonic()
+            processor._last_output_at = now - (_STUCK_RESET_SECONDS + 1.0)
+            processor._last_write_at = now - 0.05
+
+            processor._check_watchdog()
+            # _mark_broken() only clears the process reference and schedules
+            # a fire-and-forget kill/reap — give it a turn to run.
+            await asyncio.sleep(0.05)
+
+            assert processor._ffmpeg_process is None
+            proc.kill.assert_called_once()
+            # The watchdog itself does not cancel the stale writer/reader
+            # tasks (see _mark_broken's docstring — a task can't await-cancel
+            # itself) — they're still alive at this point, just orphaned.
+            assert processor._writer_task is stale_writer_task
+            assert processor._reader_task is stale_reader_task
+            assert not stale_writer_task.done()
+            assert not stale_reader_task.done()
+
+            # Simulate the restart backoff window having elapsed.
+            processor._last_restart_failure = None
+
+            new_proc = MagicMock()
+            new_proc.stdin = MagicMock()
+            new_proc.stdin.write = MagicMock()
+            new_proc.stdin.drain = AsyncMock()
+            new_proc.stdin.is_closing = MagicMock(return_value=False)
+            new_proc.stdin.close = MagicMock()
+            new_proc.stdin.wait_closed = AsyncMock(return_value=None)
+            new_proc.stdout = MagicMock()
+            new_proc.stdout.read = AsyncMock(return_value=b"\x03\x04" * 100)
+            new_proc.returncode = None
+            new_proc.wait = AsyncMock(return_value=None)
+            new_proc.kill = MagicMock()
+
+            async def _restart_new(sample_rate, num_channels):
+                processor._ffmpeg_process = new_proc
+                processor._ffmpeg_input_rate = sample_rate
+                processor._ffmpeg_input_channels = num_channels
+
+            with patch.object(processor, "_restart_ffmpeg", new=_restart_new):
+                out = await _drain_until_nonempty(processor, _FRAME_48K_MONO)
+
+            assert out != b""
+            # The next process_frame() call must have cleanly torn down the
+            # stale pair via _stop_pipeline_locked()...
+            assert stale_writer_task.cancelled() or stale_writer_task.done()
+            assert stale_reader_task.cancelled() or stale_reader_task.done()
+            # ...and spun up a genuinely fresh pair bound to the new process.
+            assert processor._writer_task is not None
+            assert processor._writer_task is not stale_writer_task
+            assert not processor._writer_task.done()
+            assert processor._reader_task is not None
+            assert processor._reader_task is not stale_reader_task
+            assert not processor._reader_task.done()
+            assert processor._ffmpeg_process is new_proc
+        finally:
+            await processor.close()
+
+    @pytest.mark.asyncio
+    async def test_enqueue_write_drops_oldest_keeps_newest_when_queue_full(self, caplog):
+        """_enqueue_write's backpressure path: once the write queue is at its
+        bound, the oldest queued frame must be evicted in favor of the
+        newest one (never blocking/raising for the caller), the overflow
+        warning must log once per outage (not once per dropped frame), and
+        must reset once the queue accepts a write without overflowing again."""
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+        processor._write_queue = asyncio.Queue(maxsize=_MAX_WRITE_QUEUE_FRAMES)
+
+        frames = [f"frame-{i}".encode() for i in range(_MAX_WRITE_QUEUE_FRAMES)]
+        for f in frames:
+            processor._enqueue_write(f)
+        assert processor._write_queue.qsize() == _MAX_WRITE_QUEUE_FRAMES
+        assert processor._write_backpressure_logged is False
+
+        with caplog.at_level(logging.WARNING):
+            processor._enqueue_write(b"overflow-1")
+
+        assert processor._write_queue.qsize() == _MAX_WRITE_QUEUE_FRAMES
+        queued = []
+        while not processor._write_queue.empty():
+            queued.append(processor._write_queue.get_nowait())
+        assert frames[0] not in queued  # oldest evicted
+        assert queued[-1] == b"overflow-1"  # newest kept, at the back
+        overflow_warnings = [r for r in caplog.records if "write queue full" in r.message]
+        assert len(overflow_warnings) == 1
+        assert processor._write_backpressure_logged is True
+
+        # Re-fill to the bound and overflow again without a successful drain
+        # in between — must NOT log a second time for the same outage.
+        for f in frames:
+            processor._write_queue.put_nowait(f)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            processor._enqueue_write(b"overflow-2")
+        overflow_warnings = [r for r in caplog.records if "write queue full" in r.message]
+        assert len(overflow_warnings) == 0
+
+        # A write that doesn't hit the full-queue branch resets the flag so
+        # a later, distinct outage logs again.
+        processor._write_queue.get_nowait()  # make room
+        processor._enqueue_write(b"normal-frame")
+        assert processor._write_backpressure_logged is False
+
+    @pytest.mark.asyncio
+    async def test_push_output_nowait_drops_oldest_keeps_newest_when_queue_full(self, caplog):
+        """Equivalent backpressure coverage for the reader-side output
+        queue via _push_output_nowait: oldest chunk evicted, newest chunk
+        kept, overflow warning rate-limited to once per outage, and reset
+        once a push succeeds without overflowing."""
+        processor = LiveKitAudioProcessor(output_sample_rate=16000)
+        output_queue: asyncio.Queue = asyncio.Queue(maxsize=_MAX_OUTPUT_QUEUE_CHUNKS)
+        processor._output_queue = output_queue
+
+        chunks = [f"chunk-{i}".encode() for i in range(_MAX_OUTPUT_QUEUE_CHUNKS)]
+        for c in chunks:
+            processor._push_output_nowait(output_queue, c)
+        assert output_queue.qsize() == _MAX_OUTPUT_QUEUE_CHUNKS
+        assert processor._output_backpressure_logged is False
+
+        with caplog.at_level(logging.WARNING):
+            processor._push_output_nowait(output_queue, b"overflow-1")
+
+        assert output_queue.qsize() == _MAX_OUTPUT_QUEUE_CHUNKS
+        queued = []
+        while not output_queue.empty():
+            queued.append(output_queue.get_nowait())
+        assert chunks[0] not in queued  # oldest evicted
+        assert queued[-1] == b"overflow-1"  # newest kept, at the back
+        overflow_warnings = [r for r in caplog.records if "output queue full" in r.message]
+        assert len(overflow_warnings) == 1
+        assert processor._output_backpressure_logged is True
+
+        # Re-fill to the bound and overflow again without a successful drain
+        # in between — must NOT log a second time for the same outage.
+        for c in chunks:
+            output_queue.put_nowait(c)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            processor._push_output_nowait(output_queue, b"overflow-2")
+        overflow_warnings = [r for r in caplog.records if "output queue full" in r.message]
+        assert len(overflow_warnings) == 0
+
+        # A push that doesn't hit the full-queue branch resets the flag so a
+        # later, distinct outage logs again.
+        output_queue.get_nowait()  # make room
+        processor._push_output_nowait(output_queue, b"normal-chunk")
+        assert processor._output_backpressure_logged is False
+
+    @pytest.mark.asyncio
+    async def test_close_cancels_writer_and_reader_tasks_and_reaps_process(self):
+        """Graceful shutdown: close() must cancel both background tasks
+        (including unblocking a writer parked on write_queue.get() via the
+        None sentinel) and reap the ffmpeg process, leaving the processor in
+        a clean state that a subsequent process_frame() call could safely
+        restart from."""
         processor = LiveKitAudioProcessor(output_sample_rate=16000)
 
         proc = MagicMock()
         proc.stdin = MagicMock()
         proc.stdin.write = MagicMock()
         proc.stdin.drain = AsyncMock()
+        proc.stdin.is_closing = MagicMock(return_value=False)
+        proc.stdin.close = MagicMock()
+        proc.stdin.wait_closed = AsyncMock(return_value=None)
         proc.stdout = MagicMock()
-        proc.stdout.read = AsyncMock(side_effect=asyncio.TimeoutError())
+        # Reader task blocks "forever" (never returns) until cancelled —
+        # exercises the task.cancel() path rather than a read that happens
+        # to return on its own.
+        stdout_read_started = asyncio.Event()
 
-        processor._ffmpeg_process = proc
-        processor._ffmpeg_input_rate = 48000
-        processor._ffmpeg_input_channels = 1
+        async def _blocking_read(*_args, **_kwargs):
+            stdout_read_started.set()
+            await asyncio.sleep(3600)
 
-        for _ in range(5):
-            out = await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
-            assert out == b""
-
-        # After several (but not too many) consecutive timeouts, the SAME
-        # process must still be in place — not reset/killed.
-        assert processor._ffmpeg_process is proc
-
-    @pytest.mark.asyncio
-    async def test_sustained_read_timeouts_eventually_reset_ffmpeg(self):
-        """A process that never recovers across many consecutive timeouts is
-        genuinely stuck and must still eventually self-heal."""
-        processor = LiveKitAudioProcessor(output_sample_rate=16000)
-
-        proc = MagicMock()
-        proc.stdin = MagicMock()
-        proc.stdin.write = MagicMock()
-        proc.stdin.drain = AsyncMock()
-        proc.stdout = MagicMock()
-        proc.stdout.read = AsyncMock(side_effect=asyncio.TimeoutError())
+        proc.stdout.read = _blocking_read
         proc.returncode = None
         proc.wait = AsyncMock(return_value=None)
         proc.kill = MagicMock()
 
-        processor._ffmpeg_process = proc
-        processor._ffmpeg_input_rate = 48000
-        processor._ffmpeg_input_channels = 1
+        async def _restart(sample_rate, num_channels):
+            processor._ffmpeg_process = proc
+            processor._ffmpeg_input_rate = sample_rate
+            processor._ffmpeg_input_channels = num_channels
 
-        from app.voice.audio_transcoder import _MAX_CONSECUTIVE_READ_TIMEOUTS
-
-        for _ in range(_MAX_CONSECUTIVE_READ_TIMEOUTS):
+        with patch.object(processor, "_restart_ffmpeg", new=_restart):
             await processor.process_frame(_FRAME_48K_MONO, sample_rate=48000, num_channels=1)
 
+        writer_task = processor._writer_task
+        reader_task = processor._reader_task
+        assert writer_task is not None
+        assert reader_task is not None
+        await asyncio.wait_for(stdout_read_started.wait(), timeout=1.0)
+        # The writer task has drained the one enqueued frame and is now
+        # parked on write_queue.get() waiting for the next frame — nothing
+        # left to feed it before shutdown.
+
+        await processor.close()
+
+        assert writer_task.cancelled() or writer_task.done()
+        assert reader_task.cancelled() or reader_task.done()
+        assert processor._writer_task is None
+        assert processor._reader_task is None
+        assert processor._write_queue is None
+        assert processor._output_queue is None
         assert processor._ffmpeg_process is None
+
+        # The stale process is reaped by a fire-and-forget task kicked off
+        # at the end of _stop_pipeline_locked() — give it a turn to run
+        # before asserting it actually killed the process.
+        for _ in range(20):
+            if proc.kill.called:
+                break
+            await asyncio.sleep(0.01)
+        proc.kill.assert_called_once()
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes the Share Demo Link (browser call) flow: the greeting TTS played, but user speech never produced a transcript, so the LLM/TTS never continued.
- Root cause: `LiveKitAudioProcessor._ffmpeg_convert()` wrote each ~10ms LiveKit frame into ffmpeg's stdin then blocked on a single stdout read (up to 500ms) before it could write the next frame, serializing write/read and starving STT (Deepgram/Google) of real-time audio — endpointing never fired, so no final transcript was ever produced.
- Fix: split writing and reading into independent `asyncio.Task`s (`_writer_loop`, `_reader_loop`) bridged by two bounded `asyncio.Queue`s, with non-blocking enqueue/drain from `process_frame()`. Backpressure drops the oldest queued item (rate-limited log) instead of blocking or growing unbounded.
- Replaced the old per-call consecutive-read-timeout reset heuristic with a time-based watchdog (5s of no output while writes are active ⇒ restart ffmpeg).
- Hardening from review: `close()` now awaits the ffmpeg process reap (previously fire-and-forget, risking orphaned ffmpeg processes at shutdown/high call volume); mid-call restarts keep the non-blocking fire-and-forget kill so the hot path is never blocked.
- Scope confirmed contained to `app/voice/audio_transcoder.py` (`LiveKitAudioProcessor`) — the Twilio path (`bidirectional_stream.py`) and the outbound TTS publish path are untouched.

## Test plan
- [x] `pytest tests/voice/ -q` — 250 passed, no regressions
- [x] `ruff check app/voice/audio_transcoder.py tests/voice/test_livekit_audio_subscriber.py` — clean
- [x] New/rewritten tests cover: mid-call ffmpeg death self-heal, watchdog reset with live writer/reader tasks, graceful shutdown task cancellation + process reap, write/output queue backpressure drop-oldest behavior
- [ ] Manual live "Share Demo Link" call to confirm STT/LLM/TTS end-to-end under real network conditions (no automated way to verify this in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)