### PR TITLE
feat(flows): add paginated flow-data list endpoint

### DIFF
--- a/app/api/v2/routers/flow_data.py
+++ b/app/api/v2/routers/flow_data.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Body, Depends, Request, status
+from fastapi import APIRouter, Body, Depends, Query, Request, status
 from sqlalchemy.orm import Session
 
 from app.api.deps import (
@@ -16,6 +16,7 @@ from app.schemas.call_flow import (
     FlowDataResponse,
     FlowDataUpdate,
     FlowValidationResponse,
+    PaginatedFlowDataResponse,
 )
 from app.services.audit_service import log_audit_event
 from app.services.call_flow_service import call_flow_service
@@ -25,6 +26,23 @@ router = APIRouter(prefix="/flows", tags=["Visual Flow Editor"])
 
 def _tenant_id(principal: User | ApiKeyPrincipal) -> uuid.UUID:
     return principal.current_tenant_id
+
+
+@router.get(
+    "/flow-data",
+    response_model=PaginatedFlowDataResponse,
+    status_code=status.HTTP_200_OK,
+    summary="List visual and pre-compiled flow graphs across the workspace",
+)
+def list_flow_data(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100, alias="pageSize"),
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> PaginatedFlowDataResponse:
+    return call_flow_service.list_flow_data(
+        db, _tenant_id(principal), page, page_size
+    )
 
 
 @router.put(

--- a/app/repositories/call_flow_repository.py
+++ b/app/repositories/call_flow_repository.py
@@ -74,6 +74,36 @@ class CallFlowRepository:
         )
         return list(rows), total
 
+    def find_flow_data_by_workspace(
+        self,
+        tenant_id: uuid.UUID,
+        *,
+        page: int = 1,
+        limit: int = 20,
+    ) -> tuple[list[CallFlow], int]:
+        offset = (page - 1) * limit
+        filters = [
+            CallFlow.tenant_id == tenant_id,
+            CallFlow.is_deleted == False,  # noqa: E712
+        ]
+        total = int(
+            self.db.execute(
+                select(func.count(CallFlow.id)).where(*filters)
+            ).scalar_one()
+        )
+        rows = (
+            self.db.execute(
+                select(CallFlow)
+                .where(*filters)
+                .order_by(CallFlow.created_at.desc())
+                .offset(offset)
+                .limit(limit)
+            )
+            .scalars()
+            .all()
+        )
+        return list(rows), total
+
     def update(self, flow: CallFlow, fields: dict[str, Any]) -> CallFlow:
         for key, value in fields.items():
             setattr(flow, key, value)

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -312,3 +312,26 @@ class FlowValidationResponse(BaseModel):
     validation_errors: List[FlowValidationError] = Field(
         default_factory=list, serialization_alias="validationErrors"
     )
+
+
+class FlowDataListItem(BaseModel):
+    """A single flow's visual/pre-compiled graph, used in the paginated list."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    flow_id: uuid.UUID = Field(..., serialization_alias="flowId")
+    name: str
+    flow_data: Dict[str, Any] | None = Field(None, serialization_alias="flowData")
+    flow_data_compiled: Dict[str, Any] | None = Field(None, serialization_alias="flowDataCompiled")
+    updated_at: datetime | None = Field(None, serialization_alias="updatedAt")
+
+
+class PaginatedFlowDataResponse(BaseModel):
+    """Response body for ``GET /api/v2/flows/flow-data``."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    data: List[FlowDataListItem]
+    total: int
+    page: int
+    page_size: int = Field(..., serialization_alias="pageSize")

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -6,6 +6,7 @@ import uuid
 from fastapi import HTTPException, status
 from scipy.stats import chi2_contingency
 from sqlalchemy import case, func, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from app.core.logger import logger
@@ -34,10 +35,12 @@ from app.schemas.call_flow import (
     CallerMemorySettingsUpdate,
     CallFlowSettingsUpdate,
     CallFlowUpdate,
+    FlowDataListItem,
     FlowDataResponse,
     FlowDataUpdate,
     FlowValidationError,
     FlowValidationResponse,
+    PaginatedFlowDataResponse,
     PostCallActionsSettingsResponse,
     PostCallActionsSettingsUpdate,
     PostCallAnalysisSettingsResponse,
@@ -770,6 +773,46 @@ class CallFlowService:
 
 
     # ── Visual Flow Editor ────────────────────────────────────────────────
+
+    def list_flow_data(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        page: int,
+        limit: int,
+    ) -> PaginatedFlowDataResponse:
+        repo = CallFlowRepository(db)
+        try:
+            rows, total = repo.find_flow_data_by_workspace(
+                tenant_id, page=page, limit=limit
+            )
+        except SQLAlchemyError:
+            logger.exception(
+                "Failed to list flow-data for tenant %s (page=%s, limit=%s)",
+                tenant_id,
+                page,
+                limit,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to list flow data",
+            )
+
+        return PaginatedFlowDataResponse(
+            data=[
+                FlowDataListItem(
+                    flow_id=f.id,
+                    name=f.name,
+                    flow_data=f.flow_data,
+                    flow_data_compiled=f.flow_data_compiled,
+                    updated_at=f.updated_at,
+                )
+                for f in rows
+            ],
+            total=total,
+            page=page,
+            page_size=limit,
+        )
 
     def get_flow_data(
         self, db: Session, flow_id: uuid.UUID, tenant_id: uuid.UUID

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8966,6 +8966,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/flow-data:
+    get:
+      tags:
+      - Visual Flow Editor
+      summary: List visual and pre-compiled flow graphs across the workspace
+      operationId: list_flow_data_api_v2_flows_flow_data_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+          title: Page
+      - name: pageSize
+        in: query
+        required: false
+        schema:
+          type: integer
+          maximum: 100
+          minimum: 1
+          default: 20
+          title: Pagesize
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedFlowDataResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/flow-data:
     put:
       tags:
@@ -13412,6 +13451,34 @@ components:
       - skill
       - confidence
       title: ExtractedSkill
+    FlowDataListItem:
+      properties:
+        flowId:
+          type: string
+          format: uuid
+          title: Flowid
+        name:
+          type: string
+          title: Name
+        flowData:
+          additionalProperties: true
+          type: object
+          nullable: true
+        flowDataCompiled:
+          additionalProperties: true
+          type: object
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - flowId
+      - name
+      title: FlowDataListItem
+      description: A single flow's visual/pre-compiled graph, used in the paginated
+        list.
     FlowDataResponse:
       properties:
         flowData:
@@ -15260,6 +15327,30 @@ components:
       - page
       - page_size
       title: PaginatedBatchJobs
+    PaginatedFlowDataResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/FlowDataListItem'
+          type: array
+          title: Data
+        total:
+          type: integer
+          title: Total
+        page:
+          type: integer
+          title: Page
+        pageSize:
+          type: integer
+          title: Pagesize
+      type: object
+      required:
+      - data
+      - total
+      - page
+      - pageSize
+      title: PaginatedFlowDataResponse
+      description: Response body for ``GET /api/v2/flows/flow-data``.
     PaginatedPaymentResponse:
       properties:
         items:

--- a/tests/api/v2/test_flow_data_list.py
+++ b/tests/api/v2/test_flow_data_list.py
@@ -1,0 +1,213 @@
+"""Tests for GET /api/v2/flows/flow-data — paginated visual/pre-compiled
+flow-graph listing scoped to the caller's workspace.
+
+Coverage:
+  - Happy path: paginated list, correct camelCase field names.
+  - Tenant isolation: another tenant's flows never appear.
+  - Soft-deleted flows are excluded.
+  - Pagination: page/pageSize control the slice, total reflects full count.
+  - Auth: unauthenticated request is rejected by require_readonly_or_api_key.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal, *, override_auth=True):
+    from app.api.deps import (
+        get_db,
+        require_readonly_or_api_key,
+    )
+    from app.api.v2.routers.flow_data import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if override_auth:
+        mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"FlowDataListWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"flow_data_list_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def other_workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"FlowDataListWS-Other-{uuid.uuid4().hex[:8]}",
+        schema_name=f"flow_data_list_ws_other_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+def _agent(db, tenant):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=tenant.id,
+        name="Flow Data List Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _flow(db, tenant, agent, *, name="Flow", is_deleted=False, flow_data=None, flow_data_compiled=None):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=tenant.id,
+        agent_id=agent.id,
+        name=name,
+        direction="inbound",
+        is_deleted=is_deleted,
+        flow_data=flow_data,
+        flow_data_compiled=flow_data_compiled,
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+class TestListFlowData:
+    def test_happy_path_returns_paginated_camel_case_response(self, db, workspace):
+        agent = _agent(db, workspace)
+        flow = _flow(
+            db,
+            workspace,
+            agent,
+            name="My Flow",
+            flow_data={"nodes": [{"id": "start", "type": "start", "data": {}}]},
+            flow_data_compiled={"start": {"node": {"type": "start"}}},
+        )
+
+        client = _build_app(db, _principal(workspace.id))
+        resp = client.get("/flows/flow-data")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+
+        assert body["total"] >= 1
+        assert body["page"] == 1
+        assert body["pageSize"] == 20
+
+        item = next(i for i in body["data"] if i["flowId"] == str(flow.id))
+        assert item["name"] == "My Flow"
+        assert item["flowData"] == {"nodes": [{"id": "start", "type": "start", "data": {}}]}
+        assert item["flowDataCompiled"] == {"start": {"node": {"type": "start"}}}
+        assert "updatedAt" in item
+        # confirm no snake_case leakage
+        assert "flow_id" not in item
+        assert "flow_data" not in item
+        assert "flow_data_compiled" not in item
+        assert "updated_at" not in item
+
+    def test_tenant_isolation_excludes_other_tenants_flows(
+        self, db, workspace, other_workspace
+    ):
+        agent_a = _agent(db, workspace)
+        agent_b = _agent(db, other_workspace)
+        flow_a = _flow(db, workspace, agent_a, name="Tenant A Flow")
+        flow_b = _flow(db, other_workspace, agent_b, name="Tenant B Flow")
+
+        client = _build_app(db, _principal(workspace.id))
+        resp = client.get("/flows/flow-data")
+
+        assert resp.status_code == 200, resp.text
+        ids = [i["flowId"] for i in resp.json()["data"]]
+        assert str(flow_a.id) in ids
+        assert str(flow_b.id) not in ids
+
+    def test_soft_deleted_flows_are_excluded(self, db, workspace):
+        agent = _agent(db, workspace)
+        active_flow = _flow(db, workspace, agent, name="Active Flow")
+        deleted_flow = _flow(
+            db, workspace, agent, name="Deleted Flow", is_deleted=True
+        )
+
+        client = _build_app(db, _principal(workspace.id))
+        resp = client.get("/flows/flow-data")
+
+        assert resp.status_code == 200, resp.text
+        ids = [i["flowId"] for i in resp.json()["data"]]
+        assert str(active_flow.id) in ids
+        assert str(deleted_flow.id) not in ids
+
+    def test_pagination_slices_results_and_total_reflects_full_count(
+        self, db, workspace
+    ):
+        agent = _agent(db, workspace)
+        flows = [
+            _flow(db, workspace, agent, name=f"Paginated Flow {i}") for i in range(5)
+        ]
+
+        client = _build_app(db, _principal(workspace.id))
+
+        resp_page1 = client.get("/flows/flow-data?page=1&pageSize=2")
+        assert resp_page1.status_code == 200, resp_page1.text
+        body1 = resp_page1.json()
+        assert body1["page"] == 1
+        assert body1["pageSize"] == 2
+        assert len(body1["data"]) == 2
+        assert body1["total"] >= 5
+
+        resp_page2 = client.get("/flows/flow-data?page=2&pageSize=2")
+        assert resp_page2.status_code == 200, resp_page2.text
+        body2 = resp_page2.json()
+        assert body2["page"] == 2
+        assert len(body2["data"]) == 2
+
+        # No overlap between page 1 and page 2 for this tenant's flows
+        ids_page1 = {i["flowId"] for i in body1["data"]}
+        ids_page2 = {i["flowId"] for i in body2["data"]}
+        assert ids_page1.isdisjoint(ids_page2)
+
+    def test_unauthenticated_request_is_rejected(self, db, workspace):
+        client = _build_app(db, _principal(workspace.id), override_auth=False)
+
+        resp = client.get("/flows/flow-data")
+
+        assert resp.status_code == 401, resp.text


### PR DESCRIPTION
Adds GET /api/v2/flows/flow-data to list visual and pre-compiled flow graphs (flow_data, flow_data_compiled) across a workspace, filtered by tenant_id and is_deleted, with readonly-or-api-key auth and pagination.