### PR TITLE
feat(voice): add Speechmatics as a new STT provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,6 +141,11 @@ SIP_PASSWORD=
 # Deepgram (default STT)
 DEEPGRAM_API_KEY=
 
+# Speechmatics (optional STT provider — native VAD/end-of-utterance)
+SPEECHMATICS_API_KEY=
+# Leave blank to use the SDK default (wss://eu2.rt.speechmatics.com/v2)
+SPEECHMATICS_RT_URL=
+
 # Stripe
 STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...

--- a/alembic/versions/20260813_add_speechmatics_stt_provider.py
+++ b/alembic/versions/20260813_add_speechmatics_stt_provider.py
@@ -1,0 +1,96 @@
+"""add speechmatics stt provider and catalog model
+
+Revision ID: 20260813_speechmatics_stt
+Revises: 20260813_drop_bk_appt
+Create Date: 2026-08-13
+
+New sttprovider row for Speechmatics + one sttmodel row ("enhanced") using
+MULAW 8kHz (Twilio-native path, same as Deepgram). metadata_json carries
+Speechmatics-specific engine params (end_of_utterance_silence_trigger,
+max_delay, max_delay_mode) so resolve_stt_runtime() needs no code changes.
+"""
+from typing import Sequence, Union
+
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260813_speechmatics_stt"
+down_revision: Union[str, Sequence[str], None] = "20260813_drop_bk_appt"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO sttprovider (id, slug, display_name, is_active, supports_streaming)
+            VALUES (gen_random_uuid(), 'speechmatics', 'Speechmatics', true, true)
+            ON CONFLICT (slug) DO NOTHING
+            """
+        )
+    )
+
+    speechmatics_id = conn.execute(
+        sa.text("SELECT id FROM sttprovider WHERE slug = 'speechmatics'")
+    ).scalar()
+    if speechmatics_id is None:
+        return
+
+    model_rows = [
+        (
+            "enhanced",
+            "Speechmatics (Enhanced)",
+            "en",
+            8000,
+            "MULAW",
+            {
+                "model": "enhanced",
+                "end_of_utterance_silence_trigger": 0.5,
+                "max_delay": 2.0,
+                "max_delay_mode": "flexible",
+            },
+        ),
+    ]
+    for external_model_id, display_name, language_code, sample_rate_hz, encoding, metadata in model_rows:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO sttmodel (
+                  id, provider_id, external_model_id, display_name,
+                  language_code, sample_rate_hz, encoding, metadata_json, is_active
+                )
+                VALUES (
+                  gen_random_uuid(), CAST(:provider_id AS uuid), :external_model_id,
+                  :display_name, :language_code, :sample_rate_hz, :encoding,
+                  CAST(:metadata_json AS jsonb), true
+                )
+                ON CONFLICT (provider_id, external_model_id) DO NOTHING
+                """
+            ),
+            {
+                "provider_id": str(speechmatics_id),
+                "external_model_id": external_model_id,
+                "display_name": display_name,
+                "language_code": language_code,
+                "sample_rate_hz": sample_rate_hz,
+                "encoding": encoding,
+                "metadata_json": json.dumps(metadata),
+            },
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM sttmodel
+            WHERE provider_id IN (SELECT id FROM sttprovider WHERE slug = 'speechmatics')
+            """
+        )
+    )
+    op.execute(sa.text("DELETE FROM sttprovider WHERE slug = 'speechmatics'"))

--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -73,7 +73,7 @@ class ResolvedLlmRuntime:
 class ResolvedSttRuntime:
     """Runtime STT config resolved from agent + optional flow settings override."""
 
-    provider_slug: str          # "deepgram" | "google" | "elevenlabs"
+    provider_slug: str          # "deepgram" | "google" | "speechmatics" | "elevenlabs"
     model_id: str               # user-facing modelId e.g. "nova-3", "chirp-3"
     language_code: str          # BCP-47 e.g. "en-AU", "en"
     sample_rate_hz: int         # from sttmodel catalog (e.g. 8000 or 16000)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -551,6 +551,18 @@ class Settings(BaseSettings):
     GOOGLE_STT_SAMPLE_RATE: int = 8000
     GOOGLE_STT_ENCODING: str = "MULAW"  # Twilio's audio encoding
 
+    # Speechmatics Speech-to-Text (optional provider — native VAD/end-of-utterance)
+    SPEECHMATICS_API_KEY: str = ""
+    # Leave blank to use the speechmatics-rt SDK default (wss://eu2.rt.speechmatics.com/v2)
+    SPEECHMATICS_RT_URL: str = ""
+    SPEECHMATICS_STT_MODEL: str = "enhanced"  # "enhanced" | "standard"
+    SPEECHMATICS_STT_LANGUAGE: str = "en"
+    # Silence (seconds) before Speechmatics' server-side EndOfUtterance fires.
+    # Range 0-2s per Speechmatics docs; must stay below SPEECHMATICS_MAX_DELAY.
+    SPEECHMATICS_EOT_SILENCE_TRIGGER_SEC: float = 0.5
+    # Max seconds of latency Speechmatics may take to finalize a transcript segment.
+    SPEECHMATICS_MAX_DELAY_SEC: float = 2.0
+
     # Deepgram Speech-to-Text (replaces Google STT for streaming + batch)
     DEEPGRAM_API_KEY: str = ""
     DEEPGRAM_STT_MODEL: str = "nova-3"

--- a/app/services/speechmatics_stt_service.py
+++ b/app/services/speechmatics_stt_service.py
@@ -1,0 +1,303 @@
+"""
+Speechmatics Speech-to-Text: streaming (Twilio MULAW / LiveKit LINEAR16) provider.
+Provider implementation used by SttPipeline, mirroring deepgram_stt_service.py's
+duck-typed session contract (push_audio/finish/start/get_result).
+
+Unlike Deepgram/Google (sync SDKs bridged into asyncio via a background thread),
+speechmatics-rt's AsyncClient is asyncio-native, so the session runs directly on
+the caller's event loop with no thread/queue.Queue bridge needed.
+
+Turn detection uses Speechmatics' own server-side EndOfUtterance signal (driven
+by transcription_config.conversation_config.end_of_utterance_silence_trigger) —
+no separate VAD is implemented here. AddTranscript segments are accumulated but
+withheld from the pipeline as interim-only; only EndOfUtterance promotes the
+accumulated text to a pipeline-final (is_final=True), matching how Deepgram's
+speech_final gates turn-end for Nova.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict
+
+from speechmatics.rt import (
+    AsyncClient,
+    AudioEncoding,
+    AudioFormat,
+    ConversationConfig,
+    Model,
+    ServerMessageType,
+    StaticKeyAuth,
+    TranscriptionConfig,
+)
+
+from app.core.config import settings
+from app.core.logger import logger
+
+
+def _avg_confidence(msg: Dict[str, Any]) -> float:
+    results = msg.get("results") or []
+    confidences = []
+    for item in results:
+        alts = item.get("alternatives") or []
+        if alts:
+            confidences.append(float(alts[0].get("confidence") or 0.0))
+    if not confidences:
+        return 0.0
+    return sum(confidences) / len(confidences)
+
+
+class SpeechmaticsSTTService:
+    """Service for Speechmatics realtime streaming STT."""
+
+    def __init__(self) -> None:
+        key = (settings.SPEECHMATICS_API_KEY or "").strip()
+        self._api_key = key or None
+        if key:
+            logger.info("Speechmatics STT configured")
+        else:
+            logger.warning("SPEECHMATICS_API_KEY not set — STT will fail until configured")
+
+    class StreamingSTTSession:
+        """
+        Long-lived Speechmatics realtime transcription over WebSocket.
+        Exposes a stable session interface (push_audio, finish, start, get_result).
+        """
+
+        def __init__(
+            self,
+            *,
+            api_key: str | None,
+            url: str | None,
+            language_code: str | None,
+            encoding: str,
+            sample_rate: int,
+            model: str | None,
+            end_of_utterance_silence_trigger: float,
+            max_delay: float,
+        ) -> None:
+            self._api_key = api_key
+            self._url = url
+            self._language_code = language_code or settings.SPEECHMATICS_STT_LANGUAGE or "en"
+            self._encoding = encoding.upper() if encoding else "MULAW"
+            self._sample_rate = sample_rate or 8000
+            self._model = model or settings.SPEECHMATICS_STT_MODEL or "enhanced"
+            self._eot_silence_trigger = end_of_utterance_silence_trigger
+            self._max_delay = max_delay
+
+            self._client: AsyncClient | None = None
+            self._audio_q: "asyncio.Queue[bytes | None]" = asyncio.Queue()
+            self._results_q: "asyncio.Queue[dict]" = asyncio.Queue()
+            self._closed = False
+            self._task_started = False
+            self._sender_task: asyncio.Task | None = None
+
+            # AddTranscript segments accumulate here; only surfaced to the
+            # pipeline (is_final=True) when the native EndOfUtterance event
+            # fires -- this is what makes Speechmatics' own VAD the sole
+            # turn-boundary signal, matching Deepgram Nova's speech_final gate.
+            self._pending_transcript = ""
+            self._pending_confidence = 0.0
+
+        def push_audio(self, audio_chunk: bytes) -> None:
+            if self._closed:
+                return
+            self._audio_q.put_nowait(audio_chunk)
+
+        def finish(self) -> None:
+            if not self._closed:
+                self._closed = True
+                self._audio_q.put_nowait(None)
+
+        async def start(self) -> None:
+            if self._task_started:
+                return
+            self._task_started = True
+
+            if not self._api_key:
+                await self._results_q.put(
+                    {"error": "Speechmatics client not initialized", "transcript": "", "confidence": 0.0, "is_final": True}
+                )
+                await self._results_q.put({"done": True})
+                return
+
+            sm_encoding = AudioEncoding.MULAW if self._encoding == "MULAW" else AudioEncoding.PCM_S16LE
+
+            try:
+                self._client = AsyncClient(
+                    auth=StaticKeyAuth(self._api_key),
+                    url=self._url or None,
+                )
+                self._register_handlers(self._client)
+
+                logger.info(
+                    "[Speechmatics STT] session_start model=%s language=%s sample_rate=%s "
+                    "encoding=%s eot_silence_trigger=%s max_delay=%s",
+                    self._model, self._language_code, self._sample_rate,
+                    self._encoding, self._eot_silence_trigger, self._max_delay,
+                )
+                await self._client.start_session(
+                    transcription_config=TranscriptionConfig(
+                        language=self._language_code,
+                        model=Model(self._model),
+                        enable_partials=True,
+                        max_delay=self._max_delay,
+                        max_delay_mode="flexible",
+                        conversation_config=ConversationConfig(
+                            end_of_utterance_silence_trigger=self._eot_silence_trigger,
+                        ),
+                    ),
+                    audio_format=AudioFormat(
+                        encoding=sm_encoding,
+                        sample_rate=self._sample_rate,
+                    ),
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error("[Speechmatics STT] session start error: %s", exc, exc_info=True)
+                await self._results_q.put(
+                    {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True, "recoverable": False}
+                )
+                await self._results_q.put({"done": True})
+                return
+
+            self._sender_task = asyncio.create_task(self._sender_loop())
+
+        def _register_handlers(self, client: AsyncClient) -> None:
+            @client.on(ServerMessageType.ADD_PARTIAL_TRANSCRIPT)
+            def _on_partial(msg: Dict[str, Any]) -> None:
+                transcript = ((msg.get("metadata") or {}).get("transcript") or "").strip()
+                if not transcript:
+                    return
+                self._results_q.put_nowait(
+                    {"transcript": transcript, "confidence": _avg_confidence(msg), "is_final": False}
+                )
+
+            @client.on(ServerMessageType.ADD_TRANSCRIPT)
+            def _on_transcript(msg: Dict[str, Any]) -> None:
+                transcript = ((msg.get("metadata") or {}).get("transcript") or "").strip()
+                if not transcript:
+                    return
+                # Withheld from the pipeline until EndOfUtterance -- AddTranscript
+                # only means "this segment's wording is settled", not "turn over".
+                self._pending_transcript = (
+                    f"{self._pending_transcript} {transcript}".strip()
+                    if self._pending_transcript
+                    else transcript
+                )
+                self._pending_confidence = _avg_confidence(msg)
+
+            @client.on(ServerMessageType.END_OF_UTTERANCE)
+            def _on_end_of_utterance(_msg: Dict[str, Any]) -> None:
+                if not self._pending_transcript:
+                    return
+                self._results_q.put_nowait(
+                    {
+                        "transcript": self._pending_transcript,
+                        "confidence": self._pending_confidence,
+                        "is_final": True,
+                    }
+                )
+                self._pending_transcript = ""
+                self._pending_confidence = 0.0
+
+            @client.on(ServerMessageType.ERROR)
+            def _on_error(msg: Dict[str, Any]) -> None:
+                reason = msg.get("reason", "unknown")
+                logger.error("[Speechmatics STT] server error: %s", reason)
+                self._results_q.put_nowait(
+                    {"error": str(reason), "transcript": "", "confidence": 0.0, "is_final": True, "recoverable": False}
+                )
+                self._results_q.put_nowait({"done": True})
+                self._closed = True
+                if self._sender_task and not self._sender_task.done():
+                    self._sender_task.cancel()
+
+            @client.on(ServerMessageType.WARNING)
+            def _on_warning(msg: Dict[str, Any]) -> None:
+                logger.warning("[Speechmatics STT] server warning: %s", msg.get("reason", "unknown"))
+
+        async def _sender_loop(self) -> None:
+            session_end_reason = "unknown"
+            try:
+                while True:
+                    chunk = await self._audio_q.get()
+                    if chunk is None:
+                        session_end_reason = "client_finish"
+                        break
+                    if not chunk:
+                        continue
+                    try:
+                        await self._client.send_audio(chunk)
+                    except Exception as exc:  # noqa: BLE001
+                        session_end_reason = "send_audio_failed"
+                        logger.error("[Speechmatics STT] send_audio failed: %s", exc, exc_info=True)
+                        await self._results_q.put(
+                            {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True}
+                        )
+                        return
+
+                try:
+                    await asyncio.wait_for(self._client.stop_session(), timeout=10.0)
+                except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001
+                    logger.warning("[Speechmatics STT] graceful stop_session failed/timed out: %s", exc)
+                    await self._client.close()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                session_end_reason = "stream_exception"
+                logger.error("[Speechmatics STT] sender loop error: %s", exc, exc_info=True)
+                await self._results_q.put(
+                    {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True}
+                )
+            finally:
+                # Flush a still-pending AddTranscript segment that never got a
+                # trailing EndOfUtterance (e.g. the caller's last utterance
+                # before hangup, finalized right as the call tears down) --
+                # otherwise it's silently dropped. Mirrors Deepgram's
+                # UtteranceEnd/pending-prefix fallback in deepgram_stt_service.py.
+                if self._pending_transcript:
+                    await self._results_q.put(
+                        {
+                            "transcript": self._pending_transcript,
+                            "confidence": self._pending_confidence,
+                            "is_final": True,
+                        }
+                    )
+                    self._pending_transcript = ""
+                    self._pending_confidence = 0.0
+                logger.info("[Speechmatics STT] session_end reason=%s", session_end_reason)
+                await self._results_q.put({"done": True})
+
+        async def get_result(self) -> Dict[str, Any]:
+            return await self._results_q.get()
+
+    def create_streaming_session(
+        self,
+        language_code: str | None = None,
+        encoding: str | None = None,
+        sample_rate: int | None = None,
+        model: str | None = None,
+        api_config: Dict[str, Any] | None = None,
+        **_kwargs: Any,
+    ) -> "SpeechmaticsSTTService.StreamingSTTSession":
+        if not self._api_key:
+            raise RuntimeError("Speechmatics client not initialized — set SPEECHMATICS_API_KEY")
+
+        cfg = api_config or {}
+        eot_silence_trigger = float(
+            cfg.get("end_of_utterance_silence_trigger", settings.SPEECHMATICS_EOT_SILENCE_TRIGGER_SEC)
+        )
+        max_delay = float(cfg.get("max_delay", settings.SPEECHMATICS_MAX_DELAY_SEC))
+
+        return SpeechmaticsSTTService.StreamingSTTSession(
+            api_key=self._api_key,
+            url=settings.SPEECHMATICS_RT_URL or None,
+            language_code=language_code,
+            encoding=encoding or "MULAW",
+            sample_rate=sample_rate or settings.STT_SAMPLE_RATE or 8000,
+            model=model or cfg.get("model") or settings.SPEECHMATICS_STT_MODEL,
+            end_of_utterance_silence_trigger=eot_silence_trigger,
+            max_delay=max_delay,
+        )
+
+
+speechmatics_stt_service = SpeechmaticsSTTService()

--- a/app/voice/stt_pipeline.py
+++ b/app/voice/stt_pipeline.py
@@ -1,8 +1,9 @@
 """
 SttPipeline — provider-agnostic streaming STT wrapper.
 
-Supports Deepgram (existing Twilio MULAW path) and Google STT (LiveKit LINEAR16
-path). Provider is selected at construction time via provider_slug.
+Supports Deepgram (existing Twilio MULAW path), Google STT (LiveKit LINEAR16
+path), and Speechmatics (Twilio MULAW path, native VAD/end-of-utterance).
+Provider is selected at construction time via provider_slug.
 
 Public interface is unchanged for existing callers (VoiceOrchestrator):
   feed_audio_chunk(bytes)
@@ -39,8 +40,10 @@ class SttPipeline:
     emits typed events, and calls legacy interim/final callbacks.
 
     Providers:
-      "deepgram"  — DeepgramSTTService (MULAW 8kHz, Twilio path)
-      "google"    — GoogleSttService (LINEAR16 16kHz, LiveKit path)
+      "deepgram"     — DeepgramSTTService (MULAW 8kHz, Twilio path)
+      "google"       — GoogleSttService (LINEAR16 16kHz, LiveKit path)
+      "speechmatics" — SpeechmaticsSTTService (MULAW 8kHz, Twilio path; native
+                       EndOfUtterance drives turn-end, no app-side endpointing)
     """
 
     def __init__(
@@ -151,6 +154,8 @@ class SttPipeline:
 
         if self._provider_slug == "google":
             await self._ensure_google_session()
+        elif self._provider_slug == "speechmatics":
+            await self._ensure_speechmatics_session()
         else:
             await self._ensure_deepgram_session()
 
@@ -180,6 +185,19 @@ class SttPipeline:
             interim_results=True,
             api_config=self._api_config,
             silence_threshold_ms=self._silence_threshold_ms,
+        )
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        asyncio.create_task(self._stt_session.start())
+
+    async def _ensure_speechmatics_session(self) -> None:
+        from app.services.speechmatics_stt_service import speechmatics_stt_service
+
+        self._stt_session = speechmatics_stt_service.create_streaming_session(
+            language_code=self._language_code,
+            encoding=self._encoding,
+            sample_rate=self._sample_rate_hz,
+            model=self._model_id,
+            api_config=self._api_config,
         )
         self._reader_task = asyncio.create_task(self._reader_loop())
         asyncio.create_task(self._stt_session.start())

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ authlib==1.7.2
 google-auth==2.52.0
 google-auth-oauthlib==1.4.0
 deepgram-sdk==6.1.1
+speechmatics-rt==1.1.0
 google-cloud-texttospeech==2.36.0
 google-cloud-speech==2.40.0
 geopy==2.4.1

--- a/tests/services/test_speechmatics_stt.py
+++ b/tests/services/test_speechmatics_stt.py
@@ -1,0 +1,240 @@
+"""Speechmatics STT: session creation, event-translation, and EndOfUtterance-gated
+turn-final mapping into SttPipeline's result-dict contract."""
+import asyncio
+
+import pytest
+
+from app.services.speechmatics_stt_service import SpeechmaticsSTTService
+from app.voice.stt_pipeline import SttPipeline
+from speechmatics.rt import ServerMessageType
+
+
+class _FakeClient:
+    """Minimal stand-in for speechmatics.rt.AsyncClient's event-registration API."""
+
+    def __init__(self):
+        self._handlers: dict = {}
+
+    def on(self, event):
+        def decorator(fn):
+            self._handlers[event] = fn
+            return fn
+        return decorator
+
+    def emit(self, event, msg):
+        handler = self._handlers.get(event)
+        assert handler is not None, f"no handler registered for {event}"
+        handler(msg)
+
+
+def _partial_msg(transcript: str) -> dict:
+    return {"message": "AddPartialTranscript", "metadata": {"transcript": transcript}, "results": []}
+
+
+def _transcript_msg(transcript: str, confidence: float) -> dict:
+    return {
+        "message": "AddTranscript",
+        "metadata": {"transcript": transcript},
+        "results": [
+            {"type": "word", "alternatives": [{"content": transcript, "confidence": confidence}]}
+        ],
+    }
+
+
+# ── create_streaming_session ──────────────────────────────────────────────
+
+
+def test_create_streaming_session_requires_api_key():
+    svc = SpeechmaticsSTTService()
+    svc._api_key = None
+    with pytest.raises(RuntimeError):
+        svc.create_streaming_session()
+
+
+def test_create_streaming_session_uses_defaults_and_overrides():
+    svc = SpeechmaticsSTTService()
+    svc._api_key = "test-key"
+
+    default_session = svc.create_streaming_session()
+    assert default_session._eot_silence_trigger == pytest.approx(0.5)
+    assert default_session._max_delay == pytest.approx(2.0)
+    assert default_session._encoding == "MULAW"
+
+    overridden = svc.create_streaming_session(
+        api_config={"end_of_utterance_silence_trigger": 0.8, "max_delay": 3.0, "model": "standard"},
+    )
+    assert overridden._eot_silence_trigger == pytest.approx(0.8)
+    assert overridden._max_delay == pytest.approx(3.0)
+    assert overridden._model == "standard"
+
+
+# ── Event translation: partial / AddTranscript-accumulate / EndOfUtterance ──
+
+
+def _make_session() -> "SpeechmaticsSTTService.StreamingSTTSession":
+    return SpeechmaticsSTTService.StreamingSTTSession(
+        api_key="test-key",
+        url=None,
+        language_code="en",
+        encoding="MULAW",
+        sample_rate=8000,
+        model="enhanced",
+        end_of_utterance_silence_trigger=0.5,
+        max_delay=2.0,
+    )
+
+
+def test_partial_transcript_emits_interim_result():
+    session = _make_session()
+    client = _FakeClient()
+    session._register_handlers(client)
+
+    client.emit(ServerMessageType.ADD_PARTIAL_TRANSCRIPT, _partial_msg("hel"))
+
+    result = session._results_q.get_nowait()
+    assert result == {"transcript": "hel", "confidence": 0.0, "is_final": False}
+
+
+def test_add_transcript_is_withheld_until_end_of_utterance():
+    session = _make_session()
+    client = _FakeClient()
+    session._register_handlers(client)
+
+    client.emit(ServerMessageType.ADD_TRANSCRIPT, _transcript_msg("hello", 0.9))
+
+    # AddTranscript alone must not surface a pipeline result -- native EOU gates it.
+    assert session._results_q.empty()
+    assert session._pending_transcript == "hello"
+
+
+def test_end_of_utterance_emits_accumulated_final_result():
+    session = _make_session()
+    client = _FakeClient()
+    session._register_handlers(client)
+
+    client.emit(ServerMessageType.ADD_TRANSCRIPT, _transcript_msg("hello", 0.9))
+    client.emit(ServerMessageType.ADD_TRANSCRIPT, _transcript_msg("there", 0.7))
+    client.emit(ServerMessageType.END_OF_UTTERANCE, {"message": "EndOfUtterance"})
+
+    result = session._results_q.get_nowait()
+    assert result["transcript"] == "hello there"
+    assert result["is_final"] is True
+    # Confidence reflects the latest accumulated segment (mirrors Deepgram's adapter).
+    assert result["confidence"] == pytest.approx(0.7)
+    # Pending buffer must reset so the next utterance starts clean.
+    assert session._pending_transcript == ""
+
+
+def test_end_of_utterance_without_prior_transcript_emits_nothing():
+    session = _make_session()
+    client = _FakeClient()
+    session._register_handlers(client)
+
+    client.emit(ServerMessageType.END_OF_UTTERANCE, {"message": "EndOfUtterance"})
+
+    assert session._results_q.empty()
+
+
+def test_sender_loop_flushes_pending_transcript_on_close_without_end_of_utterance():
+    """A caller's final utterance may finalize (AddTranscript) right as the call
+    tears down, before Speechmatics' own silence timer ever fires EndOfUtterance.
+    finish()/aclose() must not silently drop it."""
+    session = _make_session()
+    client = _FakeClient()
+    session._register_handlers(client)
+    session._client = client
+
+    async def _fake_stop_session():
+        return None
+
+    client.stop_session = _fake_stop_session
+
+    # AddTranscript arrives but EndOfUtterance never does (call ends first).
+    client.emit(ServerMessageType.ADD_TRANSCRIPT, _transcript_msg("book it", 0.85))
+    assert session._results_q.empty()
+
+    async def _run():
+        session.finish()  # pushes the None sentinel _sender_loop is waiting on
+        await session._sender_loop()
+
+    asyncio.run(_run())
+
+    flushed = session._results_q.get_nowait()
+    assert flushed == {"transcript": "book it", "confidence": 0.85, "is_final": True}
+
+    done = session._results_q.get_nowait()
+    assert done == {"done": True}
+
+
+def test_server_error_emits_error_then_done_and_stops_session():
+    session = _make_session()
+    client = _FakeClient()
+    session._register_handlers(client)
+
+    client.emit(ServerMessageType.ERROR, {"message": "Error", "reason": "boom"})
+
+    error_result = session._results_q.get_nowait()
+    assert error_result["error"] == "boom"
+    assert error_result["is_final"] is True
+    assert error_result["recoverable"] is False
+
+    done_result = session._results_q.get_nowait()
+    assert done_result == {"done": True}
+    assert session._closed is True
+
+
+# ── SttPipeline forwards model_id + api_config to the Speechmatics service ──
+
+
+def test_stt_pipeline_forwards_model_and_api_config_to_speechmatics(monkeypatch):
+    captured = {}
+
+    def fake_create_streaming_session(**kwargs):
+        captured.update(kwargs)
+
+        class FakeSession:
+            async def start(self):
+                return None
+
+            async def get_result(self):
+                await asyncio.sleep(1)
+                return {}
+
+            def push_audio(self, _):
+                return None
+
+            def finish(self):
+                return None
+
+        return FakeSession()
+
+    from app.services import speechmatics_stt_service as sm_module
+
+    monkeypatch.setattr(
+        sm_module.speechmatics_stt_service,
+        "create_streaming_session",
+        fake_create_streaming_session,
+    )
+
+    async def on_interim(_, __):
+        return None
+
+    async def on_final(_, __):
+        return None
+
+    async def _run():
+        pipeline = SttPipeline(
+            language_code="en",
+            on_interim=on_interim,
+            on_final=on_final,
+            provider_slug="speechmatics",
+            model_id="enhanced",
+            api_config={"end_of_utterance_silence_trigger": 0.8},
+        )
+        await pipeline.feed_audio_chunk(b"\x00")
+        await pipeline.aclose()
+
+    asyncio.run(_run())
+
+    assert captured.get("model") == "enhanced"
+    assert captured.get("api_config") == {"end_of_utterance_silence_trigger": 0.8}


### PR DESCRIPTION
## Summary
- Adds Speechmatics as a new STT provider, integrated into the existing provider-agnostic `SttPipeline` (single new branch in `_ensure_session`, same duck-typed session contract as Deepgram/Google — no separate pipeline).
- Turn detection uses Speechmatics' own native `EndOfUtterance` event exclusively (server-side VAD via `end_of_utterance_silence_trigger`) — `AddTranscript` segments are accumulated and only promoted to a pipeline-final result when `EndOfUtterance` fires, so exactly one LLM turn triggers per utterance. Any segment still pending when a session closes without a prior `EndOfUtterance` is flushed rather than dropped (code-reviewer caught this as a real gap; fixed + covered by a regression test).
- Works over both existing call transports with zero orchestrator changes: Twilio (MULAW 8kHz, direct feed) and LiveKit browser/"Share Demo Link" calls (forced LINEAR16 16kHz) — encoding/sample rate already flow generically through `resolve_stt_runtime()`.
- `SPEECHMATICS_API_KEY` (+ related tuning settings) follow the same flat `Settings` field pattern as `DEEPGRAM_API_KEY`; no hardcoded key anywhere. No in-repo AWS Secrets Manager code exists for any provider today — production key injection remains a deploy-side concern, same as the existing Deepgram/Google keys.
- Seeds one `sttprovider`/`sttmodel` catalog row via migration. Language selection already flows through `agent.stt_language_code` with no provider-specific restriction (matches how Deepgram/Google already support many languages off a single catalog row) — no per-language catalog seeding needed to use Speechmatics' 40+ supported languages.

## Test plan
- [x] `pytest tests/services/test_speechmatics_stt.py -v` — 9/9 passing (session config, partial/AddTranscript/EndOfUtterance event translation, pending-transcript-flush-on-close regression, server-error handling, SttPipeline forwarding)
- [x] Full existing STT suite (`test_google_stt.py`, `test_deepgram_stt_model_selection.py`, `test_stt_regressions.py`, `test_bidirectional_interim_regression.py`) — 57/57 passing, no regressions
- [x] `ruff check` clean on all new/changed files
- [x] Single Alembic head confirmed after new migration
- [x] Reviewed by `code-reviewer` agent — one high-severity finding (silent trailing-utterance drop) fixed before this PR; one accepted-parity finding (queue growth on init failure, matches existing Deepgram behavior) left as-is
- [ ] Manual live-call verification against a real `SPEECHMATICS_API_KEY` (not done in this session — no key available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)