### PR TITLE
feat(voice): add xAI Grok STT as a new STT provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,9 @@ SPEECHMATICS_API_KEY=
 # Leave blank to use the SDK default (wss://eu2.rt.speechmatics.com/v2)
 SPEECHMATICS_RT_URL=
 
+# xAI Grok STT (optional STT provider — native Smart Turn end-of-turn detection)
+XAI_API_KEY=
+
 # Stripe
 STRIPE_PUBLISHABLE_KEY=pk_test_...
 STRIPE_SECRET_KEY=sk_test_...

--- a/alembic/versions/20260814_add_xai_grok_stt_provider.py
+++ b/alembic/versions/20260814_add_xai_grok_stt_provider.py
@@ -1,0 +1,103 @@
+"""add xai grok stt provider and catalog model
+
+Revision ID: 20260814_xai_grok_stt
+Revises: 20260814_elevenlabs_scribe_stt
+Create Date: 2026-08-14
+
+Seeds a new 'xai' sttprovider row + one sttmodel row (MULAW 8kHz, Twilio-
+native, matching Deepgram/Speechmatics/ElevenLabs convention).
+
+xAI's STT API (wss://api.x.ai/v1/stt) has no model-selection parameter at
+all -- confirmed absent from both the REST and streaming query-param tables
+in xAI's official docs. external_model_id is schema-required (NOT NULL) but
+is a catalog-only placeholder here ('default'), never sent to xAI as an API
+parameter -- see app/services/xai_grok_stt_service.py's create_streaming_session().
+
+metadata_json carries xAI's native turn-detection tuning (endpointing_ms,
+smart_turn_threshold, smart_turn_timeout_ms) so resolve_stt_runtime() needs
+no code changes, same pattern as every other provider's catalog row.
+"""
+from typing import Sequence, Union
+
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "20260814_xai_grok_stt"
+down_revision: Union[str, Sequence[str], None] = "20260814_elevenlabs_scribe_stt"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO sttprovider (id, slug, display_name, is_active, supports_streaming)
+            VALUES (gen_random_uuid(), 'xai', 'xAI Grok', true, true)
+            ON CONFLICT (slug) DO NOTHING
+            """
+        )
+    )
+
+    xai_id = conn.execute(
+        sa.text("SELECT id FROM sttprovider WHERE slug = 'xai'")
+    ).scalar()
+    if xai_id is None:
+        return
+
+    model_rows = [
+        (
+            "default",
+            "xAI Grok STT",
+            "en",
+            8000,
+            "MULAW",
+            {
+                "endpointing_ms": 10,
+                "smart_turn_threshold": 0.5,
+                "smart_turn_timeout_ms": 3000,
+            },
+        ),
+    ]
+    for external_model_id, display_name, language_code, sample_rate_hz, encoding, metadata in model_rows:
+        conn.execute(
+            sa.text(
+                """
+                INSERT INTO sttmodel (
+                  id, provider_id, external_model_id, display_name,
+                  language_code, sample_rate_hz, encoding, metadata_json, is_active
+                )
+                VALUES (
+                  gen_random_uuid(), CAST(:provider_id AS uuid), :external_model_id,
+                  :display_name, :language_code, :sample_rate_hz, :encoding,
+                  CAST(:metadata_json AS jsonb), true
+                )
+                ON CONFLICT (provider_id, external_model_id) DO NOTHING
+                """
+            ),
+            {
+                "provider_id": str(xai_id),
+                "external_model_id": external_model_id,
+                "display_name": display_name,
+                "language_code": language_code,
+                "sample_rate_hz": sample_rate_hz,
+                "encoding": encoding,
+                "metadata_json": json.dumps(metadata),
+            },
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM sttmodel
+            WHERE provider_id IN (SELECT id FROM sttprovider WHERE slug = 'xai')
+            """
+        )
+    )
+    op.execute(sa.text("DELETE FROM sttprovider WHERE slug = 'xai'"))

--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -73,7 +73,7 @@ class ResolvedLlmRuntime:
 class ResolvedSttRuntime:
     """Runtime STT config resolved from agent + optional flow settings override."""
 
-    provider_slug: str          # "deepgram" | "google" | "speechmatics" | "elevenlabs"
+    provider_slug: str          # "deepgram" | "google" | "speechmatics" | "elevenlabs" | "xai"
     model_id: str               # user-facing modelId e.g. "nova-3", "chirp-3"
     language_code: str          # BCP-47 e.g. "en-AU", "en"
     sample_rate_hz: int         # from sttmodel catalog (e.g. 8000 or 16000)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -575,6 +575,23 @@ class Settings(BaseSettings):
     ELEVENLABS_SCRIBE_MIN_SPEECH_DURATION_MS: int = 100
     ELEVENLABS_SCRIBE_MIN_SILENCE_DURATION_MS: int = 100
 
+    # xAI Grok Speech-to-Text (wss://api.x.ai/v1/stt) — dedicated key, no
+    # existing xAI credential to reuse.
+    XAI_API_KEY: str = ""
+    XAI_STT_LANGUAGE: str = "en"
+    # Silence (ms) before a turn-boundary check fires. Low by design (xAI
+    # default is 10ms) -- Smart Turn's ML judgment, not raw silence duration,
+    # is what actually governs speech_final; see below.
+    XAI_STT_ENDPOINTING_MS: int = 10
+    # Native server-side turn detection: Smart Turn ML model demotes false-
+    # positive silence boundaries (mid-sentence pauses, dictating numbers) to
+    # chunk-final instead of firing speech_final. Threshold range 0.0-1.0;
+    # 0.5 = "balanced" per xAI's own docs.
+    XAI_STT_SMART_TURN_THRESHOLD: float = 0.5
+    # Safety net: force speech_final after this many ms of silence regardless
+    # of Smart Turn confidence, so a session can't hang indefinitely. Range 1-5000ms.
+    XAI_STT_SMART_TURN_TIMEOUT_MS: int = 3000
+
     # Deepgram Speech-to-Text (replaces Google STT for streaming + batch)
     DEEPGRAM_API_KEY: str = ""
     DEEPGRAM_STT_MODEL: str = "nova-3"

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -67,6 +67,7 @@ class SttProviderEnum(str, Enum):
     google = "google"
     elevenlabs = "elevenlabs"
     speechmatics = "speechmatics"
+    xai = "xai"
 
 
 class SttModelSchema(BaseModel):

--- a/app/services/xai_grok_stt_service.py
+++ b/app/services/xai_grok_stt_service.py
@@ -163,9 +163,10 @@ class XaiGrokSTTService:
 
             if not self._api_key:
                 await self._results_q.put(
-                    {"error": "xAI client not initialized", "transcript": "", "confidence": 0.0, "is_final": True}
+                    {"error": "xAI client not initialized", "transcript": "", "confidence": 0.0, "is_final": True, "recoverable": False}
                 )
                 self._push_done()
+                self._closed = True  # no sender/receiver task will ever drain push_audio()
                 return
 
             xai_encoding = "mulaw" if self._encoding == "MULAW" else "pcm"
@@ -198,6 +199,7 @@ class XaiGrokSTTService:
                     {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True, "recoverable": False}
                 )
                 self._push_done()
+                self._closed = True  # no sender/receiver task will ever drain push_audio()
                 return
 
             self._receiver_task = asyncio.create_task(self._receiver_loop())
@@ -298,7 +300,7 @@ class XaiGrokSTTService:
                         session_end_reason = "send_audio_failed"
                         logger.error("[xAI Grok STT] send failed: %s", exc, exc_info=True)
                         await self._results_q.put(
-                            {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True}
+                            {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True, "recoverable": False}
                         )
                         return
 

--- a/app/services/xai_grok_stt_service.py
+++ b/app/services/xai_grok_stt_service.py
@@ -1,0 +1,385 @@
+"""
+xAI Grok Speech-to-Text: streaming (Twilio MULAW / LiveKit LINEAR16) provider.
+Provider implementation used by SttPipeline, mirroring the duck-typed session
+contract (push_audio/finish/start/get_result) used by every other adapter.
+
+Endpoint: wss://api.x.ai/v1/stt -- a standalone, STT-only realtime WebSocket,
+verified against the raw (non-summarized) official docs markdown, distinct
+from xAI's separate full speech-to-speech agent API (wss://api.x.ai/v1/realtime,
+not used here). No vendor SDK exists for this endpoint; the official docs'
+own example uses the raw `websockets` library directly (already pinned in
+requirements.txt), so this adapter does the same -- no new dependency.
+
+Audio is sent as raw binary WebSocket frames (no base64), matching Speechmatics
+and unlike ElevenLabs. Config is via URL query parameters only -- no setup
+message required, matching ElevenLabs and unlike Speechmatics.
+
+Turn detection uses xAI's native server-side mechanisms exclusively -- no
+local/application VAD:
+  - `endpointing`: silence (ms) before a turn-boundary check fires.
+  - Smart Turn (`smart_turn` threshold + `smart_turn_timeout` safety net): an
+    ML model that judges whether a silence pause is a real turn end or just a
+    mid-sentence pause, demoting false positives to "chunk-final" instead of
+    firing the real turn boundary.
+
+CRITICAL and easy to get wrong: xAI's `transcript.partial` event carries a
+*three-state* dual flag, not a simple boolean --
+  (is_final=false, speech_final=false) -> interim, still changing
+  (is_final=true,  speech_final=false) -> "chunk-final": text locked for this
+      ~3s window, but NOT a turn boundary (e.g. Smart Turn demoted a
+      mid-sentence pause) -- must NOT be surfaced as a pipeline final, or
+      every ~3s of continuous speech would spuriously trigger an LLM turn.
+  (is_final=true,  speech_final=true)  -> the real turn boundary -- this is
+      the only case that maps to our pipeline's is_final=True.
+
+There is no flush-on-close primitive gap here (unlike ElevenLabs): xAI's
+`{"type": "audio.done"}` -> `transcript.done` is a documented graceful-drain
+sequence. Before sending it, any audio pushed since the last speech_final is
+force-finalized via `{"type": "finalize"}` (xAI's PTT primitive) so a
+caller's trailing utterance isn't silently dropped at call teardown.
+
+Unlike every other provider here, xAI's `error` event does NOT close the
+connection (per the official docs) -- it's treated as recoverable/non-fatal
+here rather than tearing the session down, matching that documented behavior.
+
+xAI's STT API has no `model` parameter at all (verified absent from both the
+REST and streaming query-param tables in the official docs) -- there is
+nothing to select. `model` is still accepted here for interface parity with
+SttPipeline's provider dispatch, but it is never sent to xAI.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Dict
+from urllib.parse import urlencode
+
+from websockets.asyncio.client import connect as websocket_connect
+
+from app.core.config import settings
+from app.core.logger import logger
+
+_XAI_STT_URL = "wss://api.x.ai/v1/stt"
+
+# Documented bounds. Values outside these ranges may be rejected or behave
+# unpredictably server-side -- clamp so a misconfigured env var/catalog
+# metadata_json value can't silently degrade a live call (lesson learned
+# from the Speechmatics/ElevenLabs adapters' equivalent review findings).
+_ENDPOINTING_MS_RANGE = (0, 5000)
+_SMART_TURN_THRESHOLD_RANGE = (0.0, 1.0)
+_SMART_TURN_TIMEOUT_MS_RANGE = (1, 5000)
+
+
+def _clamp(value: float, lo: float, hi: float, *, label: str) -> float:
+    if value < lo or value > hi:
+        logger.warning(
+            "[xAI Grok STT] %s=%s out of range [%s, %s] — clamping",
+            label, value, lo, hi,
+        )
+        return max(lo, min(hi, value))
+    return value
+
+
+def _mask_key(key: str | None) -> str:
+    """Safe, non-reversible preview for diagnostics — never logs the raw key."""
+    if not key:
+        return "<empty>"
+    if len(key) <= 8:
+        return f"<masked len={len(key)}>"
+    return f"{key[:4]}...{key[-2:]} (len={len(key)})"
+
+
+class XaiGrokSTTService:
+    """Service for xAI Grok realtime streaming STT."""
+
+    def __init__(self) -> None:
+        key = (settings.XAI_API_KEY or "").strip()
+        self._api_key = key or None
+        if key:
+            logger.info("xAI Grok STT configured (%s)", _mask_key(key))
+        else:
+            logger.warning("XAI_API_KEY not set — xAI Grok STT will fail until configured")
+
+    class StreamingSTTSession:
+        """
+        Long-lived xAI Grok realtime transcription over WebSocket.
+        Exposes a stable session interface (push_audio, finish, start, get_result).
+        """
+
+        def __init__(
+            self,
+            *,
+            api_key: str | None,
+            language_code: str | None,
+            encoding: str,
+            sample_rate: int,
+            endpointing_ms: int,
+            smart_turn_threshold: float,
+            smart_turn_timeout_ms: int,
+        ) -> None:
+            self._api_key = api_key
+            self._language_code = language_code or settings.XAI_STT_LANGUAGE or "en"
+            self._encoding = encoding.upper() if encoding else "MULAW"
+            self._sample_rate = sample_rate or 8000
+            self._endpointing_ms = endpointing_ms
+            self._smart_turn_threshold = smart_turn_threshold
+            self._smart_turn_timeout_ms = smart_turn_timeout_ms
+
+            self._ws = None
+            self._audio_q: "asyncio.Queue[bytes | None]" = asyncio.Queue()
+            self._results_q: "asyncio.Queue[dict]" = asyncio.Queue()
+            self._closed = False
+            self._task_started = False
+            self._sender_task: asyncio.Task | None = None
+            self._receiver_task: asyncio.Task | None = None
+            self._done_pushed = False
+
+            # Set when the server sends transcript.created -- audio must not
+            # be sent before this.
+            self._ready_evt = asyncio.Event()
+            # Set when the server sends transcript.done -- graceful shutdown
+            # waits on this after sending audio.done.
+            self._transcript_done_evt = asyncio.Event()
+
+            # Tracks whether speech has occurred since the last speech_final,
+            # so finish() knows whether a forced `finalize` is needed before
+            # gracefully ending via audio.done.
+            self._audio_since_final = False
+
+        def push_audio(self, audio_chunk: bytes) -> None:
+            if self._closed:
+                return
+            self._audio_q.put_nowait(audio_chunk)
+
+        def finish(self) -> None:
+            if not self._closed:
+                self._closed = True
+                self._audio_q.put_nowait(None)
+
+        async def start(self) -> None:
+            if self._task_started:
+                return
+            self._task_started = True
+
+            if not self._api_key:
+                await self._results_q.put(
+                    {"error": "xAI client not initialized", "transcript": "", "confidence": 0.0, "is_final": True}
+                )
+                self._push_done()
+                return
+
+            xai_encoding = "mulaw" if self._encoding == "MULAW" else "pcm"
+            params: Dict[str, Any] = {
+                "sample_rate": self._sample_rate,
+                "encoding": xai_encoding,
+                "interim_results": "true",
+                "endpointing": self._endpointing_ms,
+                "language": self._language_code,
+                "smart_turn": self._smart_turn_threshold,
+                "smart_turn_timeout": self._smart_turn_timeout_ms,
+            }
+            url = f"{_XAI_STT_URL}?{urlencode(params)}"
+
+            try:
+                logger.info(
+                    "[xAI Grok STT] session_start language=%s sample_rate=%s encoding=%s "
+                    "endpointing_ms=%s smart_turn=%s smart_turn_timeout_ms=%s api_key=%s",
+                    self._language_code, self._sample_rate, self._encoding,
+                    self._endpointing_ms, self._smart_turn_threshold, self._smart_turn_timeout_ms,
+                    _mask_key(self._api_key),
+                )
+                self._ws = await websocket_connect(
+                    url,
+                    additional_headers={"Authorization": f"Bearer {self._api_key}"},
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.error("[xAI Grok STT] session start error: %s", exc, exc_info=True)
+                await self._results_q.put(
+                    {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True, "recoverable": False}
+                )
+                self._push_done()
+                return
+
+            self._receiver_task = asyncio.create_task(self._receiver_loop())
+            self._sender_task = asyncio.create_task(self._sender_loop())
+
+        async def _receiver_loop(self) -> None:
+            try:
+                async for raw in self._ws:
+                    try:
+                        data = json.loads(raw)
+                    except (TypeError, ValueError):
+                        continue
+                    self._handle_message(data)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.error("[xAI Grok STT] receiver loop error: %s", exc, exc_info=True)
+            finally:
+                # Unblock a shutdown that's waiting on transcript.done if the
+                # socket just died instead of gracefully closing.
+                self._transcript_done_evt.set()
+
+        def _handle_message(self, data: Dict[str, Any]) -> None:
+            msg_type = data.get("type")
+            if msg_type == "transcript.created":
+                self._ready_evt.set()
+            elif msg_type == "transcript.partial":
+                self._handle_partial(data)
+            elif msg_type == "transcript.done":
+                self._transcript_done_evt.set()
+            elif msg_type == "error":
+                # Per xAI's docs, the connection stays open after an error --
+                # surface as recoverable, don't tear the session down.
+                reason = data.get("message", "unknown")
+                logger.warning("[xAI Grok STT] server error (non-fatal): %s", reason)
+                self._results_q.put_nowait(
+                    {"error": str(reason), "transcript": "", "confidence": 0.0, "is_final": False, "recoverable": True}
+                )
+
+        def _handle_partial(self, data: Dict[str, Any]) -> None:
+            transcript = (data.get("text") or "").strip()
+            if not transcript:
+                return
+
+            is_final = bool(data.get("is_final"))
+            speech_final = bool(data.get("speech_final"))
+
+            if not is_final:
+                # (false, false) -- interim, still changing.
+                self._audio_since_final = True
+                self._results_q.put_nowait({"transcript": transcript, "confidence": 0.0, "is_final": False})
+                return
+
+            if not speech_final:
+                # (true, false) -- chunk-final: text locked for this window
+                # but NOT a turn boundary. Withheld from the pipeline --
+                # surfacing this as is_final=True would spuriously trigger an
+                # LLM turn every ~3s of continuous speech.
+                self._audio_since_final = True
+                return
+
+            # (true, true) -- utterance-final: the real turn boundary.
+            self._audio_since_final = False
+            self._results_q.put_nowait({"transcript": transcript, "confidence": 0.0, "is_final": True})
+
+        def _push_done(self) -> None:
+            if self._done_pushed:
+                return
+            self._done_pushed = True
+            self._results_q.put_nowait({"done": True})
+
+        async def _sender_loop(self) -> None:
+            session_end_reason = "unknown"
+            try:
+                try:
+                    await asyncio.wait_for(self._ready_evt.wait(), timeout=10.0)
+                except asyncio.TimeoutError:
+                    session_end_reason = "ready_timeout"
+                    await self._results_q.put(
+                        {
+                            "error": "xAI STT did not signal ready (transcript.created) in time",
+                            "transcript": "", "confidence": 0.0, "is_final": True, "recoverable": False,
+                        }
+                    )
+                    return
+
+                while True:
+                    chunk = await self._audio_q.get()
+                    if chunk is None:
+                        session_end_reason = "client_finish"
+                        break
+                    if not chunk:
+                        continue
+                    try:
+                        await self._ws.send(chunk)  # raw binary, no base64
+                        self._audio_since_final = True
+                    except Exception as exc:  # noqa: BLE001
+                        session_end_reason = "send_audio_failed"
+                        logger.error("[xAI Grok STT] send failed: %s", exc, exc_info=True)
+                        await self._results_q.put(
+                            {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True}
+                        )
+                        return
+
+                # Graceful shutdown: force any pending speech to finalize
+                # immediately (PTT-style), then signal end-of-audio and wait
+                # for the server's documented flush-and-close acknowledgement.
+                if self._audio_since_final:
+                    try:
+                        await self._ws.send(json.dumps({"type": "finalize"}))
+                        await asyncio.sleep(0.5)  # let the resulting speech_final partial arrive
+                    except Exception as exc:  # noqa: BLE001
+                        logger.warning("[xAI Grok STT] finalize-on-close failed: %s", exc)
+
+                try:
+                    await self._ws.send(json.dumps({"type": "audio.done"}))
+                    await asyncio.wait_for(self._transcript_done_evt.wait(), timeout=5.0)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("[xAI Grok STT] graceful audio.done wait failed/timed out: %s", exc)
+
+                try:
+                    await self._ws.close()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("[xAI Grok STT] close failed: %s", exc)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                session_end_reason = "stream_exception"
+                logger.error("[xAI Grok STT] sender loop error: %s", exc, exc_info=True)
+                await self._results_q.put(
+                    {"error": str(exc), "transcript": "", "confidence": 0.0, "is_final": True}
+                )
+            finally:
+                logger.info("[xAI Grok STT] session_end reason=%s", session_end_reason)
+                self._push_done()
+                if self._receiver_task and not self._receiver_task.done():
+                    self._receiver_task.cancel()
+
+        async def get_result(self) -> Dict[str, Any]:
+            return await self._results_q.get()
+
+    def create_streaming_session(
+        self,
+        language_code: str | None = None,
+        encoding: str | None = None,
+        sample_rate: int | None = None,
+        model: str | None = None,
+        api_config: Dict[str, Any] | None = None,
+        **_kwargs: Any,
+    ) -> "XaiGrokSTTService.StreamingSTTSession":
+        """`model` is accepted for interface parity with the other STT
+        adapters' create_streaming_session() signature (SttPipeline always
+        passes model=self._model_id) but is intentionally never forwarded to
+        xAI -- the API has no model parameter."""
+        if not self._api_key:
+            raise RuntimeError("xAI client not initialized — set XAI_API_KEY")
+
+        cfg = api_config or {}
+        endpointing_ms = _clamp(
+            float(cfg.get("endpointing_ms", settings.XAI_STT_ENDPOINTING_MS)),
+            *_ENDPOINTING_MS_RANGE,
+            label="endpointing_ms",
+        )
+        smart_turn_threshold = _clamp(
+            float(cfg.get("smart_turn_threshold", settings.XAI_STT_SMART_TURN_THRESHOLD)),
+            *_SMART_TURN_THRESHOLD_RANGE,
+            label="smart_turn_threshold",
+        )
+        smart_turn_timeout_ms = _clamp(
+            float(cfg.get("smart_turn_timeout_ms", settings.XAI_STT_SMART_TURN_TIMEOUT_MS)),
+            *_SMART_TURN_TIMEOUT_MS_RANGE,
+            label="smart_turn_timeout_ms",
+        )
+        return XaiGrokSTTService.StreamingSTTSession(
+            api_key=self._api_key,
+            language_code=language_code,
+            encoding=encoding or "MULAW",
+            sample_rate=sample_rate or settings.STT_SAMPLE_RATE or 8000,
+            endpointing_ms=int(endpointing_ms),
+            smart_turn_threshold=smart_turn_threshold,
+            smart_turn_timeout_ms=int(smart_turn_timeout_ms),
+        )
+
+
+xai_grok_stt_service = XaiGrokSTTService()

--- a/app/voice/stt_pipeline.py
+++ b/app/voice/stt_pipeline.py
@@ -2,8 +2,9 @@
 SttPipeline — provider-agnostic streaming STT wrapper.
 
 Supports Deepgram (existing Twilio MULAW path), Google STT (LiveKit LINEAR16
-path), Speechmatics (Twilio MULAW path, native VAD/end-of-utterance), and
-ElevenLabs Scribe v2 Realtime (Twilio MULAW path, native VAD/commit strategy).
+path), Speechmatics (Twilio MULAW path, native VAD/end-of-utterance),
+ElevenLabs Scribe v2 Realtime (Twilio MULAW path, native VAD/commit strategy),
+and xAI Grok STT (Twilio MULAW path, native Smart Turn end-of-turn detection).
 Provider is selected at construction time via provider_slug.
 
 Public interface is unchanged for existing callers (VoiceOrchestrator):
@@ -47,6 +48,8 @@ class SttPipeline:
                        EndOfUtterance drives turn-end, no app-side endpointing)
       "elevenlabs"   — ElevenLabsScribeSTTService (MULAW 8kHz, Twilio path;
                        native VAD/commit_strategy drives turn-end)
+      "xai"          — XaiGrokSTTService (MULAW 8kHz, Twilio path; native
+                       Smart Turn / endpointing drives turn-end)
     """
 
     def __init__(
@@ -161,6 +164,8 @@ class SttPipeline:
             await self._ensure_speechmatics_session()
         elif self._provider_slug == "elevenlabs":
             await self._ensure_elevenlabs_session()
+        elif self._provider_slug == "xai":
+            await self._ensure_xai_session()
         else:
             await self._ensure_deepgram_session()
 
@@ -211,6 +216,19 @@ class SttPipeline:
         from app.services.elevenlabs_scribe_stt_service import elevenlabs_scribe_stt_service
 
         self._stt_session = elevenlabs_scribe_stt_service.create_streaming_session(
+            language_code=self._language_code,
+            encoding=self._encoding,
+            sample_rate=self._sample_rate_hz,
+            model=self._model_id,
+            api_config=self._api_config,
+        )
+        self._reader_task = asyncio.create_task(self._reader_loop())
+        asyncio.create_task(self._stt_session.start())
+
+    async def _ensure_xai_session(self) -> None:
+        from app.services.xai_grok_stt_service import xai_grok_stt_service
+
+        self._stt_session = xai_grok_stt_service.create_streaming_session(
             language_code=self._language_code,
             encoding=self._encoding,
             sample_rate=self._sample_rate_hz,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -16541,6 +16541,7 @@ components:
       - google
       - elevenlabs
       - speechmatics
+      - xai
       title: SttProviderEnum
     SttSettingsJsonSchema:
       properties:

--- a/tests/integration/test_xai_stt_live.py
+++ b/tests/integration/test_xai_stt_live.py
@@ -1,0 +1,105 @@
+"""
+Live xAI Grok STT integration tests — require a real XAI_API_KEY.
+
+Run (loads .env automatically via python-dotenv):
+
+    RUN_XAI_STT_INTEGRATION=1 pytest tests/integration/test_xai_stt_live.py -v
+
+Unlike the Google STT live test, this doesn't assert transcript accuracy
+against a fixed phrase (no shared speech fixture exists for this provider,
+and generating one requires a separate TTS credential dependency this
+provider shouldn't need). Instead it verifies the real session lifecycle
+end-to-end against xAI's actual API: connect + auth succeeds, transcript.created
+arrives, audio streams without error, and graceful shutdown (finalize ->
+audio.done -> transcript.done -> close) completes cleanly.
+"""
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv()
+
+pytestmark = pytest.mark.integration
+
+_SKIP_LIVE = pytest.mark.skipif(
+    os.environ.get("RUN_XAI_STT_INTEGRATION", "").lower() not in ("1", "true", "yes"),
+    reason="Set RUN_XAI_STT_INTEGRATION=1 to run live xAI STT tests",
+)
+
+_SKIP_NO_KEY = pytest.mark.skipif(
+    not (os.environ.get("XAI_API_KEY") or "").strip(),
+    reason="XAI_API_KEY not set — skipping live xAI STT tests",
+)
+
+
+def _synthetic_mulaw_tone(duration_sec: float = 2.0, sample_rate: int = 8000) -> bytes:
+    """Generate a synthetic tone as 8-bit MULAW — enough to exercise the
+    session lifecycle (connect/auth/stream/shutdown) without needing a real
+    speech fixture. Not expected to produce a meaningful transcript."""
+
+    def linear_to_mulaw(sample: int) -> int:
+        sign = 0 if sample >= 0 else 0x80
+        sample = min(abs(sample), 32635)
+        sample += 132
+        exponent = 7
+        for exp_mask in (0x4000, 0x2000, 0x1000, 0x0800, 0x0400, 0x0200, 0x0100):
+            if sample & exp_mask:
+                break
+            exponent -= 1
+        mantissa = (sample >> (exponent + 3)) & 0x0F
+        return ~(sign | (exponent << 4) | mantissa) & 0xFF
+
+    freq = 220.0
+    frames = bytearray()
+    for i in range(int(sample_rate * duration_sec)):
+        val = int(8000 * math.sin(2 * math.pi * freq * i / sample_rate))
+        frames.append(linear_to_mulaw(val))
+    return bytes(frames)
+
+
+@_SKIP_LIVE
+@_SKIP_NO_KEY
+class TestXaiGrokSttLive:
+    def test_session_connects_streams_and_shuts_down_cleanly(self):
+        from app.services.xai_grok_stt_service import xai_grok_stt_service
+
+        async def _run():
+            session = xai_grok_stt_service.create_streaming_session(
+                language_code="en",
+                encoding="MULAW",
+                sample_rate=8000,
+            )
+            await session.start()
+
+            audio = _synthetic_mulaw_tone()
+            chunk_size = 800  # 100ms at 8kHz mulaw
+            for offset in range(0, len(audio), chunk_size):
+                session.push_audio(audio[offset:offset + chunk_size])
+                await asyncio.sleep(0.1)
+
+            session.finish()
+
+            results = []
+            saw_done = False
+            saw_fatal_error = False
+            for _ in range(200):  # bounded drain, avoid hanging forever on a real network call
+                result = await asyncio.wait_for(session.get_result(), timeout=10.0)
+                results.append(result)
+                if result.get("done"):
+                    saw_done = True
+                    break
+                if result.get("error") and not result.get("recoverable", True):
+                    saw_fatal_error = True
+                    break
+
+            return results, saw_done, saw_fatal_error
+
+        results, saw_done, saw_fatal_error = asyncio.run(_run())
+
+        assert not saw_fatal_error, f"Session ended with a non-recoverable error: {results}"
+        assert saw_done, f"Session never reached a clean done state: {results}"

--- a/tests/services/test_xai_grok_stt.py
+++ b/tests/services/test_xai_grok_stt.py
@@ -258,6 +258,63 @@ def test_sender_loop_forwards_audio_chunks_as_raw_binary():
     assert ws.sent[0] == b"\x01\x02\x03"
 
 
+def test_send_failure_result_is_marked_non_recoverable():
+    """A send() failure tears the session down immediately (finally pushes
+    done) -- the error result must say so, or a future recoverable-aware
+    consumer would wrongly treat this as a transient/retryable condition."""
+    session = _make_session()
+
+    class _FailingWebSocket:
+        async def send(self, data):
+            raise ConnectionError("boom")
+
+        async def close(self):
+            return None
+
+    session._ws = _FailingWebSocket()
+
+    async def _run():
+        session._ready_evt.set()
+        session.push_audio(b"\x01\x02\x03")
+        session.finish()
+        await session._sender_loop()
+
+    asyncio.run(_run())
+
+    error_result = session._results_q.get_nowait()
+    assert error_result["error"] == "boom"
+    assert error_result["recoverable"] is False
+
+    done_result = session._results_q.get_nowait()
+    assert done_result == {"done": True}
+
+
+def test_start_without_api_key_closes_session_so_push_audio_is_dropped():
+    """No sender/receiver task is ever created when start() fails before
+    connecting -- push_audio() must not keep enqueueing into a queue with no
+    consumer."""
+    session = XaiGrokSTTService.StreamingSTTSession(
+        api_key=None,
+        language_code="en",
+        encoding="MULAW",
+        sample_rate=8000,
+        endpointing_ms=10,
+        smart_turn_threshold=0.5,
+        smart_turn_timeout_ms=3000,
+    )
+
+    asyncio.run(session.start())
+
+    error_result = session._results_q.get_nowait()
+    assert error_result["recoverable"] is False
+    done_result = session._results_q.get_nowait()
+    assert done_result == {"done": True}
+
+    # push_audio() after the failed start() must be a no-op, not silently queued forever.
+    session.push_audio(b"\x01\x02\x03")
+    assert session._audio_q.qsize() == 0
+
+
 def test_push_done_is_idempotent():
     session = _make_session()
     session._push_done()

--- a/tests/services/test_xai_grok_stt.py
+++ b/tests/services/test_xai_grok_stt.py
@@ -1,0 +1,324 @@
+"""xAI Grok STT: session creation, three-state transcript-flag mapping, Smart
+Turn configuration, error handling (non-fatal per xAI's docs), and the
+finalize -> audio.done graceful shutdown flow.
+
+No vendor SDK exists for wss://api.x.ai/v1/stt -- this adapter uses the raw
+websockets library directly, so tests exercise the session's own message
+handlers/sender loop rather than a vendor connection object's event API.
+"""
+import asyncio
+import json
+
+import pytest
+
+from app.services.xai_grok_stt_service import XaiGrokSTTService, _mask_key
+from app.voice.stt_pipeline import SttPipeline
+
+
+class _FakeWebSocket:
+    """Minimal stand-in for the raw `websockets` connection object."""
+
+    def __init__(self):
+        self.sent: list = []
+        self.closed = False
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        self.closed = True
+
+    def sent_json_types(self) -> list:
+        types = []
+        for item in self.sent:
+            if isinstance(item, str):
+                try:
+                    types.append(json.loads(item).get("type"))
+                except (TypeError, ValueError):
+                    pass
+        return types
+
+
+def _make_session() -> "XaiGrokSTTService.StreamingSTTSession":
+    return XaiGrokSTTService.StreamingSTTSession(
+        api_key="test-key",
+        language_code="en",
+        encoding="MULAW",
+        sample_rate=8000,
+        endpointing_ms=10,
+        smart_turn_threshold=0.5,
+        smart_turn_timeout_ms=3000,
+    )
+
+
+# ── Authentication: key never logged raw ────────────────────────────────
+
+
+def test_mask_key_never_reveals_the_raw_key():
+    assert _mask_key(None) == "<empty>"
+    assert _mask_key("") == "<empty>"
+    masked = _mask_key("xai-abcdefghijklmnopqrstuvwxyz")
+    assert "xai-abcdefghijklmnopqrstuvwxyz" not in masked
+    assert masked.startswith("xai-")
+
+
+# ── create_streaming_session ────────────────────────────────────────────
+
+
+def test_create_streaming_session_requires_api_key():
+    svc = XaiGrokSTTService()
+    svc._api_key = None
+    with pytest.raises(RuntimeError):
+        svc.create_streaming_session()
+
+
+def test_create_streaming_session_uses_defaults_and_overrides():
+    svc = XaiGrokSTTService()
+    svc._api_key = "test-key"
+
+    default_session = svc.create_streaming_session()
+    assert default_session._smart_turn_threshold == pytest.approx(0.5)
+    assert default_session._smart_turn_timeout_ms == 3000
+    assert default_session._encoding == "MULAW"
+
+    overridden = svc.create_streaming_session(
+        api_config={"smart_turn_threshold": 0.7, "smart_turn_timeout_ms": 2000, "endpointing_ms": 200},
+    )
+    assert overridden._smart_turn_threshold == pytest.approx(0.7)
+    assert overridden._smart_turn_timeout_ms == 2000
+    assert overridden._endpointing_ms == 200
+
+
+def test_create_streaming_session_clamps_out_of_range_params():
+    svc = XaiGrokSTTService()
+    svc._api_key = "test-key"
+
+    session = svc.create_streaming_session(
+        api_config={
+            "smart_turn_threshold": 5.0,  # docs range: 0.0-1.0
+            "smart_turn_timeout_ms": 99999,  # docs range: 1-5000
+            "endpointing_ms": -5,  # docs range: 0-5000
+        },
+    )
+    assert session._smart_turn_threshold == pytest.approx(1.0)
+    assert session._smart_turn_timeout_ms == 5000
+    assert session._endpointing_ms == 0
+
+
+def test_create_streaming_session_never_sends_model_param(monkeypatch):
+    """xAI's STT API has no model parameter at all -- model must be accepted
+    (for interface parity with SttPipeline's dispatch) but never forwarded."""
+    svc = XaiGrokSTTService()
+    svc._api_key = "test-key"
+
+    session = svc.create_streaming_session(model="some-model-id-should-be-ignored")
+    assert not hasattr(session, "_model")
+
+
+# ── Three-state is_final/speech_final mapping ───────────────────────────
+
+
+def test_interim_state_emits_interim_result():
+    session = _make_session()
+    session._handle_partial({"text": "hel", "is_final": False, "speech_final": False})
+
+    result = session._results_q.get_nowait()
+    assert result == {"transcript": "hel", "confidence": 0.0, "is_final": False}
+    assert session._audio_since_final is True
+
+
+def test_chunk_final_state_is_withheld_from_pipeline():
+    """(is_final=true, speech_final=false) -- text locked for this window but
+    NOT a turn boundary. Must not spuriously trigger an LLM turn."""
+    session = _make_session()
+    session._handle_partial({"text": "I will buy two", "is_final": True, "speech_final": False})
+
+    assert session._results_q.empty()
+    assert session._audio_since_final is True
+
+
+def test_utterance_final_state_emits_pipeline_final():
+    """(is_final=true, speech_final=true) -- the real turn boundary."""
+    session = _make_session()
+    session._handle_partial(
+        {"text": "I will buy two of those, please.", "is_final": True, "speech_final": True, "end_of_turn_confidence": 0.98}
+    )
+
+    result = session._results_q.get_nowait()
+    assert result == {"transcript": "I will buy two of those, please.", "confidence": 0.0, "is_final": True}
+    assert session._audio_since_final is False
+
+
+def test_empty_text_emits_nothing_regardless_of_flags():
+    session = _make_session()
+    session._handle_partial({"text": "", "is_final": True, "speech_final": True})
+    assert session._results_q.empty()
+
+
+# ── transcript.created / transcript.done / error routing ───────────────
+
+
+def test_transcript_created_sets_ready_event():
+    session = _make_session()
+    assert not session._ready_evt.is_set()
+    session._handle_message({"type": "transcript.created"})
+    assert session._ready_evt.is_set()
+
+
+def test_transcript_done_sets_done_event():
+    session = _make_session()
+    assert not session._transcript_done_evt.is_set()
+    session._handle_message({"type": "transcript.done", "text": "full transcript", "duration": 4.2})
+    assert session._transcript_done_evt.is_set()
+
+
+def test_error_event_is_recoverable_and_does_not_close_session():
+    """Per xAI's docs, the connection stays open after an error -- unlike
+    every other provider here, this must NOT be treated as fatal."""
+    session = _make_session()
+    session._handle_message({"type": "error", "message": "transient backend hiccup"})
+
+    result = session._results_q.get_nowait()
+    assert result["error"] == "transient backend hiccup"
+    assert result["recoverable"] is True
+    # Session must remain open -- no done sentinel, no _closed flag flip.
+    assert session._results_q.empty()
+    assert session._closed is False
+
+
+# ── Graceful shutdown: finalize -> audio.done ───────────────────────────
+
+
+def test_sender_loop_sends_finalize_then_audio_done_when_pending():
+    session = _make_session()
+    ws = _FakeWebSocket()
+    session._ws = ws
+
+    async def _run():
+        session._ready_evt.set()
+        session._audio_since_final = True  # speech pushed, no speech_final yet
+        session.finish()
+        # Simulate the server acking audio.done promptly so the wait doesn't time out.
+        async def _ack():
+            await asyncio.sleep(0.05)
+            session._transcript_done_evt.set()
+        asyncio.create_task(_ack())
+        await session._sender_loop()
+
+    asyncio.run(_run())
+
+    types = ws.sent_json_types()
+    assert types == ["finalize", "audio.done"]
+    assert ws.closed is True
+
+    done = session._results_q.get_nowait()
+    assert done == {"done": True}
+
+
+def test_sender_loop_skips_finalize_when_nothing_pending():
+    session = _make_session()
+    ws = _FakeWebSocket()
+    session._ws = ws
+
+    async def _run():
+        session._ready_evt.set()
+        session._audio_since_final = False  # last segment already speech_final
+        session.finish()
+        async def _ack():
+            await asyncio.sleep(0.05)
+            session._transcript_done_evt.set()
+        asyncio.create_task(_ack())
+        await session._sender_loop()
+
+    asyncio.run(_run())
+
+    types = ws.sent_json_types()
+    assert types == ["audio.done"]
+    assert ws.closed is True
+
+
+def test_sender_loop_forwards_audio_chunks_as_raw_binary():
+    session = _make_session()
+    ws = _FakeWebSocket()
+    session._ws = ws
+
+    async def _run():
+        session._ready_evt.set()
+        session.push_audio(b"\x01\x02\x03")
+        session.finish()
+        async def _ack():
+            await asyncio.sleep(0.05)
+            session._transcript_done_evt.set()
+        asyncio.create_task(_ack())
+        await session._sender_loop()
+
+    asyncio.run(_run())
+
+    # First sent item must be the raw audio bytes, not base64/JSON-wrapped.
+    assert ws.sent[0] == b"\x01\x02\x03"
+
+
+def test_push_done_is_idempotent():
+    session = _make_session()
+    session._push_done()
+    session._push_done()
+    session._push_done()
+
+    assert session._results_q.qsize() == 1
+    assert session._results_q.get_nowait() == {"done": True}
+
+
+# ── SttPipeline forwards model_id + api_config to the xAI service ──────
+
+
+def test_stt_pipeline_forwards_api_config_to_xai(monkeypatch):
+    captured = {}
+
+    def fake_create_streaming_session(**kwargs):
+        captured.update(kwargs)
+
+        class FakeSession:
+            async def start(self):
+                return None
+
+            async def get_result(self):
+                await asyncio.sleep(1)
+                return {}
+
+            def push_audio(self, _):
+                return None
+
+            def finish(self):
+                return None
+
+        return FakeSession()
+
+    from app.services import xai_grok_stt_service as xai_module
+
+    monkeypatch.setattr(
+        xai_module.xai_grok_stt_service,
+        "create_streaming_session",
+        fake_create_streaming_session,
+    )
+
+    async def on_interim(_, __):
+        return None
+
+    async def on_final(_, __):
+        return None
+
+    async def _run():
+        pipeline = SttPipeline(
+            language_code="en",
+            on_interim=on_interim,
+            on_final=on_final,
+            provider_slug="xai",
+            model_id="default",
+            api_config={"smart_turn_threshold": 0.7},
+        )
+        await pipeline.feed_audio_chunk(b"\x00")
+        await pipeline.aclose()
+
+    asyncio.run(_run())
+
+    assert captured.get("api_config") == {"smart_turn_threshold": 0.7}


### PR DESCRIPTION
## Summary
- Adds xAI Grok STT (`wss://api.x.ai/v1/stt`) as a new STT provider, integrated into the existing provider-agnostic `SttPipeline` (single new branch in `_ensure_session`, same duck-typed session contract as Deepgram/Speechmatics/ElevenLabs — no separate pipeline).
- No vendor SDK exists for this endpoint — uses the raw `websockets` library directly (already pinned), matching xAI's own official example code.
- **Verified against xAI's raw docs markdown** (not a paraphrase) that this is a genuinely separate, standalone STT-only WebSocket, distinct from xAI's unrelated full speech-to-speech agent API (`wss://api.x.ai/v1/realtime`, not used here). An earlier investigation pass wrongly concluded no realtime STT-only API existed after hitting a 404 on a mistyped doc path — corrected before any code was written.
- Turn detection uses xAI's native server-side mechanisms exclusively — `endpointing` + Smart Turn (ML-based end-of-turn confidence) — no local VAD.
- **Correctly handles the three-state `is_final`/`speech_final` dual flag**, not a simple boolean: `(false,false)`=interim, `(true,false)`=chunk-final (text locked but **not** a turn boundary — withheld from the pipeline to avoid a spurious LLM turn every ~3s of continuous speech), `(true,true)`=utterance-final (the only state mapped to pipeline `is_final=True`).
- Graceful shutdown force-finalizes any pending speech via `{"type":"finalize"}` before sending `{"type":"audio.done"}` and waiting for `transcript.done`, so a caller's trailing utterance isn't dropped at call teardown.
- `error` events are treated as recoverable/non-fatal per xAI's documented behavior (connection stays open) — unlike every other provider here, where errors are typically fatal.
- xAI's STT API has **no `model` parameter at all** (confirmed absent from both the REST and streaming query-param tables) — the catalog's `external_model_id` is a documented placeholder (`"default"`), never sent to xAI as an API parameter.
- Twilio MULAW 8kHz and LiveKit LINEAR16 16kHz both map directly with zero transcoding (`mulaw` and `pcm` are both natively supported raw encodings; `pcm@16kHz` is xAI's own documented "native rate").
- New dedicated `XAI_API_KEY` (no existing xAI credential to reuse); no hardcoded key; production injection follows the same Secrets Manager → env-var mechanism as every other provider's key.
- **Review fixes** (from an independent `code-reviewer` pass): send-failure error result now correctly marked `recoverable=False` (was inconsistently defaulting to `True` despite the session tearing down right after); `push_audio()` now stops accepting audio after a failed `start()` (no API key / connect failure) instead of enqueueing into a queue no task will ever drain.

## Test plan
- [x] `pytest tests/services/test_xai_grok_stt.py -v` — 19/19 passing (key masking, session config/clamping, `model`-never-forwarded guarantee, three-state transcript mapping, `transcript.created`/`transcript.done` routing, non-fatal error handling, `finalize`→`audio.done` shutdown sequencing, raw-binary audio forwarding, `done`-sentinel idempotency, `SttPipeline` forwarding)
- [x] Full STT suite (`pytest tests/services/ -k stt`) — 118/118 passing, no regressions across Deepgram/Google/Speechmatics/ElevenLabs
- [x] `ruff check` clean on all new/changed files
- [x] Single Alembic head confirmed; migration applied and verified against the dev DB
- [x] Reviewed by `code-reviewer` agent — two low-severity findings fixed before this PR (see above)
- [x] **User-tested and confirmed working** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)