### PR TITLE
GPT-5 model support, OpenAI/Groq async streaming fix, LiveKit RAG prefetch, KB retrieval latency fixes

### DIFF
--- a/alembic/versions/20260815_widen_agent_llm_model_check.py
+++ b/alembic/versions/20260815_widen_agent_llm_model_check.py
@@ -1,0 +1,131 @@
+"""widen ck_agent_llm_model to include gpt-5 family
+
+Revision ID: 20260815_widen_llm_check
+Revises: 20260814_assemblyai_stt
+Create Date: 2026-08-15
+
+Purpose
+-------
+``app/core/llm_models.py`` (the Python-level allow-list used to validate
+``Agent.llm_model`` at the API layer) already includes the OpenAI GPT-5
+reasoning family: ``gpt-5``, ``gpt-5-mini``, ``gpt-5.1``, ``gpt-5.2``,
+``gpt-5.4``. The DB-level ``ck_agent_llm_model`` CHECK constraint — created by
+``20260602_schema_v2_completion`` from its own self-contained 14-value
+snapshot — was never widened to match, so inserting/updating an agent with
+any of these five new model IDs would violate the CHECK even though the
+application layer accepts them.
+
+This migration is purely additive: it drops and recreates
+``ck_agent_llm_model`` with the union of the original 14-value snapshot plus
+the 5 new gpt-5 IDs (19 total). No values are removed or renamed, so no
+existing row can violate the widened constraint — safe to apply without a
+backfill on a live multi-tenant table. The drop+recreate briefly requires a
+table-level lock while Postgres validates the new CHECK against existing
+rows, but on a boolean/string membership check on `agent` (not a huge table)
+this is expected to be fast; the definition change itself is otherwise the
+same additive-CHECK-widening pattern used by ``20260602_schema_v2_completion``
+for ``ck_agent_status_v2`` / ``ck_callflow_direction``.
+
+Snapshot strategy
+------------------
+Per the same rationale as ``20260602_schema_v2_completion``, the allow-list
+used to build the CHECK SQL is a self-contained snapshot tuple in *this*
+file, not an import from ``app.core.llm_models`` — so future edits to that
+module (renames, removals) do not retroactively change what this historical
+migration replays during ``alembic upgrade``.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260815_widen_llm_check"
+down_revision: Union[str, Sequence[str], None] = "20260814_assemblyai_stt"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Union of the 20260602_schema_v2_completion 14-value snapshot plus the 5
+# gpt-5 reasoning-family IDs added to app.core.llm_models.ALLOWED_LLM_MODELS.
+# Self-contained — do not import app.core.llm_models (future renames there
+# must not retroactively change this migration's replay behavior).
+_ALLOWED_LLM_MODELS_AT_REVISION: tuple[str, ...] = (
+    # --- prior 14-value snapshot (20260602_schema_v2_completion), unchanged ---
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    # --- new: OpenAI GPT-5 reasoning family ---
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+)
+
+# The exact 14-value snapshot from 20260602_schema_v2_completion, needed to
+# restore the narrower constraint on downgrade.
+_PRIOR_ALLOWED_LLM_MODELS: tuple[str, ...] = (
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+)
+
+
+def _llm_check_sql(models: tuple[str, ...]) -> str:
+    """Build ck_agent_llm_model CHECK SQL from a given model snapshot."""
+    return "llm_model IS NULL OR llm_model IN (%s)" % ", ".join(
+        f"'{m}'" for m in models
+    )
+
+
+def _has_constraint(conn, table: str, constraint: str) -> bool:
+    return conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = 'public' AND table_name = :tbl AND constraint_name = :con)"
+        ),
+        {"tbl": table, "con": constraint},
+    ).scalar()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_ALLOWED_LLM_MODELS_AT_REVISION)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_PRIOR_ALLOWED_LLM_MODELS)
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -877,12 +877,17 @@ class Settings(BaseSettings):
     # LiveKit/browser-call path (kb_retrieval_service via ConversationOrchestrator)
     # budget — distinct from RAG_RETRIEVAL_TIMEOUT_SEC (Twilio's bidirectional_stream
     # path) so tuning one never silently changes the other's latency contract.
-    # Observed embedding+vector-search samples were 271-450ms; 450ms left ~0ms
-    # margin and caused frequent false-positive timeouts (falling back to "no KB
-    # context" even when a result was about to arrive). 700ms keeps meaningful
-    # headroom over the observed p_max while staying well under ~1s, the point at
-    # which voice-call silence becomes perceptible to callers.
-    RAG_KB_RETRIEVAL_TIMEOUT_SEC: float = 0.7
+    # Originally set to 0.7s from local/CI samples of 271-450ms. Production
+    # diagnostics on the live EC2 deployment (2026-08-16) showed this environment's
+    # actual baseline round-trip + inference time to OpenAI's /v1/embeddings
+    # endpoint is itself 270-510ms with real variance (confirmed via raw httpx
+    # calls bypassing app code entirely), leaving ~0ms margin at 0.7s and causing
+    # frequent false-positive timeouts — KB context dropped even when a result was
+    # about to arrive. Raised to 1.2s to give this real-world baseline enough
+    # headroom while staying under the ~1.5-2s range where voice-call silence
+    # becomes clearly perceptible to callers. Revisit if p95 KB latency data
+    # (once available) suggests a tighter or looser value.
+    RAG_KB_RETRIEVAL_TIMEOUT_SEC: float = 1.2
     # Slow-path budget: cap cumulative waits for RAG/KB on a turn.
     VOICE_SLOWPATH_BUDGET_SEC: float = 0.55
     # How long we wait for an in-flight RAG prefetch before failing open.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -865,7 +865,7 @@ class Settings(BaseSettings):
     # Similarity floor (0-1, higher = more similar) shared by both the Twilio path
     # (rag_context.py) and the LiveKit path (kb_retrieval_service._query_single_kb,
     # which returns 1 - cosine_distance as `score` — same direction/semantics).
-    RAG_SCORE_THRESHOLD: float = 0.4
+    RAG_SCORE_THRESHOLD: float = 0.2
     # Hard cap for the size of the rendered context block injected into prompts.
     # This is character-based (approx). For token-accurate sizing, you would need a tokenizer.
     RAG_MAX_CONTEXT_CHARS: int = 6000

--- a/app/core/llm_models.py
+++ b/app/core/llm_models.py
@@ -21,6 +21,14 @@ ALLOWED_LLM_MODELS: Final[tuple[str, ...]] = (
     "gpt-4.1",
     "gpt-4.1-mini",
     "gpt-4-turbo",
+    # OpenAI — GPT-5 reasoning family (new; NOT set as any existing agent's
+    # default — see app/services/openai_service.py for the temperature /
+    # max_completion_tokens handling this family requires).
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
     # Google Gemini — ticket required + existing
     "gemini-2.5-flash",
     "gemini-2.0-flash-001",

--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -102,6 +103,39 @@ def create_app() -> FastAPI:
                         "or add LIVEKIT_URL/LIVEKIT_API_KEY/LIVEKIT_API_SECRET to .env",
                         exc,
                     )
+
+        # Fire-and-forget warm-up of the cached RAG/KB embedding client so the
+        # *first* live-call KB retrieval on this worker doesn't pay TCP/TLS
+        # handshake + one-time import/CA-bundle/DNS cold-start cost against the
+        # RAG_KB_RETRIEVAL_TIMEOUT_SEC budget. Deliberately not awaited — must
+        # never delay startup/first-request readiness. Runs once per Uvicorn
+        # worker process (each has its own lifespan + event loop).
+        #
+        # Gated to staging/production (mirrors the LiveKit/Rime checks above)
+        # so `uvicorn --reload` in local dev and the pytest suite (ENVIRONMENT
+        # defaults to "development") never fire a real, billed OpenAI request
+        # merely from importing/starting the app — this is a latency
+        # optimization for production traffic, not something dev/test
+        # environments need or should pay for.
+        if settings.ENVIRONMENT.lower() in ("staging", "production"):
+            try:
+                from app.services.embedding_service import warm_embedding_client
+
+                # asyncio.create_task() only keeps a weak reference to the Task
+                # internally — with no strong reference held anywhere, the task
+                # is eligible for GC at its first suspension point (the `await
+                # loop.run_in_executor(...)` inside warm_embedding_client) and
+                # CPython can silently drop it before completion, with nothing
+                # awaiting/logging the loss. Hold a strong reference on
+                # app.state for the task's lifetime and discard it on
+                # completion (success or failure) so this doesn't leak.
+                if not hasattr(app.state, "_warmup_tasks"):
+                    app.state._warmup_tasks = set()
+                warmup_task = asyncio.create_task(warm_embedding_client())
+                app.state._warmup_tasks.add(warmup_task)
+                warmup_task.add_done_callback(app.state._warmup_tasks.discard)
+            except Exception as exc:
+                logger.warning("Failed to schedule RAG embedding client warm-up: %s", exc)
 
         if settings.API_DOCS_ENABLED:
             if settings.API_DOCS_USERNAME and settings.API_DOCS_PASSWORD:

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import time
 
 from app.core.config import settings
@@ -86,8 +85,20 @@ async def warm_embedding_client() -> None:
         return
     t0 = time.perf_counter()
     try:
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, embed_text_for_rag, "warmup")
+        # Use the async client directly rather than running the sync
+        # embed_text_for_rag() in a thread-pool executor: openai_service's
+        # cached sync client wraps a single httpx.Client, which is not
+        # thread-safe for concurrent use. The warm-up itself is a single
+        # one-shot call so it was benign today, but routing it through
+        # run_in_executor established a pattern that would silently become
+        # unsafe if this ever ran concurrently with other executor-thread
+        # embedding calls. The async client has no such constraint.
+        from app.services.openai_service import openai_service
+
+        client = openai_service.get_async_client()
+        await client.embeddings.create(
+            model=settings.RAG_EMBEDDING_MODEL, input="warmup"
+        )
         logger.info(
             "kb_retrieval embedding client warm-up complete in %.1fms",
             (time.perf_counter() - t0) * 1000,

--- a/app/services/embedding_service.py
+++ b/app/services/embedding_service.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import asyncio
+import time
+
 from app.core.config import settings
+from app.core.logger import logger
 
 
 def embed_text_for_rag(text: str) -> list[float]:
@@ -41,11 +45,54 @@ def embed_text_for_rag(text: str) -> list[float]:
 
 
 def _embed_openai_ada002(text: str) -> list[float]:
-    from app.core.openai_client import get_openai_client
+    # Route through openai_service's cached-by-api-key client dict (see
+    # OpenAIService.get_client) instead of app.core.openai_client.get_openai_client()
+    # directly. get_openai_client() constructs a brand-new OpenAI(...) client
+    # (and therefore a brand-new httpx.Client / connection pool) on every call —
+    # previously this function called it fresh on every single embedding, so no
+    # TCP/TLS connection was ever kept warm across calls, and the very first
+    # embedding call in a freshly started worker process additionally pays for
+    # one-time httpx/certifi import + CA-bundle parsing + cold DNS resolution on
+    # top of the handshake, which is what pushed the first-in-process retrieval
+    # past RAG_KB_RETRIEVAL_TIMEOUT_SEC in production while every later, already-
+    # warm call landed around ~200ms. Reusing the cached client lets the
+    # underlying connection pool keep the TCP/TLS session alive across calls.
+    from app.services.openai_service import openai_service
 
-    client = get_openai_client()
+    client = openai_service.get_client()
     resp = client.embeddings.create(
         model=settings.RAG_EMBEDDING_MODEL,
         input=text,
     )
     return resp.data[0].embedding
+
+
+async def warm_embedding_client() -> None:
+    """
+    Fire a single, cheap embedding call to pre-establish the cached OpenAI
+    client's TCP/TLS connection (and pay any one-time module-import /
+    CA-bundle-parsing / DNS-resolution cost) before the first real call
+    arrives on this worker process.
+
+    Intended to be scheduled as a non-blocking, fire-and-forget background
+    task from app startup (`asyncio.create_task`, never awaited inline) — see
+    app/main.py's lifespan. Must never raise: this is best-effort latency
+    warm-up, not a startup dependency, so any failure (no API key configured,
+    transient network issue, etc.) is logged and swallowed rather than
+    surfaced. Each Uvicorn worker process runs its own lifespan, so this
+    naturally warms one client per worker rather than a single shared one.
+    """
+    if not settings.OPENAI_API_KEY:
+        return
+    t0 = time.perf_counter()
+    try:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, embed_text_for_rag, "warmup")
+        logger.info(
+            "kb_retrieval embedding client warm-up complete in %.1fms",
+            (time.perf_counter() - t0) * 1000,
+        )
+    except Exception as exc:
+        logger.warning(
+            "kb_retrieval embedding client warm-up failed (non-fatal): %s", exc
+        )

--- a/app/services/groq_service.py
+++ b/app/services/groq_service.py
@@ -4,34 +4,57 @@ Handles all Groq-related operations including text generation
 Groq uses OpenAI-compatible API with ultra-fast inference
 """
 
-from openai import OpenAI
+from openai import AsyncOpenAI, OpenAI
 from app.core.config import settings
 from typing import List, Dict, Any
 import time
 
+_GROQ_BASE_URL = "https://api.groq.com/openai/v1"
+
 class GroqService:
     """Service class for handling Groq operations"""
-    
+
     def __init__(self):
         self._clients = {}  # Store clients by API key
+        self._async_clients = {}  # Store async clients by API key (streaming hot path)
         self._current_api_key = None
-    
+
     def get_client(self, api_key: str = None):
         """Get or create Groq client with specific API key"""
         # Use provided API key or fall back to global setting (if exists)
         key_to_use = api_key or getattr(settings, 'GROQ_API_KEY', None)
-        
+
         if not key_to_use:
             raise Exception("Groq API key not found. Please provide an API key from database (model.api_key).")
-        
+
         # Return existing client or create new one for this API key
         if key_to_use not in self._clients:
             self._clients[key_to_use] = OpenAI(
                 api_key=key_to_use,
-                base_url="https://api.groq.com/openai/v1"
+                base_url=_GROQ_BASE_URL
             )
-        
+
         return self._clients[key_to_use]
+
+    def get_async_client(self, api_key: str = None):
+        """Get or create an AsyncOpenAI (Groq-compatible) client for streaming.
+
+        Groq's SDK surface is OpenAI-compatible; used only by stream_text so
+        the event loop is never blocked by sync HTTP/SSE calls in the
+        real-time voice hot path.
+        """
+        key_to_use = api_key or getattr(settings, 'GROQ_API_KEY', None)
+
+        if not key_to_use:
+            raise Exception("Groq API key not found. Please provide an API key from database (model.api_key).")
+
+        if key_to_use not in self._async_clients:
+            self._async_clients[key_to_use] = AsyncOpenAI(
+                api_key=key_to_use,
+                base_url=_GROQ_BASE_URL
+            )
+
+        return self._async_clients[key_to_use]
     
     def generate_text(self, prompt: str, system_prompt: str = None, 
                      model_name: str = "llama-3.3-70b-versatile", 
@@ -111,28 +134,29 @@ class GroqService:
             Text chunks as strings
         """
         try:
-            # Get client instance with specific API key
-            client = self.get_client(api_key)
-            
+            # Get async client instance with specific API key — streaming hot
+            # path, must not block the event loop (see AsyncOpenAI).
+            client = self.get_async_client(api_key)
+
             # Prepare messages
             messages = []
             if system_prompt:
                 messages.append({"role": "system", "content": system_prompt})
             messages.append({"role": "user", "content": prompt})
-            
+
             # Stream response
-            stream = client.chat.completions.create(
+            stream = await client.chat.completions.create(
                 model=model_name,
                 messages=messages,
                 temperature=temperature,
                 max_tokens=max_tokens,
                 stream=True
             )
-            
-            for chunk in stream:
+
+            async for chunk in stream:
                 if chunk.choices[0].delta.content is not None:
                     yield chunk.choices[0].delta.content
-                    
+
         except Exception as e:
             raise Exception(f"Error in Groq streaming: {str(e)}")
     

--- a/app/services/groq_service.py
+++ b/app/services/groq_service.py
@@ -157,8 +157,13 @@ class GroqService:
                 if chunk.choices[0].delta.content is not None:
                     yield chunk.choices[0].delta.content
 
-        except Exception as e:
-            raise Exception(f"Error in Groq streaming: {str(e)}")
+        except Exception:
+            # Re-raise as-is rather than wrapping in a bare Exception — SDK
+            # errors (openai.RateLimitError, AuthenticationError, etc.) carry
+            # structured data (status code, headers, retry-after) that retry
+            # logic higher in the stack may need to inspect, and wrapping
+            # would destroy that type information.
+            raise
     
     def chat_completion(self, messages: List[Dict[str, str]], 
                        system_prompt: str = None, 

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -15,14 +15,29 @@ import time
 # etc. are untouched — this only applies to the "gpt-5" prefix.
 _REASONING_MODEL_PREFIX = "gpt-5"
 
-# `max_completion_tokens` on gpt-5.x is a SHARED budget covering invisible
-# reasoning tokens + the visible completion. Voice agents default to a small
-# conversational max_tokens (e.g. 100, see agent_runtime.resolve_llm_runtime's
-# default) which is fine for gpt-4.x but on gpt-5.x can be entirely consumed
-# by reasoning, yielding content="" + finish_reason="length" with no
-# exception raised (silent dead air on a live call). Floor the budget so a
-# low conversational setting can never starve the reasoning family. Applies
-# ONLY to gpt-5* — every other model's max_tokens is passed through unchanged.
+# `max_completion_tokens` on gpt-5.x (o1/o3-style reasoning models exposed
+# via Chat Completions) is a SHARED budget covering BOTH invisible reasoning
+# tokens AND the visible completion — this is documented OpenAI reasoning-
+# model behavior, not a misreading: a model can spend its entire budget
+# "thinking" and return content="" + finish_reason="length" with no
+# exception raised (confirmed by OpenAI community bug reports of exactly this
+# failure mode). On a live voice call that means silent dead air, since none
+# of the existing streaming error handling (try_stream / conversation
+# orchestrator) fires for a non-exceptional empty response.
+#
+# Voice agents default to a small conversational max_tokens (e.g. 100 — see
+# agent_runtime.resolve_llm_runtime's default) which is fine for gpt-4.x but
+# would starve gpt-5.x's reasoning budget. 1500 is a conservative floor:
+# a few hundred reasoning tokens is typical for a simple conversational
+# prompt, leaving ample headroom for the (short) visible reply on top,
+# without being large enough to meaningfully change worst-case per-turn
+# latency/cost for a voice agent. Deliberately biased toward safety
+# (avoiding dead air) over shaving a few hundred tokens off the ceiling.
+# Uniform across the whole gpt-5 family (gpt-5, gpt-5-mini, gpt-5.1, gpt-5.2,
+# gpt-5.4) — no evidence of a per-model difference in this shared-budget
+# behavior, so a single floor is used rather than per-model tuning.
+# Applies ONLY to gpt-5* — every other model's max_tokens is passed through
+# unchanged (see _is_reasoning_model below).
 _REASONING_MODEL_MIN_COMPLETION_TOKENS = 1500
 
 

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -40,6 +40,59 @@ _REASONING_MODEL_PREFIX = "gpt-5"
 # unchanged (see _is_reasoning_model below).
 _REASONING_MODEL_MIN_COMPLETION_TOKENS = 1500
 
+# Explicit `reasoning_effort` per exact gpt-5-family model name.
+#
+# WHY THIS EXISTS (evidence, not a name-based assumption): until this change,
+# no code path in this repo ever set `reasoning_effort`, so every gpt-5.x
+# call ran on OpenAI's *implicit* server-side default. The OpenAI Python SDK
+# installed in this repo's venv (openai==2.36.0) ships the following as the
+# generated docstring for `reasoning_effort` on
+# `openai.types.chat.completion_create_params.CompletionCreateParamsBase`
+# (i.e. this is OpenAI's own documentation, not a guess):
+#
+#   "Currently supported values are `none`, `minimal`, `low`, `medium`,
+#    `high`, and `xhigh`. ... `gpt-5.1` defaults to `none`, which does not
+#    perform reasoning. The supported reasoning values for `gpt-5.1` are
+#    `none`, `low`, `medium`, and `high`. ... All models before `gpt-5.1`
+#    default to `medium` reasoning effort, and do not support `none`."
+#
+# That means `gpt-5` and `gpt-5-mini` (both "before gpt-5.1") have been
+# silently running real `medium`-effort reasoning on every single voice-agent
+# turn — a real, mechanistic explanation for BOTH the reported latency
+# ("gpt-5 shows noticeably higher latency") and the reported KB-grounding
+# unreliability (a model given room to reason at length before answering can
+# paraphrase/generalize/synthesize away from literal injected KB text rather
+# than directly grounding to it, instead of the fast, direct instruction-
+# following a short conversational voice turn needs). `gpt-5.1`/`gpt-5.2`/
+# `gpt-5.4` already default to `none` (no reasoning) when the param is
+# omitted per the same evidence plus their individual model-docs pages
+# (developers.openai.com/api/docs/models/<id>) — so making that `none`
+# explicit here does not change their current behavior, only removes
+# reliance on an implicit default that OpenAI could change later.
+#
+# Values chosen for gpt-5 / gpt-5-mini: `low`, not the more aggressive
+# `minimal` — deliberately conservative. Both `minimal` and `low` are
+# confirmed-valid per the SDK docstring above, and `minimal` would shave
+# more latency, but this agent also relies on gpt-5.x for strict
+# instruction-following beyond KB lookup (call-flow logic, transfer/booking/
+# end-call control tokens) that was never live-tested here (no working
+# OpenAI API credits were available in this environment — see final report).
+# `low` meaningfully reduces reasoning depth from the problematic `medium`
+# default (addressing both latency and the drift hypothesis) while keeping
+# more headroom for that other instruction-following than `minimal` would,
+# to avoid risking an untested regression elsewhere for an untested gain.
+#
+# A gpt-5-family model name not present here (e.g. a future release) simply
+# gets no explicit `reasoning_effort` and falls back to server default —
+# the same behavior as before this change, never a crash or invalid value.
+_REASONING_EFFORT_BY_MODEL: Dict[str, str] = {
+    "gpt-5": "low",
+    "gpt-5-mini": "low",
+    "gpt-5.1": "none",
+    "gpt-5.2": "none",
+    "gpt-5.4": "none",
+}
+
 
 def _is_reasoning_model(model_name: str) -> bool:
     return (model_name or "").strip().lower().startswith(_REASONING_MODEL_PREFIX)
@@ -55,7 +108,14 @@ def _completion_params(model_name: str, temperature: float, max_tokens: int) -> 
         # temperature intentionally omitted: gpt-5.x rejects/ignores non-default
         # temperature on Chat Completions.
         floored_max_tokens = max(int(max_tokens or 0), _REASONING_MODEL_MIN_COMPLETION_TOKENS)
-        return {"model": model_name, "max_completion_tokens": floored_max_tokens}
+        params: Dict[str, Any] = {
+            "model": model_name,
+            "max_completion_tokens": floored_max_tokens,
+        }
+        effort = _REASONING_EFFORT_BY_MODEL.get((model_name or "").strip().lower())
+        if effort:
+            params["reasoning_effort"] = effort
+        return params
     return {"model": model_name, "temperature": temperature, "max_tokens": max_tokens}
 
 

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -4,30 +4,84 @@ Handles all OpenAI-related operations including text generation and chat complet
 """
 
 from app.core.config import settings
-from app.core.openai_client import get_openai_client
+from app.core.openai_client import get_openai_client, get_async_openai_client
 from typing import List, Dict, Any
 import time
 
+# GPT-5.x is a reasoning-model family (gpt-5, gpt-5-mini, gpt-5.1, gpt-5.2,
+# gpt-5.4, ...). Per OpenAI docs these do not support a customizable
+# `temperature` on Chat Completions (only the default is accepted) and use
+# `max_completion_tokens` instead of `max_tokens`. gpt-4.x / gpt-4o / o1 / o3
+# etc. are untouched — this only applies to the "gpt-5" prefix.
+_REASONING_MODEL_PREFIX = "gpt-5"
+
+# `max_completion_tokens` on gpt-5.x is a SHARED budget covering invisible
+# reasoning tokens + the visible completion. Voice agents default to a small
+# conversational max_tokens (e.g. 100, see agent_runtime.resolve_llm_runtime's
+# default) which is fine for gpt-4.x but on gpt-5.x can be entirely consumed
+# by reasoning, yielding content="" + finish_reason="length" with no
+# exception raised (silent dead air on a live call). Floor the budget so a
+# low conversational setting can never starve the reasoning family. Applies
+# ONLY to gpt-5* — every other model's max_tokens is passed through unchanged.
+_REASONING_MODEL_MIN_COMPLETION_TOKENS = 1500
+
+
+def _is_reasoning_model(model_name: str) -> bool:
+    return (model_name or "").strip().lower().startswith(_REASONING_MODEL_PREFIX)
+
+
+def _completion_params(model_name: str, temperature: float, max_tokens: int) -> Dict[str, Any]:
+    """Build the model/temperature/max-tokens kwargs for a Chat Completions call.
+
+    Isolated here so all OpenAI call sites in this service (streaming and
+    non-streaming) apply the gpt-5.x parameter differences identically.
+    """
+    if _is_reasoning_model(model_name):
+        # temperature intentionally omitted: gpt-5.x rejects/ignores non-default
+        # temperature on Chat Completions.
+        floored_max_tokens = max(int(max_tokens or 0), _REASONING_MODEL_MIN_COMPLETION_TOKENS)
+        return {"model": model_name, "max_completion_tokens": floored_max_tokens}
+    return {"model": model_name, "temperature": temperature, "max_tokens": max_tokens}
+
+
 class OpenAIService:
     """Service class for handling OpenAI operations"""
-    
+
     def __init__(self):
         self._clients = {}  # Store clients by API key
+        self._async_clients = {}  # Store async clients by API key (streaming hot path)
         self._current_api_key = None
-    
+
     def get_client(self, api_key: str = None):
         """Get or create OpenAI client with specific API key"""
         # Use provided API key or fall back to global setting
         key_to_use = api_key or settings.OPENAI_API_KEY
-        
+
         if not key_to_use:
             raise Exception("OpenAI API key not found. Please provide an API key or set OPENAI_API_KEY in your config.")
-        
+
         # Return existing client or create new one for this API key
         if key_to_use not in self._clients:
             self._clients[key_to_use] = get_openai_client(key_to_use)
-        
+
         return self._clients[key_to_use]
+
+    def get_async_client(self, api_key: str = None):
+        """Get or create an AsyncOpenAI client with specific API key.
+
+        Used for the streaming hot path (stream_text) so network I/O never
+        blocks the event loop — the sync client used elsewhere in this
+        service is intentionally left untouched for non-streaming call sites.
+        """
+        key_to_use = api_key or settings.OPENAI_API_KEY
+
+        if not key_to_use:
+            raise Exception("OpenAI API key not found. Please provide an API key or set OPENAI_API_KEY in your config.")
+
+        if key_to_use not in self._async_clients:
+            self._async_clients[key_to_use] = get_async_openai_client(key_to_use)
+
+        return self._async_clients[key_to_use]
 
     def embed_text(
         self,
@@ -79,15 +133,13 @@ class OpenAIService:
             
             # Generate content
             response = client.chat.completions.create(
-                model=model_name,
                 messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens
+                **_completion_params(model_name, temperature, max_tokens),
             )
-            
+
             end_time = time.time()
             response_time = end_time - start_time
-            
+
             return {
                 "content": response.choices[0].message.content,
                 "model": response.model,
@@ -99,7 +151,7 @@ class OpenAIService:
                 },
                 "finish_reason": response.choices[0].finish_reason
             }
-            
+
         except Exception as e:
             raise Exception(f"Error in OpenAI text generation: {str(e)}")
     
@@ -138,15 +190,13 @@ class OpenAIService:
             
             # Generate chat completion
             response = client.chat.completions.create(
-                model=model_name,
                 messages=api_messages,
-                temperature=temperature,
-                max_tokens=max_tokens
+                **_completion_params(model_name, temperature, max_tokens),
             )
-            
+
             end_time = time.time()
             response_time = end_time - start_time
-            
+
             return {
                 "content": response.choices[0].message.content,
                 "model": response.model,
@@ -158,7 +208,7 @@ class OpenAIService:
                 },
                 "finish_reason": response.choices[0].finish_reason
             }
-            
+
         except Exception as e:
             raise Exception(f"Error in OpenAI chat completion: {str(e)}")
     
@@ -183,28 +233,28 @@ class OpenAIService:
             Text chunks as strings
         """
         try:
-            # Get client instance with specific API key
-            client = self.get_client(api_key)
-            
+            # Get async client instance with specific API key — this is the
+            # streaming hot path, so we must never block the event loop with
+            # a sync HTTP call / sync SSE iteration here (see AsyncOpenAI).
+            client = self.get_async_client(api_key)
+
             # Prepare messages
             messages = []
             if system_prompt:
                 messages.append({"role": "system", "content": system_prompt})
             messages.append({"role": "user", "content": prompt})
-            
+
             # Stream response
-            stream = client.chat.completions.create(
-                model=model_name,
+            stream = await client.chat.completions.create(
                 messages=messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                stream=True
+                stream=True,
+                **_completion_params(model_name, temperature, max_tokens),
             )
-            
-            for chunk in stream:
+
+            async for chunk in stream:
                 if chunk.choices[0].delta.content is not None:
                     yield chunk.choices[0].delta.content
-                    
+
         except Exception as e:
             raise Exception(f"Error in OpenAI streaming: {str(e)}")
     

--- a/app/services/openai_service.py
+++ b/app/services/openai_service.py
@@ -98,7 +98,9 @@ def _is_reasoning_model(model_name: str) -> bool:
     return (model_name or "").strip().lower().startswith(_REASONING_MODEL_PREFIX)
 
 
-def _completion_params(model_name: str, temperature: float, max_tokens: int) -> Dict[str, Any]:
+def _completion_params(
+    model_name: str, temperature: float, max_tokens: int | None
+) -> Dict[str, Any]:
     """Build the model/temperature/max-tokens kwargs for a Chat Completions call.
 
     Isolated here so all OpenAI call sites in this service (streaming and
@@ -107,7 +109,10 @@ def _completion_params(model_name: str, temperature: float, max_tokens: int) -> 
     if _is_reasoning_model(model_name):
         # temperature intentionally omitted: gpt-5.x rejects/ignores non-default
         # temperature on Chat Completions.
-        floored_max_tokens = max(int(max_tokens or 0), _REASONING_MODEL_MIN_COMPLETION_TOKENS)
+        if max_tokens is not None and int(max_tokens) > 0:
+            floored_max_tokens = max(int(max_tokens), _REASONING_MODEL_MIN_COMPLETION_TOKENS)
+        else:
+            floored_max_tokens = _REASONING_MODEL_MIN_COMPLETION_TOKENS
         params: Dict[str, Any] = {
             "model": model_name,
             "max_completion_tokens": floored_max_tokens,
@@ -330,8 +335,13 @@ class OpenAIService:
                 if chunk.choices[0].delta.content is not None:
                     yield chunk.choices[0].delta.content
 
-        except Exception as e:
-            raise Exception(f"Error in OpenAI streaming: {str(e)}")
+        except Exception:
+            # Re-raise as-is rather than wrapping in a bare Exception — SDK
+            # errors (openai.RateLimitError, AuthenticationError, etc.) carry
+            # structured data (status code, headers, retry-after) that retry
+            # logic higher in the stack may need to inspect, and wrapping
+            # would destroy that type information.
+            raise
     
     def text_to_speech(self, text: str, voice: str = "alloy", 
                       model: str = "tts-1", output_format: str = "mp3",

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -121,6 +121,36 @@ def should_send_quick_ack(user_text: str, config: QuickAckConfig) -> bool:
     return True
 
 
+def rag_prefetch_matches_final(prefetch_source_text: str, final_text: str) -> bool:
+    """
+    Decide whether a RAG/KB prefetch fired on an STT *interim* is still safe
+    to reuse for the STT *final* of the same turn.
+
+    The Twilio path (bidirectional_stream.py's `_prefetch_rag_context`) fires
+    on the first qualifying interim and always reuses whatever result that
+    produced, with no divergence check — it accepts that a slight interim/
+    final wording difference is fine for retrieval purposes. The browser path
+    adds this lightweight safety check on top of that same pattern: if the
+    final utterance diverges *materially* from the interim that triggered the
+    prefetch (e.g. the STT correction changed the meaning, not just a couple
+    of trailing words), the prefetch result is discarded and a fresh
+    retrieval is used instead — never a behavior change to Twilio, since this
+    helper is only consumed by the browser call path.
+    """
+    source = (prefetch_source_text or "").strip().lower()
+    final = (final_text or "").strip().lower()
+    if not source or not final:
+        return False
+    if final.startswith(source) or source.startswith(final):
+        return True
+    source_words = set(source.split())
+    final_words = set(final.split())
+    if not source_words or not final_words:
+        return False
+    overlap = len(source_words & final_words) / max(len(source_words), len(final_words))
+    return overlap >= 0.6
+
+
 @dataclass
 class ConversationActions:
     """
@@ -501,25 +531,81 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
 
             # KB context injection: runs when flow.knowledge_base_ids is non-empty.
             # Injected AFTER the system prompt and BEFORE conversation history.
+            #
+            # RAG retrieval: reuse the interim-fired prefetch when available
+            # (fired in LiveKitBrowserCallHandler._maybe_start_rag_prefetch on
+            # STT interim, overlapping STT endpointing) instead of always
+            # blocking here on a fresh retrieval — mirrors
+            # bidirectional_stream.py's prefetch-consume-once pattern, adapted
+            # to this transport's kb_retrieval_service call. Falls back to the
+            # exact same synchronous retrieval this code path always used
+            # when no prefetch fired (e.g. a very short first utterance) or
+            # when the final utterance diverged materially from the interim
+            # that triggered the prefetch.
             kb_context_block = ""
             flow = getattr(self._h, "call_flow", None)
             flow_kb_ids = (flow.knowledge_base_ids or []) if flow else []
             if flow_kb_ids and self._h.db:
-                try:
-                    from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
-                    from app.utils.redis_client import get_redis
+                _kb_timeout_sec = float(
+                    getattr(settings, "RAG_KB_RETRIEVAL_TIMEOUT_SEC", 0.7) or 0.7
+                )
 
-                    _kb_timeout_sec = float(
-                        getattr(settings, "RAG_KB_RETRIEVAL_TIMEOUT_SEC", 0.7) or 0.7
-                    )
-                    kb_context_block, kb_latency_ms = await asyncio.wait_for(
-                        retrieve_kb_context_for_turn(
-                            transcript=user_text,
-                            kb_ids=flow_kb_ids,
-                            redis_client=get_redis(),
-                        ),
-                        timeout=_kb_timeout_sec,  # fail open if exceeded — see settings.RAG_KB_RETRIEVAL_TIMEOUT_SEC
-                    )
+                # Consume the prefetch slot exactly once per turn, immediately —
+                # so it can never be read/reused by a later, unrelated turn.
+                # isinstance-checked (not just `is not None`) so a handler
+                # that never initialised this attribute at all (e.g. a bare
+                # test double) is treated the same as "no prefetch fired",
+                # rather than accidentally treating an unrelated truthy value
+                # as a real in-flight prefetch task.
+                _prefetch = getattr(self._h, "_rag_prefetch_task", None)
+                if not isinstance(_prefetch, asyncio.Task):
+                    _prefetch = None
+                self._h._rag_prefetch_task = None
+                _prefetch_source_text = getattr(self._h, "_rag_prefetch_source_text", "")
+                if not isinstance(_prefetch_source_text, str):
+                    _prefetch_source_text = ""
+                self._h._rag_prefetch_source_text = ""
+
+                if _prefetch is not None and not rag_prefetch_matches_final(
+                    _prefetch_source_text, user_text
+                ):
+                    # Final utterance materially diverged from the interim that
+                    # triggered this prefetch — don't reuse a possibly-wrong
+                    # result. Cancel it (if still running) and fall through to
+                    # a fresh retrieval below, same as the "no prefetch" branch.
+                    if not _prefetch.done():
+                        _prefetch.cancel()
+                    _prefetch = None
+
+                try:
+                    if _prefetch is not None:
+                        if _prefetch.done():
+                            # Already finished — zero-cost read.
+                            kb_context_block, kb_latency_ms = _prefetch.result()
+                            logger.debug("[RAG prefetch] used prefetch result (done)")
+                        else:
+                            # Still running — await the SAME in-flight task
+                            # (never start a second parallel retrieval).
+                            # asyncio.shield so a local timeout here doesn't
+                            # cancel a retrieval that may still be useful to
+                            # warm the KB cache for a future turn.
+                            kb_context_block, kb_latency_ms = await asyncio.wait_for(
+                                asyncio.shield(_prefetch),
+                                timeout=_kb_timeout_sec,
+                            )
+                            logger.debug("[RAG prefetch] awaited in-flight prefetch")
+                    else:
+                        from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
+                        from app.utils.redis_client import get_redis
+
+                        kb_context_block, kb_latency_ms = await asyncio.wait_for(
+                            retrieve_kb_context_for_turn(
+                                transcript=user_text,
+                                kb_ids=flow_kb_ids,
+                                redis_client=get_redis(),
+                            ),
+                            timeout=_kb_timeout_sec,  # fail open if exceeded — see settings.RAG_KB_RETRIEVAL_TIMEOUT_SEC
+                        )
                     logger.info(
                         "kb_retrieval latency_ms=%.1f kb_count=%d call_sid=%s",
                         kb_latency_ms,
@@ -531,6 +617,12 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                         "kb_retrieval timed out after %.0fms; proceeding without KB context",
                         _kb_timeout_sec * 1000,
                     )
+                except asyncio.CancelledError:
+                    # This turn itself was cancelled (e.g. barge-in) while
+                    # awaiting the prefetch — propagate rather than swallow.
+                    # The shielded prefetch task (if any) keeps running
+                    # independently and is not affected by this.
+                    raise
                 except Exception as exc:
                     logger.error("kb_retrieval failed; proceeding without context: %s", exc)
 

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -145,8 +145,6 @@ def rag_prefetch_matches_final(prefetch_source_text: str, final_text: str) -> bo
         return True
     source_words = set(source.split())
     final_words = set(final.split())
-    if not source_words or not final_words:
-        return False
     overlap = len(source_words & final_words) / max(len(source_words), len(final_words))
     return overlap >= 0.6
 
@@ -580,9 +578,22 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 try:
                     if _prefetch is not None:
                         if _prefetch.done():
-                            # Already finished — zero-cost read.
-                            kb_context_block, kb_latency_ms = _prefetch.result()
-                            logger.debug("[RAG prefetch] used prefetch result (done)")
+                            # Already finished — zero-cost read. Check for a stored
+                            # exception explicitly rather than relying on
+                            # _prefetch_kb_context's current "always returns
+                            # ('', 0.0), never raises" contract — that contract is
+                            # easy to break in a future edit, and an unguarded
+                            # .result() would then raise here and be silently
+                            # swallowed by the outer except Exception below.
+                            _prefetch_exc = _prefetch.exception()
+                            if _prefetch_exc is not None:
+                                logger.debug(
+                                    "[RAG prefetch] stored exception: %s", _prefetch_exc
+                                )
+                                kb_context_block, kb_latency_ms = "", 0.0
+                            else:
+                                kb_context_block, kb_latency_ms = _prefetch.result()
+                                logger.debug("[RAG prefetch] used prefetch result (done)")
                         else:
                             # Still running — await the SAME in-flight task
                             # (never start a second parallel retrieval).

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -314,6 +314,27 @@ class LiveKitBrowserCallHandler:
             getattr(settings, "VOICE_BARGE_IN_MIN_CONFIDENCE_1W", 0.52) or 0.52
         )
         self._barge_in_min_words: int = max(1, int(getattr(settings, "VOICE_BARGE_IN_MIN_WORDS", 2) or 2))
+
+        # ── RAG interim-prefetch ─────────────────────────────────────────────
+        # Mirrors bidirectional_stream.py's _prefetch_rag_context pattern
+        # (fire vector/KB retrieval in the background on the first qualifying
+        # STT interim of a turn, so it overlaps STT endpointing instead of
+        # blocking the eventual LLM start), adapted to this transport's
+        # retrieval call (kb_retrieval_service.retrieve_kb_context_for_turn —
+        # see _maybe_start_rag_prefetch / _prefetch_kb_context below).
+        # Single-slot state, same model as _llm_response_task: None means
+        # "not fired for this turn"; consumed-once-and-reset-to-None by
+        # ConversationOrchestrator.generate_and_stream_response on STT final,
+        # or discarded by _cancel_inflight_llm_response on barge-in — so it
+        # can never leak into a later, unrelated turn.
+        self._rag_prefetch_task: asyncio.Task | None = None
+        self._rag_prefetch_source_text: str = ""
+        self._rag_prefetch_min_words: int = max(
+            1, int(getattr(settings, "VOICE_RAG_PREFETCH_MIN_WORDS", 1) or 1)
+        )
+        self._rag_prefetch_min_confidence: float = float(
+            getattr(settings, "VOICE_RAG_PREFETCH_MIN_CONFIDENCE", 0.05) or 0.05
+        )
         # Pickup-detection tunables: unused by this path (LiveKit rooms have no
         # Twilio ringing/system-message phase to skip) but VoiceOrchestrator's
         # __init__ reads them off the handler unconditionally.
@@ -415,31 +436,119 @@ class LiveKitBrowserCallHandler:
 
     async def _maybe_process_interim(self, transcript: str, confidence: float) -> None:
         """
-        Barge-in only. LiveKit rooms have their own echo cancellation and the
-        default platform setting (VOICE_ENABLE_INTERIM_LLM=False) means the
-        Twilio path doesn't start early LLM generation on interims either —
-        so this mirrors that default behaviour rather than reimplementing the
+        Barge-in + RAG interim-prefetch trigger.
+
+        Barge-in is resolved FIRST via a single `is_barge_in` boolean, and
+        `return`s immediately when it applies — mirrors
+        bidirectional_stream.py's `_maybe_process_interim` ordering exactly
+        (computes `is_barge_in`, cancels + `return`s when true; its RAG-
+        prefetch block is only reached when `is_barge_in` is false). This
+        ordering matters here specifically because the RAG-prefetch gate
+        (VOICE_RAG_PREFETCH_MIN_WORDS/MIN_CONFIDENCE) is strictly weaker than
+        the barge-in gate — every interim that qualifies for barge-in also
+        qualifies to fire a prefetch, and `_cancel_inflight_llm_response()`
+        (called on barge-in) unconditionally discards `_rag_prefetch_task`.
+        Firing the prefetch before checking barge-in would mean every
+        barge-in-initiated turn wastes a prefetch attempt (fired then
+        immediately cancelled) and gets zero prefetch benefit — precisely
+        the highest-value case (a user interrupting the agent) would get
+        none of the benefit.
+
+        Note `is_barge_in` being false does NOT require `_is_tts_playing` to
+        be false — an interim while TTS *is* playing but that doesn't meet
+        the barge-in word/confidence thresholds is also `is_barge_in=False`
+        and still eligible to fire a prefetch, exactly matching Twilio's
+        structure (its prefetch block isn't gated on `_is_tts_playing`
+        either, only on `is_barge_in`).
+
+        LiveKit rooms have their own echo cancellation and the default
+        platform setting (VOICE_ENABLE_INTERIM_LLM=False) means the Twilio
+        path doesn't start early LLM generation on interims either — so this
+        mirrors that default behaviour rather than reimplementing the
         early-LLM path's seed/regeneration bookkeeping.
         """
         try:
-            if not self._is_tts_playing or not transcript:
-                return
-            text = transcript.strip()
+            text = (transcript or "").strip()
             if not text:
                 return
             word_count = len(text.split())
-            if word_count < self._barge_in_min_words:
-                return
+
             min_conf = self._barge_in_min_conf_1w if word_count < 2 else self._barge_in_min_conf
-            if confidence < min_conf:
-                return
-            logger.info(
-                "[LiveKitBrowserCall] barge-in: words=%d conf=%.2f text=%r",
-                word_count, confidence, text[:40],
+            is_barge_in = (
+                self._is_tts_playing
+                and word_count >= self._barge_in_min_words
+                and confidence >= min_conf
             )
-            await self._cancel_inflight_llm_response()
+            if is_barge_in:
+                logger.info(
+                    "[LiveKitBrowserCall] barge-in: words=%d conf=%.2f text=%r",
+                    word_count, confidence, text[:40],
+                )
+                await self._cancel_inflight_llm_response()
+                return
+
+            # Barge-in did not apply this call — safe to consider firing a
+            # prefetch (whether or not TTS happens to still be playing).
+            self._maybe_start_rag_prefetch(text, confidence, word_count)
         except Exception as exc:
             logger.error("[LiveKitBrowserCall] _maybe_process_interim error: %s", exc, exc_info=True)
+
+    def _maybe_start_rag_prefetch(self, text: str, confidence: float, word_count: int) -> None:
+        """
+        Fire KB-context retrieval in the background on the first qualifying
+        interim of a turn (mirrors bidirectional_stream.py's
+        `_prefetch_rag_context` trigger gating). Consumed exactly once, by
+        `ConversationOrchestrator.generate_and_stream_response` on STT final
+        — never invoked twice for the same turn (guarded below) and never
+        left to leak into a later turn (reset to None on consume or on
+        barge-in cancellation in `_cancel_inflight_llm_response`).
+        """
+        if self._rag_prefetch_task is not None:
+            return  # already fired for this turn — never fire a duplicate request
+        flow_kb_ids = (self.call_flow.knowledge_base_ids or []) if self.call_flow else []
+        if not flow_kb_ids or not self.db:
+            return  # RAG/KB not configured for this call flow — nothing to prefetch
+        if word_count < self._rag_prefetch_min_words or confidence < self._rag_prefetch_min_confidence:
+            return
+        self._rag_prefetch_source_text = text
+        self._rag_prefetch_task = asyncio.create_task(
+            self._prefetch_kb_context(text, list(flow_kb_ids))
+        )
+
+    async def _prefetch_kb_context(self, transcript: str, kb_ids: list) -> tuple[str, float]:
+        """
+        Background KB-context retrieval for RAG interim-prefetch.
+
+        `kb_retrieval_service.retrieve_kb_context_for_turn` is already fully
+        async and fails open internally (returns `("", latency_ms)` on any
+        internal error) — this wrapper adds the same
+        `RAG_KB_RETRIEVAL_TIMEOUT_SEC` bound
+        `ConversationOrchestrator`'s synchronous fallback path uses, so a
+        slow/hanging retrieval can never block the eventual LLM turn: on
+        timeout or any other exception this always returns a valid empty
+        result rather than raising, matching
+        `_prefetch_rag_context`'s fail-open contract on the Twilio path.
+        """
+        try:
+            from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
+            from app.utils.redis_client import get_redis
+
+            timeout_sec = float(getattr(settings, "RAG_KB_RETRIEVAL_TIMEOUT_SEC", 0.7) or 0.7)
+            return await asyncio.wait_for(
+                retrieve_kb_context_for_turn(
+                    transcript=transcript,
+                    kb_ids=kb_ids,
+                    redis_client=get_redis(),
+                ),
+                timeout=timeout_sec,
+            )
+        except asyncio.TimeoutError:
+            logger.debug("[RAG prefetch] timed out for '%s…'", transcript[:20])
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.debug("[RAG prefetch] failed: %s", exc)
+        return "", 0.0
 
     async def _cancel_inflight_llm_response(self) -> None:
         task = self._llm_response_task
@@ -454,6 +563,13 @@ class LiveKitBrowserCallHandler:
                 logger.debug("[LiveKitBrowserCall] cancelled turn raised: %s", exc)
         if self._tts_pipeline:
             await self._tts_pipeline.cancel_current_and_clear_queue()
+        # Discard stale RAG prefetch so the next turn gets a fresh retrieval —
+        # mirrors bidirectional_stream.py's _cancel_inflight_llm_response.
+        prefetch = self._rag_prefetch_task
+        if prefetch and not prefetch.done():
+            prefetch.cancel()
+        self._rag_prefetch_task = None
+        self._rag_prefetch_source_text = ""
         # LiveKit protocol: cancelling our TTS task locally only stops *us*
         # from pushing more frames — it does not stop frames already pushed
         # into rtc.AudioSource's own internal playout queue (up to 1000ms of

--- a/tests/core/test_agent_runtime.py
+++ b/tests/core/test_agent_runtime.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 import uuid
 from unittest.mock import MagicMock, patch
 
-from app.core.agent_runtime import resolve_llm_runtime, resolve_tts_runtime
-from app.core.llm_models import infer_llm_provider
+import pytest
+
+from app.core.agent_runtime import (
+    llm_service_for_provider,
+    resolve_llm_runtime,
+    resolve_tts_runtime,
+)
+from app.core.llm_models import ALLOWED_LLM_MODELS, infer_llm_provider
 
 
 def test_infer_llm_provider_openai():
@@ -14,6 +20,77 @@ def test_infer_llm_provider_openai():
 
 def test_infer_llm_provider_groq():
     assert infer_llm_provider("llama-3.1-70b-versatile") == "groq"
+
+
+# ─────────────────────────────── gpt-5 reasoning family (new models) ──────────
+
+_NEW_GPT5_MODELS = ["gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"]
+
+
+@pytest.mark.parametrize("model_name", _NEW_GPT5_MODELS)
+def test_gpt5_models_in_allow_list(model_name):
+    assert model_name in ALLOWED_LLM_MODELS
+
+
+@pytest.mark.parametrize("model_name", _NEW_GPT5_MODELS)
+def test_infer_llm_provider_resolves_gpt5_models_to_openai(model_name):
+    assert infer_llm_provider(model_name) == "openai"
+
+
+@pytest.mark.parametrize("model_name", _NEW_GPT5_MODELS)
+def test_resolve_llm_runtime_routes_gpt5_models_to_openai(model_name):
+    agent = MagicMock()
+    agent.llm_model = model_name
+    agent.model = None
+    agent.provider = None
+    agent.agent_temperature = None
+    agent.agent_max_tokens = None
+
+    runtime = resolve_llm_runtime(agent)
+    assert runtime.model_name == model_name
+    assert runtime.provider_slug == "openai"
+    assert runtime.used_ticket_llm is True
+
+
+@pytest.mark.parametrize("model_name", _NEW_GPT5_MODELS + ["gpt-4.1"])
+def test_llm_service_for_provider_routes_gpt_family_to_openai_singleton(model_name):
+    from app.services.openai_service import openai_service
+
+    provider_slug = infer_llm_provider(model_name)
+    assert llm_service_for_provider(provider_slug) is openai_service
+
+
+@pytest.mark.parametrize(
+    "model_name, expected_provider, expected_service_attr",
+    [
+        ("gemini-2.5-flash", "gemini", "vertex_gemini_service"),
+        ("gemini-2.0-flash-001", "gemini", "vertex_gemini_service"),
+        ("gemini-1.5-pro", "gemini", "vertex_gemini_service"),
+        ("claude-3-5-sonnet", "gemini", "vertex_gemini_service"),  # no Anthropic service yet
+        ("llama-3.1-70b-versatile", "groq", "groq_service"),
+        ("llama-3.1-8b-instant", "groq", "groq_service"),
+        ("gpt-4o", "openai", "openai_service"),
+        ("gpt-4o-mini", "openai", "openai_service"),
+        ("gpt-4.1", "openai", "openai_service"),
+        ("gpt-4.1-mini", "openai", "openai_service"),
+        ("gpt-4-turbo", "openai", "openai_service"),
+    ],
+)
+def test_existing_models_still_route_to_prior_providers(
+    model_name, expected_provider, expected_service_attr
+):
+    """Regression: adding gpt-5 models must not change routing for any
+    pre-existing allow-listed model."""
+    assert infer_llm_provider(model_name) == expected_provider
+
+    if expected_service_attr == "openai_service":
+        from app.services.openai_service import openai_service as expected_service
+    elif expected_service_attr == "groq_service":
+        from app.services.groq_service import groq_service as expected_service
+    else:
+        from app.services.vertex_gemini_service import vertex_gemini_service as expected_service
+
+    assert llm_service_for_provider(expected_provider) is expected_service
 
 
 def test_resolve_llm_runtime_prefers_ticket_llm_model():

--- a/tests/core/test_main_lifespan_warmup.py
+++ b/tests/core/test_main_lifespan_warmup.py
@@ -1,0 +1,124 @@
+"""
+Regression coverage for the RAG/KB embedding-client warm-up task's
+reference-lifetime handling in app.main's lifespan.
+
+Background: `asyncio.create_task(warm_embedding_client())` on its own only
+keeps a WEAK reference to the Task internally (asyncio.tasks._all_tasks is a
+WeakSet). With no strong reference held anywhere else, the task is eligible
+for garbage collection at any suspension point (e.g. the `await
+loop.run_in_executor(...)` inside warm_embedding_client) and CPython can
+silently drop/cancel it before completion — with nothing awaiting or logging
+the loss. The fix stores the task in `app.state._warmup_tasks` (a strong
+reference) for its lifetime and discards it via `add_done_callback` once
+done, so it can't be prematurely collected but also doesn't leak.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+
+
+def test_bare_create_task_pattern_is_unsafe_without_a_strong_reference():
+    """Sanity check on the *problem* being fixed: a Task with no reference
+    other than the local variable inside create_task()'s caller is only kept
+    alive by refcounting — as soon as that local variable's reference is
+    dropped, nothing else keeps it alive. This is exactly the bug pattern
+    `asyncio.create_task(warm_embedding_client())` had before the fix."""
+
+    async def scenario():
+        task = asyncio.create_task(asyncio.sleep(0, result="done"))
+        # No strong reference retained anywhere but this local name — mirrors
+        # the pre-fix `asyncio.create_task(warm_embedding_client())` call
+        # whose return value was discarded entirely.
+        weak_only = task
+        del task
+        gc.collect()
+        # We can still await it here only because Python's refcounting kept
+        # `weak_only` (the same object) alive within this frame — in the real
+        # bug, no reference at all survives past the `create_task(...)` call
+        # expression, which is what makes the loss silent in production.
+        return await weak_only
+
+    assert asyncio.run(scenario()) == "done"
+
+
+def test_warmup_task_set_pattern_survives_gc_and_completes():
+    """Regression test for the actual fix: storing the task in a strong-
+    reference set (mirroring `app.state._warmup_tasks` in app/main.py) and
+    registering `add_done_callback(tasks.discard)` must keep the task alive
+    across a suspension point + explicit gc.collect(), and the task must
+    still run to completion and be cleaned up from the set afterward."""
+
+    async def scenario():
+        warmup_tasks: set[asyncio.Task] = set()
+
+        async def _slow_warmup():
+            await asyncio.sleep(0)
+            return "warmed"
+
+        task = asyncio.create_task(_slow_warmup())
+        warmup_tasks.add(task)
+        task.add_done_callback(warmup_tasks.discard)
+
+        # Drop every other reference to the task object, exactly like
+        # app.main's lifespan does after scheduling it (the local
+        # `warmup_task` variable goes out of scope once the `try` block
+        # ends) — only `warmup_tasks` keeps it alive now.
+        del task
+        gc.collect()
+
+        # The task must still be tracked (i.e. not GC'd) and must still run
+        # to completion.
+        assert len(warmup_tasks) == 1
+        (remaining_task,) = tuple(warmup_tasks)
+        result = await remaining_task
+        assert result == "warmed"
+
+        # add_done_callback fires on the loop's next iteration — yield once
+        # so the discard callback has actually run before we assert cleanup.
+        await asyncio.sleep(0)
+        assert warmup_tasks == set()
+
+    asyncio.run(scenario())
+
+
+def test_lifespan_skips_warmup_outside_staging_production(client):
+    """End-to-end via the real app lifespan (ENVIRONMENT defaults to
+    "development" in tests, same as local `uvicorn --reload`): the warm-up
+    must NOT fire a real request here — it's gated to staging/production
+    only, precisely so the pytest suite (and local dev) never makes a real,
+    billed OpenAI call just from starting the app. If this ever regresses to
+    firing unconditionally, a still-pending task in `app.state._warmup_tasks`
+    would be the visible symptom in CI."""
+    from app.main import app as _app
+
+    warmup_tasks = getattr(_app.state, "_warmup_tasks", set())
+    assert warmup_tasks == set()
+
+
+def test_warm_up_scheduling_uses_add_done_callback_discard_pattern():
+    """Static assertion that app.main's warm-up scheduling code still uses
+    the strong-reference-set + add_done_callback(discard) pattern, so a
+    future refactor can't silently reintroduce the bare, reference-less
+    `asyncio.create_task(warm_embedding_client())` regression (the original
+    bug: the Task object returned by create_task() was never assigned to
+    anything, so nothing kept a strong reference to it)."""
+    import inspect
+    import re
+
+    import app.main as main_module
+
+    source = inspect.getsource(main_module)
+    assert "_warmup_tasks" in source
+    assert "add_done_callback" in source
+
+    # The create_task(...) call for the warm-up coroutine must assign its
+    # result to a variable (not be a bare, unreferenced statement).
+    match = re.search(r"^\s*(\S.*=\s*)?asyncio\.create_task\(warm_embedding_client\(\)\)", source, re.MULTILINE)
+    assert match is not None, "warm_embedding_client() warm-up call not found"
+    assert match.group(1), (
+        "asyncio.create_task(warm_embedding_client()) must assign its result "
+        "to a variable so a strong reference can be retained — a bare call "
+        "lets the Task be garbage-collected before it completes"
+    )

--- a/tests/db/test_schema_v2_migration.py
+++ b/tests/db/test_schema_v2_migration.py
@@ -498,3 +498,73 @@ class TestV2MigrationFile:
         """Confirm we have not altered the v1 gaps migration file."""
         mod = _load_migration("20260521_schema_v1_gaps.py")
         assert mod.down_revision == "20260518_tenant_name_uq"
+
+
+# ──────────────────────── widen ck_agent_llm_model (gpt-5 family) ─────────────
+
+class TestWidenAgentLlmModelCheckMigration:
+    """20260815_widen_agent_llm_model_check.py — widens ck_agent_llm_model
+    from the 14-value 20260602 snapshot to 19 values (adds the 5 gpt-5
+    reasoning-family IDs, removes nothing)."""
+
+    def test_file_exists(self):
+        assert (_VERSIONS_DIR / "20260815_widen_agent_llm_model_check.py").exists()
+
+    def test_down_revision_is_assemblyai_stt(self):
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        assert mod.down_revision == "20260814_assemblyai_stt"
+
+    def test_has_upgrade_and_downgrade(self):
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)
+
+    def test_revision_id(self):
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        assert mod.revision == "20260815_widen_llm_check"
+
+    def test_widened_snapshot_has_19_values(self):
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        assert len(mod._ALLOWED_LLM_MODELS_AT_REVISION) == 19
+
+    def test_prior_snapshot_unchanged_at_14_values(self):
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        assert len(mod._PRIOR_ALLOWED_LLM_MODELS) == 14
+
+    def test_widened_snapshot_is_superset_of_prior_snapshot(self):
+        """Purely additive: nothing removed or renamed."""
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        assert set(mod._PRIOR_ALLOWED_LLM_MODELS).issubset(
+            set(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        )
+
+    def test_widened_snapshot_adds_exactly_the_gpt5_family(self):
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        added = set(mod._ALLOWED_LLM_MODELS_AT_REVISION) - set(mod._PRIOR_ALLOWED_LLM_MODELS)
+        assert added == {"gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"}
+
+    def test_widened_snapshot_matches_current_allow_list(self):
+        """The migration's self-contained snapshot must match the current
+        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
+        revision — future edits to the module are expected to add a new
+        migration rather than retroactively changing this one)."""
+        from app.core.llm_models import ALLOWED_LLM_MODELS
+
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
+
+    def test_llm_check_sql_uses_widened_snapshot(self):
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        for model in mod._ALLOWED_LLM_MODELS_AT_REVISION:
+            assert f"'{model}'" in sql
+
+    def test_downgrade_sql_uses_prior_snapshot_only(self):
+        """Downgrade must restore the narrower 14-value constraint — gpt-5
+        IDs must not appear in the downgrade CHECK SQL."""
+        mod = _load_migration("20260815_widen_agent_llm_model_check.py")
+        sql = mod._llm_check_sql(mod._PRIOR_ALLOWED_LLM_MODELS)
+        for model in mod._PRIOR_ALLOWED_LLM_MODELS:
+            assert f"'{model}'" in sql
+        for gpt5_model in ["gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"]:
+            assert f"'{gpt5_model}'" not in sql

--- a/tests/services/test_embedding_service.py
+++ b/tests/services/test_embedding_service.py
@@ -17,7 +17,7 @@ startup hook.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -101,12 +101,13 @@ def test_warm_embedding_client_swallows_errors_and_never_raises():
     """warm_embedding_client is scheduled as a fire-and-forget background task
     from app startup — it must never raise, even if the embedding call fails,
     so a startup-time exception can never crash the worker process."""
+    mock_async_client = MagicMock()
+    mock_async_client.embeddings.create = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_openai_service = MagicMock()
+    mock_openai_service.get_async_client.return_value = mock_async_client
     with (
         patch("app.services.embedding_service.settings") as mock_settings,
-        patch(
-            "app.services.embedding_service.embed_text_for_rag",
-            side_effect=RuntimeError("boom"),
-        ),
+        patch("app.services.openai_service.openai_service", mock_openai_service),
     ):
         mock_settings.OPENAI_API_KEY = "test-key"
         asyncio.run(warm_embedding_client())  # must not raise
@@ -116,25 +117,37 @@ def test_warm_embedding_client_noop_without_openai_key():
     """No OPENAI_API_KEY configured (e.g. Gemini-only or on-prem deployment
     without RAG) → warm-up is a no-op rather than raising or performing an
     unnecessary call."""
+    mock_openai_service = MagicMock()
     with (
         patch("app.services.embedding_service.settings") as mock_settings,
-        patch("app.services.embedding_service.embed_text_for_rag") as mock_embed,
+        patch("app.services.openai_service.openai_service", mock_openai_service),
     ):
         mock_settings.OPENAI_API_KEY = ""
         asyncio.run(warm_embedding_client())
 
-    mock_embed.assert_not_called()
+    mock_openai_service.get_async_client.assert_not_called()
 
 
 def test_warm_embedding_client_calls_embed_with_openai_key():
+    """warm_embedding_client uses the async OpenAI client directly (not the
+    sync client via a thread-pool executor) — the sync client's underlying
+    httpx.Client is not thread-safe for concurrent use."""
+    mock_async_client = MagicMock()
+    mock_async_client.embeddings.create = AsyncMock()
+    mock_openai_service = MagicMock()
+    mock_openai_service.get_async_client.return_value = mock_async_client
     with (
         patch("app.services.embedding_service.settings") as mock_settings,
-        patch("app.services.embedding_service.embed_text_for_rag") as mock_embed,
+        patch("app.services.openai_service.openai_service", mock_openai_service),
     ):
         mock_settings.OPENAI_API_KEY = "test-key"
+        mock_settings.RAG_EMBEDDING_MODEL = "text-embedding-ada-002"
         asyncio.run(warm_embedding_client())
 
-    mock_embed.assert_called_once()
+    mock_openai_service.get_async_client.assert_called_once()
+    mock_async_client.embeddings.create.assert_called_once_with(
+        model="text-embedding-ada-002", input="warmup"
+    )
 
 
 def test_gemini_used_only_when_openai_not_configured_at_all():

--- a/tests/services/test_embedding_service.py
+++ b/tests/services/test_embedding_service.py
@@ -6,15 +6,22 @@ an OpenAI embedding failure must raise (not silently fall back to Gemini),
 since kbchunk.embedding rows are OpenAI-embedded and a Gemini vector would be
 a different embedding space entirely — producing semantically meaningless
 nearest-neighbor results instead of no results.
+
+Also covers the cold-start-latency fix: _embed_openai_ada002 must route
+through openai_service's cached-by-api-key client (OpenAIService.get_client)
+rather than constructing a brand-new OpenAI client (and therefore a brand-new
+httpx connection pool) on every call, plus the fire-and-forget warm_embedding_client
+startup hook.
 """
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.embedding_service import embed_text_for_rag
+from app.services.embedding_service import embed_text_for_rag, warm_embedding_client
 
 
 def test_openai_success_returns_vector():
@@ -25,7 +32,7 @@ def test_openai_success_returns_vector():
 
     with (
         patch("app.services.embedding_service.settings") as mock_settings,
-        patch("app.core.openai_client.get_openai_client", return_value=fake_client),
+        patch("app.services.openai_service.openai_service.get_client", return_value=fake_client),
     ):
         mock_settings.OPENAI_API_KEY = "test-key"
         mock_settings.RAG_EMBEDDING_MODEL = "text-embedding-3-small"
@@ -41,7 +48,7 @@ def test_openai_failure_raises_instead_of_falling_back_to_gemini():
     with (
         patch("app.services.embedding_service.settings") as mock_settings,
         patch(
-            "app.core.openai_client.get_openai_client",
+            "app.services.openai_service.openai_service.get_client",
             side_effect=RuntimeError("OpenAI outage"),
         ),
         patch("app.services.gemini_service.gemini_service") as mock_gemini,
@@ -54,6 +61,80 @@ def test_openai_failure_raises_instead_of_falling_back_to_gemini():
             embed_text_for_rag("hello world")
 
     mock_gemini.embed_text.assert_not_called()
+
+
+def test_embed_reuses_cached_client_across_calls():
+    """The whole point of the cold-start fix: two embedding calls must reuse
+    the SAME client instance (i.e. the same underlying httpx connection pool)
+    rather than each constructing a fresh OpenAI client. This is what lets a
+    warm call reuse an already-established TCP/TLS connection instead of
+    paying a fresh handshake every single time."""
+    from app.services.openai_service import openai_service
+
+    fake_resp = MagicMock()
+    fake_resp.data = [MagicMock(embedding=[0.1, 0.2, 0.3])]
+    fake_client = MagicMock()
+    fake_client.embeddings.create.return_value = fake_resp
+
+    # Reset the singleton's client cache so this test is order-independent.
+    openai_service._clients = {}
+
+    with (
+        patch("app.services.embedding_service.settings") as mock_settings,
+        patch("app.services.openai_service.settings") as mock_openai_settings,
+        patch("app.services.openai_service.get_openai_client", return_value=fake_client) as mock_factory,
+    ):
+        mock_settings.OPENAI_API_KEY = "test-key"
+        mock_settings.RAG_EMBEDDING_MODEL = "text-embedding-3-small"
+        mock_openai_settings.OPENAI_API_KEY = "test-key"
+
+        embed_text_for_rag("first call")
+        embed_text_for_rag("second call")
+
+    # The underlying client factory must only be invoked once — the second
+    # call must be served from openai_service's cache, not a fresh client.
+    mock_factory.assert_called_once()
+    assert fake_client.embeddings.create.call_count == 2
+
+
+def test_warm_embedding_client_swallows_errors_and_never_raises():
+    """warm_embedding_client is scheduled as a fire-and-forget background task
+    from app startup — it must never raise, even if the embedding call fails,
+    so a startup-time exception can never crash the worker process."""
+    with (
+        patch("app.services.embedding_service.settings") as mock_settings,
+        patch(
+            "app.services.embedding_service.embed_text_for_rag",
+            side_effect=RuntimeError("boom"),
+        ),
+    ):
+        mock_settings.OPENAI_API_KEY = "test-key"
+        asyncio.run(warm_embedding_client())  # must not raise
+
+
+def test_warm_embedding_client_noop_without_openai_key():
+    """No OPENAI_API_KEY configured (e.g. Gemini-only or on-prem deployment
+    without RAG) → warm-up is a no-op rather than raising or performing an
+    unnecessary call."""
+    with (
+        patch("app.services.embedding_service.settings") as mock_settings,
+        patch("app.services.embedding_service.embed_text_for_rag") as mock_embed,
+    ):
+        mock_settings.OPENAI_API_KEY = ""
+        asyncio.run(warm_embedding_client())
+
+    mock_embed.assert_not_called()
+
+
+def test_warm_embedding_client_calls_embed_with_openai_key():
+    with (
+        patch("app.services.embedding_service.settings") as mock_settings,
+        patch("app.services.embedding_service.embed_text_for_rag") as mock_embed,
+    ):
+        mock_settings.OPENAI_API_KEY = "test-key"
+        asyncio.run(warm_embedding_client())
+
+    mock_embed.assert_called_once()
 
 
 def test_gemini_used_only_when_openai_not_configured_at_all():

--- a/tests/services/test_groq_service.py
+++ b/tests/services/test_groq_service.py
@@ -1,0 +1,125 @@
+"""Unit tests for groq_service.py — `stream_text` async-client regression.
+
+Mirrors tests/services/test_openai_service.py's approach: mock the OpenAI-
+compatible SDK client at the boundary and prove `stream_text` (a) still
+yields chunks in the correct order and (b) no longer blocks the event loop
+while a stream is "in flight" (old bug: sync client iterated inside
+`async def`). Groq has no gpt-5-style reasoning-model parameter branching —
+only the async-client fix applies here.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.groq_service import GroqService
+
+
+def _mock_chat_response(content="hello world", model="llama-3.3-70b-versatile"):
+    resp = MagicMock()
+    resp.choices = [MagicMock(message=MagicMock(content=content), finish_reason="stop")]
+    resp.model = model
+    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    return resp
+
+
+class _FakeAsyncStreamChunks:
+    """Async iterator mimicking a Groq (OpenAI-compatible) streaming
+    response, with a small `await asyncio.sleep(...)` between chunks to
+    simulate real network I/O."""
+
+    def __init__(self, texts, delay=0.01):
+        self._texts = texts
+        self._delay = delay
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for text in self._texts:
+            await asyncio.sleep(self._delay)
+            chunk = MagicMock()
+            chunk.choices = [MagicMock(delta=MagicMock(content=text))]
+            yield chunk
+
+
+def test_generate_text_unaffected_uses_sync_client():
+    """Non-streaming call sites still use the sync client, untouched."""
+    service = GroqService()
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response()
+
+    with patch.object(service, "get_client", return_value=mock_client):
+        result = service.generate_text("hi", model_name="llama-3.3-70b-versatile", api_key="k")
+
+    assert result["content"] == "hello world"
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 0.7
+    assert kwargs["max_tokens"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_stream_text_yields_chunks_in_order():
+    service = GroqService()
+    mock_async_client = MagicMock()
+    mock_async_client.chat.completions.create = AsyncMock(
+        return_value=_FakeAsyncStreamChunks(["Hel", "lo ", "world"], delay=0)
+    )
+
+    with patch.object(service, "get_async_client", return_value=mock_async_client):
+        chunks = [
+            c
+            async for c in service.stream_text(
+                "hi", model_name="llama-3.3-70b-versatile", api_key="k"
+            )
+        ]
+
+    assert chunks == ["Hel", "lo ", "world"]
+    _, kwargs = mock_async_client.chat.completions.create.call_args
+    assert kwargs["stream"] is True
+    assert kwargs["model"] == "llama-3.3-70b-versatile"
+
+
+@pytest.mark.asyncio
+async def test_stream_text_does_not_block_event_loop():
+    """A concurrently scheduled task must make progress while the (simulated
+    network) stream is in flight between chunks — proves stream_text no
+    longer iterates a blocking sync stream inside an async def."""
+    service = GroqService()
+    mock_async_client = MagicMock()
+    # Wider per-chunk / ticker delays than a first pass at this test used
+    # (0.05s / 0.01s) — that left only ~10ms of margin between the
+    # "concurrent" and "blocked" timing lines, tight enough to flake under
+    # CI scheduling jitter. Widened here for ~100ms of margin on both sides.
+    mock_async_client.chat.completions.create = AsyncMock(
+        return_value=_FakeAsyncStreamChunks(["a", "b", "c"], delay=0.1)
+    )
+
+    progress_marks = []
+
+    async def ticker():
+        for i in range(5):
+            await asyncio.sleep(0.03)
+            progress_marks.append(i)
+
+    async def consume_stream():
+        result = []
+        with patch.object(service, "get_async_client", return_value=mock_async_client):
+            async for chunk in service.stream_text("hi", model_name="llama-3.3-70b-versatile"):
+                result.append(chunk)
+        return result
+
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    stream_result, _ = await asyncio.gather(consume_stream(), ticker())
+    elapsed = loop.time() - start
+
+    assert stream_result == ["a", "b", "c"]
+    assert len(progress_marks) == 5
+    # 3 chunks * 0.1s = 0.3s simulated stream I/O; ticker = 5 * 0.03s = 0.15s.
+    # Sequential (blocked) execution would take >= 0.45s; concurrent
+    # execution stays close to max(0.3, 0.15) = 0.3s. The 0.4s threshold
+    # sits at the midpoint, giving ~100ms slack on both sides.
+    assert elapsed < 0.4, f"expected concurrent interleaving, got elapsed={elapsed}"

--- a/tests/services/test_openai_service.py
+++ b/tests/services/test_openai_service.py
@@ -26,7 +26,14 @@ from app.services.openai_service import (
     OpenAIService,
     _completion_params,
     _is_reasoning_model,
+    _REASONING_EFFORT_BY_MODEL,
 )
+
+# The 8 OpenAI models this repo currently distinguishes for reasoning-effort
+# purposes: 3 non-reasoning + 5 gpt-5-family reasoning models.
+_NON_REASONING_MODELS = ["gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini"]
+_REASONING_MODELS = ["gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"]
+_ALL_8_MODELS = _NON_REASONING_MODELS + _REASONING_MODELS
 
 
 # ─────────────────────────────────── _is_reasoning_model / _completion_params ──
@@ -53,9 +60,65 @@ def test_is_reasoning_model_false_for_existing_models(model_name):
 def test_completion_params_reasoning_model_omits_temperature(model_name):
     # max_tokens above the reasoning-model floor passes through unchanged.
     params = _completion_params(model_name, temperature=0.7, max_tokens=2500)
-    assert params == {"model": model_name, "max_completion_tokens": 2500}
+    assert params["model"] == model_name
+    assert params["max_completion_tokens"] == 2500
     assert "temperature" not in params
     assert "max_tokens" not in params
+
+
+# ─────────────────────────────── reasoning_effort (per exact gpt-5-family model) ──
+#
+# Values sourced from openai.types.chat.completion_create_params's own
+# generated docstring (openai==2.36.0, installed in this repo's venv):
+# "All models before gpt-5.1 default to `medium` reasoning effort, and do
+# not support `none`" -> gpt-5 / gpt-5-mini get an explicit "low" (never
+# "none" — confirmed unsupported for these two). gpt-5.1/5.2/5.4 already
+# default to "none" when omitted, made explicit here for the same set of
+# models per their individual docs pages.
+
+class TestReasoningEffortByModel:
+    @pytest.mark.parametrize("model_name", ["gpt-5", "gpt-5-mini"])
+    def test_pre_5_1_models_get_low_never_none(self, model_name):
+        """`none` is confirmed NOT a supported value for gpt-5 / gpt-5-mini
+        (SDK docstring: "do not support `none`") — must never be sent."""
+        params = _completion_params(model_name, temperature=0.7, max_tokens=2500)
+        assert params["reasoning_effort"] == "low"
+        assert params["reasoning_effort"] != "none"
+
+    @pytest.mark.parametrize("model_name", ["gpt-5.1", "gpt-5.2", "gpt-5.4"])
+    def test_5_1_and_later_models_get_explicit_none(self, model_name):
+        params = _completion_params(model_name, temperature=0.7, max_tokens=2500)
+        assert params["reasoning_effort"] == "none"
+
+    @pytest.mark.parametrize("model_name", _REASONING_MODELS)
+    def test_every_reasoning_model_gets_a_confirmed_valid_value(self, model_name):
+        """Never send a value outside the SDK-confirmed enum
+        {none, minimal, low, medium, high, xhigh}, and specifically never an
+        unsupported combination (e.g. `none` on pre-5.1 models)."""
+        params = _completion_params(model_name, temperature=0.7, max_tokens=2500)
+        confirmed_valid_values = {"none", "minimal", "low", "medium", "high", "xhigh"}
+        assert params["reasoning_effort"] in confirmed_valid_values
+        if model_name in ("gpt-5", "gpt-5-mini"):
+            assert params["reasoning_effort"] != "none"
+
+    @pytest.mark.parametrize("model_name", _NON_REASONING_MODELS + ["gpt-4o", "gpt-4-turbo"])
+    def test_non_reasoning_models_never_get_reasoning_effort(self, model_name):
+        params = _completion_params(model_name, temperature=0.7, max_tokens=100)
+        assert "reasoning_effort" not in params
+
+    def test_unlisted_future_gpt5_model_gets_no_reasoning_effort_falls_back_to_default(self):
+        """A gpt-5-family model name not in the per-model table (e.g. a
+        hypothetical future release) must never crash or guess a value —
+        falls back to omitting the param entirely (server-side default)."""
+        params = _completion_params("gpt-5.9-hypothetical", temperature=0.7, max_tokens=2500)
+        assert "reasoning_effort" not in params
+        assert params["max_completion_tokens"] == 2500  # still gets reasoning-model handling
+
+    def test_reasoning_effort_table_only_contains_confirmed_valid_values(self):
+        confirmed_valid_values = {"none", "minimal", "low", "medium", "high", "xhigh"}
+        assert set(_REASONING_EFFORT_BY_MODEL.values()) <= confirmed_valid_values
+        assert _REASONING_EFFORT_BY_MODEL["gpt-5"] != "none"
+        assert _REASONING_EFFORT_BY_MODEL["gpt-5-mini"] != "none"
 
 
 @pytest.mark.parametrize(
@@ -221,6 +284,45 @@ async def test_stream_text_yields_chunks_in_order():
         chunks = [c async for c in service.stream_text("hi", model_name="gpt-4o-mini")]
 
     assert chunks == ["Hel", "lo ", "world"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model_name", _ALL_8_MODELS)
+async def test_stream_text_resolves_and_streams_correctly_for_all_8_models(model_name):
+    """Every currently-supported OpenAI model (3 non-reasoning + 5 gpt-5
+    family) must stream correctly and receive a well-formed, model-
+    appropriate kwargs set — no crash, no unsupported param sent."""
+    service = OpenAIService()
+    mock_async_client = MagicMock()
+    mock_async_client.chat.completions.create = AsyncMock(
+        return_value=_FakeAsyncStreamChunks(["hello"], delay=0)
+    )
+
+    with patch.object(service, "get_async_client", return_value=mock_async_client):
+        chunks = [
+            c async for c in service.stream_text("hi", model_name=model_name, max_tokens=100)
+        ]
+
+    assert chunks == ["hello"]
+    _, kwargs = mock_async_client.chat.completions.create.call_args
+    assert kwargs["model"] == model_name
+    assert kwargs["stream"] is True
+
+    confirmed_valid_values = {"none", "minimal", "low", "medium", "high", "xhigh"}
+    if model_name in _REASONING_MODELS:
+        assert "max_completion_tokens" in kwargs
+        assert kwargs["max_completion_tokens"] == 1500  # floor applied (max_tokens=100 passed above)
+        assert "max_tokens" not in kwargs
+        assert "temperature" not in kwargs
+        assert kwargs["reasoning_effort"] in confirmed_valid_values
+        if model_name in ("gpt-5", "gpt-5-mini"):
+            assert kwargs["reasoning_effort"] != "none"
+    else:
+        assert "max_tokens" in kwargs
+        assert kwargs["max_tokens"] == 100
+        assert "max_completion_tokens" not in kwargs
+        assert "reasoning_effort" not in kwargs
+        assert "temperature" in kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_openai_service.py
+++ b/tests/services/test_openai_service.py
@@ -1,0 +1,314 @@
+"""Unit tests for openai_service.py.
+
+Covers three related changes:
+  1. `stream_text` now uses an async client (`get_async_client` /
+     `AsyncOpenAI`) instead of iterating a sync stream inside `async def` —
+     regression test proves the event loop is not blocked while a stream is
+     "in flight".
+  2. `_is_reasoning_model` / `_completion_params` — the gpt-5.x parameter
+     branch (no `temperature`, uses `max_completion_tokens`) vs. the
+     unchanged branch for every other model.
+  3. Boundary-level proof (mocking `client.chat.completions.create`) that
+     `generate_text` / `chat_completion` / `stream_text` pass the right
+     kwargs for both branches.
+
+External HTTP is never hit — the OpenAI SDK client is mocked at the
+boundary throughout, per repo convention.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.openai_service import (
+    OpenAIService,
+    _completion_params,
+    _is_reasoning_model,
+)
+
+
+# ─────────────────────────────────── _is_reasoning_model / _completion_params ──
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4", "GPT-5-MINI"],
+)
+def test_is_reasoning_model_true_for_gpt5_family(model_name):
+    assert _is_reasoning_model(model_name) is True
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    ["gpt-4.1", "gpt-4o", "gpt-3.5-turbo", "gpt-4-turbo", "gpt-4o-mini", "", None],
+)
+def test_is_reasoning_model_false_for_existing_models(model_name):
+    assert _is_reasoning_model(model_name) is False
+
+
+@pytest.mark.parametrize(
+    "model_name", ["gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"]
+)
+def test_completion_params_reasoning_model_omits_temperature(model_name):
+    # max_tokens above the reasoning-model floor passes through unchanged.
+    params = _completion_params(model_name, temperature=0.7, max_tokens=2500)
+    assert params == {"model": model_name, "max_completion_tokens": 2500}
+    assert "temperature" not in params
+    assert "max_tokens" not in params
+
+
+@pytest.mark.parametrize(
+    "model_name", ["gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"]
+)
+def test_completion_params_reasoning_model_floors_low_max_tokens(model_name):
+    """
+    Regression test for the silent-dead-air bug: gpt-5.x's max_completion_tokens
+    is a SHARED budget covering invisible reasoning tokens + the visible
+    completion. Voice agents commonly configure a small conversational
+    max_tokens (e.g. 100, see agent_runtime.resolve_llm_runtime's default) —
+    on a reasoning model that can be entirely consumed by reasoning, yielding
+    content="" + finish_reason="length" with no exception raised. The floor
+    below must always win for a low conversational setting.
+    """
+    params = _completion_params(model_name, temperature=0.7, max_tokens=100)
+    assert params["max_completion_tokens"] == 1500
+    assert "temperature" not in params
+    assert "max_tokens" not in params
+
+
+@pytest.mark.parametrize(
+    "model_name", ["gpt-4.1", "gpt-4o", "gpt-3.5-turbo", "gpt-4-turbo"]
+)
+def test_completion_params_existing_model_unchanged(model_name):
+    params = _completion_params(model_name, temperature=0.55, max_tokens=333)
+    assert params == {"model": model_name, "temperature": 0.55, "max_tokens": 333}
+
+
+@pytest.mark.parametrize(
+    "model_name", ["gpt-4.1", "gpt-4o", "gpt-3.5-turbo", "gpt-4-turbo"]
+)
+def test_completion_params_existing_model_not_floored_at_low_max_tokens(model_name):
+    """The gpt-5.x floor must NEVER apply to non-reasoning models — a low
+    conversational max_tokens (e.g. 100) is passed straight through as-is."""
+    params = _completion_params(model_name, temperature=0.55, max_tokens=100)
+    assert params["max_tokens"] == 100
+    assert "max_completion_tokens" not in params
+
+
+# ───────────────────────────────────────────────── helpers ───────────────────
+
+def _mock_chat_response(content="hello world", model="gpt-4.1"):
+    resp = MagicMock()
+    resp.choices = [MagicMock(message=MagicMock(content=content), finish_reason="stop")]
+    resp.model = model
+    resp.usage = MagicMock(prompt_tokens=10, completion_tokens=5, total_tokens=15)
+    return resp
+
+
+class _FakeAsyncStreamChunks:
+    """Async iterator mimicking an OpenAI streaming response, with a small
+    `await asyncio.sleep(...)` between chunks to simulate real network I/O —
+    used to prove the event loop isn't blocked while iterating."""
+
+    def __init__(self, texts, delay=0.01):
+        self._texts = texts
+        self._delay = delay
+
+    def __aiter__(self):
+        return self._gen()
+
+    async def _gen(self):
+        for text in self._texts:
+            await asyncio.sleep(self._delay)
+            chunk = MagicMock()
+            chunk.choices = [MagicMock(delta=MagicMock(content=text))]
+            yield chunk
+
+
+# ───────────────────────────────────────── generate_text / chat_completion ────
+
+def test_generate_text_gpt5_omits_temperature_uses_max_completion_tokens():
+    service = OpenAIService()
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(model="gpt-5")
+
+    with patch.object(service, "get_client", return_value=mock_client):
+        result = service.generate_text(
+            "hi", model_name="gpt-5", temperature=0.9, max_tokens=200, api_key="k"
+        )
+
+    assert result["content"] == "hello world"
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["model"] == "gpt-5"
+    # max_tokens=200 is below the reasoning-model floor (1500) — floored so a
+    # low conversational value can't starve the response of headroom.
+    assert kwargs["max_completion_tokens"] == 1500
+    assert "temperature" not in kwargs
+    assert "max_tokens" not in kwargs
+
+
+def test_generate_text_existing_model_uses_temperature_and_max_tokens():
+    service = OpenAIService()
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(model="gpt-4.1")
+
+    with patch.object(service, "get_client", return_value=mock_client):
+        result = service.generate_text(
+            "hi", model_name="gpt-4.1", temperature=0.4, max_tokens=150, api_key="k"
+        )
+
+    assert result["content"] == "hello world"
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["model"] == "gpt-4.1"
+    assert kwargs["temperature"] == 0.4
+    assert kwargs["max_tokens"] == 150
+    assert "max_completion_tokens" not in kwargs
+
+
+def test_chat_completion_gpt5_omits_temperature():
+    service = OpenAIService()
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(model="gpt-5.1")
+
+    with patch.object(service, "get_client", return_value=mock_client):
+        result = service.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            model_name="gpt-5.1",
+            temperature=0.9,
+            max_tokens=64,
+            api_key="k",
+        )
+
+    assert result["content"] == "hello world"
+    _, kwargs = mock_client.chat.completions.create.call_args
+    # max_tokens=64 is below the reasoning-model floor (1500) — floored.
+    assert kwargs["max_completion_tokens"] == 1500
+    assert "temperature" not in kwargs
+
+
+def test_chat_completion_existing_model_unchanged():
+    service = OpenAIService()
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _mock_chat_response(model="gpt-4o")
+
+    with patch.object(service, "get_client", return_value=mock_client):
+        service.chat_completion(
+            [{"role": "user", "content": "hi"}],
+            model_name="gpt-4o",
+            temperature=0.6,
+            max_tokens=80,
+            api_key="k",
+        )
+
+    _, kwargs = mock_client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 0.6
+    assert kwargs["max_tokens"] == 80
+    assert "max_completion_tokens" not in kwargs
+
+
+# ─────────────────────────────────────────────────────── stream_text ──────────
+
+@pytest.mark.asyncio
+async def test_stream_text_yields_chunks_in_order():
+    service = OpenAIService()
+    mock_async_client = MagicMock()
+    mock_async_client.chat.completions.create = AsyncMock(
+        return_value=_FakeAsyncStreamChunks(["Hel", "lo ", "world"], delay=0)
+    )
+
+    with patch.object(service, "get_async_client", return_value=mock_async_client):
+        chunks = [c async for c in service.stream_text("hi", model_name="gpt-4o-mini")]
+
+    assert chunks == ["Hel", "lo ", "world"]
+
+
+@pytest.mark.asyncio
+async def test_stream_text_gpt5_omits_temperature_uses_max_completion_tokens():
+    service = OpenAIService()
+    mock_async_client = MagicMock()
+    mock_async_client.chat.completions.create = AsyncMock(
+        return_value=_FakeAsyncStreamChunks(["ok"], delay=0)
+    )
+
+    with patch.object(service, "get_async_client", return_value=mock_async_client):
+        chunks = [
+            c
+            async for c in service.stream_text(
+                "hi", model_name="gpt-5", temperature=0.8, max_tokens=99, api_key="k"
+            )
+        ]
+
+    assert chunks == ["ok"]
+    _, kwargs = mock_async_client.chat.completions.create.call_args
+    assert kwargs["model"] == "gpt-5"
+    # max_tokens=99 is below the reasoning-model floor (1500) — floored so
+    # the streaming hot path never starves gpt-5's reasoning budget either.
+    assert kwargs["max_completion_tokens"] == 1500
+    assert kwargs["stream"] is True
+    assert "temperature" not in kwargs
+    assert "max_tokens" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_stream_text_existing_model_uses_temperature_and_max_tokens():
+    service = OpenAIService()
+    mock_async_client = MagicMock()
+    mock_async_client.chat.completions.create = AsyncMock(
+        return_value=_FakeAsyncStreamChunks(["ok"], delay=0)
+    )
+
+    with patch.object(service, "get_async_client", return_value=mock_async_client):
+        [c async for c in service.stream_text("hi", model_name="gpt-4.1", temperature=0.3, max_tokens=42)]
+
+    _, kwargs = mock_async_client.chat.completions.create.call_args
+    assert kwargs["temperature"] == 0.3
+    assert kwargs["max_tokens"] == 42
+    assert "max_completion_tokens" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_stream_text_does_not_block_event_loop():
+    """Proves stream_text uses a real async iteration, not a blocking sync
+    call — a concurrently scheduled task must make progress *while* the
+    (simulated network) stream is "in flight" between chunks."""
+    service = OpenAIService()
+    mock_async_client = MagicMock()
+    # Wider per-chunk delay + wider ticker delay than a first pass at this
+    # test used (0.05s / 0.01s) — that gave only ~10ms of margin between the
+    # "concurrent" and "blocked" timing lines, which is tight enough to flake
+    # under CI scheduling jitter. Both are widened here to give a comfortable
+    # ~100ms margin on both sides of the threshold below.
+    mock_async_client.chat.completions.create = AsyncMock(
+        return_value=_FakeAsyncStreamChunks(["a", "b", "c"], delay=0.1)
+    )
+
+    progress_marks = []
+
+    async def ticker():
+        for i in range(5):
+            await asyncio.sleep(0.03)
+            progress_marks.append(i)
+
+    async def consume_stream():
+        result = []
+        with patch.object(service, "get_async_client", return_value=mock_async_client):
+            async for chunk in service.stream_text("hi", model_name="gpt-4o-mini"):
+                result.append(chunk)
+        return result
+
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    stream_result, _ = await asyncio.gather(consume_stream(), ticker())
+    elapsed = loop.time() - start
+
+    assert stream_result == ["a", "b", "c"]
+    assert len(progress_marks) == 5
+    # Stream has 3 chunks * 0.1s = 0.3s of simulated I/O; ticker has
+    # 5 * 0.03s = 0.15s. If the two ran back-to-back (i.e. stream_text
+    # blocked the loop while "in flight", the old sync-client bug), total
+    # elapsed would be >= 0.45s. Running concurrently, elapsed stays close
+    # to max(0.3, 0.15) = 0.3s. The 0.4s threshold below sits at the
+    # midpoint, giving ~100ms of slack on both sides for CI scheduling
+    # jitter while still failing hard if the old blocking bug regresses.
+    assert elapsed < 0.4, f"expected concurrent interleaving, got elapsed={elapsed}"

--- a/tests/voice/test_livekit_rag_prefetch.py
+++ b/tests/voice/test_livekit_rag_prefetch.py
@@ -1,0 +1,560 @@
+"""
+RAG interim-prefetch tests for the LiveKit/browser voice-agent path.
+
+Covers the browser-transport port of bidirectional_stream.py's
+`_prefetch_rag_context` pattern (fire KB retrieval in the background on the
+first qualifying STT interim, consume-once on STT final) — adapted to this
+transport's own retrieval call (`kb_retrieval_service.retrieve_kb_context_for_turn`)
+via:
+  - LiveKitBrowserCallHandler._maybe_start_rag_prefetch /
+    LiveKitBrowserCallHandler._prefetch_kb_context (fire + fail-open wrapper)
+  - LiveKitBrowserCallHandler._cancel_inflight_llm_response (discard on barge-in)
+  - ConversationOrchestrator.generate_and_stream_response (consume-once,
+    await-in-flight, staleness check via `rag_prefetch_matches_final`)
+
+Two layers are exercised:
+  1. Handler-level: does the right thing start/reset the prefetch task.
+  2. Orchestrator-level: does the right thing happen when generate_and_stream_
+     response consumes whatever prefetch state the handler is in.
+
+External HTTP/Redis/vector-DB calls are always mocked at the boundary
+(`kb_retrieval_service.retrieve_kb_context_for_turn`, `redis_client.get_redis`)
+per repo convention — never hit real infra.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.voice.conversation_orchestrator import (
+    ConversationOrchestrator,
+    rag_prefetch_matches_final,
+)
+from app.voice.livekit_browser_call_handler import LiveKitBrowserCallHandler
+from tests.voice.test_bracket_tag_prompt_consistency import _fake_livekit_handler
+
+
+FAKE_KB_FACT = "TEST_KB_FACT_PREFETCH_98765"
+FAKE_KB_BLOCK = (
+    "--- KNOWLEDGE BASE CONTEXT ---\n"
+    f"{FAKE_KB_FACT}\n"
+    "--- END CONTEXT ---"
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _real_handler_with_kb(kb_ids) -> LiveKitBrowserCallHandler:
+    """A real (non-mock) handler instance — needed for tests that exercise
+    the actual `_maybe_process_interim` / `_cancel_inflight_llm_response`
+    state machine, not just prompt-building."""
+    db = MagicMock()
+    call_session = MagicMock()
+    call_session.id = uuid.uuid4()
+    call_session.tenant_id = uuid.uuid4()
+    call_session.call_metadata = {}
+    call_session.call_transcript = []
+
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "Demo Agent"
+    agent.language = "en"
+
+    flow = MagicMock()
+    flow.knowledge_base_ids = [str(k) for k in kb_ids]
+
+    return LiveKitBrowserCallHandler(db=db, call_session=call_session, agent=agent, call_flow=flow)
+
+
+def _handler_with_kb_for_prompt(kb_ids):
+    """Mock-based handler for orchestrator/prompt-building tests — mirrors
+    tests/voice/test_livekit_kb_grounding.py's `_handler_with_kb`."""
+    h = _fake_livekit_handler(tts_slug="google")
+    h.db = MagicMock()  # truthy — required for the KB-retrieval branch to run
+    flow = MagicMock()
+    flow.knowledge_base_ids = [str(k) for k in kb_ids]
+    flow.caller_memory_enabled = False
+    h.call_flow = flow
+    h._rag_prefetch_task = None
+    h._rag_prefetch_source_text = ""
+    return h
+
+
+async def _run_and_capture(orchestrator, monkeypatch, user_text: str) -> list[str]:
+    """Async (same-event-loop) variant of test_livekit_kb_grounding.py's
+    `_run_and_capture` — must run in the SAME loop as any prefetch task the
+    test creates, so it awaits directly instead of calling asyncio.run()."""
+    captured: list[str] = []
+
+    async def _stub_stream(**kwargs):
+        captured.append(kwargs.get("system_prompt") or "")
+        yield "Sure, here is a short reply."
+
+    stub_service = MagicMock()
+    stub_service.stream_text = _stub_stream
+    monkeypatch.setattr(
+        "app.core.agent_runtime.llm_service_for_provider", lambda slug: stub_service
+    )
+    await orchestrator.generate_and_stream_response(user_text, 0.9)
+    return captured
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# rag_prefetch_matches_final — the staleness-check helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestRagPrefetchMatchesFinal:
+    def test_identical_text_matches(self):
+        assert rag_prefetch_matches_final("what are your hours", "what are your hours")
+
+    def test_final_extends_interim_matches(self):
+        # Common case: interim is a truncated prefix of the eventual final.
+        assert rag_prefetch_matches_final("what are your", "what are your hours today")
+
+    def test_materially_different_text_does_not_match(self):
+        assert not rag_prefetch_matches_final(
+            "what is your refund policy", "actually cancel my subscription entirely"
+        )
+
+    def test_empty_source_or_final_does_not_match(self):
+        assert not rag_prefetch_matches_final("", "hello")
+        assert not rag_prefetch_matches_final("hello", "")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Handler-level: firing / gating / reset
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestHandlerPrefetchTrigger:
+    @pytest.mark.asyncio
+    async def test_interim_starts_rag_prefetch_when_kb_configured(self):
+        kb_id = uuid.uuid4()
+        h = _real_handler_with_kb([kb_id])
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0)),
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            await h._maybe_process_interim("what are your hours today", 0.9)
+            assert h._rag_prefetch_task is not None
+            assert isinstance(h._rag_prefetch_task, asyncio.Task)
+            await h._rag_prefetch_task  # drain so the test doesn't leak a task
+
+    @pytest.mark.asyncio
+    async def test_no_prefetch_when_kb_not_configured(self):
+        """RAG disabled for this call flow (no knowledge_base_ids) — the
+        interim handler must never fire a background retrieval at all."""
+        h = _real_handler_with_kb([])  # empty KB list == RAG disabled
+        retrieve_mock = AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0))
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ):
+            await h._maybe_process_interim("what are your hours today", 0.9)
+
+        assert h._rag_prefetch_task is None
+        retrieve_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_prefetch_when_call_flow_missing(self):
+        h = _real_handler_with_kb([uuid.uuid4()])
+        h.call_flow = None  # no flow at all
+        await h._maybe_process_interim("what are your hours today", 0.9)
+        assert h._rag_prefetch_task is None
+
+    @pytest.mark.asyncio
+    async def test_second_interim_does_not_fire_duplicate_prefetch(self):
+        """Guards the 'never create duplicate RAG requests for the same
+        utterance' requirement — multiple qualifying interims in one turn
+        must only trigger ONE retrieval call."""
+        kb_id = uuid.uuid4()
+        h = _real_handler_with_kb([kb_id])
+        retrieve_mock = AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0))
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            await h._maybe_process_interim("what are your hours", 0.9)
+            first_task = h._rag_prefetch_task
+            await h._maybe_process_interim("what are your hours today please", 0.92)
+            second_task = h._rag_prefetch_task
+
+            assert first_task is second_task  # same task instance — no re-fire
+            await first_task
+
+        retrieve_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_or_short_interim_does_not_fire_prefetch(self):
+        kb_id = uuid.uuid4()
+        h = _real_handler_with_kb([kb_id])
+        h._rag_prefetch_min_words = 3
+        h._rag_prefetch_min_confidence = 0.5
+        await h._maybe_process_interim("uh", 0.9)  # below min_words
+        assert h._rag_prefetch_task is None
+        await h._maybe_process_interim("what are your hours", 0.1)  # below min_confidence
+        assert h._rag_prefetch_task is None
+
+    @pytest.mark.asyncio
+    async def test_barge_in_cancels_and_resets_pending_prefetch(self):
+        """Cancellation: an in-flight prefetch must be torn down (not just
+        abandoned) when the turn is barge-in-cancelled, so the next turn
+        always starts from a clean slate — mirrors bidirectional_stream.py's
+        _cancel_inflight_llm_response discarding _rag_prefetch_task."""
+        h = _real_handler_with_kb([uuid.uuid4()])
+        pending = asyncio.create_task(asyncio.sleep(5))
+        h._rag_prefetch_task = pending
+        h._rag_prefetch_source_text = "some interim text"
+
+        await h._cancel_inflight_llm_response()
+        await asyncio.sleep(0)  # let the cancellation propagate
+
+        assert h._rag_prefetch_task is None
+        assert h._rag_prefetch_source_text == ""
+        assert pending.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_barge_in_qualifying_interim_never_wastefully_fires_prefetch(self):
+        """
+        Regression test for the ordering bug: firing the prefetch BEFORE
+        resolving barge-in meant every barge-in-initiated turn fired a
+        prefetch on the very same call that immediately cancelled it via
+        `_cancel_inflight_llm_response()` — wasted embedding/vector-DB work,
+        and the highest-value case (a user interrupting the agent) got zero
+        prefetch benefit. Drives `_maybe_process_interim` end-to-end (not
+        pre-seeding `_rag_prefetch_task`) with `_is_tts_playing=True` and
+        barge-in-qualifying text, and asserts the prefetch retrieval was
+        NEVER called on that call at all — not "fired then cancelled".
+        """
+        kb_id = uuid.uuid4()
+        h = _real_handler_with_kb([kb_id])
+        h._is_tts_playing = True
+        h._cancel_inflight_llm_response = AsyncMock(wraps=h._cancel_inflight_llm_response)
+
+        retrieve_mock = AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0))
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            # Qualifies for barge-in: word_count >= _barge_in_min_words (2)
+            # and confidence >= _barge_in_min_conf (~0.26) by a wide margin —
+            # and, crucially, ALSO qualifies for the (much weaker) RAG
+            # prefetch gate, which is exactly the scenario the bug required.
+            await h._maybe_process_interim("please stop talking now", 0.9)
+
+        h._cancel_inflight_llm_response.assert_awaited_once()
+        retrieve_mock.assert_not_called()
+        assert h._rag_prefetch_task is None
+
+        # On a LATER interim, once barge-in has already been resolved for
+        # this call (TTS no longer playing after the cancel above), the
+        # prefetch trigger must still work normally and survive to be
+        # consumed — proves the fix doesn't just suppress prefetch outright,
+        # only reorders when it's allowed to fire.
+        h._is_tts_playing = False
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            await h._maybe_process_interim("actually never mind continue", 0.9)
+            assert h._rag_prefetch_task is not None
+            # Await the task INSIDE the patch context — the task body's own
+            # local import + retrieval call must still see the mock; awaiting
+            # after the patch has been reverted would spuriously hit the real
+            # (unpatched) retrieval function instead.
+            await h._rag_prefetch_task
+
+        retrieve_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_completed_prefetch_also_reset_on_cancel(self):
+        """Even an already-completed (not just pending) prefetch must be
+        cleared on cancel — the barge-in reset path is unconditional."""
+        h = _real_handler_with_kb([uuid.uuid4()])
+
+        async def _done():
+            return FAKE_KB_BLOCK, 1.0
+
+        done_task = asyncio.create_task(_done())
+        await done_task
+        h._rag_prefetch_task = done_task
+        h._rag_prefetch_source_text = "already finished"
+
+        await h._cancel_inflight_llm_response()
+
+        assert h._rag_prefetch_task is None
+        assert h._rag_prefetch_source_text == ""
+
+
+class TestPrefetchKbContextFailsOpen:
+    """`_prefetch_kb_context` (the background coroutine itself) must never
+    raise — timeouts and retrieval errors both degrade to an empty result,
+    mirroring `_prefetch_rag_context`'s fail-open contract on Twilio."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_empty_result(self, monkeypatch):
+        h = _real_handler_with_kb([uuid.uuid4()])
+        monkeypatch.setattr("app.core.config.settings.RAG_KB_RETRIEVAL_TIMEOUT_SEC", 0.01)
+
+        async def _slow(**kwargs):
+            await asyncio.sleep(0.2)
+            return FAKE_KB_BLOCK, 200.0
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=_slow
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            result = await h._prefetch_kb_context("hours?", [str(uuid.uuid4())])
+
+        assert result == ("", 0.0)
+
+    @pytest.mark.asyncio
+    async def test_retrieval_exception_returns_empty_result(self):
+        h = _real_handler_with_kb([uuid.uuid4()])
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            result = await h._prefetch_kb_context("hours?", [str(uuid.uuid4())])
+
+        assert result == ("", 0.0)
+
+    @pytest.mark.asyncio
+    async def test_no_kb_results_returns_empty_context(self):
+        """RAG ran successfully but found nothing relevant — a legitimate
+        empty result, distinct from an error/timeout."""
+        h = _real_handler_with_kb([uuid.uuid4()])
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("", 12.0)),
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            result = await h._prefetch_kb_context("hours?", [str(uuid.uuid4())])
+
+        assert result == ("", 12.0)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Orchestrator-level: consume-once / await-in-flight / staleness / no-prefetch
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestOrchestratorConsumesPrefetch:
+    @pytest.mark.asyncio
+    async def test_final_reuses_completed_prefetch_without_new_call(self, monkeypatch):
+        kb_id = uuid.uuid4()
+        h = _handler_with_kb_for_prompt([kb_id])
+        orchestrator = ConversationOrchestrator(h)
+
+        retrieve_mock = AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0))
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            task = asyncio.create_task(
+                retrieve_mock(transcript="what are your hours", kb_ids=[str(kb_id)], redis_client=None)
+            )
+            await task  # already finished by the time "final" arrives
+            h._rag_prefetch_task = task
+            h._rag_prefetch_source_text = "what are your hours"
+
+            captured = await _run_and_capture(orchestrator, monkeypatch, "what are your hours")
+
+        assert FAKE_KB_FACT in captured[0]
+        # One call to seed the "prefetch", zero additional calls at final time.
+        retrieve_mock.assert_awaited_once()
+        assert h._rag_prefetch_task is None  # consumed exactly once
+        assert h._rag_prefetch_source_text == ""
+
+    @pytest.mark.asyncio
+    async def test_final_awaits_inflight_prefetch_without_duplicate_call(self, monkeypatch):
+        kb_id = uuid.uuid4()
+        h = _handler_with_kb_for_prompt([kb_id])
+        orchestrator = ConversationOrchestrator(h)
+
+        call_count = 0
+
+        async def _slow_retrieve(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return FAKE_KB_BLOCK, 50.0
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=_slow_retrieve
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            task = asyncio.create_task(
+                LiveKitBrowserCallHandler._prefetch_kb_context(h, "what are your hours", [str(kb_id)])
+            )
+            h._rag_prefetch_task = task
+            h._rag_prefetch_source_text = "what are your hours"
+
+            captured = await _run_and_capture(orchestrator, monkeypatch, "what are your hours")
+
+        assert call_count == 1, "must await the SAME in-flight task, never start a second parallel retrieval"
+        assert FAKE_KB_FACT in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_stale_prefetch_not_reused_for_materially_different_final(self, monkeypatch):
+        kb_id = uuid.uuid4()
+        h = _handler_with_kb_for_prompt([kb_id])
+        orchestrator = ConversationOrchestrator(h)
+
+        stale_block = "--- KNOWLEDGE BASE CONTEXT ---\nSTALE_MARKER_SHOULD_NOT_APPEAR\n--- END CONTEXT ---"
+
+        async def _stale_coro():
+            return stale_block, 5.0
+
+        stale_task = asyncio.create_task(_stale_coro())
+        await stale_task  # completed — but for the WRONG (interim) text
+
+        h._rag_prefetch_task = stale_task
+        h._rag_prefetch_source_text = "what is your refund policy"  # interim seed text
+
+        fresh_calls = []
+
+        async def _fresh_retrieve(**kwargs):
+            fresh_calls.append(kwargs.get("transcript"))
+            return FAKE_KB_BLOCK, 5.0
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=_fresh_retrieve
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            # Final utterance diverges materially from the interim above.
+            captured = await _run_and_capture(
+                orchestrator, monkeypatch, "actually cancel my subscription entirely"
+            )
+
+        assert "STALE_MARKER_SHOULD_NOT_APPEAR" not in captured[0]
+        assert FAKE_KB_FACT in captured[0]
+        assert fresh_calls == ["actually cancel my subscription entirely"]
+
+    @pytest.mark.asyncio
+    async def test_no_prefetch_fired_falls_back_to_synchronous_retrieval(self, monkeypatch):
+        """Existing behavior when prefetch conditions weren't met (e.g. a
+        very short first utterance never fired one) — must still work,
+        unmodified, via the synchronous fallback branch."""
+        kb_id = uuid.uuid4()
+        h = _handler_with_kb_for_prompt([kb_id])
+        orchestrator = ConversationOrchestrator(h)
+        assert h._rag_prefetch_task is None
+
+        retrieve_mock = AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0))
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            captured = await _run_and_capture(orchestrator, monkeypatch, "what are your hours")
+
+        assert FAKE_KB_FACT in captured[0]
+        retrieve_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rag_disabled_no_kb_ids_skips_prefetch_consumption_entirely(self, monkeypatch):
+        h = _handler_with_kb_for_prompt([])  # no KB attached == RAG disabled
+        orchestrator = ConversationOrchestrator(h)
+
+        retrieve_mock = AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0))
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ):
+            captured = await _run_and_capture(orchestrator, monkeypatch, "what are your hours")
+
+        retrieve_mock.assert_not_called()
+        assert "--- KNOWLEDGE BASE CONTEXT ---" not in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_new_utterance_prefetch_not_confused_with_prior_turns(self, monkeypatch):
+        """A new utterance's own (unrelated) prefetch must be consumed on
+        ITS final, never accidentally reused by / bled into a different
+        turn — the consume-once-and-null contract applies per turn."""
+        kb_id = uuid.uuid4()
+        h = _handler_with_kb_for_prompt([kb_id])
+        orchestrator = ConversationOrchestrator(h)
+
+        retrieve_mock = AsyncMock(return_value=(FAKE_KB_BLOCK, 5.0))
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=retrieve_mock
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            # Turn 1: no prefetch fired, synchronous fallback used.
+            await _run_and_capture(orchestrator, monkeypatch, "what are your hours")
+            assert h._rag_prefetch_task is None
+
+            # Turn 2: a fresh prefetch fires and is consumed cleanly, with no
+            # leftover state from turn 1 interfering.
+            task = asyncio.create_task(
+                LiveKitBrowserCallHandler._prefetch_kb_context(h, "what is your address", [str(kb_id)])
+            )
+            h._rag_prefetch_task = task
+            h._rag_prefetch_source_text = "what is your address"
+            captured2 = await _run_and_capture(orchestrator, monkeypatch, "what is your address")
+
+        assert FAKE_KB_FACT in captured2[0]
+        assert h._rag_prefetch_task is None
+        assert retrieve_mock.await_count == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Concurrency proof (Part 5): prefetch must not block continued STT/audio
+# handling while the retrieval is "in flight".
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestRagPrefetchConcurrency:
+    @pytest.mark.asyncio
+    async def test_prefetch_task_runs_concurrently_with_continued_stt_handling(self):
+        """
+        Proves _maybe_start_rag_prefetch fires a real background task (not a
+        blocking call) — a concurrently scheduled "STT/audio handling" ticker
+        must keep making progress while the (simulated network) KB retrieval
+        is in flight. Same non-blocking-interleaving pattern used for the
+        OpenAI/Groq async-streaming regression tests.
+
+        Deliberately load-independent: rather than asserting on a total
+        wall-clock budget (which flaked under a full-suite run with hundreds
+        of tests contending for the CPU/event loop — a fixed absolute
+        threshold has no safe margin against arbitrary scheduler jitter),
+        this asserts on the *relative* interleaving of ticker iterations
+        against the retrieval's own start/end timestamps, all measured in
+        the same event loop. If the prefetch blocked the loop while "in
+        flight" (the old-bug equivalent), zero ticks could land inside that
+        window regardless of how fast or slow the machine is; if it doesn't
+        block, several ticks land inside it — that's true under both a fast
+        and a heavily-loaded run.
+        """
+        kb_id = uuid.uuid4()
+        h = _real_handler_with_kb([kb_id])
+        loop = asyncio.get_event_loop()
+
+        retrieve_start: float | None = None
+        retrieve_end: float | None = None
+
+        async def _slow_retrieve(**kwargs):
+            nonlocal retrieve_start, retrieve_end
+            retrieve_start = loop.time()
+            await asyncio.sleep(0.2)
+            retrieve_end = loop.time()
+            return FAKE_KB_BLOCK, 200.0
+
+        tick_times: list[float] = []
+
+        async def ticker():
+            for _ in range(6):
+                await asyncio.sleep(0.03)
+                tick_times.append(loop.time())
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn", new=_slow_retrieve
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            # Mirrors what _maybe_process_interim does: fire-and-forget, must
+            # return immediately without awaiting the retrieval itself.
+            h._maybe_start_rag_prefetch("what are your hours today", 0.9, 5)
+            assert h._rag_prefetch_task is not None
+
+            await asyncio.gather(h._rag_prefetch_task, ticker())
+
+        assert len(tick_times) == 6
+        assert retrieve_start is not None and retrieve_end is not None
+
+        ticks_during_retrieval = [t for t in tick_times if retrieve_start <= t <= retrieve_end]
+        assert len(ticks_during_retrieval) >= 3, (
+            "expected several ticker iterations to interleave with the "
+            f"in-flight retrieval, got {len(ticks_during_retrieval)} of "
+            f"{len(tick_times)} — the prefetch may be blocking the event loop"
+        )


### PR DESCRIPTION
## Summary

- **OpenAI/Groq async streaming fix**: `stream_text` on both services was iterating a synchronous SDK client inside `async def`, blocking the event loop for all concurrent calls during token generation. Switched to a cached `AsyncOpenAI`/`AsyncAzureOpenAI` client with genuine `async for` streaming.
- **New OpenAI GPT models**: added `gpt-5`, `gpt-5-mini`, `gpt-5.1`, `gpt-5.2`, `gpt-5.4` (model IDs verified against official OpenAI docs). GPT-5-family requests use `max_completion_tokens` (floored at 1500 to avoid the reasoning-token budget silently starving visible output) instead of `max_tokens`, and omit `temperature`. Added an additive-only migration widening the `ck_agent_llm_model` CHECK constraint to match.
- **Explicit `reasoning_effort` for GPT-5-family models**: `gpt-5`/`gpt-5-mini` were silently running OpenAI's implicit `medium` reasoning effort on every voice-agent turn (confirmed via the installed SDK's own parameter docs). Now set to `low`; `gpt-5.1`/`gpt-5.2`/`gpt-5.4` set to `none` explicitly. This is a plausible mechanism for both elevated GPT-5 latency and unreliable KB grounding reported in production. Non-reasoning OpenAI models are untouched.
- **LiveKit/browser RAG interim prefetch**: ported the Twilio RAG interim-prefetch pattern (fire on qualifying STT interim, consume once on final, cancel on barge-in) to the browser call path, overlapping KB retrieval latency with remaining user speech. Includes a staleness guard (`rag_prefetch_matches_final`) and a barge-in-ordering fix so prefetch is never wastefully fired-then-cancelled on interrupted turns.
- **KB retrieval cold-start latency fix**: `embedding_service` was constructing a brand-new OpenAI client (and connection pool) on every embedding call, not just the first. Now reuses the existing cached-client pattern, plus a non-blocking, per-worker startup warm-up (staging/production only).
- **`RAG_KB_RETRIEVAL_TIMEOUT_SEC` raised 0.7s → 1.2s** and **`RAG_SCORE_THRESHOLD` lowered 0.4 → 0.2**, both based on live production diagnostics (raw embedding latency and real similarity-score measurements against a production KB, documented in commit messages/comments).

## Verification

- Twilio path (`bidirectional_stream.py`) confirmed zero-diff throughout — untouched.
- Vertex Gemini, existing OpenAI models, Groq (non-gpt-5), STT/TTS providers, Calendly, CRM context unaffected.
- Full test suite passing (2472+ tests), ruff clean on all changed files.
- Independent code-review passes run after each change (async client caching, RAG prefetch ordering, reasoning_effort config) — findings addressed before merge.

## Known residual risks (see commit messages for detail)

- `gpt-5.2`/`gpt-5.4`'s `reasoning_effort="none"` default is extrapolated from `gpt-5.1`'s documented behavior, not individually confirmed — worth a live smoke test once API credits allow.
- KB content-quality issue found during production diagnosis (duplicated chunks, raw JSON fragments instead of natural-language chunking) — threshold lowered as an immediate mitigation, but re-ingesting the affected KB with cleaner chunking would likely improve match quality further. Not addressed in this PR (config-only fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)