### PR TITLE
Migrate Vertex Gemini service to google-genai SDK; add Gemini 3 model support

### DIFF
--- a/alembic/versions/20260816_widen_agent_llm_model_check_gemini3.py
+++ b/alembic/versions/20260816_widen_agent_llm_model_check_gemini3.py
@@ -1,0 +1,140 @@
+"""widen ck_agent_llm_model to include gemini-3 family
+
+Revision ID: 20260816_widen_llm_check_g3
+Revises: 20260815_widen_llm_check
+Create Date: 2026-08-16
+
+Purpose
+-------
+``app/core/llm_models.py`` (the Python-level allow-list used to validate
+``Agent.llm_model`` at the API layer) now includes two new Google Gemini
+models: ``gemini-3-flash-preview`` (Gemini 3 Flash Preview, Vertex AI
+preview) and ``gemini-3.1-flash-lite`` (Gemini 3.1 Flash-Lite, GA as of
+May 2026). The DB-level ``ck_agent_llm_model`` CHECK constraint — most
+recently widened by ``20260815_widen_llm_check`` to a 19-value snapshot —
+was never widened to match, so inserting/updating an agent with either of
+these new model IDs would violate the CHECK even though the application
+layer accepts them.
+
+This migration is purely additive: it drops and recreates
+``ck_agent_llm_model`` with the union of the prior 19-value snapshot plus
+the 2 new gemini-3 IDs (21 total). No values are removed or renamed, so no
+existing row can violate the widened constraint — safe to apply without a
+backfill on a live multi-tenant table. The drop+recreate briefly requires a
+table-level lock while Postgres validates the new CHECK against existing
+rows, but on a boolean/string membership check on `agent` (not a huge
+table) this is expected to be fast; the definition change itself is
+otherwise the same additive-CHECK-widening pattern used by
+``20260815_widen_llm_check`` and, before it, ``20260602_schema_v2_completion``
+for ``ck_agent_status_v2`` / ``ck_callflow_direction``.
+
+Snapshot strategy
+------------------
+Per the same rationale as ``20260815_widen_llm_check``, the allow-list used
+to build the CHECK SQL is a self-contained snapshot tuple in *this* file,
+not an import from ``app.core.llm_models`` — so future edits to that module
+(renames, removals) do not retroactively change what this historical
+migration replays during ``alembic upgrade``.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260816_widen_llm_check_g3"
+down_revision: Union[str, Sequence[str], None] = "20260815_widen_llm_check"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Union of the 20260815_widen_llm_check 19-value snapshot plus the 2 new
+# Gemini 3 family IDs added to app.core.llm_models.ALLOWED_LLM_MODELS.
+# Self-contained — do not import app.core.llm_models (future renames there
+# must not retroactively change this migration's replay behavior).
+_ALLOWED_LLM_MODELS_AT_REVISION: tuple[str, ...] = (
+    # --- prior 19-value snapshot (20260815_widen_llm_check), unchanged ---
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+    # --- new: Google Gemini 3 family ---
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+)
+
+# The exact 19-value snapshot from 20260815_widen_llm_check, needed to
+# restore the narrower constraint on downgrade.
+_PRIOR_ALLOWED_LLM_MODELS: tuple[str, ...] = (
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+)
+
+
+def _llm_check_sql(models: tuple[str, ...]) -> str:
+    """Build ck_agent_llm_model CHECK SQL from a given model snapshot."""
+    return "llm_model IS NULL OR llm_model IN (%s)" % ", ".join(
+        f"'{m}'" for m in models
+    )
+
+
+def _has_constraint(conn, table: str, constraint: str) -> bool:
+    return conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = 'public' AND table_name = :tbl AND constraint_name = :con)"
+        ),
+        {"tbl": table, "con": constraint},
+    ).scalar()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_ALLOWED_LLM_MODELS_AT_REVISION)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_PRIOR_ALLOWED_LLM_MODELS)
+    )

--- a/app/core/llm_models.py
+++ b/app/core/llm_models.py
@@ -35,6 +35,9 @@ ALLOWED_LLM_MODELS: Final[tuple[str, ...]] = (
     "gemini-2.0-flash",
     "gemini-1.5-pro",
     "gemini-1.5-flash",
+    # Google Gemini — Gemini 3 family (new)
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
     # Anthropic — existing
     "claude-3-5-sonnet",
     "claude-3-haiku",

--- a/app/services/pricing_service.py
+++ b/app/services/pricing_service.py
@@ -52,6 +52,9 @@ class PricingService:
             "gemini-2.5-flash-lite": (0.05, 0.20),
             "gemini-2.0-flash": (0.05, 0.20),
             "gemini-2.0-flash-lite": (0.04, 0.15),
+            # Placeholder — same rate as gemini-2.5-flash pending official preview pricing.
+            "gemini-3-flash-preview": (0.15, 1.25),
+            "gemini-3.1-flash-lite": (0.25, 1.50),
         }
 
         # -----------------------------

--- a/app/services/vertex_gemini_service.py
+++ b/app/services/vertex_gemini_service.py
@@ -1,8 +1,12 @@
 """
 Vertex AI Gemini LLM service for real-time voice calls.
 
-Uses google-cloud-aiplatform SDK + Application Default Credentials (ADC).
+Uses the google-genai SDK (vertexai=True) + Application Default Credentials (ADC).
 Never requires a per-model api_key — auth is via GOOGLE_APPLICATION_CREDENTIALS.
+
+Migrated off ``vertexai.generative_models`` (deprecated 2025-06-24, removal date
+already passed as of this writing) to ``google.genai`` per Google's official
+migration guide.
 """
 
 from __future__ import annotations
@@ -18,18 +22,23 @@ from app.core.logger import logger
 from app.voice.llm_prompt_builder import build_vertex_contents
 
 # Lazily imported so tests can patch before import resolution.
-_vertex_init_lock = threading.Lock()
-_vertexai_initialized = False
+_vertex_client_lock = threading.Lock()
+_vertex_client = None
 
 
-def _ensure_vertex_init() -> None:
-    global _vertexai_initialized
-    if _vertexai_initialized:
-        return
-    with _vertex_init_lock:
-        if _vertexai_initialized:
-            return
-        import vertexai
+def _ensure_vertex_client():
+    """
+    Lazily build (once) and return the shared google.genai Client, configured
+    for Vertex AI + ADC. Thread-safe double-checked locking, mirroring the old
+    _ensure_vertex_init() singleton pattern.
+    """
+    global _vertex_client
+    if _vertex_client is not None:
+        return _vertex_client
+    with _vertex_client_lock:
+        if _vertex_client is not None:
+            return _vertex_client
+        from google import genai
 
         project = settings.GOOGLE_CLOUD_PROJECT_ID or settings.GCP_PROJECT_ID
         location = settings.VERTEX_AI_LOCATION
@@ -37,8 +46,8 @@ def _ensure_vertex_init() -> None:
             raise RuntimeError(
                 "Vertex AI requires GOOGLE_CLOUD_PROJECT_ID or GCP_PROJECT_ID in config."
             )
-        vertexai.init(project=project, location=location)
-        _vertexai_initialized = True
+        _vertex_client = genai.Client(vertexai=True, project=project, location=location)
+        return _vertex_client
 
 
 class VertexLlmErrorType(str, enum.Enum):
@@ -58,17 +67,18 @@ def _classify_vertex_error(exc: Exception) -> VertexLlmError:
     name = type(exc).__name__
     msg = str(exc)
 
-    # Match against google.api_core exception types when the package is available.
-    # Catch TypeError as a defensive measure: google.api_core's custom metaclass
-    # (_GoogleAPICallErrorMeta) can raise TypeError on isinstance() in some
-    # Python/test-runner environments when the class identity is ambiguous.
+    # Match against google.genai.errors.APIError (base for ClientError/ServerError)
+    # when the package is available — mirrors the old google.api_core matching.
     try:
-        from google.api_core.exceptions import DeadlineExceeded, ResourceExhausted
+        from google.genai import errors as genai_errors
 
-        if isinstance(exc, ResourceExhausted):
-            return VertexLlmError(f"Vertex quota exceeded: {msg}", VertexLlmErrorType.QUOTA)
-        if isinstance(exc, DeadlineExceeded):
-            return VertexLlmError(f"Vertex deadline exceeded: {msg}", VertexLlmErrorType.TIMEOUT)
+        if isinstance(exc, genai_errors.APIError):
+            code = getattr(exc, "code", None)
+            status = (getattr(exc, "status", None) or "").upper()
+            if code == 429 or status == "RESOURCE_EXHAUSTED":
+                return VertexLlmError(f"Vertex quota exceeded: {msg}", VertexLlmErrorType.QUOTA)
+            if code in (504, 408) or status == "DEADLINE_EXCEEDED":
+                return VertexLlmError(f"Vertex deadline exceeded: {msg}", VertexLlmErrorType.TIMEOUT)
     except (ImportError, TypeError):
         pass
 
@@ -87,12 +97,12 @@ def _build_calendly_tool():
     Gemini FunctionDeclarations for the Calendly booking flow:
       - check_availability(date): list bookable slots
       - book_appointment(slot, attendee_email): schedule on Calendly
-    Lazily imported so environments without google-cloud-aiplatform installed
+    Lazily imported so environments without google-genai installed
     can still import this module (matches the rest of this file's pattern).
     """
-    from vertexai.generative_models import FunctionDeclaration, Tool
+    from google.genai import types
 
-    check_availability = FunctionDeclaration(
+    check_availability = types.FunctionDeclaration(
         name="check_availability",
         description=(
             "Check available appointment slots on the connected Calendly calendar. "
@@ -110,7 +120,7 @@ def _build_calendly_tool():
             "required": ["date"],
         },
     )
-    book_appointment = FunctionDeclaration(
+    book_appointment = types.FunctionDeclaration(
         name="book_appointment",
         description="Schedule an appointment on Calendly for a previously offered slot.",
         parameters={
@@ -128,12 +138,28 @@ def _build_calendly_tool():
             "required": ["slot", "attendee_email"],
         },
     )
-    return Tool(function_declarations=[check_availability, book_appointment])
+    return types.Tool(function_declarations=[check_availability, book_appointment])
+
+
+def _extract_finish_reason_error(response) -> VertexLlmError | None:
+    """Inspect candidate finish_reason for content-filter blocks. Returns None if clean."""
+    try:
+        candidates = getattr(response, "candidates", None) or []
+        if candidates:
+            finish = getattr(candidates[0], "finish_reason", None)
+            if finish and str(finish) not in ("STOP", "MAX_TOKENS", "1", "2"):
+                return VertexLlmError(
+                    f"Vertex content blocked: finish_reason={finish}",
+                    VertexLlmErrorType.CONTENT_FILTER,
+                )
+    except Exception as exc:
+        logger.debug("[VertexGemini] finish_reason inspection failed: %s", exc)
+    return None
 
 
 class VertexGeminiService:
     """
-    Singleton service that streams Gemini 2.5 Flash responses via Vertex AI.
+    Singleton service that streams Gemini responses via Vertex AI (google-genai SDK).
 
     Auth: Application Default Credentials — never reads model.api_key.
     """
@@ -158,47 +184,36 @@ class VertexGeminiService:
         Raises VertexLlmError on quota/timeout/filter failures (caller maps to fallback).
         """
         try:
-            _ensure_vertex_init()
+            client = _ensure_vertex_client()
         except Exception as exc:
             raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
 
         try:
-            from vertexai.generative_models import GenerativeModel, GenerationConfig
+            from google.genai import types
         except ImportError as exc:
             raise VertexLlmError(
-                "google-cloud-aiplatform is not installed. Add it to requirements.txt.",
+                "google-genai is not installed. Add it to requirements.txt.",
                 VertexLlmErrorType.UNKNOWN,
             ) from exc
-
-        # Build model with system_instruction (never log full prompt).
-        model_kwargs: dict = {}
-        if system_prompt:
-            model_kwargs["system_instruction"] = system_prompt
-
-        model = GenerativeModel(
-            model_name=model_name,
-            **model_kwargs,
-        )
 
         max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)
         contents = build_vertex_contents(
             conversation_history, prompt, kb_context, max_turns=max_turns
         )
 
-        generation_config = GenerationConfig(
-            temperature=float(temperature),
-            max_output_tokens=int(max_tokens),
-        )
+        config_kwargs: dict = {
+            "temperature": float(temperature),
+            "max_output_tokens": int(max_tokens),
+        }
+        if system_prompt:
+            config_kwargs["system_instruction"] = system_prompt
+        generation_config = types.GenerateContentConfig(**config_kwargs)
 
-        # Use the async SDK method so chunks are yielded as they arrive without
-        # blocking the event loop.  The sync generate_content() path runs its
-        # entire HTTP round-trip inside asyncio.to_thread and only returns after
-        # ALL tokens are buffered — effectively disabling streaming.
         try:
-            response_stream = await model.generate_content_async(
-                contents,
-                generation_config=generation_config,
-                stream=True,
+            response_stream = await client.aio.models.generate_content_stream(
+                model=model_name,
+                contents=contents,
+                config=generation_config,
             )
             async for response in response_stream:
                 # Honour barge-in / interruption cancel
@@ -210,19 +225,9 @@ class VertexGeminiService:
                     text = response.text
                 except Exception:
                     # Candidate may be blocked or empty (content filter)
-                    try:
-                        candidates = getattr(response, "candidates", [])
-                        if candidates:
-                            finish = getattr(candidates[0], "finish_reason", None)
-                            if finish and str(finish) not in ("STOP", "MAX_TOKENS", "1", "2"):
-                                raise VertexLlmError(
-                                    f"Vertex content blocked: finish_reason={finish}",
-                                    VertexLlmErrorType.CONTENT_FILTER,
-                                )
-                    except VertexLlmError:
-                        raise
-                    except Exception as exc:
-                        logger.debug("[VertexGemini] finish_reason inspection failed: %s", exc)
+                    filter_err = _extract_finish_reason_error(response)
+                    if filter_err is not None:
+                        raise filter_err
                     continue
 
                 if text:
@@ -249,38 +254,40 @@ class VertexGeminiService:
 
         If the model returns a function_call part, ``tool_executor(name, args)``
         is awaited to resolve it, the result is fed back as a
-        ``Part.from_function_response``, and generation resumes so the model
+        ``types.Part.from_function_response``, and generation resumes so the model
         can produce the final spoken reply. Returns the final text (never a
         raw function-call JSON blob).
         """
         try:
-            _ensure_vertex_init()
+            client = _ensure_vertex_client()
         except Exception as exc:
             raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
 
         try:
-            from vertexai.generative_models import GenerativeModel, GenerationConfig, Content, Part
+            from google.genai import types
         except ImportError as exc:
             raise VertexLlmError(
-                "google-cloud-aiplatform is not installed. Add it to requirements.txt.",
+                "google-genai is not installed. Add it to requirements.txt.",
                 VertexLlmErrorType.UNKNOWN,
             ) from exc
 
-        model_kwargs: dict = {"tools": [_build_calendly_tool()]}
+        config_kwargs: dict = {
+            "temperature": float(temperature),
+            "max_output_tokens": int(max_tokens),
+            "tools": [_build_calendly_tool()],
+        }
         if system_prompt:
-            model_kwargs["system_instruction"] = system_prompt
-
-        model = GenerativeModel(model_name=model_name, **model_kwargs)
+            config_kwargs["system_instruction"] = system_prompt
+        generation_config = types.GenerateContentConfig(**config_kwargs)
 
         max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)
         contents = build_vertex_contents(conversation_history, prompt, None, max_turns=max_turns)
-        generation_config = GenerationConfig(
-            temperature=float(temperature), max_output_tokens=int(max_tokens)
-        )
 
         try:
-            response = await model.generate_content_async(
-                contents, generation_config=generation_config
+            response = await client.aio.models.generate_content(
+                model=model_name,
+                contents=contents,
+                config=generation_config,
             )
 
             candidate = response.candidates[0] if response.candidates else None
@@ -299,14 +306,19 @@ class VertexGeminiService:
 
             contents.append(candidate.content)
             contents.append(
-                Content(
-                    role="function",
-                    parts=[Part.from_function_response(name=fc_name, response=tool_result)],
+                # google.genai's own automatic-function-calling loop builds this turn
+                # with role="user" (not "function" — that was the old vertexai SDK's
+                # convention). See google.genai.models.Models._generate_content_afc.
+                types.Content(
+                    role="user",
+                    parts=[types.Part.from_function_response(name=fc_name, response=tool_result)],
                 )
             )
 
-            follow_up = await model.generate_content_async(
-                contents, generation_config=generation_config
+            follow_up = await client.aio.models.generate_content(
+                model=model_name,
+                contents=contents,
+                config=generation_config,
             )
             return (follow_up.text or "").strip()
         except VertexLlmError:
@@ -332,39 +344,36 @@ class VertexGeminiService:
         del api_key  # Vertex uses ADC only
         start_time = time.time()
         try:
-            _ensure_vertex_init()
+            client = _ensure_vertex_client()
         except Exception as exc:
             raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
 
         try:
-            from vertexai.generative_models import GenerativeModel, GenerationConfig
+            from google.genai import types
         except ImportError as exc:
             raise VertexLlmError(
-                "google-cloud-aiplatform is not installed.",
+                "google-genai is not installed.",
                 VertexLlmErrorType.UNKNOWN,
             ) from exc
 
-        model_kwargs: dict = {}
+        config_kwargs: dict = {
+            "temperature": float(temperature),
+            "max_output_tokens": int(max_tokens),
+        }
         if system_prompt:
-            model_kwargs["system_instruction"] = system_prompt
+            config_kwargs["system_instruction"] = system_prompt
+        generation_config = types.GenerateContentConfig(**config_kwargs)
 
-        model = GenerativeModel(
-            model_name=model_name,
-            **model_kwargs,
-        )
         max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)
         contents = build_vertex_contents(
             conversation_history, prompt, kb_context, max_turns=max_turns
         )
-        generation_config = GenerationConfig(
-            temperature=float(temperature),
-            max_output_tokens=int(max_tokens),
-        )
 
         try:
-            response = model.generate_content(
-                contents,
-                generation_config=generation_config,
+            response = client.models.generate_content(
+                model=model_name,
+                contents=contents,
+                config=generation_config,
             )
             response_text = (response.text or "").strip()
         except Exception as exc:

--- a/app/services/vertex_gemini_service.py
+++ b/app/services/vertex_gemini_service.py
@@ -23,31 +23,56 @@ from app.voice.llm_prompt_builder import build_vertex_contents
 
 # Lazily imported so tests can patch before import resolution.
 _vertex_client_lock = threading.Lock()
-_vertex_client = None
+_vertex_clients: dict[str, Any] = {}
+
+# As of 2026-08, Google only serves Gemini 3-family models from Vertex AI's
+# ``global`` endpoint — regional endpoints (including our configured
+# settings.VERTEX_AI_LOCATION, e.g. "us-central1") return 404 for these
+# specific model IDs. This is expected to change as Google rolls out regional
+# availability for Gemini 3, so keep this as an easily-editable allowlist
+# rather than scattering region special-cases through the call sites.
+_GLOBAL_ONLY_MODELS: set[str] = {
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+}
 
 
-def _ensure_vertex_client():
+def _location_for_model(model_name: str) -> str:
     """
-    Lazily build (once) and return the shared google.genai Client, configured
-    for Vertex AI + ADC. Thread-safe double-checked locking, mirroring the old
-    _ensure_vertex_init() singleton pattern.
+    Return the Vertex AI location to use for a given model ID: "global" for
+    models in _GLOBAL_ONLY_MODELS, otherwise settings.VERTEX_AI_LOCATION.
+    Exact-match on model_name (these are exact model IDs, not prefixes).
     """
-    global _vertex_client
-    if _vertex_client is not None:
-        return _vertex_client
+    if model_name in _GLOBAL_ONLY_MODELS:
+        return "global"
+    return settings.VERTEX_AI_LOCATION
+
+
+def _ensure_vertex_client(location: str):
+    """
+    Lazily build (once per location) and return a shared google.genai Client,
+    configured for Vertex AI + ADC. Thread-safe double-checked locking,
+    mirroring the old _ensure_vertex_init() singleton pattern, but keyed by
+    location so global-only models (see _GLOBAL_ONLY_MODELS) can use the
+    "global" endpoint while other models keep using settings.VERTEX_AI_LOCATION.
+    """
+    existing = _vertex_clients.get(location)
+    if existing is not None:
+        return existing
     with _vertex_client_lock:
-        if _vertex_client is not None:
-            return _vertex_client
+        existing = _vertex_clients.get(location)
+        if existing is not None:
+            return existing
         from google import genai
 
         project = settings.GOOGLE_CLOUD_PROJECT_ID or settings.GCP_PROJECT_ID
-        location = settings.VERTEX_AI_LOCATION
         if not project:
             raise RuntimeError(
                 "Vertex AI requires GOOGLE_CLOUD_PROJECT_ID or GCP_PROJECT_ID in config."
             )
-        _vertex_client = genai.Client(vertexai=True, project=project, location=location)
-        return _vertex_client
+        client = genai.Client(vertexai=True, project=project, location=location)
+        _vertex_clients[location] = client
+        return client
 
 
 class VertexLlmErrorType(str, enum.Enum):
@@ -184,7 +209,7 @@ class VertexGeminiService:
         Raises VertexLlmError on quota/timeout/filter failures (caller maps to fallback).
         """
         try:
-            client = _ensure_vertex_client()
+            client = _ensure_vertex_client(_location_for_model(model_name))
         except Exception as exc:
             raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
 
@@ -259,7 +284,7 @@ class VertexGeminiService:
         raw function-call JSON blob).
         """
         try:
-            client = _ensure_vertex_client()
+            client = _ensure_vertex_client(_location_for_model(model_name))
         except Exception as exc:
             raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
 
@@ -344,7 +369,7 @@ class VertexGeminiService:
         del api_key  # Vertex uses ADC only
         start_time = time.time()
         try:
-            client = _ensure_vertex_client()
+            client = _ensure_vertex_client(_location_for_model(model_name))
         except Exception as exc:
             raise VertexLlmError(f"Vertex init failed: {exc}", VertexLlmErrorType.UNKNOWN) from exc
 

--- a/app/services/vertex_gemini_service.py
+++ b/app/services/vertex_gemini_service.py
@@ -36,6 +36,31 @@ _GLOBAL_ONLY_MODELS: set[str] = {
     "gemini-3.1-flash-lite",
 }
 
+# Gemini 3-family "thinking" budget, capped for real-time voice latency.
+# ``gemini-3-flash-preview`` defaults to thinking_level="high" when unset per
+# Google's docs — too slow for a live phone call (extra round-trip before the
+# first spoken word). MUST be "minimal", not "low": thinking tokens are
+# deducted from max_output_tokens on this model, and this service's callers
+# use small voice-turn budgets (max_tokens=100 for stream_text/generate_text,
+# 200 for generate_with_tools). Verified against the live API: at "low",
+# max_tokens=60 produced 57 thinking tokens and ZERO visible text
+# (finish_reason=MAX_TOKENS, empty response — the caller would go silent
+# mid-call); even max_tokens=100 left only 4 tokens for actual output. At
+# "minimal", thinking is negligible (thoughts_token_count=None) and the full
+# answer is reliably produced well within a 60-100 token budget. Do not
+# change this to "low"/"medium"/"high" without also verifying against the
+# live API that it still fits this service's max_tokens defaults.
+# ``gemini-3.1-flash-lite`` already defaults to "minimal", but is pinned
+# explicitly here for the same reason this repo already pins
+# ``reasoning_effort`` for GPT-5 models (see _REASONING_EFFORT_BY_MODEL in
+# openai_service.py) rather than relying on an implicit provider default that
+# could change. Models not listed here (e.g. gemini-2.5-flash) get no
+# thinking_config at all — unconfigured, unchanged.
+_THINKING_LEVEL_BY_MODEL: dict[str, str] = {
+    "gemini-3-flash-preview": "MINIMAL",
+    "gemini-3.1-flash-lite": "MINIMAL",
+}
+
 
 def _location_for_model(model_name: str) -> str:
     """
@@ -232,6 +257,9 @@ class VertexGeminiService:
         }
         if system_prompt:
             config_kwargs["system_instruction"] = system_prompt
+        thinking_level = _THINKING_LEVEL_BY_MODEL.get(model_name)
+        if thinking_level:
+            config_kwargs["thinking_config"] = types.ThinkingConfig(thinking_level=thinking_level)
         generation_config = types.GenerateContentConfig(**config_kwargs)
 
         try:
@@ -303,6 +331,9 @@ class VertexGeminiService:
         }
         if system_prompt:
             config_kwargs["system_instruction"] = system_prompt
+        thinking_level = _THINKING_LEVEL_BY_MODEL.get(model_name)
+        if thinking_level:
+            config_kwargs["thinking_config"] = types.ThinkingConfig(thinking_level=thinking_level)
         generation_config = types.GenerateContentConfig(**config_kwargs)
 
         max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)
@@ -387,6 +418,9 @@ class VertexGeminiService:
         }
         if system_prompt:
             config_kwargs["system_instruction"] = system_prompt
+        thinking_level = _THINKING_LEVEL_BY_MODEL.get(model_name)
+        if thinking_level:
+            config_kwargs["thinking_config"] = types.ThinkingConfig(thinking_level=thinking_level)
         generation_config = types.GenerateContentConfig(**config_kwargs)
 
         max_turns = getattr(settings, "VOICE_LLM_HISTORY_MAX_TURNS", 20)

--- a/app/voice/llm_prompt_builder.py
+++ b/app/voice/llm_prompt_builder.py
@@ -13,13 +13,13 @@ def _load_vertex_models():
     global _Content, _Part
     if _Content is None:
         try:
-            from vertexai.generative_models import Content, Part
+            from google.genai import types
         except ImportError as exc:
             raise ImportError(
-                "google-cloud-aiplatform is required for build_vertex_contents. "
+                "google-genai is required for build_vertex_contents. "
                 "Add it to requirements.txt."
             ) from exc
-        _Content, _Part = Content, Part
+        _Content, _Part = types.Content, types.Part
     return _Content, _Part
 
 
@@ -82,7 +82,7 @@ def build_vertex_contents(
     Maps (role, text) tuples:  "client" → "user",  "agent" → "model".
     Prunes to max_turns pairs. kb_context is appended to the current user turn.
 
-    Returns a list of vertexai.generative_models.Content objects.
+    Returns a list of google.genai.types.Content objects.
     """
     Content, Part = _load_vertex_models()
 
@@ -92,13 +92,13 @@ def build_vertex_contents(
         if not text:
             continue
         vertex_role = "user" if role == "client" else "model"
-        contents.append(Content(role=vertex_role, parts=[Part.from_text(text)]))
+        contents.append(Content(role=vertex_role, parts=[Part.from_text(text=text)]))
 
     user_text = caller_transcript or ""
     if kb_context:
         user_text = f"{user_text}\n\n[CONTEXT]\n{kb_context}"
 
     if user_text:
-        contents.append(Content(role="user", parts=[Part.from_text(user_text)]))
+        contents.append(Content(role="user", parts=[Part.from_text(text=user_text)]))
 
     return contents

--- a/tests/db/test_schema_v2_migration.py
+++ b/tests/db/test_schema_v2_migration.py
@@ -543,15 +543,37 @@ class TestWidenAgentLlmModelCheckMigration:
         added = set(mod._ALLOWED_LLM_MODELS_AT_REVISION) - set(mod._PRIOR_ALLOWED_LLM_MODELS)
         assert added == {"gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"}
 
-    def test_widened_snapshot_matches_current_allow_list(self):
-        """The migration's self-contained snapshot must match the current
-        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
-        revision — future edits to the module are expected to add a new
-        migration rather than retroactively changing this one)."""
-        from app.core.llm_models import ALLOWED_LLM_MODELS
-
+    def test_widened_snapshot_is_frozen_historical_value(self):
+        """This migration's snapshot is a historical point-in-time value —
+        it is NOT expected to track the current live
+        app.core.llm_models.ALLOWED_LLM_MODELS allow-list once a later
+        migration (e.g. 20260816_widen_agent_llm_model_check_gemini3.py)
+        widens the constraint further. Per the module docstring, future
+        edits to the allow-list are expected to add a new migration rather
+        than retroactively changing this one, so this snapshot must stay
+        pinned to its original 19-value set."""
         mod = _load_migration("20260815_widen_agent_llm_model_check.py")
-        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
+        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == {
+            "gpt-4o-mini",
+            "gpt-4o",
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4-turbo",
+            "gemini-2.5-flash",
+            "gemini-2.0-flash-001",
+            "gemini-2.0-flash",
+            "gemini-1.5-pro",
+            "gemini-1.5-flash",
+            "claude-3-5-sonnet",
+            "claude-3-haiku",
+            "llama-3.1-70b-versatile",
+            "llama-3.1-8b-instant",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.1",
+            "gpt-5.2",
+            "gpt-5.4",
+        }
 
     def test_llm_check_sql_uses_widened_snapshot(self):
         mod = _load_migration("20260815_widen_agent_llm_model_check.py")
@@ -568,3 +590,79 @@ class TestWidenAgentLlmModelCheckMigration:
             assert f"'{model}'" in sql
         for gpt5_model in ["gpt-5", "gpt-5-mini", "gpt-5.1", "gpt-5.2", "gpt-5.4"]:
             assert f"'{gpt5_model}'" not in sql
+
+
+# ─────────────────── widen ck_agent_llm_model (gemini-3 family) ──────────────
+
+class TestWidenAgentLlmModelCheckGemini3Migration:
+    """20260816_widen_agent_llm_model_check_gemini3.py — widens
+    ck_agent_llm_model from the 19-value 20260815 snapshot to 21 values (adds
+    the 2 Gemini 3 family IDs, removes nothing)."""
+
+    def test_file_exists(self):
+        assert (
+            _VERSIONS_DIR / "20260816_widen_agent_llm_model_check_gemini3.py"
+        ).exists()
+
+    def test_down_revision_is_gpt5_widen_migration(self):
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        assert mod.down_revision == "20260815_widen_llm_check"
+
+    def test_has_upgrade_and_downgrade(self):
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)
+
+    def test_revision_id(self):
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        assert mod.revision == "20260816_widen_llm_check_g3"
+
+    def test_widened_snapshot_has_21_values(self):
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        assert len(mod._ALLOWED_LLM_MODELS_AT_REVISION) == 21
+
+    def test_prior_snapshot_unchanged_at_19_values(self):
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        assert len(mod._PRIOR_ALLOWED_LLM_MODELS) == 19
+
+    def test_widened_snapshot_is_superset_of_prior_snapshot(self):
+        """Purely additive: nothing removed or renamed."""
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        assert set(mod._PRIOR_ALLOWED_LLM_MODELS).issubset(
+            set(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        )
+
+    def test_widened_snapshot_adds_exactly_the_gemini3_family(self):
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        added = set(mod._ALLOWED_LLM_MODELS_AT_REVISION) - set(
+            mod._PRIOR_ALLOWED_LLM_MODELS
+        )
+        assert added == {"gemini-3-flash-preview", "gemini-3.1-flash-lite"}
+
+    def test_widened_snapshot_matches_current_allow_list(self):
+        """The migration's self-contained snapshot must match the current
+        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
+        revision — this is now the latest widening migration, so this
+        assertion correctly lives here; future edits to the module are
+        expected to add a new migration rather than retroactively changing
+        this one)."""
+        from app.core.llm_models import ALLOWED_LLM_MODELS
+
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
+
+    def test_llm_check_sql_uses_widened_snapshot(self):
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        for model in mod._ALLOWED_LLM_MODELS_AT_REVISION:
+            assert f"'{model}'" in sql
+
+    def test_downgrade_sql_uses_prior_snapshot_only(self):
+        """Downgrade must restore the narrower 19-value constraint — the two
+        new gemini-3 IDs must not appear in the downgrade CHECK SQL."""
+        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
+        sql = mod._llm_check_sql(mod._PRIOR_ALLOWED_LLM_MODELS)
+        for model in mod._PRIOR_ALLOWED_LLM_MODELS:
+            assert f"'{model}'" in sql
+        for gemini3_model in ["gemini-3-flash-preview", "gemini-3.1-flash-lite"]:
+            assert f"'{gemini3_model}'" not in sql

--- a/tests/services/test_calendly_integration.py
+++ b/tests/services/test_calendly_integration.py
@@ -375,29 +375,12 @@ class TestTokenEncryption:
             decrypt_calendly_token("not-a-valid-ciphertext", MagicMock())
 
 
-# ── Gemini function-calling: function-response Content wrapping ────────────────
-# Regression test: appending a bare Part (instead of a Content(role="function", ...))
-# to `contents` crashes the Vertex SDK's content-conversion step the moment any
-# other Content object is present in the list.
-
-
-class TestGenerateWithToolsContentWrapping:
-    def test_function_response_is_wrapped_in_content_not_bare_part(self):
-        pytest.importorskip("vertexai")
-        from vertexai.generative_models import Content, Part
-        from vertexai.generative_models._generative_models import _content_types_to_gapic_contents
-
-        user_content = Content(role="user", parts=[Part.from_text("hi")])
-        model_content = Content(role="model", parts=[Part.from_text("calling tool")])
-        function_response_content = Content(
-            role="function",
-            parts=[Part.from_function_response(name="check_availability", response={"ok": True})],
-        )
-
-        # This is exactly the shape generate_with_tools() must build. A bare
-        # Part in this list (instead of wrapping it in Content) raises
-        # AttributeError here.
-        result = _content_types_to_gapic_contents(
-            [user_content, model_content, function_response_content]
-        )
-        assert len(result) == 3
+# Note: function-response Content-wrapping coverage for
+# VertexGeminiService.generate_with_tools() (the google-genai SDK path this
+# service actually uses) lives in tests/voice/test_vertex_llm.py — see
+# TestGenerateWithTools there. This file previously had a regression test
+# here (TestGenerateWithToolsContentWrapping) that exercised the OLD
+# `vertexai.generative_models` SDK directly via
+# `pytest.importorskip("vertexai")`, but vertex_gemini_service.py no longer
+# imports that SDK at all (migrated to google.genai) — it was testing dead
+# code and was removed rather than left as false confidence.

--- a/tests/voice/test_vertex_llm.py
+++ b/tests/voice/test_vertex_llm.py
@@ -441,6 +441,204 @@ class TestModelToLocationRoutingEndToEnd:
         mock_ensure.assert_called_once_with(expected_location)
 
 
+class TestThinkingConfigRouting:
+    """
+    _THINKING_LEVEL_BY_MODEL pins an explicit ``thinking_config`` for the
+    Gemini 3 family (latency-sensitive real-time voice). Confirms the
+    ``config`` object actually passed to the underlying
+    ``generate_content``/``generate_content_stream`` call carries the right
+    ``thinking_config.thinking_level`` for mapped models, and — the more
+    important regression guard — that unmapped models (e.g.
+    ``gemini-2.5-flash``) get no ``thinking_config`` at all, i.e.
+    ``config.thinking_config is None``.
+
+    Uses ``_real_google_genai()`` (see top of file) rather than the
+    conftest-stubbed MagicMock ``google.genai``, because a MagicMock
+    ``types.GenerateContentConfig(**kwargs)`` call wouldn't actually store
+    ``kwargs`` as inspectable attributes on its return value — only the real
+    ``GenerateContentConfig``/``ThinkingConfig`` objects let us assert on the
+    real field values the SDK will see.
+    """
+
+    @pytest.mark.parametrize(
+        "model_name,expected_level",
+        [
+            ("gemini-3-flash-preview", "MINIMAL"),
+            ("gemini-3.1-flash-lite", "MINIMAL"),
+        ],
+    )
+    def test_stream_text_sets_thinking_config_for_mapped_models(self, model_name, expected_level):
+        with _real_google_genai():
+            mock_stream = AsyncMock(return_value=_async_fake_response_iter(["ok"]))
+            client = _make_mock_genai_client(stream=mock_stream)
+
+            async def _run():
+                with (
+                    patch(
+                        "app.services.vertex_gemini_service._ensure_vertex_client",
+                        return_value=client,
+                    ),
+                    patch(
+                        "app.services.vertex_gemini_service.build_vertex_contents",
+                        return_value=[],
+                    ),
+                ):
+                    svc = VertexGeminiService()
+                    async for _ in svc.stream_text(prompt="hi", model_name=model_name):
+                        pass
+
+            asyncio.run(_run())
+
+        config = mock_stream.call_args.kwargs["config"]
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_level == expected_level
+
+    def test_stream_text_no_thinking_config_for_unmapped_model(self):
+        """gemini-2.5-flash is not in _THINKING_LEVEL_BY_MODEL — config must
+        stay byte-for-byte unchanged (no thinking_config key at all)."""
+        with _real_google_genai():
+            mock_stream = AsyncMock(return_value=_async_fake_response_iter(["ok"]))
+            client = _make_mock_genai_client(stream=mock_stream)
+
+            async def _run():
+                with (
+                    patch(
+                        "app.services.vertex_gemini_service._ensure_vertex_client",
+                        return_value=client,
+                    ),
+                    patch(
+                        "app.services.vertex_gemini_service.build_vertex_contents",
+                        return_value=[],
+                    ),
+                ):
+                    svc = VertexGeminiService()
+                    async for _ in svc.stream_text(prompt="hi", model_name="gemini-2.5-flash"):
+                        pass
+
+            asyncio.run(_run())
+
+        config = mock_stream.call_args.kwargs["config"]
+        assert config.thinking_config is None
+
+    @pytest.mark.parametrize(
+        "model_name,expected_level",
+        [
+            ("gemini-3-flash-preview", "MINIMAL"),
+            ("gemini-3.1-flash-lite", "MINIMAL"),
+        ],
+    )
+    def test_generate_text_sets_thinking_config_for_mapped_models(self, model_name, expected_level):
+        with _real_google_genai():
+            mock_response = SimpleNamespace(text="Hello")
+            mock_generate = MagicMock(return_value=mock_response)
+            client = _make_mock_genai_client(generate=mock_generate)
+
+            with (
+                patch(
+                    "app.services.vertex_gemini_service._ensure_vertex_client",
+                    return_value=client,
+                ),
+                patch(
+                    "app.services.vertex_gemini_service.build_vertex_contents",
+                    return_value=[],
+                ),
+            ):
+                svc = VertexGeminiService()
+                svc.generate_text(prompt="hi", model_name=model_name)
+
+        config = mock_generate.call_args.kwargs["config"]
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_level == expected_level
+
+    def test_generate_text_no_thinking_config_for_unmapped_model(self):
+        with _real_google_genai():
+            mock_response = SimpleNamespace(text="Hello")
+            mock_generate = MagicMock(return_value=mock_response)
+            client = _make_mock_genai_client(generate=mock_generate)
+
+            with (
+                patch(
+                    "app.services.vertex_gemini_service._ensure_vertex_client",
+                    return_value=client,
+                ),
+                patch(
+                    "app.services.vertex_gemini_service.build_vertex_contents",
+                    return_value=[],
+                ),
+            ):
+                svc = VertexGeminiService()
+                svc.generate_text(prompt="hi", model_name="gemini-2.5-flash")
+
+        config = mock_generate.call_args.kwargs["config"]
+        assert config.thinking_config is None
+
+    @pytest.mark.parametrize(
+        "model_name,expected_level",
+        [
+            ("gemini-3-flash-preview", "MINIMAL"),
+            ("gemini-3.1-flash-lite", "MINIMAL"),
+        ],
+    )
+    def test_generate_with_tools_sets_thinking_config_for_mapped_models(
+        self, model_name, expected_level
+    ):
+        with _real_google_genai():
+            response = SimpleNamespace(text="Hi there", candidates=[])
+            async_generate = AsyncMock(return_value=response)
+            client = _make_mock_genai_client(async_generate=async_generate)
+            tool_executor = AsyncMock()
+
+            async def _run():
+                with (
+                    patch(
+                        "app.services.vertex_gemini_service._ensure_vertex_client",
+                        return_value=client,
+                    ),
+                    patch(
+                        "app.services.vertex_gemini_service.build_vertex_contents",
+                        return_value=[],
+                    ),
+                ):
+                    svc = VertexGeminiService()
+                    return await svc.generate_with_tools(
+                        prompt="hi", model_name=model_name, tool_executor=tool_executor
+                    )
+
+            asyncio.run(_run())
+
+        config = async_generate.call_args.kwargs["config"]
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_level == expected_level
+
+    def test_generate_with_tools_no_thinking_config_for_unmapped_model(self):
+        with _real_google_genai():
+            response = SimpleNamespace(text="Hi there", candidates=[])
+            async_generate = AsyncMock(return_value=response)
+            client = _make_mock_genai_client(async_generate=async_generate)
+            tool_executor = AsyncMock()
+
+            async def _run():
+                with (
+                    patch(
+                        "app.services.vertex_gemini_service._ensure_vertex_client",
+                        return_value=client,
+                    ),
+                    patch(
+                        "app.services.vertex_gemini_service.build_vertex_contents",
+                        return_value=[],
+                    ),
+                ):
+                    svc = VertexGeminiService()
+                    return await svc.generate_with_tools(
+                        prompt="hi", model_name="gemini-2.5-flash", tool_executor=tool_executor
+                    )
+
+            asyncio.run(_run())
+
+        config = async_generate.call_args.kwargs["config"]
+        assert config.thinking_config is None
+
+
 def _fake_response_iter(texts: list[str]):
     """Return sync iterator of fake Vertex response chunks."""
     class _FakeChunk:

--- a/tests/voice/test_vertex_llm.py
+++ b/tests/voice/test_vertex_llm.py
@@ -28,6 +28,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.voice.llm_prompt_builder import (
+    build_history_text,
+    build_kb_context_for_vertex,
+    build_vertex_contents,
+    prune_history_to_turns,
+)
+
 
 @contextlib.contextmanager
 def _real_google_genai():
@@ -54,13 +61,6 @@ def _real_google_genai():
 # ─────────────────────────────────────────────────────────────────────────────
 # llm_prompt_builder — pure functions
 # ─────────────────────────────────────────────────────────────────────────────
-
-from app.voice.llm_prompt_builder import (
-    build_history_text,
-    build_kb_context_for_vertex,
-    build_vertex_contents,
-    prune_history_to_turns,
-)
 
 
 class TestPruneHistoryToTurns:
@@ -212,7 +212,233 @@ from app.services.vertex_gemini_service import (  # noqa: E402
     VertexLlmError,
     VertexLlmErrorType,
     _classify_vertex_error,
+    _ensure_vertex_client,
+    _location_for_model,
+    _vertex_clients,
 )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _location_for_model — pure routing function
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLocationForModel:
+    @pytest.mark.parametrize(
+        "model_name", ["gemini-3-flash-preview", "gemini-3.1-flash-lite"]
+    )
+    def test_global_only_models_route_to_global(self, model_name):
+        assert _location_for_model(model_name) == "global"
+
+    @pytest.mark.parametrize(
+        "model_name",
+        ["gemini-2.5-flash", "gemini-2.0-flash", "some-future-model-id"],
+    )
+    def test_other_models_route_to_configured_location(self, model_name, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.VERTEX_AI_LOCATION",
+            "us-central1",
+        )
+        assert _location_for_model(model_name) == "us-central1"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _ensure_vertex_client — per-location caching
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestEnsureVertexClientCaching:
+    """
+    ``_ensure_vertex_client`` does ``from google import genai`` then
+    ``genai.Client(...)``. Because tests/conftest.py stubs
+    ``sys.modules["google"]`` as a bare ``MagicMock()`` (not a real package),
+    ``from google import genai`` resolves via attribute access on that mock
+    object (``sys.modules["google"].genai``), NOT via ``sys.modules["google.genai"]``
+    — those are two distinct mock objects. So the patch target here has to be
+    the attribute actually consulted at call time: ``sys.modules["google"].genai``.
+    ``unittest.mock.patch("google.genai.Client", ...)`` looks unintuitive but
+    would silently patch the wrong object and never observe a call.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_client_cache(self):
+        """_vertex_clients is a module-level cache — clear before/after each
+        test so tests don't leak state into each other."""
+        _vertex_clients.clear()
+        yield
+        _vertex_clients.clear()
+
+    def _patch_genai_client(self, monkeypatch, mock_client_cls):
+        fake_genai = SimpleNamespace(Client=mock_client_cls)
+        monkeypatch.setattr(sys.modules["google"], "genai", fake_genai, raising=False)
+
+    def test_same_location_returns_cached_client(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.GOOGLE_CLOUD_PROJECT_ID",
+            "test-project",
+        )
+        mock_client_cls = MagicMock(side_effect=lambda **_kwargs: MagicMock())
+        self._patch_genai_client(monkeypatch, mock_client_cls)
+
+        client1 = _ensure_vertex_client("us-central1")
+        client2 = _ensure_vertex_client("us-central1")
+
+        assert client1 is client2
+        mock_client_cls.assert_called_once()
+
+    def test_different_locations_each_get_own_client(self, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.GOOGLE_CLOUD_PROJECT_ID",
+            "test-project",
+        )
+        mock_client_cls = MagicMock(side_effect=lambda **_kwargs: MagicMock())
+        self._patch_genai_client(monkeypatch, mock_client_cls)
+
+        global_client = _ensure_vertex_client("global")
+        regional_client = _ensure_vertex_client("us-central1")
+        # Requesting each location again should hit the cache, not
+        # construct a new client.
+        global_client_again = _ensure_vertex_client("global")
+        regional_client_again = _ensure_vertex_client("us-central1")
+
+        assert global_client is not regional_client
+        assert global_client is global_client_again
+        assert regional_client is regional_client_again
+        assert mock_client_cls.call_count == 2
+        call_locations = {c.kwargs["location"] for c in mock_client_cls.call_args_list}
+        assert call_locations == {"global", "us-central1"}
+
+    def test_no_project_configured_raises_runtime_error_for_any_location(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.GOOGLE_CLOUD_PROJECT_ID", None
+        )
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.GCP_PROJECT_ID", None
+        )
+        with pytest.raises(RuntimeError, match="Vertex AI requires"):
+            _ensure_vertex_client("global")
+        with pytest.raises(RuntimeError, match="Vertex AI requires"):
+            _ensure_vertex_client("us-central1")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# End-to-end: model_name → location routing through the public API
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestModelToLocationRoutingEndToEnd:
+    """Confirms stream_text/generate_text/generate_with_tools call
+    _ensure_vertex_client with the correct location for a given model_name,
+    by patching _ensure_vertex_client itself and inspecting the location it
+    was invoked with (rather than going through the real genai.Client)."""
+
+    @pytest.mark.parametrize(
+        "model_name,expected_location",
+        [
+            ("gemini-3-flash-preview", "global"),
+            ("gemini-3.1-flash-lite", "global"),
+            ("gemini-2.5-flash", "us-central1"),
+        ],
+    )
+    def test_stream_text_routes_location(self, model_name, expected_location, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.VERTEX_AI_LOCATION",
+            "us-central1",
+        )
+        mock_stream = AsyncMock(return_value=_async_fake_response_iter(["ok"]))
+        client = _make_mock_genai_client(stream=mock_stream)
+        mock_ensure = MagicMock(return_value=client)
+
+        async def _run():
+            with (
+                patch(
+                    "app.services.vertex_gemini_service._ensure_vertex_client",
+                    mock_ensure,
+                ),
+                patch(
+                    "app.services.vertex_gemini_service.build_vertex_contents",
+                    return_value=[],
+                ),
+            ):
+                svc = VertexGeminiService()
+                async for _ in svc.stream_text(prompt="hi", model_name=model_name):
+                    pass
+
+        asyncio.run(_run())
+        mock_ensure.assert_called_once_with(expected_location)
+
+    @pytest.mark.parametrize(
+        "model_name,expected_location",
+        [
+            ("gemini-3-flash-preview", "global"),
+            ("gemini-3.1-flash-lite", "global"),
+            ("gemini-2.5-flash", "us-central1"),
+        ],
+    )
+    def test_generate_text_routes_location(self, model_name, expected_location, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.VERTEX_AI_LOCATION",
+            "us-central1",
+        )
+        mock_response = SimpleNamespace(text="Hello")
+        mock_generate = MagicMock(return_value=mock_response)
+        client = _make_mock_genai_client(generate=mock_generate)
+        mock_ensure = MagicMock(return_value=client)
+
+        with (
+            patch(
+                "app.services.vertex_gemini_service._ensure_vertex_client",
+                mock_ensure,
+            ),
+            patch(
+                "app.services.vertex_gemini_service.build_vertex_contents",
+                return_value=[],
+            ),
+        ):
+            svc = VertexGeminiService()
+            svc.generate_text(prompt="hi", model_name=model_name)
+
+        mock_ensure.assert_called_once_with(expected_location)
+
+    @pytest.mark.parametrize(
+        "model_name,expected_location",
+        [
+            ("gemini-3-flash-preview", "global"),
+            ("gemini-3.1-flash-lite", "global"),
+            ("gemini-2.5-flash", "us-central1"),
+        ],
+    )
+    def test_generate_with_tools_routes_location(self, model_name, expected_location, monkeypatch):
+        monkeypatch.setattr(
+            "app.services.vertex_gemini_service.settings.VERTEX_AI_LOCATION",
+            "us-central1",
+        )
+        response = SimpleNamespace(text="Hi there", candidates=[])
+        async_generate = AsyncMock(return_value=response)
+        client = _make_mock_genai_client(async_generate=async_generate)
+        mock_ensure = MagicMock(return_value=client)
+        tool_executor = AsyncMock()
+
+        async def _run():
+            with (
+                patch(
+                    "app.services.vertex_gemini_service._ensure_vertex_client",
+                    mock_ensure,
+                ),
+                patch(
+                    "app.services.vertex_gemini_service.build_vertex_contents",
+                    return_value=[],
+                ),
+            ):
+                svc = VertexGeminiService()
+                return await svc.generate_with_tools(
+                    prompt="hi", model_name=model_name, tool_executor=tool_executor
+                )
+
+        asyncio.run(_run())
+        mock_ensure.assert_called_once_with(expected_location)
 
 
 def _fake_response_iter(texts: list[str]):
@@ -513,7 +739,7 @@ class TestGenerateWithTools:
         follow-up generate_content call's contents include a
         types.Content(role="user", parts=[Part.from_function_response(...)]) turn —
         this is the regression guard for the role="function" → role="user" bug fix."""
-        fake_types = _install_fake_genai_types(monkeypatch)
+        _install_fake_genai_types(monkeypatch)
 
         fc_part = _make_fc_part("check_availability", {"date": "2026-08-17"})
         candidate_content = SimpleNamespace(parts=[fc_part])

--- a/tests/voice/test_vertex_llm.py
+++ b/tests/voice/test_vertex_llm.py
@@ -3,15 +3,53 @@ Unit tests for Vertex AI Gemini LLM integration.
 
 Covers: prompt construction, history pruning, cancellation, error fallback,
 and credential routing.  All Vertex SDK calls are mocked — no real GCP calls.
+
+Note on the google-genai SDK and tests/conftest.py: conftest stubs
+``sys.modules["google.genai"]`` with a bare ``MagicMock()`` for the whole
+test session so unrelated unit tests never need real GCP credentials or the
+SDK installed. That's fine for tests that only need to control the shape of
+values returned from mocked calls (stream_text/generate_text/
+generate_with_tools tests below configure their own fake client). But a
+couple of tests here intentionally want to exercise the *real* installed
+``google-genai==2.3.0`` package's actual behavior (``Part.from_text`` being
+keyword-only, real ``google.genai.errors.ClientError``/``ServerError``
+construction and their ``isinstance`` relationship to ``APIError`` as
+consumed by ``_classify_vertex_error``) — see ``_real_google_genai()``
+below, which temporarily swaps out the conftest stub for those cases only.
 """
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import sys
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+
+@contextlib.contextmanager
+def _real_google_genai():
+    """
+    Temporarily undo conftest's ``google`` / ``google.genai`` MagicMock stub
+    so ``import google.genai...`` resolves to the real installed package for
+    the duration of the ``with`` block, then restore the stub so it doesn't
+    leak into other tests/files.
+    """
+    saved = {k: v for k, v in sys.modules.items() if k == "google" or k.startswith("google.")}
+    for k in list(saved):
+        del sys.modules[k]
+    try:
+        import google.genai.types as real_types
+        import google.genai.errors as real_errors
+
+        yield real_types, real_errors
+    finally:
+        for k in list(sys.modules):
+            if k == "google" or k.startswith("google."):
+                del sys.modules[k]
+        sys.modules.update(saved)
 
 # ─────────────────────────────────────────────────────────────────────────────
 # llm_prompt_builder — pure functions
@@ -84,16 +122,24 @@ class TestBuildKbContextForVertex:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# build_vertex_contents — needs vertexai stubs
+# build_vertex_contents — needs google.genai.types stubs
 # ─────────────────────────────────────────────────────────────────────────────
 
 class _FakePart:
+    """
+    Mirrors the real ``google.genai.types.Part.from_text(*, text: str)``
+    signature — keyword-only, confirmed against the installed
+    google-genai==2.3.0 package. ``llm_prompt_builder.build_vertex_contents``
+    calls it as ``Part.from_text(text=text)``; if that ever regressed to a
+    positional call, this fake would raise TypeError just like the real SDK.
+    """
+
     def __init__(self, text: str):
         self.text = text
 
     @staticmethod
-    def from_text(t: str) -> "_FakePart":
-        return _FakePart(t)
+    def from_text(*, text: str) -> "_FakePart":
+        return _FakePart(text)
 
 
 class _FakeContent:
@@ -102,59 +148,59 @@ class _FakeContent:
         self.parts = parts
 
 
-def _patch_vertexai_models(monkeypatch):
-    fake = SimpleNamespace(Content=_FakeContent, Part=_FakePart)
-    monkeypatch.setattr(
-        "app.voice.llm_prompt_builder.build_vertex_contents.__globals__",
-        {},
-        raising=False,
-    )
-    return fake
-
-
 class TestBuildVertexContents:
-    def _run(self, history, transcript, kb=None, max_turns=20):
-        # Patch vertexai.generative_models before calling
-        import sys
-        fake_module = SimpleNamespace(
-            Content=_FakeContent,
-            Part=_FakePart,
-        )
-        sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
-        sys.modules["vertexai.generative_models"] = fake_module
-        contents = build_vertex_contents(history, transcript, kb, max_turns)
-        return contents
+    def _run(self, history, transcript, kb=None, max_turns=20, monkeypatch=None):
+        import app.voice.llm_prompt_builder as prompt_builder_module
 
-    def test_empty_history(self):
-        contents = self._run([], "Hello there")
+        fake_types = SimpleNamespace(Content=_FakeContent, Part=_FakePart)
+        # monkeypatch.setitem restores the original (conftest-stubbed)
+        # sys.modules entry after this test — must not leak into other
+        # tests, several of which need google.genai.types.GenerateContentConfig.
+        monkeypatch.setitem(sys.modules, "google.genai", MagicMock(types=fake_types))
+        # Force _load_vertex_models() to re-resolve Content/Part against our
+        # fake types module rather than reusing whatever a prior test cached.
+        monkeypatch.setattr(prompt_builder_module, "_Content", None)
+        monkeypatch.setattr(prompt_builder_module, "_Part", None)
+        return build_vertex_contents(history, transcript, kb, max_turns)
+
+    def test_empty_history(self, monkeypatch):
+        contents = self._run([], "Hello there", monkeypatch=monkeypatch)
         assert len(contents) == 1
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "Hello there"
 
-    def test_role_mapping(self):
+    def test_role_mapping(self, monkeypatch):
         history = [("client", "Hi"), ("agent", "Hello")]
-        contents = self._run(history, "What is 2+2?")
+        contents = self._run(history, "What is 2+2?", monkeypatch=monkeypatch)
         assert contents[0].role == "user"
         assert contents[1].role == "model"
         assert contents[2].role == "user"
         assert contents[2].parts[0].text == "What is 2+2?"
 
-    def test_kb_context_appended_to_user(self):
-        contents = self._run([], "my question", kb="some context")
+    def test_kb_context_appended_to_user(self, monkeypatch):
+        contents = self._run([], "my question", kb="some context", monkeypatch=monkeypatch)
         assert "some context" in contents[0].parts[0].text
         assert "my question" in contents[0].parts[0].text
 
-    def test_history_pruned_to_max_turns(self):
+    def test_history_pruned_to_max_turns(self, monkeypatch):
         history = []
         for i in range(25):
             history.append(("client", f"u{i}"))
             history.append(("agent", f"a{i}"))
-        contents = self._run(history, "current", max_turns=20)
+        contents = self._run(history, "current", max_turns=20, monkeypatch=monkeypatch)
         # 20 turns = 40 messages + 1 current user turn
         assert len(contents) == 41
         # Oldest dropped
         assert contents[0].role == "user"
         assert contents[0].parts[0].text == "u5"
+
+    def test_part_from_text_is_keyword_only(self):
+        """Regression guard for the real SDK's actual signature difference
+        from the deprecated vertexai SDK: Part.from_text(text) positionally
+        must fail, only Part.from_text(text=...) is valid."""
+        with pytest.raises(TypeError):
+            _FakePart.from_text("positional not allowed")
+        assert _FakePart.from_text(text="ok").text == "ok"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -196,28 +242,44 @@ async def _async_fake_response_iter(texts: list[str]):
         yield _FakeChunk(t)
 
 
-def test_vertex_stream_text_yields_chunks():
-    """Happy path: stream returns token chunks in order via generate_content_async."""
+def _make_mock_genai_client(*, stream=None, generate=None, async_generate=None):
+    """
+    Build a MagicMock standing in for the google.genai.Client returned by
+    _ensure_vertex_client(). Only the pieces stream_text/generate_text/
+    generate_with_tools actually touch are configured:
+      - client.aio.models.generate_content_stream — async def, returns an
+        AsyncIterator when awaited (real SDK shape, confirmed against the
+        installed google-genai==2.3.0 source).
+      - client.models.generate_content — plain sync method.
+      - client.aio.models.generate_content — async method (used by
+        generate_with_tools).
+    """
+    client = MagicMock()
+    if stream is not None:
+        client.aio.models.generate_content_stream = stream
+    if generate is not None:
+        client.models.generate_content = generate
+    if async_generate is not None:
+        client.aio.models.generate_content = async_generate
+    return client
+
+
+@pytest.mark.parametrize(
+    "model_name", ["gemini-2.5-flash", "gemini-3-flash-preview", "gemini-3.1-flash-lite"]
+)
+def test_vertex_stream_text_yields_chunks(model_name):
+    """Happy path: stream returns token chunks in order via
+    client.aio.models.generate_content_stream, and model_name is forwarded
+    verbatim to the model= kwarg (covers both existing and new Gemini 3
+    model IDs)."""
     chunks = ["Hello", " there", "!"]
 
-    import sys
-
-    mock_model = MagicMock()
-    mock_model.generate_content_async = AsyncMock(
-        return_value=_async_fake_response_iter(chunks)
-    )
-
-    sys.modules["vertexai"] = SimpleNamespace(init=lambda **k: None)
-    sys.modules["vertexai.generative_models"] = SimpleNamespace(
-        GenerativeModel=MagicMock(return_value=mock_model),
-        GenerationConfig=MagicMock(),
-        Content=_FakeContent,
-        Part=_FakePart,
-    )
+    mock_stream = AsyncMock(return_value=_async_fake_response_iter(chunks))
+    client = _make_mock_genai_client(stream=mock_stream)
 
     async def _run():
         with (
-            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service._ensure_vertex_client", return_value=client),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
         ):
             svc = VertexGeminiService()
@@ -225,7 +287,7 @@ def test_vertex_stream_text_yields_chunks():
             async for chunk in svc.stream_text(
                 prompt="hi",
                 system_prompt="be helpful",
-                model_name="gemini-2.5-flash",
+                model_name=model_name,
                 temperature=0.3,
                 max_tokens=100,
             ):
@@ -234,29 +296,17 @@ def test_vertex_stream_text_yields_chunks():
 
     result = asyncio.run(_run())
     assert result == chunks
+    assert mock_stream.call_args.kwargs["model"] == model_name
 
 
 def test_vertex_generative_model_uses_short_model_name():
     """SDK expects short names (e.g. gemini-2.5-flash), not publishers/google/models/ prefix."""
-    import sys
-
-    mock_model = MagicMock()
-    mock_model.generate_content_async = AsyncMock(
-        return_value=_async_fake_response_iter(["ok"])
-    )
-    mock_generative_model = MagicMock(return_value=mock_model)
-
-    sys.modules["vertexai"] = SimpleNamespace(init=lambda **k: None)
-    sys.modules["vertexai.generative_models"] = SimpleNamespace(
-        GenerativeModel=mock_generative_model,
-        GenerationConfig=MagicMock(),
-        Content=_FakeContent,
-        Part=_FakePart,
-    )
+    mock_stream = AsyncMock(return_value=_async_fake_response_iter(["ok"]))
+    client = _make_mock_genai_client(stream=mock_stream)
 
     async def _run():
         with (
-            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service._ensure_vertex_client", return_value=client),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
         ):
             svc = VertexGeminiService()
@@ -264,44 +314,35 @@ def test_vertex_generative_model_uses_short_model_name():
                 pass
 
     asyncio.run(_run())
-    mock_generative_model.assert_called_once()
-    assert mock_generative_model.call_args.kwargs["model_name"] == "gemini-2.5-flash"
-    assert "publishers/" not in mock_generative_model.call_args.kwargs["model_name"]
+    mock_stream.assert_called_once()
+    assert mock_stream.call_args.kwargs["model"] == "gemini-2.5-flash"
+    assert "publishers/" not in mock_stream.call_args.kwargs["model"]
 
 
 def test_vertex_stream_text_awaits_coroutine_from_generate_content_async():
-    """Regression: GenerativeModel.generate_content_async is itself `async def` —
-    even with stream=True it returns a coroutine that must be awaited to get the
-    actual AsyncIterable[GenerationResponse] (verified against the installed
-    google-cloud-aiplatform SDK: `generate_content_async` returns
-    `await self._generate_content_streaming_async(...)`). A prior version of this
-    code (and this test) assumed the opposite — that the SDK call synchronously
-    returned an async generator — which raised
-    `TypeError: 'async for' requires an object with __aiter__ method, got coroutine`
-    against the real SDK. This test builds an actual coroutine (not a MagicMock)
-    to make sure `stream_text` really does `await` the call rather than iterating
-    its return value directly."""
+    """Documents the new SDK's actual async-streaming shape (confirmed against
+    the installed google-genai==2.3.0 source:
+    `AsyncModels.generate_content_stream` is itself declared `async def ... ->
+    AsyncIterator[...]`, i.e. calling it returns a coroutine that must be
+    awaited to get the actual async-iterable, exactly as documented in the
+    SDK's own usage example: `async for chunk in await
+    client.aio.models.generate_content_stream(...)`.
+
+    This test builds a hand-written `async def` (not an AsyncMock) for
+    `generate_content_stream` to prove `stream_text` really does `await` the
+    call before iterating, rather than iterating a bare coroutine directly
+    (which would raise `TypeError: 'async for' requires an object with
+    __aiter__ method, got coroutine`)."""
     chunks = ["ok"]
 
-    async def generate_content_async(*_args, **_kwargs):
+    async def generate_content_stream(*_args, **_kwargs):
         return _async_fake_response_iter(chunks)
 
-    import sys
-
-    mock_model = MagicMock()
-    mock_model.generate_content_async = generate_content_async
-
-    sys.modules["vertexai"] = SimpleNamespace(init=lambda **k: None)
-    sys.modules["vertexai.generative_models"] = SimpleNamespace(
-        GenerativeModel=MagicMock(return_value=mock_model),
-        GenerationConfig=MagicMock(),
-        Content=_FakeContent,
-        Part=_FakePart,
-    )
+    client = _make_mock_genai_client(stream=generate_content_stream)
 
     async def _run():
         with (
-            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service._ensure_vertex_client", return_value=client),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
         ):
             svc = VertexGeminiService()
@@ -315,7 +356,7 @@ def test_vertex_stream_text_awaits_coroutine_from_generate_content_async():
 
 
 def test_vertex_stream_cancelled_by_event():
-    """cancel_event stops the stream mid-way via generate_content_async."""
+    """cancel_event stops the stream mid-way via generate_content_stream."""
     chunks = ["tok1", "tok2", "tok3", "tok4"]
     cancel = asyncio.Event()
 
@@ -333,22 +374,12 @@ def test_vertex_stream_cancelled_by_event():
                 cancel.set()
             yield _ChunkObj(t)
 
-    import sys
-    sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
-
-    mock_model = MagicMock()
-    mock_model.generate_content_async = AsyncMock(return_value=_cancelling_iter())
-
-    sys.modules["vertexai.generative_models"] = SimpleNamespace(
-        GenerativeModel=MagicMock(return_value=mock_model),
-        GenerationConfig=MagicMock(),
-        Content=_FakeContent,
-        Part=_FakePart,
-    )
+    mock_stream = AsyncMock(return_value=_cancelling_iter())
+    client = _make_mock_genai_client(stream=mock_stream)
 
     async def _run():
         with (
-            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service._ensure_vertex_client", return_value=client),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
         ):
             svc = VertexGeminiService()
@@ -367,35 +398,219 @@ def test_vertex_stream_cancelled_by_event():
     assert "tok4" not in result
 
 
-def test_vertex_generate_text_returns_content():
-    """Non-streaming generate_text for legacy gather / live-voice paths."""
+@pytest.mark.parametrize(
+    "model_name", ["gemini-2.5-flash", "gemini-3-flash-preview", "gemini-3.1-flash-lite"]
+)
+def test_vertex_generate_text_returns_content(model_name):
+    """Non-streaming generate_text for legacy gather / live-voice paths,
+    via client.models.generate_content (plain sync call, no .aio)."""
     mock_response = SimpleNamespace(text="Hello from Vertex")
-    mock_model = MagicMock()
-    mock_model.generate_content.return_value = mock_response
-
-    import sys
-    sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
-    sys.modules["vertexai.generative_models"] = SimpleNamespace(
-        GenerativeModel=MagicMock(return_value=mock_model),
-        GenerationConfig=MagicMock(),
-        Content=_FakeContent,
-        Part=_FakePart,
-    )
+    mock_generate = MagicMock(return_value=mock_response)
+    client = _make_mock_genai_client(generate=mock_generate)
 
     with (
-        patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+        patch("app.services.vertex_gemini_service._ensure_vertex_client", return_value=client),
         patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
     ):
         svc = VertexGeminiService()
         result = svc.generate_text(
             prompt="hi",
             system_prompt="You are helpful",
-            model_name="gemini-2.5-flash",
+            model_name=model_name,
         )
 
     assert result["content"] == "Hello from Vertex"
-    assert result["model"] == "gemini-2.5-flash"
+    assert result["model"] == model_name
     assert result["response_time"] >= 0
+    assert mock_generate.call_args.kwargs["model"] == model_name
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VertexGeminiService — generate_with_tools
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeToolPart:
+    """Mirrors ``google.genai.types.Part.from_function_response(*, name, response)``
+    closely enough to assert on what generate_with_tools builds."""
+
+    def __init__(self, name, response):
+        self.name = name
+        self.response = response
+
+    @staticmethod
+    def from_function_response(*, name, response):
+        return _FakeToolPart(name, response)
+
+
+class _FakeToolContent:
+    def __init__(self, role, parts):
+        self.role = role
+        self.parts = parts
+
+
+def _install_fake_genai_types(monkeypatch):
+    """
+    Swap ``sys.modules["google.genai"]`` for a controlled fake ``types``
+    namespace (same technique as ``TestBuildVertexContents._run`` above) so
+    ``types.Content(role=..., parts=...)`` / ``types.Part.from_function_response``
+    calls inside ``generate_with_tools`` build real, inspectable objects
+    instead of opaque MagicMock auto-attrs. ``monkeypatch`` restores the
+    original (conftest-stubbed) sys.modules entry after the test.
+    Returns the fake ``types`` namespace for assertions.
+    """
+    fake_types = SimpleNamespace(
+        Content=_FakeToolContent,
+        Part=_FakeToolPart,
+        FunctionDeclaration=MagicMock(),
+        Tool=MagicMock(),
+        GenerateContentConfig=MagicMock(),
+    )
+    monkeypatch.setitem(sys.modules, "google.genai", MagicMock(types=fake_types))
+    return fake_types
+
+
+def _make_fc_part(name: str, args):
+    """A fake response Part carrying a function_call, matching the shape
+    ``generate_with_tools`` reads: ``part.function_call.name`` / ``.args``."""
+    return SimpleNamespace(function_call=SimpleNamespace(name=name, args=args))
+
+
+class TestGenerateWithTools:
+    def test_no_function_call_returns_text_directly(self):
+        """No function_call part in the response → returns response.text.strip(),
+        tool_executor is never called, and there is no follow-up generate_content
+        call (client.aio.models.generate_content is called exactly once)."""
+        response = SimpleNamespace(text="  Hello, how can I help?  ", candidates=[])
+        async_generate = AsyncMock(return_value=response)
+        client = _make_mock_genai_client(async_generate=async_generate)
+        tool_executor = AsyncMock()
+
+        async def _run():
+            with (
+                patch(
+                    "app.services.vertex_gemini_service._ensure_vertex_client",
+                    return_value=client,
+                ),
+                patch(
+                    "app.services.vertex_gemini_service.build_vertex_contents",
+                    return_value=[],
+                ),
+            ):
+                svc = VertexGeminiService()
+                return await svc.generate_with_tools(
+                    prompt="hi", tool_executor=tool_executor
+                )
+
+        result = asyncio.run(_run())
+
+        assert result == "Hello, how can I help?"
+        tool_executor.assert_not_called()
+        async_generate.assert_awaited_once()
+
+    def test_function_call_invokes_tool_executor_and_wraps_response_in_content(self, monkeypatch):
+        """Function_call present → tool_executor is awaited with (name, args); the
+        follow-up generate_content call's contents include a
+        types.Content(role="user", parts=[Part.from_function_response(...)]) turn —
+        this is the regression guard for the role="function" → role="user" bug fix."""
+        fake_types = _install_fake_genai_types(monkeypatch)
+
+        fc_part = _make_fc_part("check_availability", {"date": "2026-08-17"})
+        candidate_content = SimpleNamespace(parts=[fc_part])
+        first_response = SimpleNamespace(candidates=[SimpleNamespace(content=candidate_content)])
+        follow_up_response = SimpleNamespace(text="  You're all set for 10am.  ")
+
+        async_generate = AsyncMock(side_effect=[first_response, follow_up_response])
+        client = _make_mock_genai_client(async_generate=async_generate)
+
+        tool_result = {"slots": ["2026-08-17T10:00:00Z"]}
+        tool_executor = AsyncMock(return_value=tool_result)
+
+        base_contents: list = []
+
+        async def _run():
+            with (
+                patch(
+                    "app.services.vertex_gemini_service._ensure_vertex_client",
+                    return_value=client,
+                ),
+                patch(
+                    "app.services.vertex_gemini_service.build_vertex_contents",
+                    return_value=base_contents,
+                ),
+            ):
+                svc = VertexGeminiService()
+                return await svc.generate_with_tools(
+                    prompt="What's available tomorrow?", tool_executor=tool_executor
+                )
+
+        result = asyncio.run(_run())
+
+        # tool_executor awaited with the resolved (name, args)
+        tool_executor.assert_awaited_once_with("check_availability", {"date": "2026-08-17"})
+
+        # Two generate_content calls: the initial turn + the follow-up after
+        # the tool result is fed back.
+        assert async_generate.await_count == 2
+
+        # The function-response turn must be wrapped in Content(role="user", ...)
+        # — NOT role="function" (the old vertexai SDK convention this was fixed
+        # away from).
+        follow_up_contents = async_generate.call_args_list[1].kwargs["contents"]
+        function_response_turns = [
+            c for c in follow_up_contents if isinstance(c, _FakeToolContent)
+        ]
+        assert len(function_response_turns) == 1
+        wrapped_turn = function_response_turns[0]
+        assert wrapped_turn.role == "user"
+
+        # Part.from_function_response called with the right name/response.
+        assert len(wrapped_turn.parts) == 1
+        wrapped_part = wrapped_turn.parts[0]
+        assert isinstance(wrapped_part, _FakeToolPart)
+        assert wrapped_part.name == "check_availability"
+        assert wrapped_part.response == tool_result
+
+        # The model's own function_call turn is also appended onto the same
+        # contents list used for the follow-up call.
+        assert candidate_content in follow_up_contents
+
+        # Final text comes from the follow-up call's .text, stripped.
+        assert result == "You're all set for 10am."
+
+    def test_function_call_with_no_args_defaults_to_empty_dict(self, monkeypatch):
+        """fc.args falsy (None) → fc_args passed to tool_executor is {} (matches
+        `dict(fc.args) if fc.args else {}` in the source)."""
+        _install_fake_genai_types(monkeypatch)
+
+        fc_part = _make_fc_part("book_appointment", None)
+        candidate_content = SimpleNamespace(parts=[fc_part])
+        first_response = SimpleNamespace(candidates=[SimpleNamespace(content=candidate_content)])
+        follow_up_response = SimpleNamespace(text="Booked.")
+
+        async_generate = AsyncMock(side_effect=[first_response, follow_up_response])
+        client = _make_mock_genai_client(async_generate=async_generate)
+        tool_executor = AsyncMock(return_value={"booked": True})
+
+        async def _run():
+            with (
+                patch(
+                    "app.services.vertex_gemini_service._ensure_vertex_client",
+                    return_value=client,
+                ),
+                patch(
+                    "app.services.vertex_gemini_service.build_vertex_contents",
+                    return_value=[],
+                ),
+            ):
+                svc = VertexGeminiService()
+                return await svc.generate_with_tools(
+                    prompt="Book it", tool_executor=tool_executor
+                )
+
+        asyncio.run(_run())
+
+        tool_executor.assert_awaited_once_with("book_appointment", {})
 
 
 def test_vertex_stream_quota_error_raises_vertex_llm_error():
@@ -412,22 +627,10 @@ def test_vertex_stream_quota_error_raises_vertex_llm_error():
 
     # Also verify the VertexGeminiService raises VertexLlmError on SDK errors
     async def _run():
-        import sys
-        sys.modules.setdefault("vertexai", SimpleNamespace(init=lambda **k: None))
-
-        mock_model = MagicMock()
-        mock_model.generate_content_async = AsyncMock(
-            side_effect=RuntimeError("quota exceeded in stream")
-        )
-
-        sys.modules["vertexai.generative_models"] = SimpleNamespace(
-            GenerativeModel=MagicMock(return_value=mock_model),
-            GenerationConfig=MagicMock(),
-            Content=_FakeContent,
-            Part=_FakePart,
-        )
+        mock_stream = AsyncMock(side_effect=RuntimeError("quota exceeded in stream"))
+        client = _make_mock_genai_client(stream=mock_stream)
         with (
-            patch("app.services.vertex_gemini_service._ensure_vertex_init"),
+            patch("app.services.vertex_gemini_service._ensure_vertex_client", return_value=client),
             patch("app.services.vertex_gemini_service.build_vertex_contents", return_value=[]),
         ):
             svc = VertexGeminiService()
@@ -438,6 +641,42 @@ def test_vertex_stream_quota_error_raises_vertex_llm_error():
 
     error_type = asyncio.run(_run())
     assert error_type == VertexLlmErrorType.QUOTA
+
+
+class TestClassifyVertexErrorGenaiTypes:
+    """
+    _classify_vertex_error's primary branch matches real
+    google.genai.errors.APIError/ClientError/ServerError by .code/.status.
+    tests/conftest.py stubs google.genai as a MagicMock for the whole
+    session, which would make `isinstance(exc, genai_errors.APIError)`
+    raise TypeError (caught, falls through to the message-based fallback)
+    rather than exercising this branch — so these two tests use
+    _real_google_genai() to temporarily restore the real installed package.
+    """
+
+    def test_client_error_429_resource_exhausted_is_quota(self):
+        with _real_google_genai() as (_types, real_errors):
+            # Real APIError.__init__(code, response_json, response=None) signature,
+            # confirmed against the installed google-genai==2.3.0 source.
+            exc = real_errors.ClientError(
+                429, {"error": {"status": "RESOURCE_EXHAUSTED", "message": "quota exceeded"}}
+            )
+            assert exc.code == 429
+            assert exc.status == "RESOURCE_EXHAUSTED"
+
+            vertex_err = _classify_vertex_error(exc)
+        assert vertex_err.error_type == VertexLlmErrorType.QUOTA
+
+    def test_client_error_504_deadline_exceeded_is_timeout(self):
+        with _real_google_genai() as (_types, real_errors):
+            exc = real_errors.ServerError(
+                504, {"error": {"status": "DEADLINE_EXCEEDED", "message": "deadline exceeded"}}
+            )
+            assert exc.code == 504
+            assert exc.status == "DEADLINE_EXCEEDED"
+
+            vertex_err = _classify_vertex_error(exc)
+        assert vertex_err.error_type == VertexLlmErrorType.TIMEOUT
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Migrates `VertexGeminiService` off the deprecated `vertexai.generative_models` SDK (removal date already passed) onto the replacement `google-genai` SDK, preserving streaming, barge-in cancellation, and Calendly tool-calling behavior. Fixed a `role="function"` vs `role="user"` mismatch in the tool-calling follow-up turn during the migration (caught in code review, would have silently broken live appointment booking).
- Adds `gemini-3-flash-preview` and `gemini-3.1-flash-lite` to the agent `llm_model` allow-list (Python allow-list + DB CHECK constraint migration) and pricing table.
- Fixes a live 404: Google currently only serves the Gemini 3 family from Vertex AI's `global` endpoint, not the configured regional endpoint (`us-central1`). Added per-model region routing (`_location_for_model`) with a client cached per location — `gemini-2.5-flash` and all other models are unaffected and keep using the regional endpoint.
- Fixes a live empty-response bug: `gemini-3-flash-preview`'s default `thinking_level="high"` (and an initial `"low"` attempt) consumes tokens from the same `max_output_tokens` budget used for the spoken reply, and could exhaust it entirely (`finish_reason=MAX_TOKENS`, zero output). Pinned both Gemini 3 models to `thinking_level="minimal"`, verified live to reliably fit the answer within this service's existing token budgets.

## Operational note

`gemini-3-flash-preview` is fully wired (allow-list, DB constraint, pricing, region routing, thinking config) but is **not** the default production model — live concurrent-load testing found it returns 429s above ~10 concurrent requests on the current GCP project quota. `gemini-3.1-flash-lite` did not show that ceiling across sequential (15 calls) and concurrent (5/10 concurrent) live testing and is the recommended model of the two for production traffic today.

## Test plan

- [x] Full test suite green (`pytest tests/ -q`)
- [x] `ruff check .` clean
- [x] Live-verified against the real Vertex AI API (not just mocked): region routing, `thinking_config` behavior, and the empty-response failure mode this PR fixes
- [x] Live streaming latency + stability benchmarks for `gemini-3.1-flash-lite` (15 sequential + up to 10 concurrent, zero errors)
- [x] Live concurrent-load test for `gemini-3-flash-preview` isolating its 429 ceiling (~10 concurrent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)