### PR TITLE
Gemini Live native-audio speech-to-speech models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ TTS_PROVIDER=elevenlabs
 TTS_API_KEY=
 ELEVENLABS_API_KEY=
 RIME_API_KEY=
+HUME_API_KEY=
 # Symmetric encryption key for agent.encrypted_elevenlabs_api_key (pgp_sym_encrypt).
 ELEVENLABS_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
 

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ alembic/versions/*.pyc
 # Local Claude Code subagent configs (personal dev workflow, not shared)
 .claude/agents/
 
+# Local-only Claude Code persona/approach file (personal dev workflow, not shared)
+.claude/Personality/
+
 # Mac
 .DS_Store
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ---
 
+## Local persona file
+
+If `.claude/Personality/SOUL.md` exists, read it before starting work. It's a
+local-only, gitignored file (`.claude/Personality/`, never pushed to GitHub)
+where the maintainer records how they want Claude to approach this specific
+codebase — mindset, priorities, and working style — as a complement to the
+concrete rules below. It is not a substitute for anything in this file: the
+architecture, conventions, and agent-routing rules here still apply in full:
+`SOUL.md` shapes judgment calls, it doesn't override documented behavior. If
+it's absent, proceed as normal; it's optional per-developer, not shared
+project configuration.
+
+---
+
 ## Knowledge base vault
 
 A local-only Obsidian vault documenting this backend lives adjacent to this repo at `../tgs-agent-be-vault/` (i.e. `/Users/mc/tgs-agent-be-vault/`), sibling to `tgs-agent-be/`. Start at `00 Home/Home.md`.

--- a/alembic/versions/20260817_widen_agent_llm_model_check_gemini_live.py
+++ b/alembic/versions/20260817_widen_agent_llm_model_check_gemini_live.py
@@ -1,0 +1,151 @@
+"""widen ck_agent_llm_model to include gemini live native-audio models
+
+Revision ID: 20260817_widen_llm_check_glive
+Revises: 20260816_widen_llm_check_g3
+Create Date: 2026-08-17
+
+Purpose
+-------
+``app/core/llm_models.py`` (the Python-level allow-list used to validate
+``Agent.llm_model`` at the API layer) now includes three new Google Gemini
+Live speech-to-speech native-audio models: ``gemini-live-2.5-flash-native-audio``,
+``gemini-live-2.5-flash-preview-native-audio-09-2025``, and
+``gemini-3.1-flash-live-preview``. The DB-level ``ck_agent_llm_model`` CHECK
+constraint — most recently widened by ``20260816_widen_llm_check_g3`` to a
+21-value snapshot — was never widened to match, so inserting/updating an
+agent with any of these new model IDs would violate the CHECK even though
+the application layer accepts them.
+
+This migration is purely additive: it drops and recreates
+``ck_agent_llm_model`` with the union of the prior 21-value snapshot plus
+the 3 new gemini-live IDs (24 total). No values are removed or renamed, so no
+existing row can violate the widened constraint — safe to apply without a
+backfill on a live multi-tenant table. The drop+recreate briefly requires a
+table-level lock while Postgres validates the new CHECK against existing
+rows, but on a boolean/string membership check on `agent` (not a huge
+table) this is expected to be fast; the definition change itself is
+otherwise the same additive-CHECK-widening pattern used by
+``20260816_widen_llm_check_g3``, ``20260815_widen_llm_check``, and, before
+them, ``20260602_schema_v2_completion`` for ``ck_agent_status_v2`` /
+``ck_callflow_direction``.
+
+Note: these three model IDs select an entirely different call pipeline
+(speech-to-speech, no external STT/TTS) — this migration only widens the
+CHECK so the value is storable; it does not change any pipeline behavior.
+
+Snapshot strategy
+------------------
+Per the same rationale as ``20260816_widen_llm_check_g3``, the allow-list
+used to build the CHECK SQL is a self-contained snapshot tuple in *this*
+file, not an import from ``app.core.llm_models`` — so future edits to that
+module (renames, removals) do not retroactively change what this historical
+migration replays during ``alembic upgrade``.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260817_widen_llm_check_glive"
+down_revision: Union[str, Sequence[str], None] = "20260816_widen_llm_check_g3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Union of the 20260816_widen_llm_check_g3 21-value snapshot plus the 3 new
+# Gemini Live native-audio model IDs added to
+# app.core.llm_models.ALLOWED_LLM_MODELS. Self-contained — do not import
+# app.core.llm_models (future renames there must not retroactively change
+# this migration's replay behavior).
+_ALLOWED_LLM_MODELS_AT_REVISION: tuple[str, ...] = (
+    # --- prior 21-value snapshot (20260816_widen_llm_check_g3), unchanged ---
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+    # --- new: Google Gemini Live native-audio family ---
+    "gemini-live-2.5-flash-native-audio",
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "gemini-3.1-flash-live-preview",
+)
+
+# The exact 21-value snapshot from 20260816_widen_llm_check_g3, needed to
+# restore the narrower constraint on downgrade.
+_PRIOR_ALLOWED_LLM_MODELS: tuple[str, ...] = (
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+)
+
+
+def _llm_check_sql(models: tuple[str, ...]) -> str:
+    """Build ck_agent_llm_model CHECK SQL from a given model snapshot."""
+    return "llm_model IS NULL OR llm_model IN (%s)" % ", ".join(
+        f"'{m}'" for m in models
+    )
+
+
+def _has_constraint(conn, table: str, constraint: str) -> bool:
+    return conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = 'public' AND table_name = :tbl AND constraint_name = :con)"
+        ),
+        {"tbl": table, "con": constraint},
+    ).scalar()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_ALLOWED_LLM_MODELS_AT_REVISION)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_PRIOR_ALLOWED_LLM_MODELS)
+    )

--- a/alembic/versions/20260817b_widen_agent_llm_model_check_openai_realtime.py
+++ b/alembic/versions/20260817b_widen_agent_llm_model_check_openai_realtime.py
@@ -1,0 +1,151 @@
+"""widen ck_agent_llm_model to include OpenAI Realtime speech-to-speech models
+
+Revision ID: 20260817_widen_llm_check_oair
+Revises: 20260817_widen_llm_check_glive
+Create Date: 2026-08-17
+
+Purpose
+-------
+``app/core/llm_models.py`` now includes two new OpenAI Realtime
+speech-to-speech native-audio models: ``gpt-realtime`` and
+``gpt-realtime-2``. The DB-level ``ck_agent_llm_model`` CHECK constraint —
+most recently widened by ``20260817_widen_llm_check_glive`` to a 24-value
+snapshot — was never widened to match, so inserting/updating an agent with
+either of these new model IDs would violate the CHECK even though the
+application layer accepts them.
+
+This migration is purely additive: it drops and recreates
+``ck_agent_llm_model`` with the union of the prior 24-value snapshot plus
+the 2 new OpenAI Realtime IDs (26 total). No values are removed or renamed,
+so no existing row can violate the widened constraint — safe to apply
+without a backfill on a live multi-tenant table. Same additive-CHECK-
+widening pattern used by ``20260817_widen_llm_check_glive``,
+``20260816_widen_llm_check_g3``, ``20260815_widen_llm_check``, and, before
+them, ``20260602_schema_v2_completion``.
+
+Note: these two model IDs select an entirely different call pipeline
+(speech-to-speech via OpenAI's Realtime API, no external STT/TTS) — this
+migration only widens the CHECK so the value is storable; it does not
+change any pipeline behavior.
+
+Snapshot strategy
+------------------
+Per the same rationale as the prior widening migrations, the allow-list
+used to build the CHECK SQL is a self-contained snapshot tuple in *this*
+file, not an import from ``app.core.llm_models`` — so future edits to that
+module (renames, removals) do not retroactively change what this historical
+migration replays during ``alembic upgrade``.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260817_widen_llm_check_oair"
+down_revision: Union[str, Sequence[str], None] = "20260817_widen_llm_check_glive"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Union of the 20260817_widen_llm_check_glive 24-value snapshot plus the 2
+# new OpenAI Realtime model IDs added to
+# app.core.llm_models.ALLOWED_LLM_MODELS. Self-contained — do not import
+# app.core.llm_models (future renames there must not retroactively change
+# this migration's replay behavior).
+_ALLOWED_LLM_MODELS_AT_REVISION: tuple[str, ...] = (
+    # --- prior 24-value snapshot (20260817_widen_llm_check_glive), unchanged ---
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+    "gemini-live-2.5-flash-native-audio",
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "gemini-3.1-flash-live-preview",
+    # --- new: OpenAI Realtime speech-to-speech native-audio family ---
+    "gpt-realtime",
+    "gpt-realtime-2",
+)
+
+# The exact 24-value snapshot from 20260817_widen_llm_check_glive, needed to
+# restore the narrower constraint on downgrade.
+_PRIOR_ALLOWED_LLM_MODELS: tuple[str, ...] = (
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+    "gemini-live-2.5-flash-native-audio",
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "gemini-3.1-flash-live-preview",
+)
+
+
+def _llm_check_sql(models: tuple[str, ...]) -> str:
+    """Build ck_agent_llm_model CHECK SQL from a given model snapshot."""
+    return "llm_model IS NULL OR llm_model IN (%s)" % ", ".join(
+        f"'{m}'" for m in models
+    )
+
+
+def _has_constraint(conn, table: str, constraint: str) -> bool:
+    return conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = 'public' AND table_name = :tbl AND constraint_name = :con)"
+        ),
+        {"tbl": table, "con": constraint},
+    ).scalar()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_ALLOWED_LLM_MODELS_AT_REVISION)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_PRIOR_ALLOWED_LLM_MODELS)
+    )

--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -311,7 +311,9 @@ def resolve_tts_runtime(
         if adapter_slug == "rime" and not voice_id:
             voice_id = "mistv2_Wildflower"
         elif adapter_slug == "hume" and not voice_id:
-            voice_id = "Male English Actor"
+            from app.services.hume_tts_service import HUME_DEFAULT_VOICE
+
+            voice_id = HUME_DEFAULT_VOICE
         settings.setdefault("language_code", language)
         return ResolvedTtsRuntime(
             adapter_slug=adapter_slug,

--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -28,6 +28,8 @@ _TICKET_TTS_TO_ADAPTER: dict[str, str] = {
     "11labs_byo": "elevenlabs",
     # "rime" now has its own adapter — no longer falls back to google.
     "rime": "rime",
+    # "hume" needs no entry — .get(slug, slug) already falls through unchanged
+    # since the ticket slug and adapter slug are identical.
 }
 
 def _coerce_float(value: Any, default: float) -> float:
@@ -115,9 +117,10 @@ def _decrypt_stored_api_key(
 
 
 def _ticket_tts_triad(agent: Agent) -> bool:
-    # Rime has a built-in default voice — allow ticket path even without explicit voice_id.
+    # Rime and Hume both have a built-in default voice — allow ticket path
+    # even without explicit voice_id.
     has_voice = bool(agent.tts_voice_external_id) or (
-        (agent.tts_provider_slug or "").lower() == "rime"
+        (agent.tts_provider_slug or "").lower() in ("rime", "hume")
     )
     return bool(agent.tts_provider_slug and agent.tts_language and has_voice)
 
@@ -304,9 +307,11 @@ def resolve_tts_runtime(
                     f"Agent {agent.id}: stored BYO ElevenLabs API key is corrupted or "
                     "unreadable. Re-save the API key in agent settings."
                 ) from exc
-        # For Rime: ensure default voice when none configured.
+        # For Rime/Hume: ensure default voice when none configured.
         if adapter_slug == "rime" and not voice_id:
             voice_id = "mistv2_Wildflower"
+        elif adapter_slug == "hume" and not voice_id:
+            voice_id = "Male English Actor"
         settings.setdefault("language_code", language)
         return ResolvedTtsRuntime(
             adapter_slug=adapter_slug,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -161,6 +161,8 @@ class TtsSettings(BaseModel):
     provider: str = Field(default="elevenlabs", validation_alias="TTS_PROVIDER")
     api_key: str = Field(default="", validation_alias="TTS_API_KEY")
     rime_api_key: str = Field(default="", validation_alias="RIME_API_KEY")
+    hume_api_key: str = Field(default="", validation_alias="HUME_API_KEY")
+    hume_sample_rate_hz: int = Field(default=48000, validation_alias="HUME_TTS_SAMPLE_RATE_HZ")
     elevenlabs_api_key: str = Field(default="", validation_alias="ELEVENLABS_API_KEY")
     elevenlabs_encryption_key: str = Field(
         default="", validation_alias="ELEVENLABS_ENCRYPTION_KEY"
@@ -464,6 +466,17 @@ class Settings(BaseSettings):
 
     # Rime Labs TTS Configuration
     RIME_API_KEY: str = ""
+
+    # Hume AI TTS Configuration
+    HUME_API_KEY: str = ""
+    # ASSUMED default — Hume's PCM streaming output sample rate is not
+    # documented publicly as of this integration (2026-08). 48000 Hz is a
+    # reasonable industry-standard guess for a modern neural TTS PCM stream,
+    # but MUST be verified against a real Hume account/API key before this
+    # goes to production traffic; override via env var if Hume support
+    # confirms a different value. Drives PCMStreamDownsampler's src_rate_hz
+    # when converting Hume's PCM16LE chunks down to mulaw 8kHz for Twilio.
+    HUME_TTS_SAMPLE_RATE_HZ: int = 48000
 
     # ElevenLabs Configuration
     ELEVENLABS_API_KEY: str = ""
@@ -1114,6 +1127,8 @@ class Settings(BaseSettings):
             provider=self.TTS_PROVIDER,
             api_key=self.TTS_API_KEY,
             rime_api_key=self.RIME_API_KEY,
+            hume_api_key=self.HUME_API_KEY,
+            hume_sample_rate_hz=self.HUME_TTS_SAMPLE_RATE_HZ,
             elevenlabs_api_key=self.ELEVENLABS_API_KEY,
             elevenlabs_encryption_key=self.ELEVENLABS_ENCRYPTION_KEY,
             enable_audio_tags=self.ENABLE_ELEVENLABS_AUDIO_TAGS,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -93,6 +93,9 @@ class LlmSettings(BaseModel):
     openai_api_key: str = Field(default="", validation_alias="OPENAI_API_KEY")
     openai_base_url: str = Field(default="", validation_alias="OPENAI_BASE_URL")
     openai_api_version: str = Field(default="", validation_alias="OPENAI_API_VERSION")
+    openai_realtime_transcription_model: str = Field(
+        default="whisper-1", validation_alias="OPENAI_REALTIME_TRANSCRIPTION_MODEL"
+    )
     # Gemini / Vertex
     gemini_api_key: str = Field(default="", validation_alias="GEMINI_API_KEY")
     google_application_credentials: str = Field(
@@ -449,6 +452,15 @@ class Settings(BaseSettings):
     DEFAULT_LLM_PROVIDER: str = "gemini"
     # OpenAI Configuration
     OPENAI_API_KEY: str = ""
+    # Input-audio transcription model for OpenAI Realtime sessions (separate
+    # from the main gpt-realtime*/gpt-realtime-2 model itself). Defaults to
+    # whisper-1 — OpenAI's oldest, most universally-enabled transcription
+    # model — since newer options like gpt-4o-mini-transcribe require
+    # per-project access that isn't guaranteed to be enabled (confirmed via
+    # a real call: model_not_found for gpt-4o-mini-transcribe on a project
+    # that otherwise has full Realtime API access). Override per-environment
+    # if a project has access to a better model.
+    OPENAI_REALTIME_TRANSCRIPTION_MODEL: str = "whisper-1"
 
     # Rime Labs TTS Configuration
     RIME_API_KEY: str = ""
@@ -1077,6 +1089,7 @@ class Settings(BaseSettings):
             openai_api_key=self.OPENAI_API_KEY,
             openai_base_url=self.OPENAI_BASE_URL,
             openai_api_version=self.OPENAI_API_VERSION,
+            openai_realtime_transcription_model=self.OPENAI_REALTIME_TRANSCRIPTION_MODEL,
             gemini_api_key=self.GEMINI_API_KEY,
             google_application_credentials=self.GOOGLE_APPLICATION_CREDENTIALS,
             google_cloud_project_id=self.GOOGLE_CLOUD_PROJECT_ID,

--- a/app/core/llm_models.py
+++ b/app/core/llm_models.py
@@ -48,6 +48,15 @@ ALLOWED_LLM_MODELS: Final[tuple[str, ...]] = (
     "gemini-live-2.5-flash-native-audio",
     "gemini-live-2.5-flash-preview-native-audio-09-2025",
     "gemini-3.1-flash-live-preview",
+    # OpenAI — Realtime speech-to-speech native-audio models (new). Same
+    # "NOT a text model" caveat as the Gemini Live family above: selecting
+    # one of these routes the whole call through OpenAI's Realtime API
+    # (caller audio in, OpenAI's native audio out, no external STT/TTS). See
+    # OPENAI_REALTIME_MODELS below and is_openai_realtime_model() for the
+    # routing predicate. `infer_llm_provider` already returns "openai" for
+    # any "gpt"-prefixed model — no change needed there.
+    "gpt-realtime",
+    "gpt-realtime-2",
     # Anthropic — existing
     "claude-3-5-sonnet",
     "claude-3-haiku",
@@ -107,6 +116,42 @@ def is_gemini_live_native_audio_model(model_name: str) -> bool:
     native-audio.
     """
     return (model_name or "") in GEMINI_LIVE_MODELS
+
+
+#: Per-model config for the OpenAI Realtime speech-to-speech family.
+#: Confirmed against the installed openai==2.36.0 SDK's own generated types
+#: (openai.types.realtime.call_accept_params's model Literal enum) — see
+#: app/services/openai_realtime_service.py for the session wrapper.
+#:
+#: - ``gpt-realtime``: the original flagship Realtime model (GA Aug 2025).
+#:   No `reasoning` config — the Realtime API's reasoning_effort knob is
+#:   documented as only applying to reasoning-capable Realtime models.
+#: - ``gpt-realtime-2``: newer reasoning-capable generation. Capped to a low
+#:   reasoning effort by default (see openai_realtime_service.py's
+#:   _REASONING_EFFORT_BY_MODEL) for the same voice-turn-latency reason
+#:   gpt-5/gpt-5-mini's Chat Completions reasoning_effort is capped in
+#:   app/services/openai_service.py — an uncapped reasoning budget on a
+#:   live voice turn risks noticeable dead air before the model starts
+#:   speaking.
+#:
+#: Both models use plain API-key auth (settings.OPENAI_API_KEY via
+#: app.core.openai_client.get_async_openai_client) — no ephemeral-token
+#: dance, since this backend always proxies rather than handing a token to
+#: a browser/mobile client directly.
+OPENAI_REALTIME_MODELS: Final[tuple[str, ...]] = ("gpt-realtime", "gpt-realtime-2")
+
+
+def is_openai_realtime_model(model_name: str) -> bool:
+    """
+    Return True if ``model_name`` is one of the OpenAI Realtime
+    speech-to-speech native-audio models (:data:`OPENAI_REALTIME_MODELS`).
+
+    Exact-match check, mirroring is_gemini_live_native_audio_model()'s
+    reasoning — these models require a completely different call pipeline
+    (caller audio in, OpenAI's own native audio out, no external STT/TTS),
+    not just another text-generation ``gpt-*`` model.
+    """
+    return (model_name or "") in OPENAI_REALTIME_MODELS
 
 
 def infer_llm_provider(model_name: str) -> str:

--- a/app/core/llm_models.py
+++ b/app/core/llm_models.py
@@ -38,6 +38,16 @@ ALLOWED_LLM_MODELS: Final[tuple[str, ...]] = (
     # Google Gemini — Gemini 3 family (new)
     "gemini-3-flash-preview",
     "gemini-3.1-flash-lite",
+    # Google Gemini — Live/native-audio speech-to-speech models (new). These
+    # are NOT text models — selecting one routes the whole call through a
+    # completely different pipeline (caller audio in, Gemini's native audio
+    # out, no external STT/TTS). See GEMINI_LIVE_MODELS below for the
+    # per-model auth/location config and is_gemini_live_native_audio_model()
+    # for the routing predicate. `infer_llm_provider` still returns "gemini"
+    # for these (they start with "gemini") — no change needed there.
+    "gemini-live-2.5-flash-native-audio",
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "gemini-3.1-flash-live-preview",
     # Anthropic — existing
     "claude-3-5-sonnet",
     "claude-3-haiku",
@@ -55,6 +65,48 @@ def is_allowed_llm_model(model: str) -> bool:
 def allowed_llm_models() -> list[str]:
     """Return a fresh list copy — safe to embed in JSON responses."""
     return list(ALLOWED_LLM_MODELS)
+
+
+#: Per-model auth/location config for the Gemini Live native-audio family.
+#: Confirmed live against the real API (2026-08-17) — each model has a
+#: *different* auth/location requirement, so this MUST stay a per-model
+#: table rather than collapsing to one global auth mode:
+#:
+#: - ``gemini-live-2.5-flash-native-audio`` / \
+#:   ``gemini-live-2.5-flash-preview-native-audio-09-2025``: Vertex AI / ADC,
+#:   regional ``us-central1`` only (confirmed NOT available on ``global`` —
+#:   the opposite restriction from the Gemini 3 text family in
+#:   ``vertex_gemini_service.py``'s ``_GLOBAL_ONLY_MODELS``).
+#: - ``gemini-3.1-flash-live-preview``: Gemini Developer API / API key
+#:   (``settings.GEMINI_API_KEY``) — confirmed NOT available on Vertex AI for
+#:   this project in any region (404 across 4 locations x 6 model-ID
+#:   spellings). This is a deliberate, scoped exception to this codebase's
+#:   otherwise Vertex/ADC-only convention for Gemini models — approved by the
+#:   user. The other two models must never read ``GEMINI_API_KEY``.
+GEMINI_LIVE_MODELS: Final[dict[str, dict[str, str | None]]] = {
+    "gemini-live-2.5-flash-native-audio": {"auth": "vertex", "location": "us-central1"},
+    "gemini-live-2.5-flash-preview-native-audio-09-2025": {
+        "auth": "vertex",
+        "location": "us-central1",
+    },
+    "gemini-3.1-flash-live-preview": {"auth": "api_key", "location": None},
+}
+
+
+def is_gemini_live_native_audio_model(model_name: str) -> bool:
+    """
+    Return True if ``model_name`` is one of the Gemini Live speech-to-speech
+    native-audio models (:data:`GEMINI_LIVE_MODELS`).
+
+    Exact-match check — these models require a completely different call
+    pipeline (caller audio in, Gemini's own native audio out, no external
+    STT/TTS), not just another text-generation ``gemini-*`` model routed
+    through the usual streaming-text pipeline. Do not loosen this to a
+    prefix/substring match: other ``gemini-*``/``gemini-live-*`` strings
+    that are not in the allow-list must not be silently treated as
+    native-audio.
+    """
+    return (model_name or "") in GEMINI_LIVE_MODELS
 
 
 def infer_llm_provider(model_name: str) -> str:

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -182,6 +182,43 @@ def get_rime_api_key() -> str:
 
 
 @lru_cache(maxsize=1)
+def get_hume_api_key() -> str:
+    """
+    Return the Hume AI TTS API key appropriate for the current environment.
+
+    - production/staging → GCP Secret Manager (secret name: HUME_API_KEY), with
+      env-var fallback so deployments that set the var directly still work.
+    - development → plain env-var / .env value.
+
+    Raises ValueError (development) or RuntimeError (staging/production) if no
+    key is available so callers fail at startup rather than sending unauthenticated
+    requests mid-call.
+    """
+    env = settings.ENVIRONMENT.lower()
+
+    if env in ("production", "staging"):
+        secret_key = _fetch_from_secret_manager("HUME_API_KEY")
+        if secret_key:
+            return secret_key
+        # Fall back to env var (covers deployments that inject the var via CI/CD).
+        env_key = getattr(settings, "HUME_API_KEY", "") or ""
+        if env_key.strip():
+            return env_key.strip()
+        raise RuntimeError(
+            f"HUME_API_KEY unavailable in {env}. "
+            "Set it in GCP Secret Manager (secret: HUME_API_KEY) or as an env var."
+        )
+
+    # development — plain env var / .env
+    env_key = getattr(settings, "HUME_API_KEY", "") or ""
+    if not env_key.strip():
+        raise ValueError(
+            "HUME_API_KEY is not set. Add it to your .env file for local development."
+        )
+    return env_key.strip()
+
+
+@lru_cache(maxsize=1)
 def _load_hubspot_production_credentials() -> Tuple[str, str]:
     """Fetch HubSpot OAuth app credentials from Secret Manager (cached after first call)."""
     client_id = _fetch_from_secret_manager("HUBSPOT_CLIENT_ID") or settings.HUBSPOT_CLIENT_ID

--- a/app/main.py
+++ b/app/main.py
@@ -31,7 +31,7 @@ def create_app() -> FastAPI:
     from app.utils.arq_pool import init_arq_pool
     from app.utils.rate_limiter import init_rate_limiter
     from app.core.config import settings
-    from app.core.secret_manager import get_rime_api_key
+    from app.core.secret_manager import get_hume_api_key, get_rime_api_key
     from app.core.shutdown import graceful_shutdown
     from app.core.exception_handlers import register_exception_handlers
     from app.middleware.api_key_middleware import ApiKeyMiddleware
@@ -85,6 +85,20 @@ def create_app() -> FastAPI:
                 raise
             else:
                 logger.warning("Rime TTS not configured: %s — fine if TTS_PROVIDER is not 'rime'", exc)
+
+        try:
+            get_hume_api_key()
+            logger.info("Hume TTS API key configured")
+        except (ValueError, RuntimeError) as exc:
+            # Hume is opt-in (not seeded as an always-available platform default
+            # the way Rime is) — only hard-fail startup when it's actually the
+            # configured default provider. Mirrors the Rime check above.
+            env = settings.ENVIRONMENT.lower()
+            if env in ("staging", "production") and settings.TTS_PROVIDER == "hume":
+                logger.error("Hume TTS misconfigured: %s", exc)
+                raise
+            else:
+                logger.warning("Hume TTS not configured: %s — fine if TTS_PROVIDER is not 'hume'", exc)
 
         if settings.LIVEKIT_ENABLED:
             from app.core.secret_manager import get_livekit_credentials

--- a/app/main.py
+++ b/app/main.py
@@ -89,6 +89,19 @@ def create_app() -> FastAPI:
         try:
             get_hume_api_key()
             logger.info("Hume TTS API key configured")
+            # HUME_TTS_SAMPLE_RATE_HZ's default (48000) is an ASSUMED value,
+            # not confirmed against Hume's public docs -- if the actual
+            # stream rate differs, PCMStreamDownsampler downsamples at the
+            # wrong ratio and every Twilio call using Hume produces
+            # silently garbled (pitch-shifted/distorted) audio with no
+            # runtime error. Surface this loudly at startup so operators
+            # verify against a real Hume account before production traffic.
+            logger.warning(
+                "Hume TTS sample rate is assumed to be %d Hz (unverified against "
+                "Hume's public docs) — confirm against a real Hume account before "
+                "production traffic. Override via HUME_TTS_SAMPLE_RATE_HZ if different.",
+                settings.HUME_TTS_SAMPLE_RATE_HZ,
+            )
         except (ValueError, RuntimeError) as exc:
             # Hume is opt-in (not seeded as an always-available platform default
             # the way Rime is) — only hard-fail startup when it's actually the

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -100,7 +100,8 @@ from sqlalchemy.orm import Session
 import json
 import base64
 import asyncio
-from typing import List
+import dataclasses
+from typing import Any, List
 import time
 from datetime import datetime, date
 import uuid
@@ -211,6 +212,30 @@ _EMAIL_AGENT_PROMPT_FOR_EXTENDED_STT_RE = re.compile(
     r"\bspell\b.*\b(?:e-?mail|email)|\b(?:e-?mail|email)\b.*\bspell\b"
     r")",
 )
+
+
+@dataclasses.dataclass
+class _SystemPromptBuildResult:
+    """
+    Everything build_system_prompt()'s internals compute that
+    generate_and_stream_response() also needs after the call returns.
+
+    Returned directly rather than stashed as self._sp_* instance attributes:
+    a stash-on-self would be a latent cross-turn data-corruption bug waiting
+    to happen the moment any await is introduced between the
+    build_system_prompt() call and the read-back (two STT-finals on the same
+    handler CAN run concurrently — see VoiceOrchestrator._on_final spawning
+    each as its own asyncio.Task). A returned value has no such window.
+    """
+
+    system_prompt: str
+    turn_context: Any
+    booking_intent_turn: bool
+    follow_up_active: bool
+    low_latency_fastpath: bool
+    vertex_kb_context: str | None
+    llm_runtime: Any
+    rag_trace: Any
 
 
 class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin, FlowPipelineMixin):
@@ -1368,6 +1393,529 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin,
             agent_id=rag_agent_scope,
         )
 
+    async def build_system_prompt(self, user_text: str, confidence: float) -> str:
+        """Public string-returning entry point — see _build_system_prompt_full
+        for the full result (used internally by generate_and_stream_response,
+        which also needs the auxiliary values computed along the way).
+        Called directly by VoiceOrchestrator._start_gemini_live_session for
+        the Gemini Live native-audio session's system_instruction."""
+        return (await self._build_system_prompt_full(user_text, confidence)).system_prompt
+
+    async def _build_system_prompt_full(
+        self, user_text: str, confidence: float
+    ) -> "_SystemPromptBuildResult":
+        """
+        Assemble the full system prompt for a turn: booking/follow-up intent
+        detection, LLM-runtime resolution, latency-fastpath decision, quick-ack
+        dispatch, RAG/KB context retrieval, conversation history windowing,
+        base/agent-override/model-override prompt branching, Vertex KB
+        attachment, A/B prompt override, call-policy block, and the current
+        date/time + user-signals prepend.
+
+        Behavior-preserving extraction from ``generate_and_stream_response``
+        (which used to build this prompt inline) — reused as-is by that
+        method's streaming-text path AND by the Gemini Live native-audio
+        session's ``system_instruction`` at session start (see
+        ``VoiceOrchestrator._start_gemini_live_session``, which calls this
+        directly on a ``BidirectionalStreamHandler`` instance for Twilio
+        calls — never ``ConversationOrchestrator.build_system_prompt``, which
+        is a separate, LiveKit-browser-only implementation with materially
+        different content).
+
+        Deliberately does NOT handle the ``is_greeting`` early-return branch —
+        that happens earlier in ``generate_and_stream_response``, before this
+        method would ever be reached, so an empty ``user_text`` here (as used
+        for the Gemini Live session-start call) is treated as an ordinary,
+        non-greeting turn.
+
+        A handful of locals computed here are also needed by the LLM
+        dispatch / Calendly logic that runs after this returns in
+        ``generate_and_stream_response`` (``turn_context``,
+        ``booking_intent_turn``, ``follow_up_active``,
+        ``low_latency_fastpath``, ``_vertex_kb_context``, ``_llm_runtime``).
+        Recomputing them there would re-run side-effecting/expensive work
+        (the quick-ack fire-and-forget task, the RAG prefetch-consume-once
+        read) a second time, so instead they are stashed on ``self`` here and
+        read back by the caller immediately after the call — see the
+        ``_sp_*`` attributes below.
+        """
+        import json
+        from datetime import datetime, timezone
+
+        self._voice_metrics.start_generation()
+        self._metric_gen_start_ts = time.perf_counter()
+        _stt_to_gen_ms = (self._metric_gen_start_ts - self._metric_stt_final_ts) * 1000
+        if self._metric_stt_final_ts > 0:
+            logger.info("[Metrics] stt_final_to_gen_start=%.0f ms", _stt_to_gen_ms)
+        slowpath_started_at = time.perf_counter()
+
+        def _remaining_slowpath_budget(default_timeout: float) -> float:
+            budget = float(getattr(settings, "VOICE_SLOWPATH_BUDGET_SEC", 0.55) or 0.55)
+            budget = max(0.12, min(3.0, budget))
+            elapsed = time.perf_counter() - slowpath_started_at
+            remaining = max(0.05, budget - elapsed)
+            return min(max(0.05, default_timeout), remaining)
+
+        booking_intent_turn = self._is_booking_intent_turn(user_text)
+        follow_up_active = bool(
+            self.call_session
+            and self.call_session.call_metadata
+            and self.call_session.call_metadata.get("appointment_id")
+        )
+        _llm_runtime = resolve_llm_runtime(self.agent)
+        _use_vertex_llm = (_llm_runtime.provider_slug or "").lower() == "gemini"
+        _vertex_kb_context = ""
+        low_latency_fastpath = self._should_use_latency_fastpath(
+            user_text, booking_intent_turn
+        )
+
+        # Fire quick-ack immediately (fire-and-forget) so the user hears audio
+        # while the LLM+RAG+KB pipeline runs.  Only on the slow path (fastpath
+        # queries have sub-500ms LLM TTFT so a quick-ack would finish before the
+        # LLM chunk is ready, creating a silence gap rather than masking latency).
+        # In V2 TtsPipeline, synthesis is parallel: the LLM's first chunk starts
+        # synthesising in the background while quick-ack is still playing, so by
+        # the time quick-ack ends the real audio is typically already ready.
+        if user_text and not low_latency_fastpath:
+            asyncio.create_task(self._send_quick_acknowledgement(user_text))
+
+        turn_context = build_turn_context(
+            user_text,
+            confidence,
+            booking_context_active=self._is_booking_context_active(user_text),
+            is_final=True,
+        )
+
+        # ------- RAG: build knowledge base context in voice layer -------
+        tenant_uuid = self.call_session.tenant_id if self.call_session else None
+        agent_uuid = self.agent.id if self.agent else None
+        rag_agent_scope = None if (self.agent and self.agent.is_inbound_agent) else agent_uuid
+
+        # RAG retrieval: use prefetched result when available (fired on interim
+        # so it overlaps Deepgram endpointing), otherwise run synchronously.
+        rag_context_block = ""
+        rag_trace: dict = {}
+        _prefetch = self._rag_prefetch_task
+        self._rag_prefetch_task = None  # Consume once per turn
+        if low_latency_fastpath:
+            rag_trace = {"status": "skipped_fastpath"}
+            if _prefetch and not _prefetch.done():
+                _prefetch.cancel()
+        else:
+            try:
+                if _prefetch is not None:
+                    if _prefetch.done():
+                        # Already finished — zero-cost read
+                        rag_context_block, rag_trace = _prefetch.result()
+                        logger.debug("[RAG] used prefetch result (done)")
+                    else:
+                        # Still running — wait with reduced timeout (most work already done)
+                        prefetch_wait_cap = float(
+                            getattr(settings, "VOICE_RAG_PREFETCH_AWAIT_SEC", 0.18) or 0.18
+                        )
+                        rag_context_block, rag_trace = await asyncio.wait_for(
+                            asyncio.shield(_prefetch),
+                            timeout=_remaining_slowpath_budget(
+                                min(max(0.05, prefetch_wait_cap), settings.RAG_RETRIEVAL_TIMEOUT_SEC)
+                            ),
+                        )
+                        logger.debug("[RAG] awaited in-flight prefetch")
+                else:
+                    # No prefetch fired (e.g., very short utterance, final-only path)
+                    loop = asyncio.get_running_loop()
+
+                    def _build_rag():
+                        return build_rag_context_block_with_trace(
+                            user_text=user_text,
+                            tenant_id=tenant_uuid,
+                            agent_id=rag_agent_scope,
+                        )
+
+                    rag_context_block, rag_trace = await asyncio.wait_for(
+                        loop.run_in_executor(None, _build_rag),
+                        timeout=_remaining_slowpath_budget(settings.RAG_RETRIEVAL_TIMEOUT_SEC),
+                    )
+            except asyncio.TimeoutError:
+                rag_context_block, rag_trace = build_rag_context_block_with_trace(
+                    user_text="",
+                    tenant_id=tenant_uuid,
+                    agent_id=rag_agent_scope,
+                )
+                rag_trace["status"] = "timeout"
+                rag_trace["timeout"] = True
+            except Exception as e:
+                logger.error("RAG context build failed unexpectedly: %s", e, exc_info=True)
+                rag_context_block, rag_trace = build_rag_context_block_with_trace(
+                    user_text="",
+                    tenant_id=tenant_uuid,
+                    agent_id=rag_agent_scope,
+                )
+                rag_trace["status"] = "failure"
+                rag_trace["error"] = str(e)
+
+        # Use call-start-cached KB blocks (fetched once in _prefetch_kb_blocks_at_call_start).
+        # These are agent/tenant-level and don't change during the call, so serving
+        # them from cache costs 0ms versus the previous 50-200ms parallel executor fetch.
+        # Fall back to live fetch only if the cache background task hasn't finished yet
+        # (race on the very first turn of an extremely fast caller — rare in practice).
+        inbound_kb_docs_context_block = ""
+        if not low_latency_fastpath:
+            if self._kb_cache_ready:
+                inbound_kb_docs_context_block = self._cached_inbound_kb_block
+            else:
+                skip_live_kb = bool(
+                    getattr(settings, "VOICE_SKIP_LIVE_KB_FETCH_ON_COLD_START", True)
+                )
+                if skip_live_kb:
+                    logger.debug("[KB] cache cold; skipping live fetch for latency budget")
+                else:
+                    # Cache not ready yet — live fetch as fallback.
+                    _loop = asyncio.get_running_loop()
+
+                    async def _fetch_inbound_kb_live() -> str:
+                        if not (self.agent and self.agent.is_inbound_agent and tenant_uuid and agent_uuid):
+                            return ""
+                        try:
+                            return await _loop.run_in_executor(
+                                None,
+                                lambda: agent_service.build_inbound_kb_documents_context_block(
+                                    db=self.db, inbound_agent_id=agent_uuid, tenant_id=tenant_uuid,
+                                ),
+                            )
+                        except Exception as exc:
+                            logger.warning("KB live-fetch (inbound) failed: %s", exc)
+                            return ""
+
+                    try:
+                        inbound_kb_docs_context_block = await asyncio.wait_for(
+                            _fetch_inbound_kb_live(),
+                            timeout=_remaining_slowpath_budget(0.25),
+                        )
+                    except asyncio.TimeoutError:
+                        logger.debug("[KB] live fetch timeout; continuing without live KB blocks")
+                    except Exception as exc:
+                        logger.debug("[KB] live fetch failed; continuing without live KB blocks: %s", exc)
+
+        # One-line RAG summary (safe: no chunk text, no secrets)
+        try:
+            logger.info(
+                "RAG trace summary: status=%s timeout=%s initial=%s filtered=%s retrieve_error=%s",
+                rag_trace.get("status"),
+                rag_trace.get("timeout"),
+                rag_trace.get("initial_retrieved_count"),
+                rag_trace.get("filtered_count"),
+                rag_trace.get("retrieve_error"),
+            )
+        except Exception:  # noqa: S110 - logging must never break voice calls
+            pass
+        
+        # Build history text from in-memory cache (avoids re-parsing the growing
+        # call_transcript JSON on every turn — O(n) JSON parse that gets slower
+        # as the call continues).  _conversation_history_cache is appended to
+        # directly by _add_to_transcript so it's always up-to-date.
+        # Fallback: if cache is empty but DB has a transcript, seed from DB once.
+        if not self._conversation_history_cache and self.call_session and self.call_session.call_transcript:
+            try:
+                raw = self.call_session.call_transcript
+                parsed = json.loads(raw) if isinstance(raw, str) else raw
+                for msg in (parsed or []):
+                    if isinstance(msg, dict):
+                        role = msg.get("role", "")
+                        content = msg.get("content") or msg.get("message", "")
+                        mtype = msg.get("message_type", "")
+                        if content and role in ("client", "agent") and mtype not in ("greeting", "system", "status"):
+                            self._conversation_history_cache.append((role, content))
+            except Exception as exc:
+                logger.debug("Failed to seed conversation history cache from DB transcript: %s", exc)
+
+        history_text = ""
+        if self._conversation_history_cache:
+            try:
+                filtered = self._conversation_history_cache
+
+                # Booking flows use a slightly wider window to keep service/date/slot
+                # in context, but capped at 20 to avoid prompt bloat that inflates LLM TTFT.
+                # (Previous default of 39 was adding ~1000 tokens to the prompt on long calls.)
+                max_msgs = getattr(self, "HISTORY_MAX_MESSAGES", 50)
+                if low_latency_fastpath:
+                    # Keep at least 12 on fast path — intake flows span 6+ phases and
+                    # cutting to 6 drops early context (name, issue, location already given),
+                    # causing the agent to re-ask questions the caller already answered.
+                    max_msgs = min(max_msgs, 60)
+                if self._is_booking_context_active(user_text):
+                    max_msgs = min(max(max_msgs, 60), 60)
+                if len(filtered) > max_msgs:
+                    filtered = filtered[-max_msgs:]
+
+                history_text = "\n".join(
+                    f"{role.capitalize()}: {content}" for role, content in filtered
+                )
+            except Exception:
+                history_text = ""
+
+        if _use_vertex_llm:
+            history_text = (
+                "(Prior conversation turns are provided separately — "
+                "maintain continuity; do not re-ask answered questions.)"
+            )
+        
+        booking_memory_block = self._build_booking_memory_block()
+
+        # Build system prompt with agent personality + history
+        agent_name = self.agent.name if self.agent and self.agent.name else "AI Assistant"
+        agent_language = self.agent.language if self.agent and self.agent.language else "en"
+        v_add = ""
+        if self.call_session and self.call_session.call_metadata:
+            voice_ctx = self.call_session.call_metadata.get("voice_dynamic_context")
+            if isinstance(voice_ctx, dict):
+                v_add = (voice_ctx.get("system_prompt_addendum") or "").strip()
+        v_block = (
+            f"\n\n# THIS CALL — CANDIDATE & ROLE\n{v_add}\n"
+            if v_add
+            else ""
+        )
+        tts_provider = getattr(self.agent, "tts_provider", None) if self.agent else None
+        tts_provider_slug = (getattr(tts_provider, "slug", None) or "").lower()
+        elevenlabs_audio_tags_enabled = supports_elevenlabs_audio_tags(tts_provider_slug)
+        if elevenlabs_audio_tags_enabled:
+            output_plain_text_rule, no_ssml_rule_base, no_ssml_rule = (
+                get_elevenlabs_voice_prompt_rule_lines()
+            )
+        else:
+            output_plain_text_rule = (
+                "- OUTPUT PLAIN TEXT ONLY: Do NOT output SSML, XML, or any tags. "
+                "Prosody is handled by the system."
+            )
+            no_ssml_rule_base = (
+                "4. NO SSML: Do NOT output <speak>, <prosody>, or any XML tags. Plain text only."
+            )
+            no_ssml_rule = "3. NO SSML: Plain text only. No <speak>, <prosody>, or XML."
+        elevenlabs_audio_tag_block = build_elevenlabs_audio_tag_prompt_block(tts_provider_slug)
+        # When ElevenLabs audio tags are enabled, the authoritative rule lives solely in
+        # elevenlabs_audio_tag_block above — do not also emit a contradictory generic
+        # "never use bracket tags" line. Only non-ElevenLabs (or disabled) calls need it.
+        no_bracket_tags_line = (
+            ""
+            if elevenlabs_audio_tags_enabled
+            else (
+                "- NO BRACKET TAGS: Never output bracketed tags like [pause], [laugh], [breathes], "
+                "[excited], [1], [2], or any similar annotation. These will not be rendered — they "
+                "will be read aloud literally."
+            )
+        )
+
+        # Inbound: opening may play once via TTS at pickup — do not instruct LLM to repeat verbatim on every "hi".
+        _inbound_call = (
+            self.call_session is not None
+            and (self.call_session.call_type or "").lower() == "inbound"
+        )
+        _has_opening_cfg = bool(self.agent) and (
+            (getattr(self.agent, "greeting_message", None) or "").strip()
+            or (getattr(self.agent, "first_message", None) or "").strip()
+        )
+        greeting_instruction_block = (
+            "\n- GREETING: A short opening may play once automatically at call start (inbound). "
+            "If the caller says hi, hello, or similar later, acknowledge in one brief phrase only — "
+            "do not repeat the full opening greeting verbatim.\n"
+            if (_inbound_call and _has_opening_cfg)
+            else ""
+        )
+
+        _recruitment_screening_block = ""
+        if self._jd_recruitment_screening_active():
+            _recruitment_screening_block = """
+# RECRUITMENT OUTBOUND SCREENING (THIS CALL — OVERRIDES CONFLICTING GENERIC RULES)
+- If the user says not interested, wrong number, wrong person, wrong call, not available, stop calling, or cannot do this now (clear no) — reply with ONE short polite sentence and end with [END_CALL] only. No follow-up questions. No persuasion.
+- Never ask a question that is already answered in "Previous conversation" above; move to the next step in YOUR ROLE block.
+- On successful completion of the full screening per YOUR ROLE block, your last reply must include [SCREENING_QUALIFIED] immediately before [END_CALL] as instructed there.
+- If an intro already played at call start, do not repeat the same full intro; continue the flow.
+"""
+
+        # No business facts source remains; always inject the "do not invent" guard
+        # so the LLM never fabricates business details.
+        _bk_block = (
+            "# AUTHORITATIVE BUSINESS FACTS\n"
+            "No verified business facts are loaded for this call.\n"
+            "CRITICAL: Do NOT invent or assume ANY business details (name, address, phone, "
+            "email, services, prices, hours, or any other specifics).\n"
+            "If the caller asks about the business, say that specific information is not "
+            "available to you right now and offer to help in another way."
+        )
+
+        if _use_vertex_llm:
+            from app.voice.llm_prompt_builder import build_kb_context_for_vertex
+
+            _vertex_kb_context = build_kb_context_for_vertex(
+                inbound_kb_docs_context_block,
+                "",
+                empty_guard=_bk_block,
+            )
+            inbound_kb_docs_context_block = ""
+            _bk_block = (
+                "# AUTHORITATIVE BUSINESS FACTS\n"
+                "Business facts and inbound documents are attached as knowledge context "
+                "with each user message — apply grounding rules using that context.\n"
+            )
+
+        # Base prompt for phone conversations (voice-first, plain text only, no SSML)
+        base_prompt = f"""# ROLE
+You are {agent_name}, having a real-time phone call with a human.
+{v_block}
+# STYLE & TONE
+- VOICE-FIRST: Your output is for Text-to-Speech. Use short, punchy sentences.
+- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
+- CONCISE: Max 20 words per response unless explaining something complex.
+- NO ROBOT TALK: Avoid "As an AI" or formal greetings. Use "Hey," "Hi," or "Hello."
+{output_plain_text_rule}
+{no_bracket_tags_line}
+- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").{greeting_instruction_block}
+# CONVERSATION STATE
+Previous conversation:
+{history_text}
+
+{booking_memory_block}
+{rag_context_block}
+{inbound_kb_docs_context_block}
+{_recruitment_screening_block}
+# CRITICAL RULES
+1. CONVERSATION CONTINUITY: Read "Previous conversation" above before every reply. Any information already given by the caller (name, location, issue, timing) is still valid — do not ask for it again. Do not restart from the beginning of your flow mid-call. If the caller corrects or updates a previously given answer (e.g., corrects their name), acknowledge it and continue from the current step, not step one.
+2. NO REPETITION: Never ask a question that was already asked and answered in the transcript. Move to the next unanswered item only.
+3. HANDLING SILENCE: If the user says something vague, ask a single clarifying question.
+4. TERMINATION: When the objective is met, say a friendly goodbye and end your response with exactly [END_CALL].
+5. BUSINESS FACTS: For any question about the business name, address, phone, email, website, services, or pricing — answer using AUTHORITATIVE BUSINESS FACTS and, when present in this prompt, KNOWLEDGE BASE CONTEXT; both are authoritative sources for this call regardless of where each appears in this prompt. Never say you don't know if the answer is there. Never invent details that are not written in either.
+6. SERVICE SCOPE: Strictly follow "BUSINESS SCOPE & POLICY — STRICT RULES" inside AUTHORITATIVE BUSINESS FACTS. Only offer the services listed there. If the caller asks for something we don't offer, politely decline and pivot to what we actually do.
+7. SERVICE AREA: If Service Areas are listed and restricted and the caller is outside them, apologize, briefly name the areas we cover, say a short goodbye, and end your response with exactly [END_CALL]. If Service Areas describe global/remote/worldwide coverage, never refuse based on location.
+{no_ssml_rule_base}
+
+{elevenlabs_audio_tag_block}
+
+{_bk_block}
+# GOAL
+Continue the conversation based on the history above. Be {agent_name}."""
+
+        # A/B prompt testing: variant + resolved prompt text are locked onto
+        # call_metadata at dispatch time (see ab_testing_service) and never
+        # re-resolved mid-call, so the same variant is used for the whole call.
+        ab_prompt_override = None
+        if self.call_session and self.call_session.call_metadata:
+            ab_prompt_override = self.call_session.call_metadata.get("ab_prompt_text")
+
+        # Use agent's custom system prompt if available, otherwise use base prompt
+        if self.agent and self.agent.system_prompt:
+            # Agent has custom system prompt - grounding rules placed BEFORE custom
+            # instructions so factual constraints cannot be overridden by agent config.
+            effective_custom_prompt = ab_prompt_override or self.agent.system_prompt
+            system_prompt = f"""# ROLE
+You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
+
+# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING CUSTOM INSTRUCTIONS)
+These rules override any conflicting custom instructions below. Never deviate from them.
+1. BUSINESS FACTS: Answer questions about business name, address, phone, email, website, services, or pricing using AUTHORITATIVE BUSINESS FACTS and, when present in this prompt, KNOWLEDGE BASE CONTEXT — both are authoritative sources for this call regardless of where each appears in this prompt. Never invent or assume any detail not explicitly written in either. If a fact is absent from both, say it is not available.
+2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
+3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
+4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
+
+{_bk_block}
+
+# CUSTOM INSTRUCTIONS
+{effective_custom_prompt}
+{v_block}
+# STYLE & TONE
+- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
+- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
+{output_plain_text_rule}
+{no_bracket_tags_line}
+- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").{greeting_instruction_block}
+# CONVERSATION STATE
+Previous conversation:
+{history_text}
+
+{booking_memory_block}
+{rag_context_block}
+{inbound_kb_docs_context_block}
+{_recruitment_screening_block}
+# CRITICAL RULES
+1. CONVERSATION CONTINUITY: Read "Previous conversation" above before every reply. Any information the caller already gave (name, location, issue, timing) is still valid — do not ask for it again, and do not restart your intake flow from the beginning mid-call. If the caller corrects a previously given answer (e.g., corrects their name), acknowledge it and continue from the current step, not step one.
+2. NO REPETITION: Never ask a question that was already asked and answered in the transcript above. Move to the next unanswered item only.
+3. TERMINATION: When all objectives from your custom instructions are complete, say a friendly goodbye and end your response with exactly [END_CALL].
+{no_ssml_rule}
+
+{elevenlabs_audio_tag_block}
+
+# GOAL
+Follow your custom instructions. Continue from the history above. Be {agent_name}."""
+        elif self.agent and self.agent.model and self.agent.model.system_prompt:
+            # Model has system prompt - grounding rules placed BEFORE model instructions.
+            effective_model_prompt = ab_prompt_override or self.agent.model.system_prompt
+            system_prompt = f"""# ROLE
+You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
+
+# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING MODEL INSTRUCTIONS)
+These rules override any conflicting model instructions below. Never deviate from them.
+1. BUSINESS FACTS: Answer questions about business name, address, phone, email, website, services, or pricing using AUTHORITATIVE BUSINESS FACTS and, when present in this prompt, KNOWLEDGE BASE CONTEXT — both are authoritative sources for this call regardless of where each appears in this prompt. Never invent or assume any detail not explicitly written in either. If a fact is absent from both, say it is not available.
+2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
+3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
+4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
+
+{_bk_block}
+
+# MODEL INSTRUCTIONS
+{effective_model_prompt}
+{v_block}
+# STYLE & TONE
+- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
+- NATURAL: Use fillers like "uhm," "well," "I see" occasionally.
+{output_plain_text_rule}
+{no_bracket_tags_line}{greeting_instruction_block}
+# CONVERSATION STATE
+Previous conversation:
+{history_text}
+
+{booking_memory_block}
+{rag_context_block}
+{inbound_kb_docs_context_block}
+# CRITICAL RULES
+1. CONVERSATION CONTINUITY: Read "Previous conversation" above before every reply. Any information the caller already gave (name, location, issue, timing) is still valid — do not ask for it again, and do not restart your intake flow from the beginning mid-call. If the caller corrects a previously given answer (e.g., corrects their name), acknowledge it and continue from the current step, not step one.
+2. NO REPETITION: Never ask a question that was already asked and answered in the transcript above. Move to the next unanswered item only.
+3. TERMINATION: When all objectives are complete, say a friendly goodbye and end your response with exactly [END_CALL].
+{no_ssml_rule}
+
+{elevenlabs_audio_tag_block}
+
+# GOAL
+Follow the model instructions. Continue from the history above. Be {agent_name}."""
+        else:
+            # Use base prompt
+            system_prompt = base_prompt
+
+        call_policy_block = agent_service.build_call_policy_block(
+            transfer_route=getattr(self.agent, "transfer_route", None) if self.agent else None,
+        )
+        if call_policy_block:
+            system_prompt = call_policy_block + "\n" + system_prompt
+
+        # Prepend current date/time so the agent knows what "today", "tomorrow",
+        # and "past slots" mean. Also injected into appointment booking flow.
+        _now_local = datetime.now(timezone.utc)
+        _now_str = _now_local.strftime("%A, %B %d, %Y at %I:%M %p UTC")
+        _user_signals = build_user_signals_block(turn_context)
+        system_prompt = (
+            f"# CURRENT DATE & TIME\nNow: {_now_str}\n\n"
+            f"{_user_signals}\n\n"
+            + system_prompt
+        )
+
+        return _SystemPromptBuildResult(
+            system_prompt=system_prompt,
+            turn_context=turn_context,
+            booking_intent_turn=booking_intent_turn,
+            follow_up_active=follow_up_active,
+            low_latency_fastpath=low_latency_fastpath,
+            vertex_kb_context=_vertex_kb_context,
+            llm_runtime=_llm_runtime,
+            rag_trace=rag_trace,
+        )
+
     async def generate_and_stream_response(
         self,
         user_text: str,
@@ -1385,9 +1933,6 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin,
             is_greeting: If True, plays inbound one-time opening (greeting_message / first_message) without LLM
         """
         try:
-            from datetime import datetime, timezone
-            import json
-
             # Ambient per-turn context for TtsPipeline's humanization decision
             # (app.voice.humanization_engine) — read via getattr, never required,
             # so any change here can't break TTS. Confidence is threaded through
@@ -1454,6 +1999,32 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin,
                 # Add greeting to transcript
                 await self._add_to_transcript("agent", greeting_text, "greeting")
 
+                # Gemini Live native-audio calls must never invoke the external
+                # TTS provider (see CLAUDE.md / the approved plan) — route the
+                # greeting through the live session's own send_text so Gemini
+                # speaks it in its native voice, instead of queue_tts below.
+                # If the session isn't up yet (still starting, or fell back to
+                # the legacy pipeline), skip the scripted greeting entirely —
+                # the caller simply gets no opener and the conversation starts
+                # on their first utterance. This must never fall through to
+                # queue_tts()/TtsPipeline for a native-audio agent.
+                _vo = getattr(self, "_voice_orchestrator", None)
+                if _vo is not None and getattr(_vo, "_is_gemini_live", False):
+                    session = _vo._gemini_live_session
+                    if session is not None:
+                        try:
+                            await session.send_text(greeting_text, turn_complete=True)
+                        except Exception as exc:
+                            logger.warning(
+                                "[GeminiLive] failed to send greeting via live session: %s", exc
+                            )
+                    else:
+                        logger.debug(
+                            "[GeminiLive] skipping scripted greeting — live session not ready yet"
+                        )
+                    self._twilio_buffer_primed = False
+                    return
+
                 # Queue greeting TTS directly (skip LLM!)
                 if not self._tts_pipeline:
                     return
@@ -1476,468 +2047,15 @@ class BidirectionalStreamHandler(BookingMixin, TtsStreamMixin, CallControlMixin,
             self._is_tts_playing = False        # Audio not yet streaming for this turn
             self._tts_play_start_ts = 0.0     # Clear dead-zone anchor from previous utterance
 
-            self._voice_metrics.start_generation()
-            self._metric_gen_start_ts = time.perf_counter()
-            _stt_to_gen_ms = (self._metric_gen_start_ts - self._metric_stt_final_ts) * 1000
-            if self._metric_stt_final_ts > 0:
-                logger.info("[Metrics] stt_final_to_gen_start=%.0f ms", _stt_to_gen_ms)
-            slowpath_started_at = time.perf_counter()
-
-            def _remaining_slowpath_budget(default_timeout: float) -> float:
-                budget = float(getattr(settings, "VOICE_SLOWPATH_BUDGET_SEC", 0.55) or 0.55)
-                budget = max(0.12, min(3.0, budget))
-                elapsed = time.perf_counter() - slowpath_started_at
-                remaining = max(0.05, budget - elapsed)
-                return min(max(0.05, default_timeout), remaining)
-
-            booking_intent_turn = self._is_booking_intent_turn(user_text)
-            follow_up_active = bool(
-                self.call_session
-                and self.call_session.call_metadata
-                and self.call_session.call_metadata.get("appointment_id")
-            )
-            _llm_runtime = resolve_llm_runtime(self.agent)
-            _use_vertex_llm = (_llm_runtime.provider_slug or "").lower() == "gemini"
-            _vertex_kb_context = ""
-            low_latency_fastpath = self._should_use_latency_fastpath(
-                user_text, booking_intent_turn
-            )
-
-            # Fire quick-ack immediately (fire-and-forget) so the user hears audio
-            # while the LLM+RAG+KB pipeline runs.  Only on the slow path (fastpath
-            # queries have sub-500ms LLM TTFT so a quick-ack would finish before the
-            # LLM chunk is ready, creating a silence gap rather than masking latency).
-            # In V2 TtsPipeline, synthesis is parallel: the LLM's first chunk starts
-            # synthesising in the background while quick-ack is still playing, so by
-            # the time quick-ack ends the real audio is typically already ready.
-            if user_text and not low_latency_fastpath:
-                asyncio.create_task(self._send_quick_acknowledgement(user_text))
-
-            turn_context = build_turn_context(
-                user_text,
-                confidence,
-                booking_context_active=self._is_booking_context_active(user_text),
-                is_final=True,
-            )
-
-            # ------- RAG: build knowledge base context in voice layer -------
-            tenant_uuid = self.call_session.tenant_id if self.call_session else None
-            agent_uuid = self.agent.id if self.agent else None
-            rag_agent_scope = None if (self.agent and self.agent.is_inbound_agent) else agent_uuid
-
-            # RAG retrieval: use prefetched result when available (fired on interim
-            # so it overlaps Deepgram endpointing), otherwise run synchronously.
-            rag_context_block = ""
-            rag_trace: dict = {}
-            _prefetch = self._rag_prefetch_task
-            self._rag_prefetch_task = None  # Consume once per turn
-            if low_latency_fastpath:
-                rag_trace = {"status": "skipped_fastpath"}
-                if _prefetch and not _prefetch.done():
-                    _prefetch.cancel()
-            else:
-                try:
-                    if _prefetch is not None:
-                        if _prefetch.done():
-                            # Already finished — zero-cost read
-                            rag_context_block, rag_trace = _prefetch.result()
-                            logger.debug("[RAG] used prefetch result (done)")
-                        else:
-                            # Still running — wait with reduced timeout (most work already done)
-                            prefetch_wait_cap = float(
-                                getattr(settings, "VOICE_RAG_PREFETCH_AWAIT_SEC", 0.18) or 0.18
-                            )
-                            rag_context_block, rag_trace = await asyncio.wait_for(
-                                asyncio.shield(_prefetch),
-                                timeout=_remaining_slowpath_budget(
-                                    min(max(0.05, prefetch_wait_cap), settings.RAG_RETRIEVAL_TIMEOUT_SEC)
-                                ),
-                            )
-                            logger.debug("[RAG] awaited in-flight prefetch")
-                    else:
-                        # No prefetch fired (e.g., very short utterance, final-only path)
-                        loop = asyncio.get_running_loop()
-
-                        def _build_rag():
-                            return build_rag_context_block_with_trace(
-                                user_text=user_text,
-                                tenant_id=tenant_uuid,
-                                agent_id=rag_agent_scope,
-                            )
-
-                        rag_context_block, rag_trace = await asyncio.wait_for(
-                            loop.run_in_executor(None, _build_rag),
-                            timeout=_remaining_slowpath_budget(settings.RAG_RETRIEVAL_TIMEOUT_SEC),
-                        )
-                except asyncio.TimeoutError:
-                    rag_context_block, rag_trace = build_rag_context_block_with_trace(
-                        user_text="",
-                        tenant_id=tenant_uuid,
-                        agent_id=rag_agent_scope,
-                    )
-                    rag_trace["status"] = "timeout"
-                    rag_trace["timeout"] = True
-                except Exception as e:
-                    logger.error("RAG context build failed unexpectedly: %s", e, exc_info=True)
-                    rag_context_block, rag_trace = build_rag_context_block_with_trace(
-                        user_text="",
-                        tenant_id=tenant_uuid,
-                        agent_id=rag_agent_scope,
-                    )
-                    rag_trace["status"] = "failure"
-                    rag_trace["error"] = str(e)
-
-            # Use call-start-cached KB blocks (fetched once in _prefetch_kb_blocks_at_call_start).
-            # These are agent/tenant-level and don't change during the call, so serving
-            # them from cache costs 0ms versus the previous 50-200ms parallel executor fetch.
-            # Fall back to live fetch only if the cache background task hasn't finished yet
-            # (race on the very first turn of an extremely fast caller — rare in practice).
-            inbound_kb_docs_context_block = ""
-            if not low_latency_fastpath:
-                if self._kb_cache_ready:
-                    inbound_kb_docs_context_block = self._cached_inbound_kb_block
-                else:
-                    skip_live_kb = bool(
-                        getattr(settings, "VOICE_SKIP_LIVE_KB_FETCH_ON_COLD_START", True)
-                    )
-                    if skip_live_kb:
-                        logger.debug("[KB] cache cold; skipping live fetch for latency budget")
-                    else:
-                        # Cache not ready yet — live fetch as fallback.
-                        _loop = asyncio.get_running_loop()
-
-                        async def _fetch_inbound_kb_live() -> str:
-                            if not (self.agent and self.agent.is_inbound_agent and tenant_uuid and agent_uuid):
-                                return ""
-                            try:
-                                return await _loop.run_in_executor(
-                                    None,
-                                    lambda: agent_service.build_inbound_kb_documents_context_block(
-                                        db=self.db, inbound_agent_id=agent_uuid, tenant_id=tenant_uuid,
-                                    ),
-                                )
-                            except Exception as exc:
-                                logger.warning("KB live-fetch (inbound) failed: %s", exc)
-                                return ""
-
-                        try:
-                            inbound_kb_docs_context_block = await asyncio.wait_for(
-                                _fetch_inbound_kb_live(),
-                                timeout=_remaining_slowpath_budget(0.25),
-                            )
-                        except asyncio.TimeoutError:
-                            logger.debug("[KB] live fetch timeout; continuing without live KB blocks")
-                        except Exception as exc:
-                            logger.debug("[KB] live fetch failed; continuing without live KB blocks: %s", exc)
-
-            # One-line RAG summary (safe: no chunk text, no secrets)
-            try:
-                logger.info(
-                    "RAG trace summary: status=%s timeout=%s initial=%s filtered=%s retrieve_error=%s",
-                    rag_trace.get("status"),
-                    rag_trace.get("timeout"),
-                    rag_trace.get("initial_retrieved_count"),
-                    rag_trace.get("filtered_count"),
-                    rag_trace.get("retrieve_error"),
-                )
-            except Exception:  # noqa: S110 - logging must never break voice calls
-                pass
-            
-            # Build history text from in-memory cache (avoids re-parsing the growing
-            # call_transcript JSON on every turn — O(n) JSON parse that gets slower
-            # as the call continues).  _conversation_history_cache is appended to
-            # directly by _add_to_transcript so it's always up-to-date.
-            # Fallback: if cache is empty but DB has a transcript, seed from DB once.
-            if not self._conversation_history_cache and self.call_session and self.call_session.call_transcript:
-                try:
-                    raw = self.call_session.call_transcript
-                    parsed = json.loads(raw) if isinstance(raw, str) else raw
-                    for msg in (parsed or []):
-                        if isinstance(msg, dict):
-                            role = msg.get("role", "")
-                            content = msg.get("content") or msg.get("message", "")
-                            mtype = msg.get("message_type", "")
-                            if content and role in ("client", "agent") and mtype not in ("greeting", "system", "status"):
-                                self._conversation_history_cache.append((role, content))
-                except Exception as exc:
-                    logger.debug("Failed to seed conversation history cache from DB transcript: %s", exc)
-
-            history_text = ""
-            if self._conversation_history_cache:
-                try:
-                    filtered = self._conversation_history_cache
-
-                    # Booking flows use a slightly wider window to keep service/date/slot
-                    # in context, but capped at 20 to avoid prompt bloat that inflates LLM TTFT.
-                    # (Previous default of 39 was adding ~1000 tokens to the prompt on long calls.)
-                    max_msgs = getattr(self, "HISTORY_MAX_MESSAGES", 50)
-                    if low_latency_fastpath:
-                        # Keep at least 12 on fast path — intake flows span 6+ phases and
-                        # cutting to 6 drops early context (name, issue, location already given),
-                        # causing the agent to re-ask questions the caller already answered.
-                        max_msgs = min(max_msgs, 60)
-                    if self._is_booking_context_active(user_text):
-                        max_msgs = min(max(max_msgs, 60), 60)
-                    if len(filtered) > max_msgs:
-                        filtered = filtered[-max_msgs:]
-
-                    history_text = "\n".join(
-                        f"{role.capitalize()}: {content}" for role, content in filtered
-                    )
-                except Exception:
-                    history_text = ""
-
-            if _use_vertex_llm:
-                history_text = (
-                    "(Prior conversation turns are provided separately — "
-                    "maintain continuity; do not re-ask answered questions.)"
-                )
-            
-            booking_memory_block = self._build_booking_memory_block()
-
-            # Build system prompt with agent personality + history
-            agent_name = self.agent.name if self.agent and self.agent.name else "AI Assistant"
-            agent_language = self.agent.language if self.agent and self.agent.language else "en"
-            v_add = ""
-            if self.call_session and self.call_session.call_metadata:
-                voice_ctx = self.call_session.call_metadata.get("voice_dynamic_context")
-                if isinstance(voice_ctx, dict):
-                    v_add = (voice_ctx.get("system_prompt_addendum") or "").strip()
-            v_block = (
-                f"\n\n# THIS CALL — CANDIDATE & ROLE\n{v_add}\n"
-                if v_add
-                else ""
-            )
-            tts_provider = getattr(self.agent, "tts_provider", None) if self.agent else None
-            tts_provider_slug = (getattr(tts_provider, "slug", None) or "").lower()
-            elevenlabs_audio_tags_enabled = supports_elevenlabs_audio_tags(tts_provider_slug)
-            if elevenlabs_audio_tags_enabled:
-                output_plain_text_rule, no_ssml_rule_base, no_ssml_rule = (
-                    get_elevenlabs_voice_prompt_rule_lines()
-                )
-            else:
-                output_plain_text_rule = (
-                    "- OUTPUT PLAIN TEXT ONLY: Do NOT output SSML, XML, or any tags. "
-                    "Prosody is handled by the system."
-                )
-                no_ssml_rule_base = (
-                    "4. NO SSML: Do NOT output <speak>, <prosody>, or any XML tags. Plain text only."
-                )
-                no_ssml_rule = "3. NO SSML: Plain text only. No <speak>, <prosody>, or XML."
-            elevenlabs_audio_tag_block = build_elevenlabs_audio_tag_prompt_block(tts_provider_slug)
-            # When ElevenLabs audio tags are enabled, the authoritative rule lives solely in
-            # elevenlabs_audio_tag_block above — do not also emit a contradictory generic
-            # "never use bracket tags" line. Only non-ElevenLabs (or disabled) calls need it.
-            no_bracket_tags_line = (
-                ""
-                if elevenlabs_audio_tags_enabled
-                else (
-                    "- NO BRACKET TAGS: Never output bracketed tags like [pause], [laugh], [breathes], "
-                    "[excited], [1], [2], or any similar annotation. These will not be rendered — they "
-                    "will be read aloud literally."
-                )
-            )
-
-            # Inbound: opening may play once via TTS at pickup — do not instruct LLM to repeat verbatim on every "hi".
-            _inbound_call = (
-                self.call_session is not None
-                and (self.call_session.call_type or "").lower() == "inbound"
-            )
-            _has_opening_cfg = bool(self.agent) and (
-                (getattr(self.agent, "greeting_message", None) or "").strip()
-                or (getattr(self.agent, "first_message", None) or "").strip()
-            )
-            greeting_instruction_block = (
-                "\n- GREETING: A short opening may play once automatically at call start (inbound). "
-                "If the caller says hi, hello, or similar later, acknowledge in one brief phrase only — "
-                "do not repeat the full opening greeting verbatim.\n"
-                if (_inbound_call and _has_opening_cfg)
-                else ""
-            )
-
-            _recruitment_screening_block = ""
-            if self._jd_recruitment_screening_active():
-                _recruitment_screening_block = """
-# RECRUITMENT OUTBOUND SCREENING (THIS CALL — OVERRIDES CONFLICTING GENERIC RULES)
-- If the user says not interested, wrong number, wrong person, wrong call, not available, stop calling, or cannot do this now (clear no) — reply with ONE short polite sentence and end with [END_CALL] only. No follow-up questions. No persuasion.
-- Never ask a question that is already answered in "Previous conversation" above; move to the next step in YOUR ROLE block.
-- On successful completion of the full screening per YOUR ROLE block, your last reply must include [SCREENING_QUALIFIED] immediately before [END_CALL] as instructed there.
-- If an intro already played at call start, do not repeat the same full intro; continue the flow.
-"""
-
-            # No business facts source remains; always inject the "do not invent" guard
-            # so the LLM never fabricates business details.
-            _bk_block = (
-                "# AUTHORITATIVE BUSINESS FACTS\n"
-                "No verified business facts are loaded for this call.\n"
-                "CRITICAL: Do NOT invent or assume ANY business details (name, address, phone, "
-                "email, services, prices, hours, or any other specifics).\n"
-                "If the caller asks about the business, say that specific information is not "
-                "available to you right now and offer to help in another way."
-            )
-
-            if _use_vertex_llm:
-                from app.voice.llm_prompt_builder import build_kb_context_for_vertex
-
-                _vertex_kb_context = build_kb_context_for_vertex(
-                    inbound_kb_docs_context_block,
-                    "",
-                    empty_guard=_bk_block,
-                )
-                inbound_kb_docs_context_block = ""
-                _bk_block = (
-                    "# AUTHORITATIVE BUSINESS FACTS\n"
-                    "Business facts and inbound documents are attached as knowledge context "
-                    "with each user message — apply grounding rules using that context.\n"
-                )
-
-            # Base prompt for phone conversations (voice-first, plain text only, no SSML)
-            base_prompt = f"""# ROLE
-You are {agent_name}, having a real-time phone call with a human.
-{v_block}
-# STYLE & TONE
-- VOICE-FIRST: Your output is for Text-to-Speech. Use short, punchy sentences.
-- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
-- CONCISE: Max 20 words per response unless explaining something complex.
-- NO ROBOT TALK: Avoid "As an AI" or formal greetings. Use "Hey," "Hi," or "Hello."
-{output_plain_text_rule}
-{no_bracket_tags_line}
-- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").{greeting_instruction_block}
-# CONVERSATION STATE
-Previous conversation:
-{history_text}
-
-{booking_memory_block}
-{rag_context_block}
-{inbound_kb_docs_context_block}
-{_recruitment_screening_block}
-# CRITICAL RULES
-1. CONVERSATION CONTINUITY: Read "Previous conversation" above before every reply. Any information already given by the caller (name, location, issue, timing) is still valid — do not ask for it again. Do not restart from the beginning of your flow mid-call. If the caller corrects or updates a previously given answer (e.g., corrects their name), acknowledge it and continue from the current step, not step one.
-2. NO REPETITION: Never ask a question that was already asked and answered in the transcript. Move to the next unanswered item only.
-3. HANDLING SILENCE: If the user says something vague, ask a single clarifying question.
-4. TERMINATION: When the objective is met, say a friendly goodbye and end your response with exactly [END_CALL].
-5. BUSINESS FACTS: For any question about the business name, address, phone, email, website, services, or pricing — answer using AUTHORITATIVE BUSINESS FACTS and, when present in this prompt, KNOWLEDGE BASE CONTEXT; both are authoritative sources for this call regardless of where each appears in this prompt. Never say you don't know if the answer is there. Never invent details that are not written in either.
-6. SERVICE SCOPE: Strictly follow "BUSINESS SCOPE & POLICY — STRICT RULES" inside AUTHORITATIVE BUSINESS FACTS. Only offer the services listed there. If the caller asks for something we don't offer, politely decline and pivot to what we actually do.
-7. SERVICE AREA: If Service Areas are listed and restricted and the caller is outside them, apologize, briefly name the areas we cover, say a short goodbye, and end your response with exactly [END_CALL]. If Service Areas describe global/remote/worldwide coverage, never refuse based on location.
-{no_ssml_rule_base}
-
-{elevenlabs_audio_tag_block}
-
-{_bk_block}
-# GOAL
-Continue the conversation based on the history above. Be {agent_name}."""
-
-            # A/B prompt testing: variant + resolved prompt text are locked onto
-            # call_metadata at dispatch time (see ab_testing_service) and never
-            # re-resolved mid-call, so the same variant is used for the whole call.
-            ab_prompt_override = None
-            if self.call_session and self.call_session.call_metadata:
-                ab_prompt_override = self.call_session.call_metadata.get("ab_prompt_text")
-
-            # Use agent's custom system prompt if available, otherwise use base prompt
-            if self.agent and self.agent.system_prompt:
-                # Agent has custom system prompt - grounding rules placed BEFORE custom
-                # instructions so factual constraints cannot be overridden by agent config.
-                effective_custom_prompt = ab_prompt_override or self.agent.system_prompt
-                system_prompt = f"""# ROLE
-You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
-
-# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING CUSTOM INSTRUCTIONS)
-These rules override any conflicting custom instructions below. Never deviate from them.
-1. BUSINESS FACTS: Answer questions about business name, address, phone, email, website, services, or pricing using AUTHORITATIVE BUSINESS FACTS and, when present in this prompt, KNOWLEDGE BASE CONTEXT — both are authoritative sources for this call regardless of where each appears in this prompt. Never invent or assume any detail not explicitly written in either. If a fact is absent from both, say it is not available.
-2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
-3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
-4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
-
-{_bk_block}
-
-# CUSTOM INSTRUCTIONS
-{effective_custom_prompt}
-{v_block}
-# STYLE & TONE
-- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
-- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
-{output_plain_text_rule}
-{no_bracket_tags_line}
-- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").{greeting_instruction_block}
-# CONVERSATION STATE
-Previous conversation:
-{history_text}
-
-{booking_memory_block}
-{rag_context_block}
-{inbound_kb_docs_context_block}
-{_recruitment_screening_block}
-# CRITICAL RULES
-1. CONVERSATION CONTINUITY: Read "Previous conversation" above before every reply. Any information the caller already gave (name, location, issue, timing) is still valid — do not ask for it again, and do not restart your intake flow from the beginning mid-call. If the caller corrects a previously given answer (e.g., corrects their name), acknowledge it and continue from the current step, not step one.
-2. NO REPETITION: Never ask a question that was already asked and answered in the transcript above. Move to the next unanswered item only.
-3. TERMINATION: When all objectives from your custom instructions are complete, say a friendly goodbye and end your response with exactly [END_CALL].
-{no_ssml_rule}
-
-{elevenlabs_audio_tag_block}
-
-# GOAL
-Follow your custom instructions. Continue from the history above. Be {agent_name}."""
-            elif self.agent and self.agent.model and self.agent.model.system_prompt:
-                # Model has system prompt - grounding rules placed BEFORE model instructions.
-                effective_model_prompt = ab_prompt_override or self.agent.model.system_prompt
-                system_prompt = f"""# ROLE
-You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
-
-# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING MODEL INSTRUCTIONS)
-These rules override any conflicting model instructions below. Never deviate from them.
-1. BUSINESS FACTS: Answer questions about business name, address, phone, email, website, services, or pricing using AUTHORITATIVE BUSINESS FACTS and, when present in this prompt, KNOWLEDGE BASE CONTEXT — both are authoritative sources for this call regardless of where each appears in this prompt. Never invent or assume any detail not explicitly written in either. If a fact is absent from both, say it is not available.
-2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
-3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
-4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
-
-{_bk_block}
-
-# MODEL INSTRUCTIONS
-{effective_model_prompt}
-{v_block}
-# STYLE & TONE
-- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
-- NATURAL: Use fillers like "uhm," "well," "I see" occasionally.
-{output_plain_text_rule}
-{no_bracket_tags_line}{greeting_instruction_block}
-# CONVERSATION STATE
-Previous conversation:
-{history_text}
-
-{booking_memory_block}
-{rag_context_block}
-{inbound_kb_docs_context_block}
-# CRITICAL RULES
-1. CONVERSATION CONTINUITY: Read "Previous conversation" above before every reply. Any information the caller already gave (name, location, issue, timing) is still valid — do not ask for it again, and do not restart your intake flow from the beginning mid-call. If the caller corrects a previously given answer (e.g., corrects their name), acknowledge it and continue from the current step, not step one.
-2. NO REPETITION: Never ask a question that was already asked and answered in the transcript above. Move to the next unanswered item only.
-3. TERMINATION: When all objectives are complete, say a friendly goodbye and end your response with exactly [END_CALL].
-{no_ssml_rule}
-
-{elevenlabs_audio_tag_block}
-
-# GOAL
-Follow the model instructions. Continue from the history above. Be {agent_name}."""
-            else:
-                # Use base prompt
-                system_prompt = base_prompt
-
-            call_policy_block = agent_service.build_call_policy_block(
-                transfer_route=getattr(self.agent, "transfer_route", None) if self.agent else None,
-            )
-            if call_policy_block:
-                system_prompt = call_policy_block + "\n" + system_prompt
-
-            # Prepend current date/time so the agent knows what "today", "tomorrow",
-            # and "past slots" mean. Also injected into appointment booking flow.
-            _now_local = datetime.now(timezone.utc)
-            _now_str = _now_local.strftime("%A, %B %d, %Y at %I:%M %p UTC")
-            _user_signals = build_user_signals_block(turn_context)
-            system_prompt = (
-                f"# CURRENT DATE & TIME\nNow: {_now_str}\n\n"
-                f"{_user_signals}\n\n"
-                + system_prompt
-            )
+            _sp_result = await self._build_system_prompt_full(user_text, confidence)
+            system_prompt = _sp_result.system_prompt
+            turn_context = _sp_result.turn_context
+            booking_intent_turn = _sp_result.booking_intent_turn
+            follow_up_active = _sp_result.follow_up_active
+            low_latency_fastpath = _sp_result.low_latency_fastpath
+            _vertex_kb_context = _sp_result.vertex_kb_context
+            _llm_runtime = _sp_result.llm_runtime
+            rag_trace = _sp_result.rag_trace
 
             # Model/provider/temperature resolved early for Vertex prompt shaping.
             model_name = _llm_runtime.model_name

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -2025,6 +2025,28 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                     self._twilio_buffer_primed = False
                     return
 
+                # Mirror-image bypass for OpenAI Realtime native-audio calls —
+                # same rationale as the Gemini Live branch above, routed
+                # through OpenAIRealtimeSession.send_text(respond=True) so
+                # OpenAI actually speaks the greeting (unlike the mid-call KB
+                # refresh's respond=False, this scripted greeting SHOULD be
+                # spoken as a real turn).
+                if _vo is not None and getattr(_vo, "_is_openai_realtime", False):
+                    session = _vo._openai_realtime_session
+                    if session is not None:
+                        try:
+                            await session.send_text(greeting_text, respond=True)
+                        except Exception as exc:
+                            logger.warning(
+                                "[OpenAIRealtime] failed to send greeting via live session: %s", exc
+                            )
+                    else:
+                        logger.debug(
+                            "[OpenAIRealtime] skipping scripted greeting — live session not ready yet"
+                        )
+                    self._twilio_buffer_primed = False
+                    return
+
                 # Queue greeting TTS directly (skip LLM!)
                 if not self._tts_pipeline:
                     return

--- a/app/routers/hubspot_integration.py
+++ b/app/routers/hubspot_integration.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
 from sqlalchemy.orm import Session
 
@@ -46,12 +46,23 @@ def _tenant_id(principal) -> uuid.UUID:
 
 @router.get("/connect",include_in_schema=False)
 async def hubspot_connect(
+    request: Request,
     principal=Depends(require_admin),
 ):
-    """Redirect to HubSpot's OAuth consent page. Scopes: contacts read/write."""
+    """Redirect to HubSpot's OAuth consent page. Scopes: contacts read/write.
+
+    Frontend `fetch()` calls send `Accept: application/json` and can't follow
+    a cross-origin 302 to HubSpot with our auth headers attached, so they get
+    the URL back as JSON instead and navigate to it themselves. Normal browser
+    navigation (no `Accept: application/json`) keeps the existing 302.
+    """
     tenant_id = _tenant_id(principal)
     state = hubspot_service.build_oauth_state(tenant_id)
     auth_url = hubspot_service.build_authorization_url(state)
+
+    if request.headers.get("accept") == "application/json":
+        return JSONResponse(content={"authorization_url": auth_url})
+
     return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
 
 

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -39,6 +39,7 @@ class TtsProviderEnum(str, Enum):
     rime = "rime"
     elevenlabs = "elevenlabs"
     elevenlabs_byo = "elevenlabs_byo"
+    hume = "hume"
 
 
 class AgentStatusEnum(str, Enum):

--- a/app/services/gemini_live_service.py
+++ b/app/services/gemini_live_service.py
@@ -241,12 +241,30 @@ class GeminiLiveSession:
         """Send one chunk of raw PCM16/16kHz/mono caller audio. Caller must
         have already converted to this format (e.g. via
         ``gemini_live_audio_bridge.mulaw8k_to_pcm16_16k``) — this module has
-        zero telephony-format knowledge."""
+        zero telephony-format knowledge.
+
+        Safe no-op once the session is closed/closing — the audio-forwarding
+        background task (``LiveKitAudioSubscriber`` / Twilio's media-stream
+        loop) is stopped independently of this session's teardown, so a few
+        straggler chunks arriving after ``close()`` has already fired are
+        expected, not exceptional. Without this guard those stragglers hit
+        the underlying websocket mid-close-handshake and raise
+        ``ConnectionClosedError``/``TimeoutError``, which the caller then
+        logs at ERROR level for what is actually a benign shutdown race."""
+        if not pcm16_16k_bytes or self._closed:
+            return
         from google.genai import types
 
-        await self._session.send_realtime_input(
-            audio=types.Blob(data=pcm16_16k_bytes, mime_type="audio/pcm;rate=16000")
-        )
+        try:
+            await self._session.send_realtime_input(
+                audio=types.Blob(data=pcm16_16k_bytes, mime_type="audio/pcm;rate=16000")
+            )
+        except Exception:
+            if self._closed:
+                # Lost the race: close() ran concurrently with this send.
+                # Benign — swallow rather than surface as an error.
+                return
+            raise
 
     async def send_text(self, text: str, turn_complete: bool = True) -> None:
         from google.genai import types

--- a/app/services/gemini_live_service.py
+++ b/app/services/gemini_live_service.py
@@ -305,12 +305,16 @@ class GeminiLiveSession:
                     except Exception as exc:
                         await self._report_error(exc)
                 if turn_msg_count == 0:
-                    # receive() returned with zero messages instead of raising —
-                    # treat as a dead/closed connection rather than busy-loop
-                    # re-invoking it forever.
+                    # Defensive guard, not currently reachable against the pinned
+                    # google-genai SDK: a dead/closed connection makes receive()
+                    # raise (handled by the except below), not return an empty
+                    # generator. This only exists in case a future SDK version
+                    # ever yields zero messages instead of raising — without it,
+                    # re-invoking receive() forever in that case would busy-spin
+                    # the event loop rather than ending the call gracefully.
                     logger.warning(
                         "[GeminiLiveSession] receive() yielded no messages model=%s — "
-                        "ending receive loop (connection likely closed)",
+                        "ending receive loop",
                         self.model_name,
                     )
                     break

--- a/app/services/gemini_live_service.py
+++ b/app/services/gemini_live_service.py
@@ -1,0 +1,301 @@
+"""
+Gemini Live (speech-to-speech native-audio) session wrapper.
+
+Mirrors ``app/services/vertex_gemini_service.py``'s module shape but wraps a
+*stateful* Live session instead of one-shot request/response calls. This
+module has ZERO knowledge of Twilio/LiveKit/MULAW/telephony — it only speaks
+raw PCM16 bytes in (16kHz, caller -> Gemini) and out (24kHz, Gemini ->
+caller), exactly like ``vertex_gemini_service.py`` has zero knowledge of any
+TTS/STT provider. Byte-level format conversion to/from telephony formats
+lives in ``app/voice/gemini_live_audio_bridge.py``; wiring this session into
+an actual call transport is out of scope for this module (see
+``app/core/llm_models.py``'s ``GEMINI_LIVE_MODELS``/
+``is_gemini_live_native_audio_model`` for the routing predicate used by
+transport handlers).
+
+Auth is per-model (see ``GEMINI_LIVE_MODELS``): two models use Vertex AI/ADC
+(reusing ``vertex_gemini_service._ensure_vertex_client`` verbatim — same
+client type, same location-keyed cache, no duplication), one uses the
+Gemini Developer API with ``settings.GEMINI_API_KEY`` as a deliberate, scoped
+exception (see that constant's docstring for why).
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+from typing import Any, Awaitable, Callable, Sequence
+
+from app.core.config import settings
+from app.core.llm_models import GEMINI_LIVE_MODELS
+from app.core.logger import logger
+from app.services.vertex_gemini_service import (
+    VertexLlmError,
+    VertexLlmErrorType,
+    _classify_vertex_error,
+    _ensure_vertex_client,
+)
+
+DEFAULT_VOICE_NAME = "Puck"
+
+_api_key_client_lock = threading.Lock()
+_api_key_client: Any = None
+
+
+def _ensure_api_key_client():
+    """
+    Lazily build (once, process-wide) and return a shared google.genai
+    Client configured for the Gemini Developer API (API-key auth) — used
+    only by ``gemini-3.1-flash-live-preview`` (see ``GEMINI_LIVE_MODELS``).
+    Unlike ``_ensure_vertex_client``, this is NOT location-keyed: the
+    Developer API is not project/location-scoped.
+    """
+    global _api_key_client
+    if _api_key_client is not None:
+        return _api_key_client
+    with _api_key_client_lock:
+        if _api_key_client is not None:
+            return _api_key_client
+        from google import genai
+
+        api_key = settings.GEMINI_API_KEY
+        if not api_key:
+            raise RuntimeError(
+                "GEMINI_API_KEY is required for Gemini Live Developer-API models "
+                "(e.g. gemini-3.1-flash-live-preview)."
+            )
+        _api_key_client = genai.Client(api_key=api_key)
+        return _api_key_client
+
+
+class GeminiLiveSession:
+    """
+    Transport-agnostic wrapper around one ``google.genai`` Live API session.
+
+    Usage (by a future transport-handler wiring, not part of this task):
+      session = GeminiLiveSession(agent.llm_model)
+      await session.start(system_instruction=..., on_audio_chunk=..., on_interrupted=...)
+      await session.send_audio(pcm16_16k_bytes)   # per caller-audio chunk
+      ...
+      await session.close()
+    """
+
+    def __init__(self, model_name: str) -> None:
+        config = GEMINI_LIVE_MODELS.get(model_name)
+        if config is None:
+            raise ValueError(
+                f"'{model_name}' is not a Gemini Live native-audio model. "
+                f"Valid models: {sorted(GEMINI_LIVE_MODELS)}"
+            )
+        self.model_name = model_name
+        self._auth_mode: str = config["auth"]
+        self._location: str | None = config["location"]
+
+        self._client: Any = None
+        self._connect_cm: Any = None
+        self._session: Any = None
+        self._receive_task: asyncio.Task | None = None
+        self._closed = False
+
+        # Registered by start(); consumed by _receive_loop.
+        self.on_audio_chunk: Callable[[bytes], Awaitable[None]] | None = None
+        self.on_interrupted: Callable[[], Awaitable[None]] | None = None
+        self.on_input_transcript: Callable[[str, bool], Awaitable[None]] | None = None
+        self.on_output_transcript: Callable[[str, bool], Awaitable[None]] | None = None
+        self.on_tool_call: Callable[[Sequence[Any]], Awaitable[None]] | None = None
+        self.on_error: Callable[[VertexLlmError], Awaitable[None]] | None = None
+
+    def _build_client(self):
+        if self._auth_mode == "vertex":
+            return _ensure_vertex_client(self._location)
+        if self._auth_mode == "api_key":
+            return _ensure_api_key_client()
+        raise VertexLlmError(
+            f"Unknown Gemini Live auth mode '{self._auth_mode}' for model {self.model_name}",
+            VertexLlmErrorType.UNKNOWN,
+        )
+
+    async def start(
+        self,
+        *,
+        system_instruction: str,
+        voice_name: str = DEFAULT_VOICE_NAME,
+        language_code: str | None = None,
+        on_audio_chunk: Callable[[bytes], Awaitable[None]],
+        on_interrupted: Callable[[], Awaitable[None]],
+        on_input_transcript: Callable[[str, bool], Awaitable[None]] | None = None,
+        on_output_transcript: Callable[[str, bool], Awaitable[None]] | None = None,
+        on_tool_call: Callable[[Sequence[Any]], Awaitable[None]] | None = None,
+        on_error: Callable[[VertexLlmError], Awaitable[None]] | None = None,
+        tools: list | None = None,
+    ) -> None:
+        """
+        Open the Live session: build the right client for this model's auth
+        mode, connect, and start the background receive loop. Raises
+        ``VertexLlmError`` on any setup failure (bad model, missing
+        credentials, SDK/connect errors).
+        """
+        self.on_audio_chunk = on_audio_chunk
+        self.on_interrupted = on_interrupted
+        self.on_input_transcript = on_input_transcript
+        self.on_output_transcript = on_output_transcript
+        self.on_tool_call = on_tool_call
+        self.on_error = on_error
+
+        try:
+            from google.genai import types
+        except ImportError as exc:
+            raise VertexLlmError(
+                "google-genai is not installed. Add it to requirements.txt.",
+                VertexLlmErrorType.UNKNOWN,
+            ) from exc
+
+        try:
+            self._client = self._build_client()
+        except VertexLlmError:
+            raise
+        except Exception as exc:
+            raise VertexLlmError(
+                f"Gemini Live client init failed: {exc}", VertexLlmErrorType.UNKNOWN
+            ) from exc
+
+        speech_config = types.SpeechConfig(
+            voice_config=types.VoiceConfig(
+                prebuilt_voice_config=types.PrebuiltVoiceConfig(voice_name=voice_name)
+            ),
+            language_code=language_code,
+        )
+        config_kwargs: dict = {
+            "response_modalities": ["AUDIO"],
+            "speech_config": speech_config,
+            "input_audio_transcription": types.AudioTranscriptionConfig(),
+            "output_audio_transcription": types.AudioTranscriptionConfig(),
+        }
+        if system_instruction:
+            config_kwargs["system_instruction"] = system_instruction
+        if tools:
+            config_kwargs["tools"] = tools
+        live_config = types.LiveConnectConfig(**config_kwargs)
+
+        try:
+            self._connect_cm = self._client.aio.live.connect(
+                model=self.model_name, config=live_config
+            )
+            self._session = await self._connect_cm.__aenter__()
+        except Exception as exc:
+            self._connect_cm = None
+            raise _classify_vertex_error(exc) from exc
+
+        self._receive_task = asyncio.create_task(self._receive_loop())
+
+    async def send_audio(self, pcm16_16k_bytes: bytes) -> None:
+        """Send one chunk of raw PCM16/16kHz/mono caller audio. Caller must
+        have already converted to this format (e.g. via
+        ``gemini_live_audio_bridge.mulaw8k_to_pcm16_16k``) — this module has
+        zero telephony-format knowledge."""
+        from google.genai import types
+
+        await self._session.send_realtime_input(
+            audio=types.Blob(data=pcm16_16k_bytes, mime_type="audio/pcm;rate=16000")
+        )
+
+    async def send_text(self, text: str, turn_complete: bool = True) -> None:
+        from google.genai import types
+
+        content = types.Content(role="user", parts=[types.Part.from_text(text=text)])
+        await self._session.send_client_content(turns=content, turn_complete=turn_complete)
+
+    async def send_tool_response(self, function_responses) -> None:
+        await self._session.send_tool_response(function_responses=function_responses)
+
+    async def close(self) -> None:
+        """
+        Idempotent teardown — safe to call multiple times, and safe to call
+        from a ``finally``/shutdown path. Never raises: all teardown errors
+        are swallowed and logged.
+        """
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._receive_task is not None:
+            self._receive_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await self._receive_task
+            self._receive_task = None
+
+        if self._connect_cm is not None:
+            try:
+                await self._connect_cm.__aexit__(None, None, None)
+            except Exception as exc:
+                logger.debug("[GeminiLiveSession] close: session teardown error (ignored): %s", exc)
+            self._connect_cm = None
+
+        self._session = None
+
+    async def _receive_loop(self) -> None:
+        """Consume ``session.receive()`` and demux each ``LiveServerMessage``
+        into the registered callbacks. Any exception (SDK or otherwise) is
+        translated to ``VertexLlmError`` and routed to ``on_error`` if set,
+        else logged."""
+        try:
+            async for message in self._session.receive():
+                try:
+                    await self._handle_message(message)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    await self._report_error(exc)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            await self._report_error(exc)
+
+    async def _report_error(self, exc: Exception) -> None:
+        err = exc if isinstance(exc, VertexLlmError) else _classify_vertex_error(exc)
+        if self.on_error is not None:
+            await self.on_error(err)
+        else:
+            logger.error("[GeminiLiveSession] %s (model=%s): %s", err.error_type, self.model_name, err)
+
+    async def _handle_message(self, message: Any) -> None:
+        if getattr(message, "setup_complete", None):
+            logger.info("[GeminiLiveSession] setup_complete model=%s", self.model_name)
+
+        server_content = getattr(message, "server_content", None)
+        if server_content is not None:
+            model_turn = getattr(server_content, "model_turn", None)
+            if model_turn is not None:
+                for part in getattr(model_turn, "parts", None) or []:
+                    inline_data = getattr(part, "inline_data", None)
+                    data = getattr(inline_data, "data", None) if inline_data is not None else None
+                    if data and self.on_audio_chunk is not None:
+                        await self.on_audio_chunk(data)
+
+            if getattr(server_content, "interrupted", False) and self.on_interrupted is not None:
+                await self.on_interrupted()
+
+            input_transcript = getattr(server_content, "input_transcription", None)
+            if input_transcript is not None and self.on_input_transcript is not None:
+                await self.on_input_transcript(
+                    getattr(input_transcript, "text", "") or "",
+                    bool(getattr(input_transcript, "finished", False)),
+                )
+
+            output_transcript = getattr(server_content, "output_transcription", None)
+            if output_transcript is not None and self.on_output_transcript is not None:
+                await self.on_output_transcript(
+                    getattr(output_transcript, "text", "") or "",
+                    bool(getattr(output_transcript, "finished", False)),
+                )
+
+        tool_call = getattr(message, "tool_call", None)
+        if tool_call is not None and self.on_tool_call is not None:
+            function_calls = getattr(tool_call, "function_calls", None) or []
+            await self.on_tool_call(function_calls)
+
+        if getattr(message, "go_away", None):
+            logger.warning(
+                "[GeminiLiveSession] go_away received model=%s — no action taken (phase 1)",
+                self.model_name,
+            )

--- a/app/services/gemini_live_service.py
+++ b/app/services/gemini_live_service.py
@@ -143,6 +143,12 @@ class GeminiLiveSession:
         self.on_interrupted: Callable[[], Awaitable[None]] | None = None
         self.on_input_transcript: Callable[[str, bool], Awaitable[None]] | None = None
         self.on_output_transcript: Callable[[str, bool], Awaitable[None]] | None = None
+        # Fired on every ``server_content.turn_complete == True`` message —
+        # the only reliable turn-boundary signal for these models (see
+        # ``on_input_transcript``/``on_output_transcript`` docstrings in
+        # ``VoiceOrchestrator``: per-fragment ``finished`` flags are NOT
+        # trustworthy turn boundaries for the native-audio model family).
+        self.on_turn_complete: Callable[[], Awaitable[None]] | None = None
         self.on_tool_call: Callable[[Sequence[Any]], Awaitable[None]] | None = None
         self.on_error: Callable[[VertexLlmError], Awaitable[None]] | None = None
 
@@ -166,6 +172,7 @@ class GeminiLiveSession:
         on_interrupted: Callable[[], Awaitable[None]],
         on_input_transcript: Callable[[str, bool], Awaitable[None]] | None = None,
         on_output_transcript: Callable[[str, bool], Awaitable[None]] | None = None,
+        on_turn_complete: Callable[[], Awaitable[None]] | None = None,
         on_tool_call: Callable[[Sequence[Any]], Awaitable[None]] | None = None,
         on_error: Callable[[VertexLlmError], Awaitable[None]] | None = None,
         tools: list | None = None,
@@ -180,6 +187,7 @@ class GeminiLiveSession:
         self.on_interrupted = on_interrupted
         self.on_input_transcript = on_input_transcript
         self.on_output_transcript = on_output_transcript
+        self.on_turn_complete = on_turn_complete
         self.on_tool_call = on_tool_call
         self.on_error = on_error
 
@@ -227,33 +235,7 @@ class GeminiLiveSession:
             self._connect_cm = None
             raise _classify_vertex_error(exc) from exc
 
-        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge)
-        logger.info(
-            "[GeminiLiveDiag] __aenter__ returned session=%s model=%s — creating receive task",
-            type(self._session).__name__, self.model_name,
-        )
         self._receive_task = asyncio.create_task(self._receive_loop())
-        # DIAGNOSTIC: confirm the task object is a real, live asyncio.Task
-        # (not silently GC'd / not already done) right after creation, and
-        # attach a done_callback so we get a log line the instant it exits
-        # for ANY reason (normal StopAsyncIteration, exception, or cancel) —
-        # today _receive_loop() can return normally (async-for simply runs
-        # out of items) with zero log trace, which is indistinguishable from
-        # "still running" without this.
-        def _diag_receive_task_done(t: "asyncio.Task") -> None:
-            try:
-                exc = t.exception() if not t.cancelled() else None
-            except Exception as e:  # exception() itself can raise
-                exc = e
-            logger.info(
-                "[GeminiLiveDiag] receive_task DONE model=%s cancelled=%s exception=%r",
-                self.model_name, t.cancelled(), exc,
-            )
-        self._receive_task.add_done_callback(_diag_receive_task_done)
-        logger.info(
-            "[GeminiLiveDiag] receive_task created model=%s task_done=%s",
-            self.model_name, self._receive_task.done(),
-        )
 
     async def send_audio(self, pcm16_16k_bytes: bytes) -> None:
         """Send one chunk of raw PCM16/16kHz/mono caller audio. Caller must
@@ -261,18 +243,6 @@ class GeminiLiveSession:
         ``gemini_live_audio_bridge.mulaw8k_to_pcm16_16k``) — this module has
         zero telephony-format knowledge."""
         from google.genai import types
-
-        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge):
-        # cheap counter to confirm the send side keeps succeeding for the
-        # whole call (vs. silently hanging/failing) without logging every
-        # single 20ms chunk.
-        self._diag_send_count = getattr(self, "_diag_send_count", 0) + 1
-        if self._diag_send_count % 50 == 1:  # ~ once/second at 20ms frames
-            logger.info(
-                "[GeminiLiveDiag] send_audio count=%d model=%s receive_task_done=%s",
-                self._diag_send_count, self.model_name,
-                self._receive_task.done() if self._receive_task else None,
-            )
 
         await self._session.send_realtime_input(
             audio=types.Blob(data=pcm16_16k_bytes, mime_type="audio/pcm;rate=16000")
@@ -317,10 +287,6 @@ class GeminiLiveSession:
         into the registered callbacks. Any exception (SDK or otherwise) is
         translated to ``VertexLlmError`` and routed to ``on_error`` if set,
         else logged."""
-        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge)
-        logger.info("[GeminiLiveDiag] _receive_loop ENTERED model=%s", self.model_name)
-        msg_count = 0
-        turn_count = 0
         try:
             # session.receive() is an async-generator that, per google-genai's
             # live.py implementation, yields only until the first
@@ -329,46 +295,28 @@ class GeminiLiveSession:
             # whole call. It must be re-invoked for every subsequent turn,
             # hence the outer while loop below.
             while True:
-                turn_count += 1
                 turn_msg_count = 0
                 async for message in self._session.receive():
-                    msg_count += 1
                     turn_msg_count += 1
-                    logger.info(
-                        "[GeminiLiveDiag] server message #%d (turn %d) model=%s type=%s",
-                        msg_count, turn_count, self.model_name, type(message).__name__,
-                    )
                     try:
                         await self._handle_message(message)
                     except asyncio.CancelledError:
                         raise
                     except Exception as exc:
-                        logger.warning(
-                            "[GeminiLiveDiag] _handle_message raised on message #%d: %r",
-                            msg_count, exc,
-                        )
                         await self._report_error(exc)
                 if turn_msg_count == 0:
                     # receive() returned with zero messages instead of raising —
                     # treat as a dead/closed connection rather than busy-loop
                     # re-invoking it forever.
                     logger.warning(
-                        "[GeminiLiveDiag] receive() yielded no messages on turn %d "
-                        "model=%s — ending receive loop (connection likely closed)",
-                        turn_count, self.model_name,
+                        "[GeminiLiveSession] receive() yielded no messages model=%s — "
+                        "ending receive loop (connection likely closed)",
+                        self.model_name,
                     )
                     break
         except asyncio.CancelledError:
-            logger.info(
-                "[GeminiLiveDiag] _receive_loop CANCELLED model=%s after %d messages/%d turns",
-                self.model_name, msg_count, turn_count,
-            )
             raise
         except Exception as exc:
-            logger.info(
-                "[GeminiLiveDiag] _receive_loop raised model=%s after %d messages/%d turns: %r",
-                self.model_name, msg_count, turn_count, exc,
-            )
             await self._report_error(exc)
 
     async def _report_error(self, exc: Exception) -> None:
@@ -379,49 +327,17 @@ class GeminiLiveSession:
             logger.error("[GeminiLiveSession] %s (model=%s): %s", err.error_type, self.model_name, err)
 
     async def _handle_message(self, message: Any) -> None:
-        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge):
-        # log which top-level fields are present on this message — type/event
-        # name only, never raw audio bytes or transcript text — so we can see
-        # exactly what Gemini is sending without guessing at SDK field names.
-        logger.info(
-            "[GeminiLiveDiag] _handle_message model=%s setup_complete=%s "
-            "has_server_content=%s has_tool_call=%s go_away=%s",
-            self.model_name,
-            bool(getattr(message, "setup_complete", None)),
-            getattr(message, "server_content", None) is not None,
-            getattr(message, "tool_call", None) is not None,
-            bool(getattr(message, "go_away", None)),
-        )
-
         if getattr(message, "setup_complete", None):
             logger.info("[GeminiLiveSession] setup_complete model=%s", self.model_name)
 
         server_content = getattr(message, "server_content", None)
         if server_content is not None:
             model_turn = getattr(server_content, "model_turn", None)
-            # DIAGNOSTIC
-            logger.info(
-                "[GeminiLiveDiag] server_content model=%s has_model_turn=%s "
-                "interrupted=%s turn_complete=%s",
-                self.model_name,
-                model_turn is not None,
-                bool(getattr(server_content, "interrupted", False)),
-                bool(getattr(server_content, "turn_complete", False)),
-            )
             if model_turn is not None:
                 parts = getattr(model_turn, "parts", None) or []
                 for part in parts:
                     inline_data = getattr(part, "inline_data", None)
                     data = getattr(inline_data, "data", None) if inline_data is not None else None
-                    # DIAGNOSTIC — byte count only, never raw audio.
-                    logger.info(
-                        "[GeminiLiveDiag] model_turn part model=%s has_inline_data=%s "
-                        "data_len=%s on_audio_chunk_registered=%s",
-                        self.model_name,
-                        inline_data is not None,
-                        len(data) if data else 0,
-                        self.on_audio_chunk is not None,
-                    )
                     if data and self.on_audio_chunk is not None:
                         await self.on_audio_chunk(data)
 
@@ -441,6 +357,16 @@ class GeminiLiveSession:
                     getattr(output_transcript, "text", "") or "",
                     bool(getattr(output_transcript, "finished", False)),
                 )
+
+            # Wire-protocol turn boundary: per-fragment ``finished`` flags on
+            # input/output transcription are NOT reliable for the
+            # native-audio model family (may never fire, or fire on an
+            # incremental fragment rather than the full utterance — see
+            # VoiceOrchestrator's input/output transcript buffering). This
+            # standalone, payload-less flag is the only signal callers should
+            # treat as an actual turn boundary.
+            if getattr(server_content, "turn_complete", False) and self.on_turn_complete is not None:
+                await self.on_turn_complete()
 
         tool_call = getattr(message, "tool_call", None)
         if tool_call is not None and self.on_tool_call is not None:

--- a/app/services/gemini_live_service.py
+++ b/app/services/gemini_live_service.py
@@ -38,6 +38,47 @@ from app.services.vertex_gemini_service import (
 
 DEFAULT_VOICE_NAME = "Puck"
 
+# All 30 Gemini Live prebuilt native-audio voices, confirmed against Google's
+# published voice list (Zephyr, Kore, Orus, ... Sulafat). PrebuiltVoiceConfig
+# rejects anything outside this set, so validate here rather than letting a
+# bad agent.tts_voice_external_id value 400 the whole session at start().
+VALID_VOICE_NAMES: frozenset[str] = frozenset(
+    {
+        "Zephyr", "Kore", "Orus", "Autonoe", "Umbriel", "Erinome", "Laomedeia",
+        "Schedar", "Achird", "Sadachbia", "Puck", "Fenrir", "Aoede", "Enceladus",
+        "Algieba", "Algenib", "Achernar", "Gacrux", "Zubenelgenubi", "Sadaltager",
+        "Charon", "Leda", "Callirrhoe", "Iapetus", "Despina", "Rasalgethi",
+        "Alnilam", "Pulcherrima", "Vindemiatrix", "Sulafat",
+    }
+)
+
+
+def resolve_voice_name(requested: str | None) -> str:
+    """
+    Map an agent's configured voice to a valid Gemini Live prebuilt voice
+    name, falling back to DEFAULT_VOICE_NAME when unset or not a real Gemini
+    Live voice (e.g. an ElevenLabs/Rime/Google TTS voice ID left over from
+    before the agent was switched to a native-audio model — those IDs mean
+    nothing here and must never be passed through raw).
+    """
+    if not requested:
+        return DEFAULT_VOICE_NAME
+    for valid in VALID_VOICE_NAMES:
+        if valid.lower() == requested.strip().lower():
+            return valid
+    # Distinguish "no voice configured" (silent, above) from "configured
+    # voice doesn't resolve" (logged) — the latter usually means a leftover
+    # ElevenLabs/Rime/Google TTS voice ID from before the agent was switched
+    # to a native-audio model, but could also be a real typo/misconfiguration
+    # worth a support/eng follow-up, so it shouldn't be indistinguishable
+    # from the benign case in production logs.
+    logger.info(
+        "[GeminiLive] agent voice '%s' is not a valid Gemini Live voice name — "
+        "falling back to %s",
+        requested, DEFAULT_VOICE_NAME,
+    )
+    return DEFAULT_VOICE_NAME
+
 _api_key_client_lock = threading.Lock()
 _api_key_client: Any = None
 

--- a/app/services/gemini_live_service.py
+++ b/app/services/gemini_live_service.py
@@ -227,7 +227,33 @@ class GeminiLiveSession:
             self._connect_cm = None
             raise _classify_vertex_error(exc) from exc
 
+        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge)
+        logger.info(
+            "[GeminiLiveDiag] __aenter__ returned session=%s model=%s — creating receive task",
+            type(self._session).__name__, self.model_name,
+        )
         self._receive_task = asyncio.create_task(self._receive_loop())
+        # DIAGNOSTIC: confirm the task object is a real, live asyncio.Task
+        # (not silently GC'd / not already done) right after creation, and
+        # attach a done_callback so we get a log line the instant it exits
+        # for ANY reason (normal StopAsyncIteration, exception, or cancel) —
+        # today _receive_loop() can return normally (async-for simply runs
+        # out of items) with zero log trace, which is indistinguishable from
+        # "still running" without this.
+        def _diag_receive_task_done(t: "asyncio.Task") -> None:
+            try:
+                exc = t.exception() if not t.cancelled() else None
+            except Exception as e:  # exception() itself can raise
+                exc = e
+            logger.info(
+                "[GeminiLiveDiag] receive_task DONE model=%s cancelled=%s exception=%r",
+                self.model_name, t.cancelled(), exc,
+            )
+        self._receive_task.add_done_callback(_diag_receive_task_done)
+        logger.info(
+            "[GeminiLiveDiag] receive_task created model=%s task_done=%s",
+            self.model_name, self._receive_task.done(),
+        )
 
     async def send_audio(self, pcm16_16k_bytes: bytes) -> None:
         """Send one chunk of raw PCM16/16kHz/mono caller audio. Caller must
@@ -235,6 +261,18 @@ class GeminiLiveSession:
         ``gemini_live_audio_bridge.mulaw8k_to_pcm16_16k``) — this module has
         zero telephony-format knowledge."""
         from google.genai import types
+
+        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge):
+        # cheap counter to confirm the send side keeps succeeding for the
+        # whole call (vs. silently hanging/failing) without logging every
+        # single 20ms chunk.
+        self._diag_send_count = getattr(self, "_diag_send_count", 0) + 1
+        if self._diag_send_count % 50 == 1:  # ~ once/second at 20ms frames
+            logger.info(
+                "[GeminiLiveDiag] send_audio count=%d model=%s receive_task_done=%s",
+                self._diag_send_count, self.model_name,
+                self._receive_task.done() if self._receive_task else None,
+            )
 
         await self._session.send_realtime_input(
             audio=types.Blob(data=pcm16_16k_bytes, mime_type="audio/pcm;rate=16000")
@@ -279,17 +317,58 @@ class GeminiLiveSession:
         into the registered callbacks. Any exception (SDK or otherwise) is
         translated to ``VertexLlmError`` and routed to ``on_error`` if set,
         else logged."""
+        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge)
+        logger.info("[GeminiLiveDiag] _receive_loop ENTERED model=%s", self.model_name)
+        msg_count = 0
+        turn_count = 0
         try:
-            async for message in self._session.receive():
-                try:
-                    await self._handle_message(message)
-                except asyncio.CancelledError:
-                    raise
-                except Exception as exc:
-                    await self._report_error(exc)
+            # session.receive() is an async-generator that, per google-genai's
+            # live.py implementation, yields only until the first
+            # server_content.turn_complete=True message and then returns
+            # (StopAsyncIteration) — it covers a single model turn, not the
+            # whole call. It must be re-invoked for every subsequent turn,
+            # hence the outer while loop below.
+            while True:
+                turn_count += 1
+                turn_msg_count = 0
+                async for message in self._session.receive():
+                    msg_count += 1
+                    turn_msg_count += 1
+                    logger.info(
+                        "[GeminiLiveDiag] server message #%d (turn %d) model=%s type=%s",
+                        msg_count, turn_count, self.model_name, type(message).__name__,
+                    )
+                    try:
+                        await self._handle_message(message)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        logger.warning(
+                            "[GeminiLiveDiag] _handle_message raised on message #%d: %r",
+                            msg_count, exc,
+                        )
+                        await self._report_error(exc)
+                if turn_msg_count == 0:
+                    # receive() returned with zero messages instead of raising —
+                    # treat as a dead/closed connection rather than busy-loop
+                    # re-invoking it forever.
+                    logger.warning(
+                        "[GeminiLiveDiag] receive() yielded no messages on turn %d "
+                        "model=%s — ending receive loop (connection likely closed)",
+                        turn_count, self.model_name,
+                    )
+                    break
         except asyncio.CancelledError:
+            logger.info(
+                "[GeminiLiveDiag] _receive_loop CANCELLED model=%s after %d messages/%d turns",
+                self.model_name, msg_count, turn_count,
+            )
             raise
         except Exception as exc:
+            logger.info(
+                "[GeminiLiveDiag] _receive_loop raised model=%s after %d messages/%d turns: %r",
+                self.model_name, msg_count, turn_count, exc,
+            )
             await self._report_error(exc)
 
     async def _report_error(self, exc: Exception) -> None:
@@ -300,16 +379,49 @@ class GeminiLiveSession:
             logger.error("[GeminiLiveSession] %s (model=%s): %s", err.error_type, self.model_name, err)
 
     async def _handle_message(self, message: Any) -> None:
+        # DIAGNOSTIC (temporary — root-cause investigation, strip before merge):
+        # log which top-level fields are present on this message — type/event
+        # name only, never raw audio bytes or transcript text — so we can see
+        # exactly what Gemini is sending without guessing at SDK field names.
+        logger.info(
+            "[GeminiLiveDiag] _handle_message model=%s setup_complete=%s "
+            "has_server_content=%s has_tool_call=%s go_away=%s",
+            self.model_name,
+            bool(getattr(message, "setup_complete", None)),
+            getattr(message, "server_content", None) is not None,
+            getattr(message, "tool_call", None) is not None,
+            bool(getattr(message, "go_away", None)),
+        )
+
         if getattr(message, "setup_complete", None):
             logger.info("[GeminiLiveSession] setup_complete model=%s", self.model_name)
 
         server_content = getattr(message, "server_content", None)
         if server_content is not None:
             model_turn = getattr(server_content, "model_turn", None)
+            # DIAGNOSTIC
+            logger.info(
+                "[GeminiLiveDiag] server_content model=%s has_model_turn=%s "
+                "interrupted=%s turn_complete=%s",
+                self.model_name,
+                model_turn is not None,
+                bool(getattr(server_content, "interrupted", False)),
+                bool(getattr(server_content, "turn_complete", False)),
+            )
             if model_turn is not None:
-                for part in getattr(model_turn, "parts", None) or []:
+                parts = getattr(model_turn, "parts", None) or []
+                for part in parts:
                     inline_data = getattr(part, "inline_data", None)
                     data = getattr(inline_data, "data", None) if inline_data is not None else None
+                    # DIAGNOSTIC — byte count only, never raw audio.
+                    logger.info(
+                        "[GeminiLiveDiag] model_turn part model=%s has_inline_data=%s "
+                        "data_len=%s on_audio_chunk_registered=%s",
+                        self.model_name,
+                        inline_data is not None,
+                        len(data) if data else 0,
+                        self.on_audio_chunk is not None,
+                    )
                     if data and self.on_audio_chunk is not None:
                         await self.on_audio_chunk(data)
 

--- a/app/services/hume_tts_service.py
+++ b/app/services/hume_tts_service.py
@@ -1,0 +1,261 @@
+"""
+Hume AI TTS service — streaming WebSocket synthesis for real-time calling.
+
+API: wss://api.hume.ai/v0/tts/stream/input?api_key={api_key}&format_type=pcm&instant_mode=true
+Audio: server streams JSON messages containing base64-encoded raw PCM16LE
+mono audio chunks. There is no explicit per-chunk sample rate in the
+protocol; see `settings.HUME_TTS_SAMPLE_RATE_HZ` (app/core/config.py) for
+the configured-but-ASSUMED source rate this service downsamples from — that
+value is not confirmed by Hume's public docs as of this integration and
+should be verified against a real account/API key before production
+traffic depends on it.
+
+Telephony output: mulaw 8 kHz (matches Twilio MULAW 8000), produced
+incrementally via `PCMStreamDownsampler` as WebSocket chunks arrive.
+
+This integration deliberately mirrors Rime's "one WebSocket request per
+pipeline chunk" model (see rime_tts_service.py) — NOT a persistent,
+cross-turn streaming-input session (that's an ElevenLabs Phase 6-3 only
+feature, out of scope here).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import re
+import time
+from typing import Any, AsyncIterator
+
+from app.core.config import settings
+from app.core.logger import logger
+from app.core.secret_manager import get_hume_api_key
+from app.utils.audio_utils import PCMStreamDownsampler
+
+_HUME_WS_URL = "wss://api.hume.ai/v0/tts/stream/input"
+_DEFAULT_VOICE = "Male English Actor"
+_DEFAULT_VOICE_PROVIDER = "HUME_AI"
+
+# Mirrors the connect-timeout budget used elsewhere on the hot TTS path
+# (see app/services/elevenlabs_ws_session.py::_WS_CONNECT_TIMEOUT_S).
+_WS_CONNECT_TIMEOUT_S: float = 5.0
+# Idle read timeout per incoming message — guards against a stalled Hume
+# connection hanging a chunk forever.
+_WS_RECV_TIMEOUT_S: float = 15.0
+
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+class HumeTtsServiceError(RuntimeError):
+    """Connect/auth/send/receive failure talking to Hume's TTS WebSocket."""
+
+
+def _looks_like_uuid(value: str) -> bool:
+    try:
+        return bool(_UUID_RE.match(value.strip()))
+    except (TypeError, AttributeError):
+        return False
+
+
+_API_KEY_QS_RE = re.compile(r"(api_key=)[^&\s]+")
+
+
+def _redact(text: str) -> str:
+    """Strip the `api_key=...` query-string value out of any string before
+    it's logged or included in a raised exception's message — defensive
+    insurance against a future `websockets` version (or connection error
+    path) that embeds the request URI in its own str()/repr(), which today's
+    pinned websockets==16.0 does not for the exception types actually
+    reachable here."""
+    return _API_KEY_QS_RE.sub(r"\1<redacted>", text)
+
+
+def _build_voice_payload(voice_external_id: str, voice_provider: str) -> dict[str, Any]:
+    voice_id = (voice_external_id or "").strip() or _DEFAULT_VOICE
+    if _looks_like_uuid(voice_id):
+        return {"id": voice_id}
+    return {"name": voice_id, "provider": voice_provider}
+
+
+class HumeTtsService:
+    """Thin async wrapper around the Hume TTS WebSocket streaming endpoint."""
+
+    def __init__(self) -> None:
+        # Resolve once at construction so a missing key fails before any live call.
+        self._api_key = get_hume_api_key()
+
+    def _build_url(self) -> str:
+        return f"{_HUME_WS_URL}?api_key={self._api_key}&format_type=pcm&instant_mode=true"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def stream_text_to_speech(
+        self,
+        text: str,
+        voice_external_id: str = _DEFAULT_VOICE,
+        voice_provider: str = _DEFAULT_VOICE_PROVIDER,
+        speed: float = 1.0,
+        description: str | None = None,
+        src_sample_rate_hz: int | None = None,
+    ) -> AsyncIterator[bytes]:
+        """
+        Async generator yielding raw mulaw 8kHz audio byte chunks in
+        real-time, decoded and downsampled incrementally as Hume's
+        WebSocket sends PCM16LE audio messages.
+
+        Opens one WebSocket per call (one-shot request/response, `close:
+        true` sent in the single outbound message) — not a persistent
+        cross-turn session.
+        """
+        if not text or not text.strip():
+            return
+
+        try:
+            import websockets
+        except ImportError as exc:  # pragma: no cover - dependency is pinned in requirements.txt
+            raise HumeTtsServiceError(
+                "the 'websockets' package is not installed"
+            ) from exc
+
+        src_rate = src_sample_rate_hz or settings.HUME_TTS_SAMPLE_RATE_HZ
+        downsampler = PCMStreamDownsampler(src_rate, 8000)
+
+        voice_payload = _build_voice_payload(voice_external_id, voice_provider)
+        message: dict[str, Any] = {
+            "text": text.strip(),
+            "voice": voice_payload,
+            "speed": float(speed),
+            "close": True,
+        }
+        if description:
+            message["description"] = description[:100]
+
+        url = self._build_url()
+        t0 = time.perf_counter()
+        first_chunk = True
+
+        try:
+            ws = await asyncio.wait_for(
+                websockets.connect(url), timeout=_WS_CONNECT_TIMEOUT_S
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            raise HumeTtsServiceError(
+                f"failed to open Hume TTS WebSocket: {_redact(str(exc))}"
+            ) from exc
+
+        try:
+            try:
+                await ws.send(json.dumps(message))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                raise HumeTtsServiceError(
+                    f"failed to send to Hume TTS WebSocket: {_redact(str(exc))}"
+                ) from exc
+
+            while True:
+                try:
+                    raw_msg = await asyncio.wait_for(ws.recv(), timeout=_WS_RECV_TIMEOUT_S)
+                except asyncio.CancelledError:
+                    raise
+                except asyncio.TimeoutError as exc:
+                    raise HumeTtsServiceError(
+                        f"Hume TTS WebSocket idle timeout after {_WS_RECV_TIMEOUT_S}s"
+                    ) from exc
+                except websockets.ConnectionClosedOK as exc:
+                    # Server closed cleanly after honoring `close: true` —
+                    # expected end-of-stream for the one-shot-per-chunk model.
+                    logger.debug("[Hume] connection closed normally: %s", exc)
+                    break
+                except Exception as exc:
+                    # Abnormal close / protocol error — this is a real failure,
+                    # not a benign end-of-stream. Surface it (mirrors Rime's
+                    # HTTP error handling) so the caller's fallback path
+                    # actually engages instead of a chunk silently going dark.
+                    logger.error("[Hume] receive loop failed: %s", exc)
+                    raise HumeTtsServiceError(
+                        f"Hume TTS WebSocket receive failed: {_redact(str(exc))}"
+                    ) from exc
+
+                try:
+                    msg = json.loads(raw_msg)
+                except (json.JSONDecodeError, TypeError):
+                    continue
+
+                msg_type = msg.get("type")
+                if msg_type == "timestamp":
+                    continue
+                if msg_type == "error":
+                    error_detail = msg.get("message") or msg.get("error") or msg
+                    logger.error("[Hume] TTS error response: %s", error_detail)
+                    raise HumeTtsServiceError(f"Hume TTS error: {error_detail}")
+                if msg_type != "audio":
+                    # Unrecognized message type — log it (visible in logs,
+                    # unlike a fully silent break) and end the stream. Not
+                    # raised, since Hume's message vocabulary beyond
+                    # audio/timestamp/error isn't fully documented and an
+                    # unknown-but-benign message type shouldn't hard-fail a call.
+                    logger.warning(
+                        "[Hume] unexpected message type %r — ending stream", msg_type
+                    )
+                    break
+
+                audio_b64 = msg.get("audio")
+                if audio_b64:
+                    try:
+                        pcm_bytes = base64.b64decode(audio_b64)
+                    except Exception as exc:  # noqa: BLE001 - malformed payload must not kill the loop
+                        logger.warning("[Hume] failed to decode audio chunk: %s", exc)
+                        pcm_bytes = b""
+                    if pcm_bytes:
+                        mulaw_bytes = downsampler.feed(pcm_bytes)
+                        if mulaw_bytes:
+                            if first_chunk:
+                                latency_ms = (time.perf_counter() - t0) * 1000
+                                logger.info(
+                                    "[Hume] first audio chunk latency: %.0f ms (voice=%s)",
+                                    latency_ms, voice_external_id,
+                                )
+                                first_chunk = False
+                            yield mulaw_bytes
+
+                if bool(msg.get("is_last_chunk")):
+                    break
+
+            tail = downsampler.flush()
+            if tail:
+                yield tail
+        finally:
+            try:
+                await ws.close()
+            except Exception as exc:  # noqa: BLE001 - best-effort close, already tearing down
+                logger.debug("[Hume] close() raised during teardown: %s", exc)
+
+    async def synthesize(
+        self,
+        text: str,
+        voice_external_id: str = _DEFAULT_VOICE,
+        voice_provider: str = _DEFAULT_VOICE_PROVIDER,
+        speed: float = 1.0,
+        description: str | None = None,
+    ) -> bytes:
+        """Collect full audio into memory (used by batch/cache paths)."""
+        chunks: list[bytes] = []
+        async for chunk in self.stream_text_to_speech(
+            text=text,
+            voice_external_id=voice_external_id,
+            voice_provider=voice_provider,
+            speed=speed,
+            description=description,
+        ):
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+
+hume_tts_service = HumeTtsService()

--- a/app/services/hume_tts_service.py
+++ b/app/services/hume_tts_service.py
@@ -183,9 +183,32 @@ class HumeTtsService:
                         f"Hume TTS WebSocket receive failed: {_redact(str(exc))}"
                     ) from exc
 
+                if isinstance(raw_msg, (bytes, bytearray)):
+                    # Binary WebSocket frame: Hume sends raw audio payload
+                    # directly (no JSON/base64 envelope) for at least some
+                    # requests under format_type=pcm — observed in production
+                    # (a text-frame-only assumption crashed on non-UTF-8
+                    # binary audio bytes here). No `is_last_chunk`/`type`
+                    # metadata is available for these frames; stream end is
+                    # detected via ConnectionClosedOK / idle timeout / a
+                    # subsequent JSON control message instead.
+                    pcm_bytes = bytes(raw_msg)
+                    if pcm_bytes:
+                        mulaw_bytes = downsampler.feed(pcm_bytes)
+                        if mulaw_bytes:
+                            if first_chunk:
+                                latency_ms = (time.perf_counter() - t0) * 1000
+                                logger.info(
+                                    "[Hume] first audio chunk latency: %.0f ms (voice=%s)",
+                                    latency_ms, voice_external_id,
+                                )
+                                first_chunk = False
+                            yield mulaw_bytes
+                    continue
+
                 try:
                     msg = json.loads(raw_msg)
-                except (json.JSONDecodeError, TypeError):
+                except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
                     continue
 
                 msg_type = msg.get("type")

--- a/app/services/hume_tts_service.py
+++ b/app/services/hume_tts_service.py
@@ -33,7 +33,11 @@ from app.core.secret_manager import get_hume_api_key
 from app.utils.audio_utils import PCMStreamDownsampler
 
 _HUME_WS_URL = "wss://api.hume.ai/v0/tts/stream/input"
-_DEFAULT_VOICE = "Male English Actor"
+# Public — imported by agent_runtime.py / tts_stream_mixin.py /
+# livekit_browser_call_handler.py so the default voice string exists in
+# exactly one place instead of being duplicated (and risking drift/typos).
+HUME_DEFAULT_VOICE = "Male English Actor"
+_DEFAULT_VOICE = HUME_DEFAULT_VOICE
 _DEFAULT_VOICE_PROVIDER = "HUME_AI"
 
 # Mirrors the connect-timeout budget used elsewhere on the hot TTS path
@@ -83,11 +87,19 @@ class HumeTtsService:
     """Thin async wrapper around the Hume TTS WebSocket streaming endpoint."""
 
     def __init__(self) -> None:
-        # Resolve once at construction so a missing key fails before any live call.
-        self._api_key = get_hume_api_key()
+        # Resolved lazily on first call, not here -- this class is
+        # constructed as a module-level singleton at import time, and Hume
+        # is an optional/BYO provider most tenants never configure. Eagerly
+        # calling get_hume_api_key() (which raises when unset) would crash
+        # any eager import of this module for every tenant, not just ones
+        # using Hume.
+        pass
+
+    def _get_api_key(self) -> str:
+        return get_hume_api_key()
 
     def _build_url(self) -> str:
-        return f"{_HUME_WS_URL}?api_key={self._api_key}&format_type=pcm&instant_mode=true"
+        return f"{_HUME_WS_URL}?api_key={self._get_api_key()}&format_type=pcm&instant_mode=true"
 
     # ------------------------------------------------------------------
     # Public API
@@ -132,6 +144,14 @@ class HumeTtsService:
             "close": True,
         }
         if description:
+            # 100-char limit is not documented in Hume's public API docs --
+            # logged so a silently-truncated acting instruction (e.g. cut
+            # mid-sentence) is at least traceable, rather than an invisible
+            # behavior change.
+            if len(description) > 100:
+                logger.debug(
+                    "[Hume] description truncated from %d to 100 chars", len(description)
+                )
             message["description"] = description[:100]
 
         url = self._build_url()

--- a/app/services/openai_realtime_service.py
+++ b/app/services/openai_realtime_service.py
@@ -57,6 +57,7 @@ import enum
 import json
 from typing import Any, Awaitable, Callable
 
+from app.core.config import settings
 from app.core.llm_models import OPENAI_REALTIME_MODELS
 from app.core.logger import logger
 from app.core.openai_client import get_async_openai_client
@@ -324,7 +325,14 @@ class OpenAIRealtimeSession:
             "audio": {
                 "input": {
                     "format": _audio_format_dict(audio_format),
-                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    # Configurable — see settings.llm.openai_realtime_transcription_model's
+                    # docstring: newer transcription models (gpt-4o-mini-transcribe
+                    # etc.) require per-project OpenAI access that isn't
+                    # guaranteed to be enabled even when the project has full
+                    # Realtime API access for the main model itself (confirmed
+                    # via a real call hitting model_not_found). whisper-1 is
+                    # the safe, universally-available default.
+                    "transcription": {"model": settings.llm.openai_realtime_transcription_model},
                     "turn_detection": {
                         "type": "server_vad",
                         "interrupt_response": True,

--- a/app/services/openai_realtime_service.py
+++ b/app/services/openai_realtime_service.py
@@ -356,13 +356,29 @@ class OpenAIRealtimeSession:
         """Send one chunk of raw caller audio, already encoded in whatever
         format this session was started with (`audio_format` — mu-law 8kHz
         for Twilio, PCM16 24kHz for LiveKit). This module has zero
-        telephony-format knowledge beyond that string."""
-        if not audio_bytes:
+        telephony-format knowledge beyond that string.
+
+        Safe no-op once the session is closed/closing — the audio-forwarding
+        background task (``LiveKitAudioSubscriber`` / Twilio's media-stream
+        loop) is stopped independently of this session's teardown, so a few
+        straggler chunks arriving after ``close()`` has already fired are
+        expected, not exceptional. Without this guard those stragglers hit
+        the underlying websocket mid-close-handshake and raise
+        ``ConnectionClosedError``/``TimeoutError``, which the caller then
+        logs at ERROR level for what is actually a benign shutdown race."""
+        if not audio_bytes or self._closed:
             return
-        await self._connection.send({
-            "type": "input_audio_buffer.append",
-            "audio": base64.b64encode(audio_bytes).decode("ascii"),
-        })
+        try:
+            await self._connection.send({
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(audio_bytes).decode("ascii"),
+            })
+        except Exception:
+            if self._closed:
+                # Lost the race: close() ran concurrently with this send.
+                # Benign — swallow rather than surface as an error.
+                return
+            raise
 
     async def send_text(self, text: str, respond: bool = True) -> None:
         """
@@ -467,6 +483,13 @@ class OpenAIRealtimeSession:
     async def _handle_event(self, event: Any) -> None:
         etype = getattr(event, "type", None)
 
+        # DIAGNOSTIC: temporary, event-type-only tracing to confirm which
+        # Realtime events actually arrive on a real call (added while
+        # investigating a "no transcript captured" report — no raw audio or
+        # transcript text is ever included here). Safe to strip once
+        # transcript capture is confirmed working on a real call.
+        logger.info("[OpenAIRealtimeSession] DIAGNOSTIC event type=%s", etype)
+
         if etype == "response.output_audio.delta":
             delta = getattr(event, "delta", None)
             if delta and self.on_audio_chunk is not None:
@@ -507,6 +530,43 @@ class OpenAIRealtimeSession:
             error_obj = getattr(event, "error", None)
             message = getattr(error_obj, "message", None) or str(error_obj) or "unknown Realtime API error"
             await self._report_error(OpenAIRealtimeError(message, OpenAIRealtimeErrorType.UNKNOWN))
+            return
+
+        if etype == "conversation.item.input_audio_transcription.failed":
+            # A single utterance's transcription failed server-side (e.g. an
+            # issue with the configured `gpt-4o-mini-transcribe` model or an
+            # audio-format mismatch). This is NOT the same as a session-fatal
+            # `error` event — the audio call itself is fine and OpenAI keeps
+            # talking; only this one utterance's transcript is lost. Log
+            # loudly (previously this fell through to the silent "benign
+            # chatter" branch below with zero visibility) but do not treat it
+            # as fatal / route through on_error, matching this codebase's
+            # fail-open philosophy for per-turn transcript/RAG failures.
+            error_obj = getattr(event, "error", None)
+            message = getattr(error_obj, "message", None) or str(error_obj) or "unknown transcription error"
+            code = getattr(error_obj, "code", None)
+            item_id = getattr(event, "item_id", None)
+            logger.warning(
+                "[OpenAIRealtimeSession] input audio transcription FAILED "
+                "(model=%s item_id=%s code=%s): %s",
+                self.model_name, item_id, code, message,
+            )
+            return
+
+        if etype in ("mcp_list_tools.failed", "response.mcp_call.failed"):
+            # Not currently used by this integration (no MCP tools are wired
+            # up here — only the Calendly function tools), but logged
+            # explicitly rather than silently dropped in case that changes,
+            # or in case the SDK reports one of these unexpectedly. Neither
+            # event type carries its own error payload (confirmed against
+            # the SDK's generated fields — just event_id/item_id); the
+            # underlying reason, if any, arrives separately via the generic
+            # "error" event handled above.
+            item_id = getattr(event, "item_id", None)
+            logger.warning(
+                "[OpenAIRealtimeSession] %s event (model=%s item_id=%s)",
+                etype, self.model_name, item_id,
+            )
             return
 
         # All other event types (session.created, response.created,

--- a/app/services/openai_realtime_service.py
+++ b/app/services/openai_realtime_service.py
@@ -1,0 +1,515 @@
+"""
+OpenAI Realtime (speech-to-speech native-audio) session wrapper.
+
+Mirrors ``app/services/gemini_live_service.py``'s module shape/callback
+contract (``GeminiLiveSession``) so ``VoiceOrchestrator`` can wire either
+provider into the same transport handlers with parallel, not shared, code
+paths (per this repo's convention of keeping the two Twilio/LiveKit
+transport handlers "deliberately parallel, not shared via inheritance" —
+same idea applied one layer down, at the provider level).
+
+This module has ZERO knowledge of Twilio/LiveKit/telephony framing — it
+only speaks whatever raw audio bytes the caller tells it to use via
+``audio_format`` (``"audio/pcmu"`` — mu-law 8kHz, a direct match for
+Twilio's own wire format, so the Twilio transport needs NO resampling
+bridge at all; or ``"audio/pcm"`` — PCM16 24kHz, symmetric in both
+directions, which is what the LiveKit browser transport's publisher speaks
+for Gemini Live too). See ``app/core/llm_models.py``'s
+``OPENAI_REALTIME_MODELS``/``is_openai_realtime_model`` for the routing
+predicate used by transport handlers.
+
+Deliberate divergences from ``GeminiLiveSession`` (do not "fix" these to
+match Gemini — they are correct as written; see each divergence's own
+docstring for the evidence):
+
+  * ``_receive_loop`` is a single flat ``while True: recv(); handle()``
+    loop — ``AsyncRealtimeConnection.recv()`` returns exactly one parsed
+    server event per call with no per-turn generator-exhaustion quirk,
+    unlike ``google.genai``'s ``session.receive()`` (whose per-turn
+    re-invocation requirement was the root cause of a real "silent after
+    turn 1" bug this repo shipped and then fixed for Gemini Live — see
+    that module's ``_receive_loop`` docstring for the incident). Wrapping
+    this loop in Gemini's outer per-turn ``while True`` here would be
+    solving a problem this SDK doesn't have.
+  * Transcripts are captured directly off
+    ``conversation.item.input_audio_transcription.completed`` /
+    ``response.output_audio_transcript.done`` — each fires exactly once
+    per utterance with the FULL final text in ``.transcript``. No
+    fragment-buffering/reassembly workaround is needed (unlike Gemini
+    Live's per-fragment ``finished``-flag unreliability) — do not port that
+    buffering pattern here, it would be solving a problem this API
+    contract doesn't have either.
+  * Barge-in is largely server-driven: session config sets
+    ``turn_detection.interrupt_response=True``, so OpenAI cancels its own
+    in-flight response server-side the moment it detects caller speech.
+    ``on_interrupted`` (wired to ``input_audio_buffer.speech_started``) is
+    still surfaced so the transport can locally clear whatever audio it
+    has already buffered/sent (mirrors Gemini Live's ``on_interrupted``
+    contract at the VoiceOrchestrator layer, even though the server-side
+    half of the interruption is automatic here and manual for Gemini).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import enum
+import json
+from typing import Any, Awaitable, Callable
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.core.logger import logger
+from app.core.openai_client import get_async_openai_client
+
+DEFAULT_VOICE_NAME = "marin"
+
+# Confirmed via the installed openai==2.36.0 SDK
+# (openai.types.realtime.realtime_audio_output.RealtimeAudioConfigOutput's
+# `voice` field / OpenAI's Realtime voices list). OpenAI recommends `marin`/
+# `cedar` for best quality on the newer Realtime models — used as the
+# default here rather than a legacy voice like `alloy`.
+VALID_VOICE_NAMES: frozenset[str] = frozenset(
+    {
+        "alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer",
+        "verse", "marin", "cedar",
+    }
+)
+
+# gpt-realtime-2 is documented (SDK-side, via RealtimeReasoning/
+# reasoning_effort) as "reasoning-capable" — an uncapped reasoning budget on
+# a live voice turn risks noticeable dead air before the model starts
+# speaking, same rationale as app.services.openai_service.py's
+# _REASONING_EFFORT_BY_MODEL cap for the gpt-5.x Chat Completions family
+# (see that module's docstring for the full incident writeup this pattern
+# is modeled on). `gpt-realtime` (the original, non-"-2" model) has no
+# reasoning config at all, so it is deliberately absent from this map —
+# sending a `reasoning` block to a non-reasoning-capable model is not
+# something this integration has verified is safe, so it is simply never
+# sent for that model.
+_REASONING_EFFORT_BY_MODEL: dict[str, str] = {
+    "gpt-realtime-2": "low",
+}
+
+# Twilio's own wire format (mu-law 8kHz) — passed straight through with NO
+# conversion, unlike Gemini Live's forced PCM16 resample round-trip (see
+# app/voice/gemini_live_audio_bridge.py). Confirmed via
+# openai.types.realtime.realtime_audio_formats.AudioPCMU: `audio/pcmu` is a
+# natively supported input AND output format.
+TWILIO_AUDIO_FORMAT = "audio/pcmu"
+# LiveKit browser transport's publisher format — PCM16, 24kHz only
+# (confirmed via AudioPCM: `rate` is `Literal[24000]`), symmetric for both
+# input and output (unlike Gemini Live's asymmetric 16kHz-in/24kHz-out).
+LIVEKIT_AUDIO_FORMAT = "audio/pcm"
+LIVEKIT_AUDIO_RATE_HZ = 24000
+
+
+def resolve_voice_name(requested: str | None) -> str:
+    """
+    Map an agent's configured voice to a valid OpenAI Realtime voice name,
+    falling back to DEFAULT_VOICE_NAME when unset or not a real Realtime
+    voice (e.g. an ElevenLabs/Rime/Google TTS voice ID left over from before
+    the agent was switched to a native-audio model). Mirrors
+    gemini_live_service.resolve_voice_name's fallback-and-log-on-mismatch
+    pattern exactly.
+    """
+    if not requested:
+        return DEFAULT_VOICE_NAME
+    for valid in VALID_VOICE_NAMES:
+        if valid.lower() == requested.strip().lower():
+            return valid
+    logger.info(
+        "[OpenAIRealtime] agent voice '%s' is not a valid OpenAI Realtime voice name — "
+        "falling back to %s",
+        requested, DEFAULT_VOICE_NAME,
+    )
+    return DEFAULT_VOICE_NAME
+
+
+class OpenAIRealtimeErrorType(str, enum.Enum):
+    QUOTA = "quota"
+    TIMEOUT = "timeout"
+    AUTH = "auth"
+    CONNECTION_CLOSED = "connection_closed"
+    UNKNOWN = "unknown"
+
+
+class OpenAIRealtimeError(Exception):
+    def __init__(
+        self, message: str, error_type: OpenAIRealtimeErrorType = OpenAIRealtimeErrorType.UNKNOWN
+    ) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
+def _classify_openai_realtime_error(exc: Exception) -> OpenAIRealtimeError:
+    """Mirrors gemini_live_service._classify_vertex_error's shape/intent,
+    against the openai-python SDK's own exception hierarchy instead of
+    google.genai's."""
+    import openai as openai_sdk
+
+    msg = str(exc)
+    if isinstance(exc, openai_sdk.RateLimitError):
+        return OpenAIRealtimeError(f"OpenAI Realtime quota exceeded: {msg}", OpenAIRealtimeErrorType.QUOTA)
+    if isinstance(exc, openai_sdk.APITimeoutError):
+        return OpenAIRealtimeError(f"OpenAI Realtime timeout: {msg}", OpenAIRealtimeErrorType.TIMEOUT)
+    if isinstance(exc, openai_sdk.AuthenticationError):
+        return OpenAIRealtimeError(f"OpenAI Realtime auth failed: {msg}", OpenAIRealtimeErrorType.AUTH)
+    if isinstance(exc, getattr(openai_sdk, "WebSocketConnectionClosedError", ())):
+        return OpenAIRealtimeError(f"OpenAI Realtime connection closed: {msg}", OpenAIRealtimeErrorType.CONNECTION_CLOSED)
+
+    name = type(exc).__name__
+    lowered = msg.lower()
+    if "quota" in lowered or ("rate" in lowered and "limit" in lowered):
+        return OpenAIRealtimeError(f"OpenAI Realtime quota: {msg}", OpenAIRealtimeErrorType.QUOTA)
+    if "timeout" in lowered or "timed out" in lowered:
+        return OpenAIRealtimeError(f"OpenAI Realtime timeout: {msg}", OpenAIRealtimeErrorType.TIMEOUT)
+    if "closed" in lowered or "ConnectionClosed" in name:
+        return OpenAIRealtimeError(f"OpenAI Realtime connection closed: {msg}", OpenAIRealtimeErrorType.CONNECTION_CLOSED)
+    return OpenAIRealtimeError(f"OpenAI Realtime error: {msg}", OpenAIRealtimeErrorType.UNKNOWN)
+
+
+def _build_calendly_tool_params() -> list[dict]:
+    """
+    OpenAI Realtime function-tool declarations for the Calendly booking
+    flow — same two tools/parameter shapes as
+    ``vertex_gemini_service._build_calendly_tool()``, translated to the
+    Realtime API's flat ``{type: "function", name, description,
+    parameters}`` tool shape (confirmed via
+    ``openai.types.realtime.RealtimeFunctionToolParam``) instead of
+    google.genai's ``FunctionDeclaration`` wrapper.
+    """
+    return [
+        {
+            "type": "function",
+            "name": "check_availability",
+            "description": (
+                "Check available appointment slots on the connected Calendly calendar. "
+                "Slot length is fixed by the connected Calendly event type — it cannot "
+                "be requested per-call."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "description": "Date to check availability for, as YYYY-MM-DD (or 'today'/'tomorrow').",
+                    },
+                },
+                "required": ["date"],
+            },
+        },
+        {
+            "type": "function",
+            "name": "book_appointment",
+            "description": "Schedule an appointment on Calendly for a previously offered slot.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "slot": {
+                        "type": "string",
+                        "description": "The chosen slot start time, ISO-8601 (UTC).",
+                    },
+                    "attendee_email": {
+                        "type": "string",
+                        "description": "The caller's email address to send the Calendly confirmation to.",
+                    },
+                },
+                "required": ["slot", "attendee_email"],
+            },
+        },
+    ]
+
+
+def _audio_format_dict(audio_format: str) -> dict:
+    if audio_format == LIVEKIT_AUDIO_FORMAT:
+        return {"type": LIVEKIT_AUDIO_FORMAT, "rate": LIVEKIT_AUDIO_RATE_HZ}
+    return {"type": audio_format}
+
+
+class OpenAIRealtimeSession:
+    """
+    Transport-agnostic wrapper around one OpenAI Realtime API connection.
+
+    Usage (mirrors GeminiLiveSession):
+      session = OpenAIRealtimeSession(agent.llm_model)
+      await session.start(system_instruction=..., audio_format="audio/pcmu",
+                           on_audio_chunk=..., on_interrupted=...)
+      await session.send_audio(mulaw_or_pcm16_bytes)   # per caller-audio chunk
+      ...
+      await session.close()
+    """
+
+    def __init__(self, model_name: str) -> None:
+        if model_name not in OPENAI_REALTIME_MODELS:
+            raise ValueError(
+                f"'{model_name}' is not an OpenAI Realtime speech-to-speech model. "
+                f"Valid models: {sorted(OPENAI_REALTIME_MODELS)}"
+            )
+        self.model_name = model_name
+
+        self._client: Any = None
+        self._connect_cm: Any = None
+        self._connection: Any = None
+        self._receive_task: asyncio.Task | None = None
+        self._closed = False
+
+        # Registered by start(); consumed by _receive_loop.
+        self.on_audio_chunk: Callable[[bytes], Awaitable[None]] | None = None
+        self.on_interrupted: Callable[[], Awaitable[None]] | None = None
+        # Demuxed from OpenAI's own input_audio_buffer.speech_stopped event
+        # (see _handle_message). Not currently wired by VoiceOrchestrator —
+        # nothing there needs a "caller stopped talking" signal yet — but the
+        # session-level plumbing is here and tested so a future turn-boundary
+        # or analytics consumer doesn't have to add wire-protocol handling.
+        self.on_speech_stopped: Callable[[], Awaitable[None]] | None = None
+        # Fires once per utterance with the FULL final transcript text — no
+        # `finished`-flag/fragment-buffering dance (see module docstring).
+        self.on_input_transcript: Callable[[str], Awaitable[None]] | None = None
+        self.on_output_transcript: Callable[[str], Awaitable[None]] | None = None
+        self.on_tool_call: Callable[[str, str, str], Awaitable[None]] | None = None
+        self.on_error: Callable[[OpenAIRealtimeError], Awaitable[None]] | None = None
+
+    def _build_client(self):
+        return get_async_openai_client()
+
+    async def start(
+        self,
+        *,
+        system_instruction: str,
+        audio_format: str = LIVEKIT_AUDIO_FORMAT,
+        voice_name: str = DEFAULT_VOICE_NAME,
+        on_audio_chunk: Callable[[bytes], Awaitable[None]],
+        on_interrupted: Callable[[], Awaitable[None]],
+        on_speech_stopped: Callable[[], Awaitable[None]] | None = None,
+        on_input_transcript: Callable[[str], Awaitable[None]] | None = None,
+        on_output_transcript: Callable[[str], Awaitable[None]] | None = None,
+        on_tool_call: Callable[[str, str, str], Awaitable[None]] | None = None,
+        on_error: Callable[[OpenAIRealtimeError], Awaitable[None]] | None = None,
+        tools: list[dict] | None = None,
+    ) -> None:
+        """
+        Open the Realtime connection, send the initial `session.update`, and
+        start the background receive loop. Raises ``OpenAIRealtimeError`` on
+        any setup failure (bad model, missing credentials, SDK/connect
+        errors) — mirrors GeminiLiveSession.start()'s contract exactly so
+        VoiceOrchestrator's pre-session-failure fallback handling can stay
+        provider-agnostic at the call site.
+        """
+        self.on_audio_chunk = on_audio_chunk
+        self.on_interrupted = on_interrupted
+        self.on_speech_stopped = on_speech_stopped
+        self.on_input_transcript = on_input_transcript
+        self.on_output_transcript = on_output_transcript
+        self.on_tool_call = on_tool_call
+        self.on_error = on_error
+
+        try:
+            self._client = self._build_client()
+        except Exception as exc:
+            raise OpenAIRealtimeError(
+                f"OpenAI Realtime client init failed: {exc}", OpenAIRealtimeErrorType.UNKNOWN
+            ) from exc
+
+        try:
+            self._connect_cm = self._client.realtime.connect(model=self.model_name)
+            self._connection = await self._connect_cm.__aenter__()
+        except Exception as exc:
+            self._connect_cm = None
+            raise _classify_openai_realtime_error(exc) from exc
+
+        session_config: dict[str, Any] = {
+            "type": "realtime",
+            "model": self.model_name,
+            "output_modalities": ["audio"],
+            "audio": {
+                "input": {
+                    "format": _audio_format_dict(audio_format),
+                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "interrupt_response": True,
+                        "create_response": True,
+                    },
+                },
+                "output": {
+                    "format": _audio_format_dict(audio_format),
+                    "voice": voice_name,
+                },
+            },
+        }
+        if system_instruction:
+            session_config["instructions"] = system_instruction
+        if tools:
+            session_config["tools"] = tools
+        effort = _REASONING_EFFORT_BY_MODEL.get(self.model_name)
+        if effort:
+            session_config["reasoning"] = {"effort": effort}
+
+        try:
+            await self._connection.send({"type": "session.update", "session": session_config})
+        except Exception as exc:
+            raise _classify_openai_realtime_error(exc) from exc
+
+        self._receive_task = asyncio.create_task(self._receive_loop())
+
+    async def send_audio(self, audio_bytes: bytes) -> None:
+        """Send one chunk of raw caller audio, already encoded in whatever
+        format this session was started with (`audio_format` — mu-law 8kHz
+        for Twilio, PCM16 24kHz for LiveKit). This module has zero
+        telephony-format knowledge beyond that string."""
+        if not audio_bytes:
+            return
+        await self._connection.send({
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(audio_bytes).decode("ascii"),
+        })
+
+    async def send_text(self, text: str, respond: bool = True) -> None:
+        """
+        Inject a text turn into the conversation via
+        `conversation.item.create` (role="user"). Unlike GeminiLiveSession's
+        single `send_client_content(turn_complete=...)` call, the Realtime
+        API separates "add this item to the conversation" from "generate a
+        response" — a context-only injection (e.g. mid-call RAG refresh)
+        must send ONLY the item-create event, never a following
+        `response.create`, or OpenAI will speak the raw injected text as if
+        it were a real reply. `respond=True` (the default — used for e.g.
+        the scripted greeting, which SHOULD be spoken) sends both.
+        """
+        if not text:
+            return
+        await self._connection.send({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        })
+        if respond:
+            await self._connection.send({"type": "response.create"})
+
+    async def send_tool_response(self, call_id: str, output: dict) -> None:
+        """
+        Resolve a function call: `conversation.item.create` with a
+        `function_call_output` item, then an explicit `response.create` to
+        prompt the model to continue — unlike GeminiLiveSession's single
+        `send_tool_response(function_responses=...)` call, the Realtime API
+        requires this second event to actually resume generation.
+        """
+        await self._connection.send({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": json.dumps(output),
+            },
+        })
+        await self._connection.send({"type": "response.create"})
+
+    async def close(self) -> None:
+        """Idempotent teardown — safe to call multiple times, and safe to
+        call from a finally/shutdown path. Never raises: all teardown
+        errors are swallowed and logged. Mirrors GeminiLiveSession.close()."""
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._receive_task is not None:
+            self._receive_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await self._receive_task
+            self._receive_task = None
+
+        if self._connect_cm is not None:
+            try:
+                await self._connect_cm.__aexit__(None, None, None)
+            except Exception as exc:
+                logger.debug("[OpenAIRealtimeSession] close: teardown error (ignored): %s", exc)
+            self._connect_cm = None
+
+        self._connection = None
+
+    async def _receive_loop(self) -> None:
+        """
+        Flat receive loop — see module docstring for why this is NOT
+        shaped like GeminiLiveSession's per-turn outer loop.
+        `connection.recv()` raising (connection genuinely dropped, or any
+        SDK-level error) ends the loop after routing to on_error/logging —
+        there is no "zero messages, retry" case to guard against here since
+        each recv() call either returns exactly one event or raises.
+        """
+        try:
+            while True:
+                try:
+                    event = await self._connection.recv()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    await self._report_error(exc)
+                    return
+                try:
+                    await self._handle_event(event)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    await self._report_error(exc)
+        except asyncio.CancelledError:
+            raise
+
+    async def _report_error(self, exc: Exception) -> None:
+        err = exc if isinstance(exc, OpenAIRealtimeError) else _classify_openai_realtime_error(exc)
+        if self.on_error is not None:
+            await self.on_error(err)
+        else:
+            logger.error("[OpenAIRealtimeSession] %s (model=%s): %s", err.error_type, self.model_name, err)
+
+    async def _handle_event(self, event: Any) -> None:
+        etype = getattr(event, "type", None)
+
+        if etype == "response.output_audio.delta":
+            delta = getattr(event, "delta", None)
+            if delta and self.on_audio_chunk is not None:
+                await self.on_audio_chunk(base64.b64decode(delta))
+            return
+
+        if etype == "input_audio_buffer.speech_started":
+            if self.on_interrupted is not None:
+                await self.on_interrupted()
+            return
+
+        if etype == "input_audio_buffer.speech_stopped":
+            if self.on_speech_stopped is not None:
+                await self.on_speech_stopped()
+            return
+
+        if etype == "conversation.item.input_audio_transcription.completed":
+            transcript = getattr(event, "transcript", "") or ""
+            if transcript and self.on_input_transcript is not None:
+                await self.on_input_transcript(transcript)
+            return
+
+        if etype == "response.output_audio_transcript.done":
+            transcript = getattr(event, "transcript", "") or ""
+            if transcript and self.on_output_transcript is not None:
+                await self.on_output_transcript(transcript)
+            return
+
+        if etype == "response.function_call_arguments.done":
+            if self.on_tool_call is not None:
+                call_id = getattr(event, "call_id", None) or ""
+                name = getattr(event, "name", None) or ""
+                arguments = getattr(event, "arguments", None) or "{}"
+                await self.on_tool_call(call_id, name, arguments)
+            return
+
+        if etype == "error":
+            error_obj = getattr(event, "error", None)
+            message = getattr(error_obj, "message", None) or str(error_obj) or "unknown Realtime API error"
+            await self._report_error(OpenAIRealtimeError(message, OpenAIRealtimeErrorType.UNKNOWN))
+            return
+
+        # All other event types (session.created, response.created,
+        # conversation.item.created, rate_limits.updated, delta variants we
+        # deliberately don't consume, etc.) are expected, benign chatter —
+        # no action needed.

--- a/app/services/tts_catalog_service.py
+++ b/app/services/tts_catalog_service.py
@@ -4,7 +4,7 @@ import uuid
 
 from sqlalchemy.orm import Session
 
-from app.core.secret_manager import get_rime_api_key
+from app.core.secret_manager import get_hume_api_key, get_rime_api_key
 from app.models.tts_provider import TTSProvider
 from app.models.tts_voice import TTSVoice
 from app.utils.tts_adapter import get_tts_adapter_for_provider
@@ -15,6 +15,11 @@ class TTSCatalogService:
     def verify_rime_api_key_configured() -> None:
         """Fail fast when Rime is enabled but RIME_API_KEY is missing or invalid."""
         get_rime_api_key()
+
+    @staticmethod
+    def verify_hume_api_key_configured() -> None:
+        """Fail fast when Hume is enabled but HUME_API_KEY is missing or invalid."""
+        get_hume_api_key()
 
     def ensure_default_provider(self, db: Session) -> TTSProvider:
         providers_to_seed = [
@@ -35,6 +40,13 @@ class TTSCatalogService:
             {
                 "slug": "rime",
                 "display_name": "Rime Labs",
+                "is_active": True,
+                "supports_streaming": True,
+                "supports_ssml": False,
+            },
+            {
+                "slug": "hume",
+                "display_name": "Hume AI",
                 "is_active": True,
                 "supports_streaming": True,
                 "supports_ssml": False,

--- a/app/utils/audio_utils.py
+++ b/app/utils/audio_utils.py
@@ -358,6 +358,104 @@ def downsample_linear_samples(samples: list[int], src_rate_hz: int, dst_rate_hz:
     return out
 
 
+class PCMStreamDownsampler:
+    """
+    Incrementally convert PCM16 LE mono chunks at an arbitrary source sample
+    rate into raw mu-law bytes at an arbitrary destination sample rate.
+
+    Generalizes the box-average downsampling approach originally written
+    for PCM16KStreamDownsampler (16kHz -> 8kHz only) to any integer ratio
+    `src_rate_hz // dst_rate_hz`. Handles:
+    - partial byte pairs across chunks (buffered across `feed()` calls)
+    - a one-time WAV header at the start of the stream
+    - src -> dst box-average downsampling
+    - direct mu-law encoding of the resulting samples (via linear_to_ulaw_sample)
+
+    `src_rate_hz` must be an integer multiple of `dst_rate_hz` (matches the
+    existing PCM16KStreamDownsampler's assumption — no fractional-ratio
+    resampling here).
+    """
+
+    __slots__ = ("_buf", "_header_done", "_factor", "_bytes_per_group")
+
+    def __init__(self, src_rate_hz: int, dst_rate_hz: int):
+        if src_rate_hz <= 0 or dst_rate_hz <= 0 or src_rate_hz % dst_rate_hz != 0:
+            raise ValueError(
+                f"Unsupported resample ratio: {src_rate_hz} -> {dst_rate_hz}"
+            )
+        self._buf = bytearray()
+        self._header_done = False
+        self._factor = src_rate_hz // dst_rate_hz
+        # `factor` int16 samples (2 bytes each) collapse into one output sample.
+        self._bytes_per_group = self._factor * 2
+
+    def _strip_header_if_ready(self) -> bool:
+        if self._header_done:
+            return True
+        if len(self._buf) < 12:
+            return False
+        if self._buf[:4] != b"RIFF" or self._buf[8:12] != b"WAVE":
+            self._header_done = True
+            return True
+        idx = self._buf.find(b"data")
+        if idx == -1 or idx + 8 > len(self._buf):
+            return False
+        del self._buf[:idx + 8]
+        self._header_done = True
+        return True
+
+    def _drain(self, take_all: bool) -> bytes:
+        group = self._bytes_per_group
+        usable = len(self._buf)
+        if not take_all:
+            usable -= usable % group
+        else:
+            usable -= usable % 2  # always need whole int16 samples
+        if usable <= 0:
+            if take_all:
+                self._buf.clear()
+            return b""
+
+        out = bytearray()
+        factor = self._factor
+        i = 0
+        while i < usable:
+            end = min(i + group, usable)
+            n = (end - i) // 2
+            if n <= 0:
+                break
+            total = 0
+            for j in range(i, i + n * 2, 2):
+                total += int.from_bytes(self._buf[j:j + 2], "little", signed=True)
+            avg = int(total / (factor if not take_all else n))
+            out.append(linear_to_ulaw_sample(avg))
+            i = end
+
+        if take_all:
+            self._buf.clear()
+        else:
+            del self._buf[:usable]
+        return bytes(out)
+
+    def feed(self, chunk: bytes) -> bytes:
+        """Feed a raw PCM16LE chunk; returns mu-law bytes for whichever
+        complete sample-groups are now available (partial trailing bytes are
+        buffered for the next call)."""
+        if chunk:
+            self._buf.extend(chunk)
+        if not self._strip_header_if_ready():
+            return b""
+        return self._drain(take_all=False)
+
+    def flush(self) -> bytes:
+        """Encode any remaining buffered bytes (a final, possibly-short
+        sample group) and clear internal state."""
+        if not self._strip_header_if_ready():
+            self._buf.clear()
+            return b""
+        return self._drain(take_all=True)
+
+
 class PCM16KStreamDownsampler:
     """
     Incrementally convert PCM16 LE 16kHz chunks to linear PCM 8kHz samples.

--- a/app/utils/audio_utils.py
+++ b/app/utils/audio_utils.py
@@ -381,7 +381,8 @@ class PCMStreamDownsampler:
     def __init__(self, src_rate_hz: int, dst_rate_hz: int):
         if src_rate_hz <= 0 or dst_rate_hz <= 0 or src_rate_hz % dst_rate_hz != 0:
             raise ValueError(
-                f"Unsupported resample ratio: {src_rate_hz} -> {dst_rate_hz}"
+                f"src_rate_hz must be a positive integer multiple of dst_rate_hz "
+                f"(got {src_rate_hz} -> {dst_rate_hz})"
             )
         self._buf = bytearray()
         self._header_done = False

--- a/app/utils/tts_adapter.py
+++ b/app/utils/tts_adapter.py
@@ -5,7 +5,7 @@ import threading
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, Coroutine
 
-from app.core.secret_manager import get_rime_api_key
+from app.core.secret_manager import get_hume_api_key, get_rime_api_key
 from app.models.tts_provider import TTSProvider
 from app.services.elevenlabs_service import elevenlabs_service
 from app.services.google_tts_service import google_tts_service
@@ -83,6 +83,60 @@ class _RimeSyncEventLoopBridge:
 
 
 _rime_sync_bridge = _RimeSyncEventLoopBridge()
+
+
+class _HumeSyncEventLoopBridge:
+    """Same rationale/pattern as `_RimeSyncEventLoopBridge` above, applied to
+    Hume's `websockets`-based streaming client instead of Rime's cached
+    httpx.AsyncClient — a websocket connection opened on one event loop
+    cannot be safely driven from a different loop either, so
+    HumeTTSAdapter.synthesize() (the sync-bridge path, invoked from a worker
+    thread via run_in_executor()) needs its own dedicated, persistent
+    background loop, kept entirely separate from Rime's bridge instance.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._start_lock = threading.Lock()
+
+    def _ensure_started(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is not None:
+            return loop
+        with self._start_lock:
+            if self._loop is not None:
+                return self._loop
+
+            ready = threading.Event()
+            state: dict[str, asyncio.AbstractEventLoop] = {}
+
+            def _run_forever() -> None:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                state["loop"] = loop
+                ready.set()
+                loop.run_forever()
+
+            thread = threading.Thread(
+                target=_run_forever,
+                name="hume-tts-sync-bridge",
+                daemon=True,
+            )
+            thread.start()
+            ready.wait()
+            self._loop = state["loop"]
+            return self._loop
+
+    def run(self, coro: "Coroutine[Any, Any, bytes]") -> bytes:
+        """Schedule `coro` on the dedicated bridge loop and block the
+        calling thread until it completes. Safe to call from any thread,
+        regardless of whether that thread has its own running event loop."""
+        loop = self._ensure_started()
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return future.result()
+
+
+_hume_sync_bridge = _HumeSyncEventLoopBridge()
 
 
 class BaseTTSProviderAdapter(ABC):
@@ -465,6 +519,128 @@ class RimeTTSAdapter(BaseTTSProviderAdapter):
         )
 
 
+class HumeTTSAdapter(BaseTTSProviderAdapter):
+    """
+    Adapter for Hume AI TTS (streaming WebSocket, `tts/stream/input`).
+
+    Telephony output: mulaw 8 kHz — matches Twilio MULAW 8000 directly
+    (downsampled incrementally from Hume's PCM16LE stream via
+    PCMStreamDownsampler; see hume_tts_service.py for details, including the
+    ASSUMED source-sample-rate caveat).
+
+    Default voice: "Male English Actor" (a HUME_AI-provider preset voice
+    from Hume's Voice Library), configurable via voice_id per agent.
+
+    settings_json keys (all optional):
+        speed              (float, default 1.0) — Hume's native speed param (0.5-2.0)
+        hume_voice_provider (str, default "HUME_AI") — "HUME_AI" | "CUSTOM_VOICE"
+        hume_description    (str) — optional free-text prosody/acting-instructions hint,
+                             Hume's own mechanism (structurally distinct from the numeric
+                             stability path build_voice_settings_overlay() drives for
+                             ElevenLabs) — passed through as-is, not derived from
+                             HumanizationDecision.
+    """
+
+    _DEFAULT_VOICE = "Male English Actor"
+
+    def __init__(self) -> None:
+        # Fail at adapter construction — not on first mid-call synthesis request.
+        self._api_key = get_hume_api_key()
+
+    def list_voices(self) -> list[dict[str, Any]]:
+        # Admin voice-picker UI path only — latency doesn't matter here.
+        import requests
+
+        try:
+            response = requests.get(
+                "https://api.hume.ai/v0/tts/voices",
+                headers={"X-Hume-Api-Key": self._api_key},
+                timeout=20,
+            )
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as exc:
+            raise RuntimeError("Failed to fetch Hume voices.") from exc
+        if isinstance(payload, dict):
+            return payload.get("voices_page") or payload.get("voices") or []
+        if isinstance(payload, list):
+            return payload
+        return []
+
+    def normalize_voice_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "external_voice_id": payload.get("id") or payload.get("name"),
+            "display_name": payload.get("name") or "Hume Voice",
+            "language_code": None,
+            "gender": None,
+            "accent": None,
+            "description": "Hume AI voice",
+            "preview_audio_url": None,
+            "sample_rate_hz": 8000,
+            "metadata_json": payload,
+        }
+
+    def synthesize(
+        self,
+        text: str,
+        voice_external_id: str,
+        settings_json: dict[str, Any] | None = None,
+    ) -> bytes:
+        cfg = dict(settings_json or {})
+        speed = float(cfg.get("speed", 1.0))
+        voice_provider = cfg.get("hume_voice_provider", "HUME_AI")
+        description = cfg.get("hume_description")
+        speaker = voice_external_id or self._DEFAULT_VOICE
+        from app.services.hume_tts_service import hume_tts_service
+
+        coro = hume_tts_service.synthesize(
+            text=text,
+            voice_external_id=speaker,
+            voice_provider=voice_provider,
+            speed=speed,
+            description=description,
+        )
+
+        # Drive the coroutine on a single persistent background event loop
+        # (see _HumeSyncEventLoopBridge above) instead of asyncio.run()'s
+        # per-call fresh-loop-then-teardown — mirrors the Rime sync-bridge
+        # rationale exactly, using its own dedicated bridge instance.
+        return _hume_sync_bridge.run(coro)
+
+    async def async_stream_synthesize(
+        self,
+        text: str,
+        voice_external_id: str,
+        settings_json: dict[str, Any] | None = None,
+    ) -> AsyncIterator[bytes]:
+        """True async streaming — yields raw mulaw bytes as they arrive."""
+        cfg = dict(settings_json or {})
+        speed = float(cfg.get("speed", 1.0))
+        voice_provider = cfg.get("hume_voice_provider", "HUME_AI")
+        description = cfg.get("hume_description")
+        speaker = voice_external_id or self._DEFAULT_VOICE
+        from app.services.hume_tts_service import hume_tts_service
+        async for chunk in hume_tts_service.stream_text_to_speech(
+            text=text,
+            voice_external_id=speaker,
+            voice_provider=voice_provider,
+            speed=speed,
+            description=description,
+        ):
+            yield chunk
+
+    def stream_synthesize(
+        self,
+        text: str,
+        voice_external_id: str,
+        settings_json: dict[str, Any] | None = None,
+    ):
+        # Sync streaming is not used for Hume; callers should use async_stream_synthesize.
+        raise NotImplementedError(
+            "Use async_stream_synthesize for Hume TTS streaming"
+        )
+
+
 def get_tts_adapter(provider_slug: str) -> BaseTTSProviderAdapter:
     slug = (provider_slug or "").strip().lower()
     if slug == "elevenlabs":
@@ -473,6 +649,8 @@ def get_tts_adapter(provider_slug: str) -> BaseTTSProviderAdapter:
         return GoogleTTSAdapter()
     if slug == "rime":
         return RimeTTSAdapter()
+    if slug == "hume":
+        return HumeTTSAdapter()
     raise ValueError(f"Unsupported TTS provider: {provider_slug}")
 
 

--- a/app/utils/tts_adapter.py
+++ b/app/utils/tts_adapter.py
@@ -541,9 +541,10 @@ class HumeTTSAdapter(BaseTTSProviderAdapter):
                              HumanizationDecision.
     """
 
-    _DEFAULT_VOICE = "Male English Actor"
-
     def __init__(self) -> None:
+        from app.services.hume_tts_service import HUME_DEFAULT_VOICE
+
+        self._DEFAULT_VOICE = HUME_DEFAULT_VOICE
         # Fail at adapter construction — not on first mid-call synthesis request.
         self._api_key = get_hume_api_key()
 

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -805,6 +805,24 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                     self._h._twilio_buffer_primed = False
                     return
 
+                # Mirror-image bypass for OpenAI Realtime native-audio calls —
+                # same rationale as the Gemini Live branch above.
+                if _vo is not None and getattr(_vo, "_is_openai_realtime", False):
+                    session = _vo._openai_realtime_session
+                    if session is not None:
+                        try:
+                            await session.send_text(greeting_text, respond=True)
+                        except Exception as exc:
+                            logger.warning(
+                                "[OpenAIRealtime] failed to send greeting via live session: %s", exc
+                            )
+                    else:
+                        logger.debug(
+                            "[OpenAIRealtime] skipping scripted greeting — live session not ready yet"
+                        )
+                    self._h._twilio_buffer_primed = False
+                    return
+
                 # Queue greeting TTS directly (skip LLM!)
                 if not self._h._tts_pipeline:
                     return

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -230,6 +230,525 @@ class ConversationOrchestrator:
 
     # ---- LLM + history orchestration ----------------------------------
 
+    async def build_system_prompt(self, user_text: str, confidence: float) -> str:
+        """
+        Assemble the full system prompt for a turn: base/agent-override/
+        model-override branching, business-facts grounding, call-policy
+        block, RAG/KB injection (prefetch-consume-once), CRM context, caller
+        memory, and HubSpot field-mapping substitution.
+
+        Behavior-preserving extraction from ``generate_and_stream_response``
+        (which used to build this prompt inline) — reused as-is by that
+        method's streaming-text path AND by the Gemini Live native-audio
+        session's ``system_instruction`` at session start (see
+        ``VoiceOrchestrator._start_gemini_live_session``). ``confidence`` is
+        accepted for signature symmetry with the STT-final callback that
+        triggers a turn but is not currently read by any branch below.
+        """
+        # Build conversation context from transcript
+        conversation_history: List[Dict[str, Any]] = []
+        if self._h.call_session and self._h.call_session.call_transcript:
+            try:
+                raw = self._h.call_session.call_transcript
+                conversation_history = json.loads(raw) if isinstance(raw, str) else list(raw)
+            except Exception:
+                conversation_history = []
+
+        # Build history text - bounded filtered history for stable long-call memory
+        history_text = ""
+        if conversation_history:
+            try:
+                history_lines: List[str] = []
+                filtered: List[Tuple[str, str]] = []
+                for msg in conversation_history:
+                    if isinstance(msg, Dict):
+                        # Handle both 'content' and 'message' keys
+                        role = msg.get("role", "unknown")
+                        content = msg.get("content") or msg.get("message", "")
+                        message_type = msg.get("message_type", "")
+
+                        # Filter: Only include client and agent messages (skip system/greeting/status messages)
+                        if (
+                            content
+                            and role in ["client", "agent"]
+                            and message_type not in ["greeting", "system", "status"]
+                        ):
+                            filtered.append((role, content))
+
+                # Use only the most recent HISTORY_MAX_MESSAGES to keep prompt within model limits
+                max_msgs = getattr(self._h, "HISTORY_MAX_MESSAGES", VOICE_TUNABLES.history_max_messages)
+                if len(filtered) > max_msgs:
+                    filtered = filtered[-max_msgs:]
+
+                # Build history text from the bounded window
+                for role, content in filtered:
+                    history_lines.append(f"{role.capitalize()}: {content}")
+
+                history_text = "\n".join(history_lines)
+            except Exception:
+                history_text = ""
+
+        # Build system prompt with agent personality + history
+        agent_name = self._h.agent.name if self._h.agent and self._h.agent.name else "AI Assistant"
+        agent_language = self._h.agent.language if self._h.agent and self._h.agent.language else "en"
+        from app.core.agent_runtime import resolve_tts_runtime
+
+        tts_provider_slug = (
+            resolve_tts_runtime(
+                self._h.agent, db=getattr(self._h, "db", None)
+            ).adapter_slug
+            if self._h.agent
+            else ""
+        )
+        elevenlabs_audio_tags_enabled = supports_elevenlabs_audio_tags(tts_provider_slug)
+        if elevenlabs_audio_tags_enabled:
+            output_plain_text_rule, no_ssml_rule_base, no_ssml_rule = (
+                get_elevenlabs_voice_prompt_rule_lines()
+            )
+        else:
+            output_plain_text_rule = (
+                "- OUTPUT PLAIN TEXT ONLY: Do NOT output SSML, XML, or any tags. "
+                "Prosody is handled by the system."
+            )
+            no_ssml_rule_base = (
+                "4. NO SSML: Do NOT output <speak>, <prosody>, or any XML tags. Plain text only."
+            )
+            no_ssml_rule = "3. NO SSML: Plain text only. No <speak>, <prosody>, or XML."
+        elevenlabs_audio_tag_block = build_elevenlabs_audio_tag_prompt_block(tts_provider_slug)
+        # When ElevenLabs audio tags are enabled, the authoritative rule lives solely in
+        # elevenlabs_audio_tag_block above — do not also emit a contradictory generic
+        # "never use bracket tags" line. Only non-ElevenLabs (or disabled) calls need it.
+        no_bracket_tags_line = (
+            ""
+            if elevenlabs_audio_tags_enabled
+            else (
+                "- NO BRACKET TAGS: Never output bracketed tags like [pause], [laugh], [breathes], "
+                "[excited], [1], [2], or any similar annotation. These will not be rendered — they "
+                "will be read aloud literally."
+            )
+        )
+
+        # Base prompt for phone conversations (voice-first, plain text only, no SSML)
+        base_prompt = f"""# ROLE
+You are {agent_name}, having a real-time phone call with a human.
+
+# STYLE & TONE
+- VOICE-FIRST: Your output is for Text-to-Speech. Use short, punchy sentences.
+- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
+- CONCISE: Max 20 words per response unless explaining something complex.
+- NO ROBOT TALK: Avoid "As an AI" or formal greetings. Use "Hey," "Hi," or "Hello."
+{output_plain_text_rule}
+- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").
+
+# CONVERSATION STATE
+Previous conversation:
+{history_text}
+
+# CRITICAL RULES
+1. NO REPETITION: If the history shows you asked a question, move to the next point.
+2. HANDLING SILENCE: If the user says something vague, ask a clarifying question.
+3. TERMINATION: When the objective is met, say a friendly goodbye and end your response with exactly [END_CALL].
+4. BUSINESS FACTS: {_BUSINESS_FACTS_GROUNDING_TEXT}
+5. SERVICE SCOPE: Strictly follow "BUSINESS SCOPE & POLICY — STRICT RULES" in AUTHORITATIVE BUSINESS FACTS. Only offer the services listed there. If asked for anything else, decline politely and offer what we actually do.
+6. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, say a short goodbye, and end your response with exactly [END_CALL]. If Service Areas describe global/remote/worldwide coverage, never refuse based on location.
+{no_ssml_rule_base}
+
+{elevenlabs_audio_tag_block}
+
+# GOAL
+Continue the conversation based on the history above. Be {agent_name}."""
+
+        # Batch calls may inject a per-row substituted prompt via call_metadata
+        batch_prompt_override = None
+        ab_prompt_override = None
+        if self._h.call_session and self._h.call_session.call_metadata:
+            batch_prompt_override = self._h.call_session.call_metadata.get(
+                "batch_prompt_override"
+            )
+            # A/B prompt testing: variant + resolved prompt text are locked onto
+            # call_metadata at dispatch time (see ab_testing_service) and never
+            # re-resolved mid-call.
+            ab_prompt_override = self._h.call_session.call_metadata.get(
+                "ab_prompt_text"
+            )
+
+        # Resolve call flow prompt override if present on session
+        flow_prompt_override = None
+        call_flow = getattr(self._h, "call_flow", None)
+        if call_flow:
+            if getattr(call_flow, "current_prompt", None) and call_flow.current_prompt.prompt_text:
+                flow_prompt_override = call_flow.current_prompt.prompt_text
+            elif call_flow.current_prompt_id and getattr(self._h, "db", None):
+                try:
+                    from sqlalchemy import select
+                    from app.models.prompt_version import PromptVersion
+                    pv = self._h.db.execute(
+                        select(PromptVersion).where(PromptVersion.id == call_flow.current_prompt_id)
+                    ).scalar_one_or_none()
+                    if pv and pv.prompt_text:
+                        flow_prompt_override = pv.prompt_text
+                except Exception as exc:
+                    logger.debug("Could not resolve call flow current_prompt: %s", exc)
+
+        # Use agent's custom system prompt / flow prompt if available, otherwise use base prompt
+        if (self._h.agent and self._h.agent.system_prompt) or flow_prompt_override:
+            effective_custom_prompt = (
+                batch_prompt_override
+                or ab_prompt_override
+                or flow_prompt_override
+                or (self._h.agent.system_prompt if self._h.agent else None)
+            )
+            system_prompt = f"""# ROLE
+You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
+
+# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING CUSTOM INSTRUCTIONS)
+These rules override any conflicting custom instructions below. Never deviate from them.
+1. BUSINESS FACTS: {_BUSINESS_FACTS_GROUNDING_TEXT}
+2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
+3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
+4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
+
+# CUSTOM INSTRUCTIONS
+{effective_custom_prompt}
+
+# STYLE & TONE
+- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
+- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
+{output_plain_text_rule}
+{no_bracket_tags_line}
+- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").
+
+# CONVERSATION STATE
+Previous conversation:
+{history_text}
+
+# CRITICAL RULES
+1. NO REPETITION: Do not repeat questions already asked. Move to the next point.
+2. TERMINATION: When all objectives from your custom instructions are complete, say a friendly goodbye and end your response with exactly [END_CALL].
+{no_ssml_rule}
+
+{elevenlabs_audio_tag_block}
+
+# GOAL
+Follow your custom instructions. Continue from the history above. Be {agent_name}."""
+        elif self._h.agent and self._h.agent.model and self._h.agent.model.system_prompt:
+            effective_model_prompt = (
+                batch_prompt_override
+                or ab_prompt_override
+                or self._h.agent.model.system_prompt
+            )
+            system_prompt = f"""# ROLE
+You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
+
+# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING MODEL INSTRUCTIONS)
+These rules override any conflicting model instructions below. Never deviate from them.
+1. BUSINESS FACTS: {_BUSINESS_FACTS_GROUNDING_TEXT}
+2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
+3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
+4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
+
+# MODEL INSTRUCTIONS
+{effective_model_prompt}
+
+# STYLE & TONE
+- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
+- NATURAL: Use fillers like "uhm," "well," "I see" occasionally.
+{output_plain_text_rule}
+{no_bracket_tags_line}
+
+# CONVERSATION STATE
+Previous conversation:
+{history_text}
+
+# CRITICAL RULES
+1. NO REPETITION: Do not repeat questions. Move to the next point.
+2. TERMINATION: When all objectives are complete, say a friendly goodbye and end your response with exactly [END_CALL].
+{no_ssml_rule}
+
+{elevenlabs_audio_tag_block}
+
+# GOAL
+Follow the model instructions. Continue from the history above. Be {agent_name}."""
+        else:
+            system_prompt = base_prompt
+
+        call_policy_block = agent_service.build_call_policy_block(
+            transfer_route=getattr(self._h.agent, "transfer_route", None) if self._h.agent else None,
+        )
+        if call_policy_block:
+            system_prompt = call_policy_block + "\n" + system_prompt
+
+        # KB context injection: runs when flow.knowledge_base_ids is non-empty.
+        # Injected AFTER the system prompt and BEFORE conversation history.
+        #
+        # RAG retrieval: reuse the interim-fired prefetch when available
+        # (fired in LiveKitBrowserCallHandler._maybe_start_rag_prefetch on
+        # STT interim, overlapping STT endpointing) instead of always
+        # blocking here on a fresh retrieval — mirrors
+        # bidirectional_stream.py's prefetch-consume-once pattern, adapted
+        # to this transport's kb_retrieval_service call. Falls back to the
+        # exact same synchronous retrieval this code path always used
+        # when no prefetch fired (e.g. a very short first utterance) or
+        # when the final utterance diverged materially from the interim
+        # that triggered the prefetch.
+        kb_context_block = ""
+        flow = getattr(self._h, "call_flow", None)
+        flow_kb_ids = (flow.knowledge_base_ids or []) if flow else []
+        if flow_kb_ids and self._h.db:
+            _kb_timeout_sec = float(
+                getattr(settings, "RAG_KB_RETRIEVAL_TIMEOUT_SEC", 0.7) or 0.7
+            )
+
+            # Consume the prefetch slot exactly once per turn, immediately —
+            # so it can never be read/reused by a later, unrelated turn.
+            # isinstance-checked (not just `is not None`) so a handler
+            # that never initialised this attribute at all (e.g. a bare
+            # test double) is treated the same as "no prefetch fired",
+            # rather than accidentally treating an unrelated truthy value
+            # as a real in-flight prefetch task.
+            _prefetch = getattr(self._h, "_rag_prefetch_task", None)
+            if not isinstance(_prefetch, asyncio.Task):
+                _prefetch = None
+            self._h._rag_prefetch_task = None
+            _prefetch_source_text = getattr(self._h, "_rag_prefetch_source_text", "")
+            if not isinstance(_prefetch_source_text, str):
+                _prefetch_source_text = ""
+            self._h._rag_prefetch_source_text = ""
+
+            if _prefetch is not None and not rag_prefetch_matches_final(
+                _prefetch_source_text, user_text
+            ):
+                # Final utterance materially diverged from the interim that
+                # triggered this prefetch — don't reuse a possibly-wrong
+                # result. Cancel it (if still running) and fall through to
+                # a fresh retrieval below, same as the "no prefetch" branch.
+                if not _prefetch.done():
+                    _prefetch.cancel()
+                _prefetch = None
+
+            try:
+                if _prefetch is not None:
+                    if _prefetch.done():
+                        # Already finished — zero-cost read. Check for a stored
+                        # exception explicitly rather than relying on
+                        # _prefetch_kb_context's current "always returns
+                        # ('', 0.0), never raises" contract — that contract is
+                        # easy to break in a future edit, and an unguarded
+                        # .result() would then raise here and be silently
+                        # swallowed by the outer except Exception below.
+                        _prefetch_exc = _prefetch.exception()
+                        if _prefetch_exc is not None:
+                            logger.debug(
+                                "[RAG prefetch] stored exception: %s", _prefetch_exc
+                            )
+                            kb_context_block, kb_latency_ms = "", 0.0
+                        else:
+                            kb_context_block, kb_latency_ms = _prefetch.result()
+                            logger.debug("[RAG prefetch] used prefetch result (done)")
+                    else:
+                        # Still running — await the SAME in-flight task
+                        # (never start a second parallel retrieval).
+                        # asyncio.shield so a local timeout here doesn't
+                        # cancel a retrieval that may still be useful to
+                        # warm the KB cache for a future turn.
+                        kb_context_block, kb_latency_ms = await asyncio.wait_for(
+                            asyncio.shield(_prefetch),
+                            timeout=_kb_timeout_sec,
+                        )
+                        logger.debug("[RAG prefetch] awaited in-flight prefetch")
+                else:
+                    from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
+                    from app.utils.redis_client import get_redis
+
+                    kb_context_block, kb_latency_ms = await asyncio.wait_for(
+                        retrieve_kb_context_for_turn(
+                            transcript=user_text,
+                            kb_ids=flow_kb_ids,
+                            redis_client=get_redis(),
+                        ),
+                        timeout=_kb_timeout_sec,  # fail open if exceeded — see settings.RAG_KB_RETRIEVAL_TIMEOUT_SEC
+                    )
+                logger.info(
+                    "kb_retrieval latency_ms=%.1f kb_count=%d call_sid=%s",
+                    kb_latency_ms,
+                    len(flow_kb_ids),
+                    getattr(self._h, "call_sid", ""),
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "kb_retrieval timed out after %.0fms; proceeding without KB context",
+                    _kb_timeout_sec * 1000,
+                )
+            except asyncio.CancelledError:
+                # This turn itself was cancelled (e.g. barge-in) while
+                # awaiting the prefetch — propagate rather than swallow.
+                # The shielded prefetch task (if any) keeps running
+                # independently and is not affected by this.
+                raise
+            except Exception as exc:
+                logger.error("kb_retrieval failed; proceeding without context: %s", exc)
+
+        # Inject KB context block between system prompt and conversation history.
+        if kb_context_block:
+            anchor = "# CONVERSATION STATE"
+            if anchor in system_prompt:
+                system_prompt = system_prompt.replace(
+                    anchor, kb_context_block + "\n\n" + anchor, 1
+                )
+            else:
+                system_prompt = system_prompt + "\n\n" + kb_context_block
+
+        # HubSpot CRM context injection: fetched once at call start (Redis-cached
+        # contact lookup) and cached on call_session.call_metadata, so every later
+        # turn (the prompt is rebuilt each turn) is a cheap in-memory dict read.
+        # Fails open on timeout/error — never blocks the call.
+        crm_context_block = ""
+        if self._h.call_session and self._h.db:
+            try:
+                from app.services.hubspot_service import get_crm_context_block_for_call
+
+                crm_context_block = await asyncio.wait_for(
+                    get_crm_context_block_for_call(self._h.db, self._h.call_session),
+                    timeout=0.6,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "HubSpot CRM context lookup timed out; proceeding without CRM context"
+                )
+            except Exception as exc:
+                logger.error(
+                    "HubSpot CRM context lookup failed; proceeding without context: %s", exc
+                )
+
+        if crm_context_block:
+            anchor = "# CONVERSATION STATE"
+            if anchor in system_prompt:
+                system_prompt = system_prompt.replace(
+                    anchor, crm_context_block + "\n\n" + anchor, 1
+                )
+            else:
+                system_prompt = system_prompt + "\n\n" + crm_context_block
+
+        # Salesforce CRM context injection: same fail-open, once-per-call,
+        # call_metadata-cached pattern as the HubSpot block above.
+        salesforce_context_block = ""
+        if self._h.call_session and self._h.db:
+            try:
+                from app.services import salesforce_service
+
+                salesforce_context_block = await asyncio.wait_for(
+                    salesforce_service.get_crm_context_block_for_call(
+                        self._h.db, self._h.call_session
+                    ),
+                    timeout=0.6,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Salesforce CRM context lookup timed out; proceeding without CRM context"
+                )
+            except Exception as exc:
+                logger.error(
+                    "Salesforce CRM context lookup failed; proceeding without context: %s", exc
+                )
+
+        if salesforce_context_block:
+            anchor = "# CONVERSATION STATE"
+            if anchor in system_prompt:
+                system_prompt = system_prompt.replace(
+                    anchor, salesforce_context_block + "\n\n" + anchor, 1
+                )
+            else:
+                system_prompt = system_prompt + "\n\n" + salesforce_context_block
+
+        # GoHighLevel (GHL) CRM context injection: same fail-open, once-per-call,
+        # call_metadata-cached pattern as the HubSpot/Salesforce blocks above.
+        ghl_context_block = ""
+        if self._h.call_session and self._h.db:
+            try:
+                from app.services import ghl_service
+
+                ghl_context_block = await asyncio.wait_for(
+                    ghl_service.get_crm_context_block_for_call(
+                        self._h.db, self._h.call_session
+                    ),
+                    timeout=0.6,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "GHL CRM context lookup timed out; proceeding without CRM context"
+                )
+            except Exception as exc:
+                logger.error(
+                    "GHL CRM context lookup failed; proceeding without context: %s", exc
+                )
+
+        if ghl_context_block:
+            anchor = "# CONVERSATION STATE"
+            if anchor in system_prompt:
+                system_prompt = system_prompt.replace(
+                    anchor, ghl_context_block + "\n\n" + anchor, 1
+                )
+            else:
+                system_prompt = system_prompt + "\n\n" + ghl_context_block
+
+        # Cross-session caller memory: fetched once at call start (DB lookup,
+        # 100ms timeout budget, fail-open) and cached on call_session.call_metadata
+        # so every later turn is a cheap in-memory dict read. Injected right after
+        # the KB/CRM context blocks and before conversation history.
+        caller_memory_block = ""
+        if self._h.call_session and self._h.db and flow and flow.caller_memory_enabled:
+            try:
+                from app.services.caller_memory_service import (
+                    get_caller_memory_context_block_for_call,
+                )
+
+                caller_memory_block = await get_caller_memory_context_block_for_call(
+                    self._h.db, self._h.call_session, flow
+                )
+            except Exception as exc:
+                logger.error(
+                    "caller_memory lookup failed; proceeding without context: %s", exc
+                )
+
+        if caller_memory_block:
+            anchor = "# CONVERSATION STATE"
+            if anchor in system_prompt:
+                system_prompt = system_prompt.replace(
+                    anchor, caller_memory_block + "\n\n" + anchor, 1
+                )
+            else:
+                system_prompt = system_prompt + "\n\n" + caller_memory_block
+
+        # HubSpot field-mapping substitution: replaces `{prompt_variable}` tokens
+        # in the prompt with tenant-configured HubSpot contact field values.
+        # Resolved once per call (Redis/DB-cached) and fails open on timeout/error.
+        if self._h.call_session and self._h.db:
+            try:
+                from app.services.hubspot_service import (
+                    apply_field_mapping_values,
+                    get_field_mapping_values_for_call,
+                )
+
+                field_mapping_values = await asyncio.wait_for(
+                    get_field_mapping_values_for_call(self._h.db, self._h.call_session),
+                    timeout=0.6,
+                )
+                if field_mapping_values:
+                    system_prompt = apply_field_mapping_values(
+                        system_prompt, field_mapping_values
+                    )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "HubSpot field mapping lookup timed out; proceeding without substitution"
+                )
+            except Exception as exc:
+                logger.error(
+                    "HubSpot field mapping lookup failed; proceeding without substitution: %s",
+                    exc,
+                )
+
+        return system_prompt
+
     async def generate_and_stream_response(
         self, user_text: str, confidence: float, is_greeting: bool = False
     ) -> None:
@@ -261,6 +780,30 @@ class ConversationOrchestrator:
 
                 # Add greeting to transcript
                 await self._h._add_to_transcript("agent", greeting_text, "greeting")
+
+                # Gemini Live native-audio calls must never invoke the external
+                # TTS provider — route the greeting through the live session's
+                # own send_text so Gemini speaks it in its native voice,
+                # instead of queue_tts below. If the session isn't up yet,
+                # skip the scripted greeting entirely rather than falling
+                # through to queue_tts()/TtsPipeline. Mirrors the same gate in
+                # BidirectionalStreamHandler.generate_and_stream_response.
+                _vo = getattr(self._h, "_voice_orchestrator", None)
+                if _vo is not None and getattr(_vo, "_is_gemini_live", False):
+                    session = _vo._gemini_live_session
+                    if session is not None:
+                        try:
+                            await session.send_text(greeting_text, turn_complete=True)
+                        except Exception as exc:
+                            logger.warning(
+                                "[GeminiLive] failed to send greeting via live session: %s", exc
+                            )
+                    else:
+                        logger.debug(
+                            "[GeminiLive] skipping scripted greeting — live session not ready yet"
+                        )
+                    self._h._twilio_buffer_primed = False
+                    return
 
                 # Queue greeting TTS directly (skip LLM!)
                 if not self._h._tts_pipeline:
@@ -294,507 +837,7 @@ class ConversationOrchestrator:
             # Send quick acknowledgement for longer queries (instant from cache!)
             await self.send_quick_acknowledgement(user_text)
 
-            # Build conversation context from transcript
-            conversation_history: List[Dict[str, Any]] = []
-            if self._h.call_session and self._h.call_session.call_transcript:
-                try:
-                    raw = self._h.call_session.call_transcript
-                    conversation_history = json.loads(raw) if isinstance(raw, str) else list(raw)
-                except Exception:
-                    conversation_history = []
-
-            # Build history text - bounded filtered history for stable long-call memory
-            history_text = ""
-            if conversation_history:
-                try:
-                    history_lines: List[str] = []
-                    filtered: List[Tuple[str, str]] = []
-                    for msg in conversation_history:
-                        if isinstance(msg, Dict):
-                            # Handle both 'content' and 'message' keys
-                            role = msg.get("role", "unknown")
-                            content = msg.get("content") or msg.get("message", "")
-                            message_type = msg.get("message_type", "")
-
-                            # Filter: Only include client and agent messages (skip system/greeting/status messages)
-                            if (
-                                content
-                                and role in ["client", "agent"]
-                                and message_type not in ["greeting", "system", "status"]
-                            ):
-                                filtered.append((role, content))
-
-                    # Use only the most recent HISTORY_MAX_MESSAGES to keep prompt within model limits
-                    max_msgs = getattr(self._h, "HISTORY_MAX_MESSAGES", VOICE_TUNABLES.history_max_messages)
-                    if len(filtered) > max_msgs:
-                        filtered = filtered[-max_msgs:]
-
-                    # Build history text from the bounded window
-                    for role, content in filtered:
-                        history_lines.append(f"{role.capitalize()}: {content}")
-
-                    history_text = "\n".join(history_lines)
-                except Exception:
-                    history_text = ""
-
-            # Build system prompt with agent personality + history
-            agent_name = self._h.agent.name if self._h.agent and self._h.agent.name else "AI Assistant"
-            agent_language = self._h.agent.language if self._h.agent and self._h.agent.language else "en"
-            from app.core.agent_runtime import resolve_tts_runtime
-
-            tts_provider_slug = (
-                resolve_tts_runtime(
-                    self._h.agent, db=getattr(self._h, "db", None)
-                ).adapter_slug
-                if self._h.agent
-                else ""
-            )
-            elevenlabs_audio_tags_enabled = supports_elevenlabs_audio_tags(tts_provider_slug)
-            if elevenlabs_audio_tags_enabled:
-                output_plain_text_rule, no_ssml_rule_base, no_ssml_rule = (
-                    get_elevenlabs_voice_prompt_rule_lines()
-                )
-            else:
-                output_plain_text_rule = (
-                    "- OUTPUT PLAIN TEXT ONLY: Do NOT output SSML, XML, or any tags. "
-                    "Prosody is handled by the system."
-                )
-                no_ssml_rule_base = (
-                    "4. NO SSML: Do NOT output <speak>, <prosody>, or any XML tags. Plain text only."
-                )
-                no_ssml_rule = "3. NO SSML: Plain text only. No <speak>, <prosody>, or XML."
-            elevenlabs_audio_tag_block = build_elevenlabs_audio_tag_prompt_block(tts_provider_slug)
-            # When ElevenLabs audio tags are enabled, the authoritative rule lives solely in
-            # elevenlabs_audio_tag_block above — do not also emit a contradictory generic
-            # "never use bracket tags" line. Only non-ElevenLabs (or disabled) calls need it.
-            no_bracket_tags_line = (
-                ""
-                if elevenlabs_audio_tags_enabled
-                else (
-                    "- NO BRACKET TAGS: Never output bracketed tags like [pause], [laugh], [breathes], "
-                    "[excited], [1], [2], or any similar annotation. These will not be rendered — they "
-                    "will be read aloud literally."
-                )
-            )
-
-            # Base prompt for phone conversations (voice-first, plain text only, no SSML)
-            base_prompt = f"""# ROLE
-You are {agent_name}, having a real-time phone call with a human.
-
-# STYLE & TONE
-- VOICE-FIRST: Your output is for Text-to-Speech. Use short, punchy sentences.
-- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
-- CONCISE: Max 20 words per response unless explaining something complex.
-- NO ROBOT TALK: Avoid "As an AI" or formal greetings. Use "Hey," "Hi," or "Hello."
-{output_plain_text_rule}
-- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").
-
-# CONVERSATION STATE
-Previous conversation:
-{history_text}
-
-# CRITICAL RULES
-1. NO REPETITION: If the history shows you asked a question, move to the next point.
-2. HANDLING SILENCE: If the user says something vague, ask a clarifying question.
-3. TERMINATION: When the objective is met, say a friendly goodbye and end your response with exactly [END_CALL].
-4. BUSINESS FACTS: {_BUSINESS_FACTS_GROUNDING_TEXT}
-5. SERVICE SCOPE: Strictly follow "BUSINESS SCOPE & POLICY — STRICT RULES" in AUTHORITATIVE BUSINESS FACTS. Only offer the services listed there. If asked for anything else, decline politely and offer what we actually do.
-6. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, say a short goodbye, and end your response with exactly [END_CALL]. If Service Areas describe global/remote/worldwide coverage, never refuse based on location.
-{no_ssml_rule_base}
-
-{elevenlabs_audio_tag_block}
-
-# GOAL
-Continue the conversation based on the history above. Be {agent_name}."""
-
-            # Batch calls may inject a per-row substituted prompt via call_metadata
-            batch_prompt_override = None
-            ab_prompt_override = None
-            if self._h.call_session and self._h.call_session.call_metadata:
-                batch_prompt_override = self._h.call_session.call_metadata.get(
-                    "batch_prompt_override"
-                )
-                # A/B prompt testing: variant + resolved prompt text are locked onto
-                # call_metadata at dispatch time (see ab_testing_service) and never
-                # re-resolved mid-call.
-                ab_prompt_override = self._h.call_session.call_metadata.get(
-                    "ab_prompt_text"
-                )
-
-            # Resolve call flow prompt override if present on session
-            flow_prompt_override = None
-            call_flow = getattr(self._h, "call_flow", None)
-            if call_flow:
-                if getattr(call_flow, "current_prompt", None) and call_flow.current_prompt.prompt_text:
-                    flow_prompt_override = call_flow.current_prompt.prompt_text
-                elif call_flow.current_prompt_id and getattr(self._h, "db", None):
-                    try:
-                        from sqlalchemy import select
-                        from app.models.prompt_version import PromptVersion
-                        pv = self._h.db.execute(
-                            select(PromptVersion).where(PromptVersion.id == call_flow.current_prompt_id)
-                        ).scalar_one_or_none()
-                        if pv and pv.prompt_text:
-                            flow_prompt_override = pv.prompt_text
-                    except Exception as exc:
-                        logger.debug("Could not resolve call flow current_prompt: %s", exc)
-
-            # Use agent's custom system prompt / flow prompt if available, otherwise use base prompt
-            if (self._h.agent and self._h.agent.system_prompt) or flow_prompt_override:
-                effective_custom_prompt = (
-                    batch_prompt_override
-                    or ab_prompt_override
-                    or flow_prompt_override
-                    or (self._h.agent.system_prompt if self._h.agent else None)
-                )
-                system_prompt = f"""# ROLE
-You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
-
-# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING CUSTOM INSTRUCTIONS)
-These rules override any conflicting custom instructions below. Never deviate from them.
-1. BUSINESS FACTS: {_BUSINESS_FACTS_GROUNDING_TEXT}
-2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
-3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
-4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
-
-# CUSTOM INSTRUCTIONS
-{effective_custom_prompt}
-
-# STYLE & TONE
-- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
-- NATURAL: Use natural fillers/interjections ONLY when they fit the emotion: "umm", "hmm", "oh", "alright", "hang on", "one moment" (max one per response).
-{output_plain_text_rule}
-{no_bracket_tags_line}
-- TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").
-
-# CONVERSATION STATE
-Previous conversation:
-{history_text}
-
-# CRITICAL RULES
-1. NO REPETITION: Do not repeat questions already asked. Move to the next point.
-2. TERMINATION: When all objectives from your custom instructions are complete, say a friendly goodbye and end your response with exactly [END_CALL].
-{no_ssml_rule}
-
-{elevenlabs_audio_tag_block}
-
-# GOAL
-Follow your custom instructions. Continue from the history above. Be {agent_name}."""
-            elif self._h.agent and self._h.agent.model and self._h.agent.model.system_prompt:
-                effective_model_prompt = (
-                    batch_prompt_override
-                    or ab_prompt_override
-                    or self._h.agent.model.system_prompt
-                )
-                system_prompt = f"""# ROLE
-You are {agent_name}, having a real-time phone call. You speak {agent_language} naturally.
-
-# GROUNDING RULES (NON-NEGOTIABLE — APPLY BEFORE READING MODEL INSTRUCTIONS)
-These rules override any conflicting model instructions below. Never deviate from them.
-1. BUSINESS FACTS: {_BUSINESS_FACTS_GROUNDING_TEXT}
-2. SERVICE SCOPE: Only offer, quote, or schedule services listed in AUTHORITATIVE BUSINESS FACTS. Politely decline anything outside that list.
-3. SERVICE AREA: If Service Areas are listed and restricted, and the caller is outside them, apologize, name the covered areas, and end with [END_CALL]. Never refuse based on location when coverage is global/remote.
-4. NO INVENTION: When you are uncertain, say so. Do not fill gaps with guesses.
-
-# MODEL INSTRUCTIONS
-{effective_model_prompt}
-
-# STYLE & TONE
-- VOICE-FIRST: Output is for Text-to-Speech. Use short sentences (max 20 words unless explaining).
-- NATURAL: Use fillers like "uhm," "well," "I see" occasionally.
-{output_plain_text_rule}
-{no_bracket_tags_line}
-
-# CONVERSATION STATE
-Previous conversation:
-{history_text}
-
-# CRITICAL RULES
-1. NO REPETITION: Do not repeat questions. Move to the next point.
-2. TERMINATION: When all objectives are complete, say a friendly goodbye and end your response with exactly [END_CALL].
-{no_ssml_rule}
-
-{elevenlabs_audio_tag_block}
-
-# GOAL
-Follow the model instructions. Continue from the history above. Be {agent_name}."""
-            else:
-                system_prompt = base_prompt
-
-            call_policy_block = agent_service.build_call_policy_block(
-                transfer_route=getattr(self._h.agent, "transfer_route", None) if self._h.agent else None,
-            )
-            if call_policy_block:
-                system_prompt = call_policy_block + "\n" + system_prompt
-
-            # KB context injection: runs when flow.knowledge_base_ids is non-empty.
-            # Injected AFTER the system prompt and BEFORE conversation history.
-            #
-            # RAG retrieval: reuse the interim-fired prefetch when available
-            # (fired in LiveKitBrowserCallHandler._maybe_start_rag_prefetch on
-            # STT interim, overlapping STT endpointing) instead of always
-            # blocking here on a fresh retrieval — mirrors
-            # bidirectional_stream.py's prefetch-consume-once pattern, adapted
-            # to this transport's kb_retrieval_service call. Falls back to the
-            # exact same synchronous retrieval this code path always used
-            # when no prefetch fired (e.g. a very short first utterance) or
-            # when the final utterance diverged materially from the interim
-            # that triggered the prefetch.
-            kb_context_block = ""
-            flow = getattr(self._h, "call_flow", None)
-            flow_kb_ids = (flow.knowledge_base_ids or []) if flow else []
-            if flow_kb_ids and self._h.db:
-                _kb_timeout_sec = float(
-                    getattr(settings, "RAG_KB_RETRIEVAL_TIMEOUT_SEC", 0.7) or 0.7
-                )
-
-                # Consume the prefetch slot exactly once per turn, immediately —
-                # so it can never be read/reused by a later, unrelated turn.
-                # isinstance-checked (not just `is not None`) so a handler
-                # that never initialised this attribute at all (e.g. a bare
-                # test double) is treated the same as "no prefetch fired",
-                # rather than accidentally treating an unrelated truthy value
-                # as a real in-flight prefetch task.
-                _prefetch = getattr(self._h, "_rag_prefetch_task", None)
-                if not isinstance(_prefetch, asyncio.Task):
-                    _prefetch = None
-                self._h._rag_prefetch_task = None
-                _prefetch_source_text = getattr(self._h, "_rag_prefetch_source_text", "")
-                if not isinstance(_prefetch_source_text, str):
-                    _prefetch_source_text = ""
-                self._h._rag_prefetch_source_text = ""
-
-                if _prefetch is not None and not rag_prefetch_matches_final(
-                    _prefetch_source_text, user_text
-                ):
-                    # Final utterance materially diverged from the interim that
-                    # triggered this prefetch — don't reuse a possibly-wrong
-                    # result. Cancel it (if still running) and fall through to
-                    # a fresh retrieval below, same as the "no prefetch" branch.
-                    if not _prefetch.done():
-                        _prefetch.cancel()
-                    _prefetch = None
-
-                try:
-                    if _prefetch is not None:
-                        if _prefetch.done():
-                            # Already finished — zero-cost read. Check for a stored
-                            # exception explicitly rather than relying on
-                            # _prefetch_kb_context's current "always returns
-                            # ('', 0.0), never raises" contract — that contract is
-                            # easy to break in a future edit, and an unguarded
-                            # .result() would then raise here and be silently
-                            # swallowed by the outer except Exception below.
-                            _prefetch_exc = _prefetch.exception()
-                            if _prefetch_exc is not None:
-                                logger.debug(
-                                    "[RAG prefetch] stored exception: %s", _prefetch_exc
-                                )
-                                kb_context_block, kb_latency_ms = "", 0.0
-                            else:
-                                kb_context_block, kb_latency_ms = _prefetch.result()
-                                logger.debug("[RAG prefetch] used prefetch result (done)")
-                        else:
-                            # Still running — await the SAME in-flight task
-                            # (never start a second parallel retrieval).
-                            # asyncio.shield so a local timeout here doesn't
-                            # cancel a retrieval that may still be useful to
-                            # warm the KB cache for a future turn.
-                            kb_context_block, kb_latency_ms = await asyncio.wait_for(
-                                asyncio.shield(_prefetch),
-                                timeout=_kb_timeout_sec,
-                            )
-                            logger.debug("[RAG prefetch] awaited in-flight prefetch")
-                    else:
-                        from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
-                        from app.utils.redis_client import get_redis
-
-                        kb_context_block, kb_latency_ms = await asyncio.wait_for(
-                            retrieve_kb_context_for_turn(
-                                transcript=user_text,
-                                kb_ids=flow_kb_ids,
-                                redis_client=get_redis(),
-                            ),
-                            timeout=_kb_timeout_sec,  # fail open if exceeded — see settings.RAG_KB_RETRIEVAL_TIMEOUT_SEC
-                        )
-                    logger.info(
-                        "kb_retrieval latency_ms=%.1f kb_count=%d call_sid=%s",
-                        kb_latency_ms,
-                        len(flow_kb_ids),
-                        getattr(self._h, "call_sid", ""),
-                    )
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "kb_retrieval timed out after %.0fms; proceeding without KB context",
-                        _kb_timeout_sec * 1000,
-                    )
-                except asyncio.CancelledError:
-                    # This turn itself was cancelled (e.g. barge-in) while
-                    # awaiting the prefetch — propagate rather than swallow.
-                    # The shielded prefetch task (if any) keeps running
-                    # independently and is not affected by this.
-                    raise
-                except Exception as exc:
-                    logger.error("kb_retrieval failed; proceeding without context: %s", exc)
-
-            # Inject KB context block between system prompt and conversation history.
-            if kb_context_block:
-                anchor = "# CONVERSATION STATE"
-                if anchor in system_prompt:
-                    system_prompt = system_prompt.replace(
-                        anchor, kb_context_block + "\n\n" + anchor, 1
-                    )
-                else:
-                    system_prompt = system_prompt + "\n\n" + kb_context_block
-
-            # HubSpot CRM context injection: fetched once at call start (Redis-cached
-            # contact lookup) and cached on call_session.call_metadata, so every later
-            # turn (the prompt is rebuilt each turn) is a cheap in-memory dict read.
-            # Fails open on timeout/error — never blocks the call.
-            crm_context_block = ""
-            if self._h.call_session and self._h.db:
-                try:
-                    from app.services.hubspot_service import get_crm_context_block_for_call
-
-                    crm_context_block = await asyncio.wait_for(
-                        get_crm_context_block_for_call(self._h.db, self._h.call_session),
-                        timeout=0.6,
-                    )
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "HubSpot CRM context lookup timed out; proceeding without CRM context"
-                    )
-                except Exception as exc:
-                    logger.error(
-                        "HubSpot CRM context lookup failed; proceeding without context: %s", exc
-                    )
-
-            if crm_context_block:
-                anchor = "# CONVERSATION STATE"
-                if anchor in system_prompt:
-                    system_prompt = system_prompt.replace(
-                        anchor, crm_context_block + "\n\n" + anchor, 1
-                    )
-                else:
-                    system_prompt = system_prompt + "\n\n" + crm_context_block
-
-            # Salesforce CRM context injection: same fail-open, once-per-call,
-            # call_metadata-cached pattern as the HubSpot block above.
-            salesforce_context_block = ""
-            if self._h.call_session and self._h.db:
-                try:
-                    from app.services import salesforce_service
-
-                    salesforce_context_block = await asyncio.wait_for(
-                        salesforce_service.get_crm_context_block_for_call(
-                            self._h.db, self._h.call_session
-                        ),
-                        timeout=0.6,
-                    )
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "Salesforce CRM context lookup timed out; proceeding without CRM context"
-                    )
-                except Exception as exc:
-                    logger.error(
-                        "Salesforce CRM context lookup failed; proceeding without context: %s", exc
-                    )
-
-            if salesforce_context_block:
-                anchor = "# CONVERSATION STATE"
-                if anchor in system_prompt:
-                    system_prompt = system_prompt.replace(
-                        anchor, salesforce_context_block + "\n\n" + anchor, 1
-                    )
-                else:
-                    system_prompt = system_prompt + "\n\n" + salesforce_context_block
-
-            # GoHighLevel (GHL) CRM context injection: same fail-open, once-per-call,
-            # call_metadata-cached pattern as the HubSpot/Salesforce blocks above.
-            ghl_context_block = ""
-            if self._h.call_session and self._h.db:
-                try:
-                    from app.services import ghl_service
-
-                    ghl_context_block = await asyncio.wait_for(
-                        ghl_service.get_crm_context_block_for_call(
-                            self._h.db, self._h.call_session
-                        ),
-                        timeout=0.6,
-                    )
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "GHL CRM context lookup timed out; proceeding without CRM context"
-                    )
-                except Exception as exc:
-                    logger.error(
-                        "GHL CRM context lookup failed; proceeding without context: %s", exc
-                    )
-
-            if ghl_context_block:
-                anchor = "# CONVERSATION STATE"
-                if anchor in system_prompt:
-                    system_prompt = system_prompt.replace(
-                        anchor, ghl_context_block + "\n\n" + anchor, 1
-                    )
-                else:
-                    system_prompt = system_prompt + "\n\n" + ghl_context_block
-
-            # Cross-session caller memory: fetched once at call start (DB lookup,
-            # 100ms timeout budget, fail-open) and cached on call_session.call_metadata
-            # so every later turn is a cheap in-memory dict read. Injected right after
-            # the KB/CRM context blocks and before conversation history.
-            caller_memory_block = ""
-            if self._h.call_session and self._h.db and flow and flow.caller_memory_enabled:
-                try:
-                    from app.services.caller_memory_service import (
-                        get_caller_memory_context_block_for_call,
-                    )
-
-                    caller_memory_block = await get_caller_memory_context_block_for_call(
-                        self._h.db, self._h.call_session, flow
-                    )
-                except Exception as exc:
-                    logger.error(
-                        "caller_memory lookup failed; proceeding without context: %s", exc
-                    )
-
-            if caller_memory_block:
-                anchor = "# CONVERSATION STATE"
-                if anchor in system_prompt:
-                    system_prompt = system_prompt.replace(
-                        anchor, caller_memory_block + "\n\n" + anchor, 1
-                    )
-                else:
-                    system_prompt = system_prompt + "\n\n" + caller_memory_block
-
-            # HubSpot field-mapping substitution: replaces `{prompt_variable}` tokens
-            # in the prompt with tenant-configured HubSpot contact field values.
-            # Resolved once per call (Redis/DB-cached) and fails open on timeout/error.
-            if self._h.call_session and self._h.db:
-                try:
-                    from app.services.hubspot_service import (
-                        apply_field_mapping_values,
-                        get_field_mapping_values_for_call,
-                    )
-
-                    field_mapping_values = await asyncio.wait_for(
-                        get_field_mapping_values_for_call(self._h.db, self._h.call_session),
-                        timeout=0.6,
-                    )
-                    if field_mapping_values:
-                        system_prompt = apply_field_mapping_values(
-                            system_prompt, field_mapping_values
-                        )
-                except asyncio.TimeoutError:
-                    logger.warning(
-                        "HubSpot field mapping lookup timed out; proceeding without substitution"
-                    )
-                except Exception as exc:
-                    logger.error(
-                        "HubSpot field mapping lookup failed; proceeding without substitution: %s",
-                        exc,
-                    )
+            system_prompt = await self.build_system_prompt(user_text, confidence)
 
             from app.core.agent_runtime import llm_service_for_provider, resolve_llm_runtime
 

--- a/app/voice/gemini_live_audio_bridge.py
+++ b/app/voice/gemini_live_audio_bridge.py
@@ -1,0 +1,152 @@
+"""
+Pure audio-conversion helpers bridging Twilio's MULAW/8kHz telephony audio
+to/from Gemini Live's required PCM16 format (16kHz mono in, 24kHz mono out —
+confirmed live against the real API, see ``app/core/llm_models.py``'s
+``GEMINI_LIVE_MODELS`` docstring).
+
+This module has ZERO knowledge of Twilio/LiveKit/call-session state — it
+only converts byte buffers. Functions here are intentionally synchronous,
+pure, and side-effect-free (no async, no I/O, no class state) so they're
+trivially unit-testable and safe to call from any transport's hot audio
+path without blocking an event loop.
+
+Design notes / tradeoffs
+-------------------------
+- **mu-law codec**: reuses this repo's existing pure-Python
+  ``ulaw_to_linear_sample`` / ``linear_samples_to_ulaw_bytes`` helpers
+  (``app/utils/audio_utils.py``), already used by ``livekit_browser_call_handler.py``'s
+  ``_LiveKitAgentAudioPublisher.publish_mulaw`` and the TTS mixing/fade code
+  in the same module. Considered stdlib ``audioop``/``audioop-lts``
+  (``audioop.ulaw2lin``/``lin2ulaw``) instead — it would be faster (C
+  implementation) and is available in this repo's Docker builder
+  (``python:3.11-slim``, confirmed via ``python3 --version`` -> 3.11.2, so
+  stdlib ``audioop`` has not yet been removed as of 3.13). But ``audioop``
+  is deprecated (removal scheduled for a future CPython) and, per a repo
+  grep, is not used anywhere else in this codebase, which otherwise
+  consistently favors the pure-Python codec in ``audio_utils.py`` for MULAW
+  math. Reusing that existing, already-tested helper avoids introducing a
+  second mu-law implementation and a stdlib-deprecation dependency for a
+  small, non-bottleneck buffer size (20ms Twilio frames are only 160 bytes).
+  If this ever becomes a measured hot-path bottleneck, swapping the per-byte
+  loop below for ``audioop.ulaw2lin``/``lin2ulaw`` is a drop-in, isolated
+  change confined to this module.
+- **Resampling (8k<->16k, 24k->8k)**: ``app/voice/audio_transcoder.py``'s
+  ``LiveKitAudioProcessor`` is a generic PCM ffmpeg-subprocess resampler,
+  but it's built as a persistent per-call subprocess with async reader/
+  writer loops — the wrong shape for a stateless, synchronous, per-buffer
+  helper (spawning a subprocess per call would dwarf the actual conversion
+  cost and add I/O to a function this module promises to keep pure/sync).
+  ``audioop.ratecv`` was considered as a synchronous alternative but rejected
+  for the same audioop-avoidance reason as the mu-law codec above.  Instead:
+  - **Downsampling** (24kHz Gemini output -> 8kHz Twilio) reuses this
+    repo's existing ``downsample_linear_samples`` (box averaging over
+    integer factors) from ``audio_utils.py`` — already used elsewhere in
+    this codebase for 16k->8k background-audio mixing, so its quality
+    tradeoff (removes enough high-frequency energy to avoid harsh aliasing
+    on phone-quality audio, per that function's own docstring) is
+    already-accepted precedent, not a new one.
+  - **Upsampling** (8kHz Twilio input -> 16kHz Gemini input) has no existing
+    helper in this repo (``downsample_linear_samples`` only handles
+    downsampling), so this module adds ``_upsample_linear_samples`` — simple
+    linear interpolation between consecutive samples, doubling sample rate
+    for the 8k->16k case. This is a well-known low-cost/reasonable-quality
+    resampling method (linear interpolation), not brick-wall/sinc-filtered,
+    so some high-frequency imaging artifacts are possible; but the target
+    is *speech input to an ASR/LLM model*, not audio played back to a human,
+    so any color introduced here has never been shown to affect this
+    model's transcription/understanding quality in Google's own docs, and
+    the intent is caller audio en route to Gemini, not Gemini's own more
+    audio-quality-sensitive playback direction (see downsampling above,
+    which handles that direction and reuses the already-vetted helper).
+"""
+from __future__ import annotations
+
+from app.utils.audio_utils import (
+    downsample_linear_samples,
+    linear_samples_to_ulaw_bytes,
+    pcm16le_bytes_to_linear_samples,
+    ulaw_to_linear_sample,
+)
+
+# Sample rates involved (confirmed live against the real API, 2026-08-17 —
+# see app/core/llm_models.py's GEMINI_LIVE_MODELS docstring for the source
+# of truth on these numbers).
+TWILIO_MULAW_RATE_HZ = 8000
+GEMINI_INPUT_PCM_RATE_HZ = 16000
+GEMINI_OUTPUT_PCM_RATE_HZ = 24000
+
+
+def _upsample_linear_samples(samples: list[int], factor: int) -> list[int]:
+    """
+    Upsample linear PCM samples by an integer ``factor`` using simple linear
+    interpolation between consecutive input samples. See module docstring
+    for the quality tradeoff rationale (speech-input direction, not
+    playback-to-human direction).
+
+    ``factor`` must be a positive integer. ``factor == 1`` (or an empty
+    input) returns a shallow copy unchanged.
+    """
+    if not samples or factor <= 1:
+        return list(samples)
+
+    n = len(samples)
+    out: list[int] = []
+    for i in range(n):
+        a = samples[i]
+        b = samples[i + 1] if i + 1 < n else a
+        for step in range(factor):
+            t = step / factor
+            out.append(int(round(a + (b - a) * t)))
+    return out
+
+
+def _linear_samples_to_pcm16le_bytes(samples: list[int]) -> bytes:
+    """Encode signed linear PCM samples to little-endian 16-bit PCM bytes,
+    clamping to the valid int16 range (defensive — interpolation/averaging
+    above should already stay in range, but never emit out-of-range bytes)."""
+    out = bytearray(len(samples) * 2)
+    for i, sample in enumerate(samples):
+        clamped = max(-32768, min(32767, int(sample)))
+        out[i * 2:i * 2 + 2] = int(clamped & 0xFFFF).to_bytes(2, "little", signed=False)
+    return bytes(out)
+
+
+def mulaw8k_to_pcm16_16k(mulaw_bytes: bytes) -> bytes:
+    """
+    Convert Twilio's inbound MULAW 8kHz mono caller audio to the raw PCM16
+    16kHz little-endian mono format Gemini Live's ``send_realtime_input``
+    expects (``audio/pcm;rate=16000``).
+
+    Pure/synchronous — safe to call from any hot audio-receive path.
+    Empty input returns empty output. Odd-length input is not meaningful for
+    MULAW (1 byte == 1 sample) so every byte is processed; there is no
+    "odd/even byte pairing" concern on the input side (unlike PCM16, see
+    ``pcm16_24k_to_mulaw8k``).
+    """
+    if not mulaw_bytes:
+        return b""
+    linear_8k = [ulaw_to_linear_sample(b) for b in mulaw_bytes]
+    linear_16k = _upsample_linear_samples(linear_8k, GEMINI_INPUT_PCM_RATE_HZ // TWILIO_MULAW_RATE_HZ)
+    return _linear_samples_to_pcm16le_bytes(linear_16k)
+
+
+def pcm16_24k_to_mulaw8k(pcm_bytes: bytes) -> bytes:
+    """
+    Convert Gemini Live's outbound raw PCM16 24kHz little-endian mono audio
+    (``audio/pcm;rate=24000``) to Twilio's outbound MULAW 8kHz mono format.
+
+    Pure/synchronous — safe to call from any hot audio-send path. Empty
+    input returns empty output. A trailing odd byte (incomplete final
+    sample) is silently dropped rather than raising — mirrors
+    ``pcm16le_bytes_to_linear_samples``'s existing odd-length handling in
+    ``audio_utils.py``.
+    """
+    if not pcm_bytes:
+        return b""
+    linear_24k = pcm16le_bytes_to_linear_samples(pcm_bytes)
+    if not linear_24k:
+        return b""
+    linear_8k = downsample_linear_samples(
+        linear_24k, GEMINI_OUTPUT_PCM_RATE_HZ, TWILIO_MULAW_RATE_HZ
+    )
+    return linear_samples_to_ulaw_bytes(linear_8k)

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -874,6 +874,8 @@ class LiveKitBrowserCallHandler:
                     external_voice_id = getattr(tts_voice, "external_voice_id", None)
                 if not external_voice_id and tts_provider_slug == "rime":
                     external_voice_id = "mistv2_Wildflower"
+                elif not external_voice_id and tts_provider_slug == "hume":
+                    external_voice_id = "Male English Actor"
                 if not external_voice_id:
                     logger.warning(
                         "[LiveKitBrowserCall] TTS voice not configured for streaming provider=%s",

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -875,7 +875,9 @@ class LiveKitBrowserCallHandler:
                 if not external_voice_id and tts_provider_slug == "rime":
                     external_voice_id = "mistv2_Wildflower"
                 elif not external_voice_id and tts_provider_slug == "hume":
-                    external_voice_id = "Male English Actor"
+                    from app.services.hume_tts_service import HUME_DEFAULT_VOICE
+
+                    external_voice_id = HUME_DEFAULT_VOICE
                 if not external_voice_id:
                     logger.warning(
                         "[LiveKitBrowserCall] TTS voice not configured for streaming provider=%s",

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -57,6 +57,7 @@ from app.utils.audio_utils import MULAW_FRAME_BYTES, ulaw_to_linear_sample
 from app.utils.ssml_utils import strip_ssml_tags
 from app.voice.conversation_orchestrator import ConversationOrchestrator, VOICE_TUNABLES
 from app.voice.gemini_live_audio_bridge import GEMINI_OUTPUT_PCM_RATE_HZ
+from app.services.openai_realtime_service import LIVEKIT_AUDIO_RATE_HZ as OPENAI_REALTIME_AUDIO_RATE_HZ
 from app.voice.humanization_engine import pause_frames_for_chunk
 
 if TYPE_CHECKING:
@@ -353,6 +354,32 @@ class _GeminiLiveAudioSink:
             )
 
 
+class _OpenAIRealtimeAudioSink:
+    """
+    OpenAI Realtime analog of ``_GeminiLiveAudioSink`` — same
+    ``stt_pipeline``-shaped adapter pattern, targeting an
+    ``OpenAIRealtimeSession`` instead. ``LiveKitAudioSubscriber`` is opened
+    with ``output_sample_rate=OPENAI_REALTIME_AUDIO_RATE_HZ`` (24kHz) for a
+    native-audio OpenAI call (see ``run_livekit_browser_call``) — exactly
+    the rate ``OpenAIRealtimeSession.send_audio`` expects when the session
+    was started with ``audio_format="audio/pcm"``, so no conversion happens
+    here either.
+    """
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    async def feed_audio_chunk(self, pcm_bytes: bytes) -> None:
+        if not pcm_bytes:
+            return
+        try:
+            await self._session.send_audio(pcm_bytes)
+        except Exception as exc:
+            logger.error(
+                "[LiveKitBrowserCall] OpenAIRealtimeSession.send_audio failed: %s", exc, exc_info=True
+            )
+
+
 class LiveKitBrowserCallHandler:
     """
     Transport adapter: implements exactly the attribute/method surface that
@@ -513,21 +540,32 @@ class LiveKitBrowserCallHandler:
     # module for the branch).
 
     async def _publish_gemini_live_audio_chunk(
-        self, pcm16_24k_bytes: bytes, cancel: asyncio.Event
+        self,
+        pcm16_24k_bytes: bytes,
+        cancel: asyncio.Event,
+        sample_rate_hz: int = GEMINI_OUTPUT_PCM_RATE_HZ,
     ) -> None:
         """
-        GeminiLiveSession audio-out sink for this transport (native-audio
-        calls only). Publishes Gemini's raw PCM16/24kHz output directly via
-        `_agent_publisher.publish_pcm` — `_agent_publisher` is opened at
-        24kHz for a native-audio call (see run_livekit_browser_call), so
-        unlike the Twilio path's `_stream_live_audio_chunk` (mu-law/8kHz),
+        Native-audio-S2S audio-out sink for this transport, shared by both
+        Gemini Live and OpenAI Realtime (see the Gemini-specific name's note
+        below). Publishes raw PCM16 output directly via
+        `_agent_publisher.publish_pcm` — `_agent_publisher` is opened at the
+        matching rate for a native-audio call (see run_livekit_browser_call),
+        so unlike the Twilio path's `_stream_live_audio_chunk` (mu-law/8kHz),
         no resampling or codec conversion happens here at all.
+
+        `sample_rate_hz` defaults to Gemini's own output rate for the
+        original Gemini call site; OpenAI Realtime's call site passes its own
+        rate explicitly instead of relying on the two providers' rates
+        happening to both be 24kHz today — a future rate change to either
+        provider must not silently mismatch the other and get audio dropped
+        by `publish_pcm`'s rate-mismatch guard.
         """
         publisher = self._agent_publisher
         if publisher is None or not publisher.connected:
             return
         await publisher.publish_pcm(
-            pcm16_24k_bytes, sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ, cancel=cancel
+            pcm16_24k_bytes, sample_rate_hz=sample_rate_hz, cancel=cancel
         )
 
     async def _clear_gemini_live_playout_queue(self) -> None:
@@ -1346,12 +1384,30 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
             await voice_orchestrator._start_gemini_live_session(handler)
             is_gemini_live = voice_orchestrator._is_gemini_live
 
-        # ── Connect agent audio-out (TTS / Gemini Live) ──────────────────────
-        # A native-audio call opens the publisher at Gemini's own 24kHz PCM
-        # output rate (no mu-law, no resampling on this path — see
+        # ── OpenAI Realtime (native-audio speech-to-speech) fork ─────────────
+        # Parallel to the Gemini Live fork above, not shared/refactored code
+        # (per this task's "strictly additive, don't touch Gemini-Live-
+        # specific code" constraint) — mutually exclusive with is_gemini_live
+        # since VoiceOrchestrator.__init__ resolves each provider from a
+        # disjoint model-ID allow-list.
+        is_openai_realtime = voice_orchestrator._is_openai_realtime
+        if is_openai_realtime:
+            await voice_orchestrator._start_openai_realtime_session(handler)
+            is_openai_realtime = voice_orchestrator._is_openai_realtime
+
+        # ── Connect agent audio-out (TTS / Gemini Live / OpenAI Realtime) ────
+        # A native-audio call opens the publisher at the provider's own 24kHz
+        # PCM output rate (no mu-law, no resampling on this path — see
         # _LiveKitAgentAudioPublisher.publish_pcm); every other call keeps the
-        # existing 8kHz mu-law-derived rate.
-        publisher_sample_rate = GEMINI_OUTPUT_PCM_RATE_HZ if is_gemini_live else _AGENT_AUDIO_SAMPLE_RATE
+        # existing 8kHz mu-law-derived rate. Gemini Live and OpenAI Realtime
+        # both happen to use 24kHz PCM16 for this transport, so the same
+        # publisher/sink plumbing serves either provider unmodified.
+        if is_gemini_live:
+            publisher_sample_rate = GEMINI_OUTPUT_PCM_RATE_HZ
+        elif is_openai_realtime:
+            publisher_sample_rate = OPENAI_REALTIME_AUDIO_RATE_HZ
+        else:
+            publisher_sample_rate = _AGENT_AUDIO_SAMPLE_RATE
         publisher = _LiveKitAgentAudioPublisher(room_name, sample_rate_hz=publisher_sample_rate)
         connected = await publisher.connect()
         if not connected:
@@ -1393,6 +1449,19 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
                 room_name=room_name,
                 stt_pipeline=_GeminiLiveAudioSink(session),
                 output_sample_rate=_STT_INPUT_SAMPLE_RATE,
+            )
+        elif is_openai_realtime:
+            # Native-audio OpenAI agents skip STT entirely too. Unlike the
+            # Gemini Live branch above, this requests LiveKitAudioSubscriber
+            # resample caller audio to 24kHz (not 16kHz) — the rate
+            # OpenAIRealtimeSession.send_audio expects when the session was
+            # started with audio_format="audio/pcm" (symmetric 24kHz in/out,
+            # unlike Gemini Live's asymmetric 16kHz-in/24kHz-out).
+            session = voice_orchestrator._openai_realtime_session
+            audio_subscriber = LiveKitAudioSubscriber(
+                room_name=room_name,
+                stt_pipeline=_OpenAIRealtimeAudioSink(session),
+                output_sample_rate=OPENAI_REALTIME_AUDIO_RATE_HZ,
             )
         else:
             from app.core.agent_runtime import resolve_stt_runtime

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -56,6 +56,7 @@ from app.services.transcript_service import transcript_service
 from app.utils.audio_utils import MULAW_FRAME_BYTES, ulaw_to_linear_sample
 from app.utils.ssml_utils import strip_ssml_tags
 from app.voice.conversation_orchestrator import ConversationOrchestrator, VOICE_TUNABLES
+from app.voice.gemini_live_audio_bridge import GEMINI_OUTPUT_PCM_RATE_HZ
 from app.voice.humanization_engine import pause_frames_for_chunk
 
 if TYPE_CHECKING:
@@ -124,11 +125,20 @@ class _LiveKitAgentAudioPublisher:
     recording-mirror path and is not in this task's touch list).
     """
 
-    def __init__(self, room_name: str) -> None:
+    def __init__(self, room_name: str, sample_rate_hz: int = _AGENT_AUDIO_SAMPLE_RATE) -> None:
         self._room_name = room_name
         self._room: Any = None
         self._source: Any = None
         self._connected = False
+        # Per-instance publish sample rate — defaults to the usual TTS-provider
+        # rate (8kHz mu-law-derived PCM), but a Gemini Live native-audio call
+        # opens this publisher at Gemini's own 24kHz output rate instead (see
+        # run_livekit_browser_call), so publish_pcm() below can push Gemini's
+        # raw PCM straight into the room with zero resampling. rtc.AudioSource
+        # takes its sample rate per-instance at construction (confirmed by
+        # reading this SDK usage), not once globally for the whole room, so
+        # this is safe to vary per call.
+        self._sample_rate = int(sample_rate_hz)
         # Rate-limits the "publish failed" warning to once per outage (rather
         # than once per ~20ms frame) so a sustained failure doesn't flood the
         # logs while still being visible at all — previously this was a bare
@@ -140,6 +150,10 @@ class _LiveKitAgentAudioPublisher:
     @property
     def connected(self) -> bool:
         return self._connected
+
+    @property
+    def sample_rate(self) -> int:
+        return self._sample_rate
 
     async def connect(self) -> bool:
         if not settings.LIVEKIT_ENABLED:
@@ -163,7 +177,7 @@ class _LiveKitAgentAudioPublisher:
             self._room = rtc.Room()
             await self._room.connect(ws_url, token)
 
-            self._source = rtc.AudioSource(_AGENT_AUDIO_SAMPLE_RATE, 1)
+            self._source = rtc.AudioSource(self._sample_rate, 1)
             track = rtc.LocalAudioTrack.create_audio_track("agent-tts-audio", self._source)
             options = rtc.TrackPublishOptions()
             options.source = rtc.TrackSource.SOURCE_MICROPHONE
@@ -221,7 +235,7 @@ class _LiveKitAgentAudioPublisher:
 
                 samples = [ulaw_to_linear_sample(b) for b in chunk]
                 pcm = struct.pack(f"<{len(samples)}h", *samples)
-                frame = rtc.AudioFrame.create(_AGENT_AUDIO_SAMPLE_RATE, 1, len(samples))
+                frame = rtc.AudioFrame.create(self._sample_rate, 1, len(samples))
                 # frame.data is a memoryview already cast to int16 ("h")
                 # format (see livekit.rtc.AudioFrame.data); assigning a plain
                 # `bytes` object (format "B") straight into it raises
@@ -240,6 +254,65 @@ class _LiveKitAgentAudioPublisher:
                 )
                 self._publish_failed_logged = True
 
+    async def publish_pcm(
+        self, pcm_bytes: bytes, sample_rate_hz: int, cancel: asyncio.Event | None = None
+    ) -> None:
+        """
+        Push raw PCM16 little-endian mono bytes directly into the outgoing
+        track — no mu-law decode, unlike publish_mulaw(). Used exclusively by
+        the Gemini Live native-audio path (see gemini_live_audio_bridge.py /
+        run_livekit_browser_call): Gemini's own audio output is already raw
+        PCM16 at 24kHz, and this publisher instance is opened at that same
+        rate (self._sample_rate) for a native-audio call, so no resampling
+        step is needed here at all — a deliberate design choice over
+        resampling 24k->8k, since rtc.AudioSource's sample rate is set once
+        per publisher instance at construction, not globally for the room.
+
+        `sample_rate_hz` is the rate the caller believes `pcm_bytes` is
+        encoded at — it must match `self._sample_rate` (the rate this
+        publisher's AudioSource was actually opened at). A mismatch would
+        silently play audio at the wrong pitch/speed, so instead of playing
+        anything, this logs once and drops the chunk.
+        """
+        if not self._connected or not self._source or not pcm_bytes:
+            return
+        if cancel is not None and cancel.is_set():
+            return
+        if sample_rate_hz != self._sample_rate:
+            if not self._publish_failed_logged:
+                logger.error(
+                    "[LiveKitBrowserCall] publish_pcm sample_rate mismatch room=%s "
+                    "publisher_rate=%d chunk_rate=%d — dropping chunk",
+                    self._room_name, self._sample_rate, sample_rate_hz,
+                )
+                self._publish_failed_logged = True
+            return
+
+        try:
+            from livekit import rtc
+        except ImportError:
+            return
+
+        try:
+            # A trailing odd byte (incomplete final PCM16 sample) is dropped
+            # rather than raising — mirrors gemini_live_audio_bridge's own
+            # odd-length handling convention.
+            num_samples = len(pcm_bytes) // 2
+            if num_samples <= 0:
+                return
+            aligned = pcm_bytes[: num_samples * 2]
+            frame = rtc.AudioFrame.create(self._sample_rate, 1, num_samples)
+            frame.data.cast("B")[:] = aligned
+            await self._source.capture_frame(frame)
+            self._publish_failed_logged = False
+        except Exception as exc:
+            if not self._publish_failed_logged:
+                logger.warning(
+                    "[LiveKitBrowserCall] publish_pcm failed room=%s: %s",
+                    self._room_name, exc, exc_info=True,
+                )
+                self._publish_failed_logged = True
+
     async def disconnect(self) -> None:
         self._connected = False
         if self._room is not None:
@@ -249,6 +322,35 @@ class _LiveKitAgentAudioPublisher:
                 logger.debug("[LiveKitBrowserCall] room disconnect failed: %s", exc)
         self._room = None
         self._source = None
+
+
+class _GeminiLiveAudioSink:
+    """
+    Minimal ``stt_pipeline``-shaped adapter so ``LiveKitAudioSubscriber``
+    (which unconditionally calls ``self._stt_pipeline.feed_audio_chunk(...)``
+    on every decoded frame) can feed a ``GeminiLiveSession`` instead of an
+    ``SttPipeline``, for native-audio agents — without widening
+    ``LiveKitAudioSubscriber``'s constructor to accept a bare callback. This
+    is the smaller, more targeted change: ``LiveKitAudioSubscriber`` already
+    resamples caller audio to LINEAR16 16kHz mono
+    (``_STT_INPUT_SAMPLE_RATE``), exactly the format
+    ``GeminiLiveSession.send_audio`` expects, so no conversion happens here
+    — only the sink changes (see the Gemini Live integration plan's
+    "Browser | in" row).
+    """
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    async def feed_audio_chunk(self, pcm_bytes: bytes) -> None:
+        if not pcm_bytes:
+            return
+        try:
+            await self._session.send_audio(pcm_bytes)
+        except Exception as exc:
+            logger.error(
+                "[LiveKitBrowserCall] GeminiLiveSession.send_audio failed: %s", exc, exc_info=True
+            )
 
 
 class LiveKitBrowserCallHandler:
@@ -402,6 +504,49 @@ class LiveKitBrowserCallHandler:
                 )
         except Exception as exc:
             logger.error("[LiveKitBrowserCall] _add_to_transcript failed: %s", exc, exc_info=True)
+
+    # ── Gemini Live (native-audio speech-to-speech) audio-out sink ──────────
+    # Wired by VoiceOrchestrator._on_gemini_live_audio_chunk /
+    # _on_gemini_live_interrupted (duck-typed via hasattr, since the Twilio
+    # handler exposes its own differently-shaped `_stream_live_audio_chunk` /
+    # `_send_twilio_clear_event` methods for the same two hooks — see that
+    # module for the branch).
+
+    async def _publish_gemini_live_audio_chunk(
+        self, pcm16_24k_bytes: bytes, cancel: asyncio.Event
+    ) -> None:
+        """
+        GeminiLiveSession audio-out sink for this transport (native-audio
+        calls only). Publishes Gemini's raw PCM16/24kHz output directly via
+        `_agent_publisher.publish_pcm` — `_agent_publisher` is opened at
+        24kHz for a native-audio call (see run_livekit_browser_call), so
+        unlike the Twilio path's `_stream_live_audio_chunk` (mu-law/8kHz),
+        no resampling or codec conversion happens here at all.
+        """
+        publisher = self._agent_publisher
+        if publisher is None or not publisher.connected:
+            return
+        await publisher.publish_pcm(
+            pcm16_24k_bytes, sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ, cancel=cancel
+        )
+
+    async def _clear_gemini_live_playout_queue(self) -> None:
+        """
+        Barge-in for the Gemini Live path on this transport: discard whatever
+        LiveKit's own AudioSource has already buffered internally (up to
+        ~1000ms) so an interruption is heard immediately instead of after the
+        already-queued audio finishes playing out. Mirrors
+        `_cancel_inflight_llm_response`'s existing `source.clear_queue()` call
+        for the regular TTS barge-in path — there is no Twilio
+        `_send_twilio_clear_event` equivalent on this transport.
+        """
+        publisher = getattr(self, "_agent_publisher", None)
+        source = getattr(publisher, "_source", None) if publisher else None
+        if source is not None:
+            try:
+                source.clear_queue()
+            except Exception:  # noqa: S110 - best-effort barge-in abort
+                pass
 
     # ── Out-of-scope side effects — clean stubs, never crash ────────────────
 
@@ -1173,9 +1318,41 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
         from app.voice.voice_orchestrator import VoiceOrchestrator
 
         voice_orchestrator = VoiceOrchestrator(handler)
+        # Back-reference so ConversationOrchestrator's greeting branch (which
+        # only has access to self._h, i.e. this handler) can check
+        # _is_gemini_live / reach _gemini_live_session — mirrors
+        # BidirectionalStreamHandler.__init__'s self._voice_orchestrator.
+        handler._voice_orchestrator = voice_orchestrator
 
-        # ── Connect agent audio-out (TTS) ───────────────────────────────────
-        publisher = _LiveKitAgentAudioPublisher(room_name)
+        # ── Gemini Live (native-audio speech-to-speech) fork ─────────────────
+        # VoiceOrchestrator.__init__ already resolved _is_gemini_live from
+        # agent.llm_model (is_gemini_live_native_audio_model) — same flag the
+        # Twilio transport uses, just read here instead of re-derived, so both
+        # transports agree on routing for the same agent. Unlike Twilio (which
+        # lazily starts the session on the first audio chunk inside
+        # on_audio_chunk — this transport's equivalent per-chunk fork point,
+        # see module docstring), this transport has no such per-chunk hook: a
+        # LiveKit browser call's whole audio path is set up once, up front, so
+        # the session is started eagerly here, before anything audio-related
+        # (including which sample rate to open the outbound publisher at) is
+        # decided. On a pre-session failure, _start_gemini_live_session's own
+        # fallback (_fallback_to_legacy_pipeline) flips
+        # voice_orchestrator._is_gemini_live back to False and swaps
+        # handler.agent.llm_model to a text model in-memory — re-read the flag
+        # below so this function falls through to the normal STT/TTS
+        # construction path for the rest of the call.
+        is_gemini_live = voice_orchestrator._is_gemini_live
+        if is_gemini_live:
+            await voice_orchestrator._start_gemini_live_session(handler)
+            is_gemini_live = voice_orchestrator._is_gemini_live
+
+        # ── Connect agent audio-out (TTS / Gemini Live) ──────────────────────
+        # A native-audio call opens the publisher at Gemini's own 24kHz PCM
+        # output rate (no mu-law, no resampling on this path — see
+        # _LiveKitAgentAudioPublisher.publish_pcm); every other call keeps the
+        # existing 8kHz mu-law-derived rate.
+        publisher_sample_rate = GEMINI_OUTPUT_PCM_RATE_HZ if is_gemini_live else _AGENT_AUDIO_SAMPLE_RATE
+        publisher = _LiveKitAgentAudioPublisher(room_name, sample_rate_hz=publisher_sample_rate)
         connected = await publisher.connect()
         if not connected:
             logger.error("[LiveKitBrowserCall] failed to connect TTS publisher room=%s", room_name)
@@ -1201,41 +1378,56 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
             publisher._room.on("participant_disconnected", _on_participant_disconnected)
             publisher._room.on("disconnected", _on_room_disconnected)
 
-        # ── Resolve + start STT ─────────────────────────────────────────────
-        from app.core.agent_runtime import resolve_stt_runtime
-
-        flow_lang = None
-        if call_flow and isinstance(call_flow.settings, dict):
-            raw = call_flow.settings.get("sttLanguageCode") or call_flow.settings.get("stt_language_code")
-            if isinstance(raw, str) and raw.strip():
-                flow_lang = raw.strip()
-
-        resolved_stt = _forced_browser_stt_runtime(
-            resolve_stt_runtime(agent, flow_language_code=flow_lang, db=db)
-        )
-
-        from app.voice.stt_pipeline import SttPipeline
-
-        stt_pipeline = SttPipeline.from_runtime_config(
-            resolved=resolved_stt,
-            on_interim=voice_orchestrator._on_interim,
-            on_final=voice_orchestrator._on_final,
-            call_session_id=handler.call_session_id,
-            agent_id=handler.agent_id,
-            event_bus=voice_orchestrator.stt_event_bus,
-        )
-        # Register onto VoiceOrchestrator so its shutdown() closes this
-        # session too (it only closes a pipeline it knows about).
-        voice_orchestrator._stt_pipeline = stt_pipeline
-        voice_orchestrator._stt_active = True
-
+        # ── Resolve + start inbound audio (STT, or Gemini Live) ──────────────
         from app.voice.livekit_audio_subscriber import LiveKitAudioSubscriber
 
-        audio_subscriber = LiveKitAudioSubscriber(
-            room_name=room_name,
-            stt_pipeline=stt_pipeline,
-            output_sample_rate=_STT_INPUT_SAMPLE_RATE,
-        )
+        if is_gemini_live:
+            # Native-audio agents skip STT entirely — SttPipeline is never
+            # constructed for this call. LiveKitAudioSubscriber already
+            # resamples caller audio to LINEAR16 16kHz mono
+            # (_STT_INPUT_SAMPLE_RATE), exactly the format
+            # GeminiLiveSession.send_audio expects, so only the sink changes
+            # (via the _GeminiLiveAudioSink adapter) — no new conversion work.
+            session = voice_orchestrator._gemini_live_session
+            audio_subscriber = LiveKitAudioSubscriber(
+                room_name=room_name,
+                stt_pipeline=_GeminiLiveAudioSink(session),
+                output_sample_rate=_STT_INPUT_SAMPLE_RATE,
+            )
+        else:
+            from app.core.agent_runtime import resolve_stt_runtime
+
+            flow_lang = None
+            if call_flow and isinstance(call_flow.settings, dict):
+                raw = call_flow.settings.get("sttLanguageCode") or call_flow.settings.get("stt_language_code")
+                if isinstance(raw, str) and raw.strip():
+                    flow_lang = raw.strip()
+
+            resolved_stt = _forced_browser_stt_runtime(
+                resolve_stt_runtime(agent, flow_language_code=flow_lang, db=db)
+            )
+
+            from app.voice.stt_pipeline import SttPipeline
+
+            stt_pipeline = SttPipeline.from_runtime_config(
+                resolved=resolved_stt,
+                on_interim=voice_orchestrator._on_interim,
+                on_final=voice_orchestrator._on_final,
+                call_session_id=handler.call_session_id,
+                agent_id=handler.agent_id,
+                event_bus=voice_orchestrator.stt_event_bus,
+            )
+            # Register onto VoiceOrchestrator so its shutdown() closes this
+            # session too (it only closes a pipeline it knows about).
+            voice_orchestrator._stt_pipeline = stt_pipeline
+            voice_orchestrator._stt_active = True
+
+            audio_subscriber = LiveKitAudioSubscriber(
+                room_name=room_name,
+                stt_pipeline=stt_pipeline,
+                output_sample_rate=_STT_INPUT_SAMPLE_RATE,
+            )
+
         audio_subscriber_task = asyncio.create_task(audio_subscriber.run())
 
         # From here on, the agent has actually joined and audio is flowing —

--- a/app/voice/metrics.py
+++ b/app/voice/metrics.py
@@ -45,6 +45,22 @@ class VoiceTurnMetrics:
         if self.turn_first_tts_queued_mono is None:
             self.turn_first_tts_queued_mono = time.perf_counter()
 
+    def mark_live_first_audio(self) -> None:
+        """
+        Gemini Live (speech-to-speech native-audio) marker: collapses what
+        would otherwise be two separate markers (mark_llm_first_token +
+        mark_first_tts_queued) into one "first audio byte from Gemini"
+        event, since there is no discrete LLM-token / TTS-queue boundary in
+        this path. Approximate turn-boundary detection is fine here (see
+        VoiceOrchestrator._on_gemini_live_audio_chunk) — reuses the same two
+        underlying fields so existing log_turn_summary/get_slo_breaches
+        consumers keep working without a native-audio-aware branch.
+        """
+        if self.turn_llm_first_token_mono is None:
+            self.turn_llm_first_token_mono = time.perf_counter()
+        if self.turn_first_tts_queued_mono is None:
+            self.turn_first_tts_queued_mono = time.perf_counter()
+
     def log_turn_summary(
         self,
         log: Any,

--- a/app/voice/tts_provider_capabilities.py
+++ b/app/voice/tts_provider_capabilities.py
@@ -114,6 +114,21 @@ _CAPABILITIES: Dict[str, TTSProviderCapabilities] = {
         supports_pause_control=False,  # reduceLatency=True actively trims inter-sentence silence
         supports_streaming_session=False,  # no persistent streaming-input protocol for Rime here
     ),
+    # HumeTTSAdapter.async_stream_synthesize (app/utils/tts_adapter.py)
+    "hume": TTSProviderCapabilities(
+        provider_slug="hume",
+        supports_streaming=True,  # sync stream_synthesize explicitly raises NotImplementedError
+        supports_ssml=False,  # Hume's WebSocket protocol has no SSML concept — plain text only
+        supports_speaking_rate=True,  # settings_json["speed"] -> Hume's native "speed" param (0.5-2.0)
+        supports_pitch=False,  # no pitch parameter in the Hume WS payload
+        supports_stability_control=False,  # Hume's prosody knob is "description" (free-text acting
+        # instructions), a structurally different mechanism from ElevenLabs' numeric
+        # stability/similarity_boost — build_voice_settings_overlay() is explicitly scoped
+        # to the numeric path and is not wired to Hume's description field
+        supports_native_expressive_tags=False,  # bracket tags are stripped for non-ElevenLabs providers
+        supports_pause_control=False,  # no native break/pause param used
+        supports_streaming_session=False,  # one-shot WS request per chunk, not a persistent session
+    ),
 }
 
 

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -450,6 +450,8 @@ class TtsStreamMixin:
                                     external_voice_id = getattr(tts_voice, "external_voice_id", None)
                                 if not external_voice_id and tts_provider_slug == "rime":
                                     external_voice_id = "mistv2_Wildflower"
+                                elif not external_voice_id and tts_provider_slug == "hume":
+                                    external_voice_id = "Male English Actor"
                                 if not external_voice_id:
                                     raise ValueError("TTS voice is not configured for streaming.")
                                 adapter = get_tts_adapter(tts_provider_slug)
@@ -774,6 +776,8 @@ class TtsStreamMixin:
                     external_voice_id = getattr(tts_voice, "external_voice_id", None)
                 if not external_voice_id and tts_provider_slug == "rime":
                     external_voice_id = "mistv2_Wildflower"
+                elif not external_voice_id and tts_provider_slug == "hume":
+                    external_voice_id = "Male English Actor"
                 if not external_voice_id:
                     return None
                 adapter = get_tts_adapter(tts_provider_slug)

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -700,14 +700,26 @@ class TtsStreamMixin:
         so Twilio's 20ms/160-byte MULAW framing/message format is not
         reimplemented here.
 
-        Cancellation is gated on ``self._voice_orchestrator._gemini_live_cancel``
-        — this path's own minimal barge-in flag (see
-        VoiceOrchestrator._on_gemini_live_interrupted) — never on
-        ``self._tts_cancel``, since no TtsPipeline task exists for this call.
+        Cancellation is gated on whichever native-audio provider's own
+        minimal barge-in flag is active for this call —
+        ``self._voice_orchestrator._gemini_live_cancel`` (see
+        VoiceOrchestrator._on_gemini_live_interrupted) or
+        ``self._voice_orchestrator._openai_realtime_cancel`` (see
+        VoiceOrchestrator._on_openai_realtime_interrupted) — never on
+        ``self._tts_cancel``, since no TtsPipeline task exists for either of
+        these calls. Both cancel Events are always constructed
+        unconditionally in ``VoiceOrchestrator.__init__`` regardless of
+        which (if either) provider is active for this call, so resolving by
+        ``_is_openai_realtime`` here is safe even before either provider's
+        session has actually started.
         """
         if not mulaw_bytes or not self.stream_sid:
             return
-        cancel = getattr(self._voice_orchestrator, "_gemini_live_cancel", None)
+        vo = self._voice_orchestrator
+        if getattr(vo, "_is_openai_realtime", False):
+            cancel = getattr(vo, "_openai_realtime_cancel", None)
+        else:
+            cancel = getattr(vo, "_gemini_live_cancel", None)
         if cancel is not None and cancel.is_set():
             return
         try:

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -451,7 +451,9 @@ class TtsStreamMixin:
                                 if not external_voice_id and tts_provider_slug == "rime":
                                     external_voice_id = "mistv2_Wildflower"
                                 elif not external_voice_id and tts_provider_slug == "hume":
-                                    external_voice_id = "Male English Actor"
+                                    from app.services.hume_tts_service import HUME_DEFAULT_VOICE
+
+                                    external_voice_id = HUME_DEFAULT_VOICE
                                 if not external_voice_id:
                                     raise ValueError("TTS voice is not configured for streaming.")
                                 adapter = get_tts_adapter(tts_provider_slug)
@@ -777,7 +779,9 @@ class TtsStreamMixin:
                 if not external_voice_id and tts_provider_slug == "rime":
                     external_voice_id = "mistv2_Wildflower"
                 elif not external_voice_id and tts_provider_slug == "hume":
-                    external_voice_id = "Male English Actor"
+                    from app.services.hume_tts_service import HUME_DEFAULT_VOICE
+
+                    external_voice_id = HUME_DEFAULT_VOICE
                 if not external_voice_id:
                     return None
                 adapter = get_tts_adapter(tts_provider_slug)

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -688,6 +688,41 @@ class TtsStreamMixin:
         except Exception as e:
             logger.error(f"Error in _stream_tts_chunk: {e}", exc_info=True)
 
+    async def _stream_live_audio_chunk(self, mulaw_bytes: bytes) -> None:
+        """
+        Minimal outbound-audio primitive for the Gemini Live (native-audio
+        speech-to-speech) path — bypasses TtsPipeline/_stream_tts_chunk
+        entirely (there is no synthesized-text chunk here, just raw MULAW
+        bytes already converted from Gemini's PCM16/24kHz output by
+        VoiceOrchestrator._on_gemini_live_audio_chunk). Reuses the same
+        low-level paced-frame-send primitive
+        (``stream_mulaw_bytes_over_twilio``) the existing TTS send loops use,
+        so Twilio's 20ms/160-byte MULAW framing/message format is not
+        reimplemented here.
+
+        Cancellation is gated on ``self._voice_orchestrator._gemini_live_cancel``
+        — this path's own minimal barge-in flag (see
+        VoiceOrchestrator._on_gemini_live_interrupted) — never on
+        ``self._tts_cancel``, since no TtsPipeline task exists for this call.
+        """
+        if not mulaw_bytes or not self.stream_sid:
+            return
+        cancel = getattr(self._voice_orchestrator, "_gemini_live_cancel", None)
+        if cancel is not None and cancel.is_set():
+            return
+        try:
+            await stream_mulaw_bytes_over_twilio(
+                websocket=self.websocket,
+                stream_sid=self.stream_sid,
+                audio_bytes=mulaw_bytes,
+                pace_20ms=True,
+                cancel=cancel,
+                prime_frames=0,
+                mirror_mulaw=self._livekit_recording_mirror(),
+            )
+        except Exception as exc:
+            logger.error("[GeminiLive] _stream_live_audio_chunk failed: %s", exc, exc_info=True)
+
     async def _prefetch_tts_audio(self, task: Dict[str, Any]) -> bytes | None:
         """
         Generate TTS audio bytes in the background WITHOUT acquiring _tts_lock

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -26,7 +26,7 @@ import time
 from typing import TYPE_CHECKING, Any, Set
 
 from app.core.config import settings
-from app.core.llm_models import is_gemini_live_native_audio_model
+from app.core.llm_models import is_gemini_live_native_audio_model, is_openai_realtime_model
 from app.core.logger import logger
 from app.utils.audio_utils import ulaw_to_linear_sample
 from app.voice.gemini_live_audio_bridge import mulaw8k_to_pcm16_16k, pcm16_24k_to_mulaw8k
@@ -45,6 +45,14 @@ if TYPE_CHECKING:
 # `agent.llm_model` is swapped to this allow-listed text model for the
 # remainder of THIS call object only (never persisted to the DB).
 _GEMINI_LIVE_FALLBACK_TEXT_MODEL = "gemini-2.5-flash"
+
+# Same idea as _GEMINI_LIVE_FALLBACK_TEXT_MODEL above, for OpenAI Realtime
+# ("gpt-realtime"/"gpt-realtime-2") pre-session failures — see
+# _start_openai_realtime_session / _fallback_to_legacy_pipeline_openai. Kept
+# in the same provider family (OpenAI) rather than falling back cross-
+# provider to a Gemini text model, since the tenant/agent is already
+# configured for an OpenAI API key.
+_OPENAI_REALTIME_FALLBACK_TEXT_MODEL = "gpt-4o-mini"
 
 
 def _resolve_initial_endpointing_ms() -> int:
@@ -202,9 +210,32 @@ class VoiceOrchestrator:
         # says next anyway.
         self._gemini_live_kb_refresh_in_flight: bool = False
 
+        # ── OpenAI Realtime (native-audio speech-to-speech) state ─────────────
+        # Parallel to the Gemini Live block above, not a shared/refactored
+        # implementation (per this task's "strictly additive, don't touch
+        # Gemini-Live-specific code" constraint) — see
+        # app/services/openai_realtime_service.py's module docstring for the
+        # deliberate behavioral divergences (no per-turn receive loop, no
+        # transcript-fragment buffering, mostly-server-driven barge-in).
+        self._is_openai_realtime: bool = is_openai_realtime_model(
+            getattr(_agent, "llm_model", None) if _agent else None
+        )
+        self._openai_realtime_session: Any = None
+        self._openai_realtime_setup_lock: asyncio.Lock = asyncio.Lock()
+        self._openai_realtime_setup_failed: bool = False
+        self._openai_realtime_cancel: asyncio.Event = asyncio.Event()
+        self._openai_realtime_first_audio_marked: bool = False
+        # No input/output transcript buffers needed here — unlike Gemini
+        # Live, OpenAI's transcription events each fire exactly once per
+        # utterance with the full final text (see
+        # openai_realtime_service.OpenAIRealtimeSession's on_input_transcript/
+        # on_output_transcript contract).
+        self._openai_realtime_kb_refresh_in_flight: bool = False
+
         logger.info(
-            "[VoiceOrchestrator] Initialized — STT lazy, TTS pipeline ready, gemini_live=%s",
-            self._is_gemini_live,
+            "[VoiceOrchestrator] Initialized — STT lazy, TTS pipeline ready, "
+            "gemini_live=%s openai_realtime=%s",
+            self._is_gemini_live, self._is_openai_realtime,
         )
 
     # ── Public interface ──────────────────────────────────────────────────────
@@ -337,6 +368,16 @@ class VoiceOrchestrator:
             # agnostic (RMS over MULAW) and stays unchanged for both paths.
             if self._is_gemini_live:
                 await self._feed_gemini_live_audio(h, audio_data)
+                return
+
+            # ── 3c. Native-audio (OpenAI Realtime) fork ─────────────────────────
+            # Same idea as 3b above, for OpenAI's Realtime speech-to-speech
+            # models. Twilio's own MULAW/8kHz wire format is sent straight
+            # through with NO conversion (see _feed_openai_realtime_audio /
+            # app.services.openai_realtime_service's module docstring) —
+            # unlike Gemini Live, which forces a PCM16 resample round-trip.
+            if self._is_openai_realtime:
+                await self._feed_openai_realtime_audio(h, audio_data)
                 return
 
             # ── 4. STT feed ───────────────────────────────────────────────────
@@ -542,6 +583,19 @@ class VoiceOrchestrator:
                 await self._flush_gemini_live_output_buffer()
         except Exception as exc:
             logger.debug("[VoiceOrchestrator] Gemini Live session close failed: %s", exc)
+
+        # Close OpenAI Realtime session (native-audio calls only — no-op
+        # otherwise). No buffer-flush step needed here (unlike the Gemini
+        # Live block above) — OpenAI's transcripts are written to
+        # call_transcript synchronously as each complete utterance arrives,
+        # never buffered.
+        try:
+            if self._openai_realtime_session is not None:
+                self._openai_realtime_cancel.set()
+                await self._openai_realtime_session.close()
+                self._openai_realtime_session = None
+        except Exception as exc:
+            logger.debug("[VoiceOrchestrator] OpenAI Realtime session close failed: %s", exc)
 
         logger.info("[VoiceOrchestrator] Shutdown complete")
 
@@ -1101,6 +1155,354 @@ class VoiceOrchestrator:
         """
         logger.error(
             "[GeminiLive] mid-call session error call_session_id=%s error_type=%s: %s",
+            getattr(self._h, "call_session_id", None),
+            getattr(err, "error_type", None),
+            err,
+        )
+        asyncio.create_task(self._h._full_shutdown())
+
+    # ── OpenAI Realtime (native-audio speech-to-speech) ─────────────────────────
+    # Parallel to the "Gemini Live" section above — see
+    # app/services/openai_realtime_service.py's module docstring for the
+    # deliberate behavioral divergences from Gemini Live (no per-turn
+    # receive loop, no transcript-fragment buffering, mostly-server-driven
+    # barge-in via turn_detection.interrupt_response).
+
+    async def _feed_openai_realtime_audio(self, h, audio_data: bytes) -> None:
+        """
+        Route one MULAW/8kHz Twilio caller-audio frame to the (lazily
+        created) OpenAIRealtimeSession for this call. Called instead of the
+        SttPipeline feed for native-audio OpenAI agents. Unlike
+        _feed_gemini_live_audio, no format conversion happens here — the
+        session is started with audio_format="audio/pcmu" for a Twilio
+        call, which OpenAI accepts natively (see
+        openai_realtime_service.TWILIO_AUDIO_FORMAT).
+        """
+        if self._openai_realtime_setup_failed:
+            return
+
+        session = self._openai_realtime_session
+        if session is None:
+            async with self._openai_realtime_setup_lock:
+                if self._openai_realtime_session is None and not self._openai_realtime_setup_failed:
+                    await self._start_openai_realtime_session(h)
+            session = self._openai_realtime_session
+
+        if session is None:
+            return  # setup failed and fallback (or shutdown) already handled it
+
+        try:
+            await session.send_audio(audio_data)
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] OpenAIRealtimeSession.send_audio failed: %s", exc, exc_info=True
+            )
+
+    async def _start_openai_realtime_session(self, h) -> None:
+        """
+        Lazily open the OpenAIRealtimeSession for this call (once). Mirrors
+        _start_gemini_live_session's transport-aware system_instruction /
+        Calendly-tool wiring exactly — only the session class, audio format,
+        and voice-resolution helper differ.
+        """
+        from app.services.openai_realtime_service import (
+            OpenAIRealtimeError,
+            OpenAIRealtimeSession,
+            LIVEKIT_AUDIO_FORMAT,
+            TWILIO_AUDIO_FORMAT,
+            resolve_voice_name as resolve_openai_voice_name,
+        )
+
+        agent = getattr(h, "agent", None)
+        model_name = getattr(agent, "llm_model", None) if agent else None
+        is_twilio_transport = hasattr(h, "build_system_prompt")
+
+        try:
+            if is_twilio_transport:
+                system_instruction = await h.build_system_prompt(user_text="", confidence=1.0)
+            else:
+                from app.voice.conversation_orchestrator import ConversationOrchestrator
+
+                conv = ConversationOrchestrator(h)
+                system_instruction = await conv.build_system_prompt(user_text="", confidence=1.0)
+        except Exception as exc:
+            logger.error(
+                "[OpenAIRealtime] build_system_prompt failed for session start; using minimal "
+                "fallback instruction: %s", exc, exc_info=True,
+            )
+            agent_name = getattr(agent, "name", None) or "AI Assistant"
+            system_instruction = f"You are {agent_name}, a helpful phone assistant."
+
+        openai_tools = None
+        on_tool_call = None
+        if hasattr(h, "_calendly_enabled") and h._calendly_enabled():
+            from app.services.openai_realtime_service import _build_calendly_tool_params
+
+            openai_tools = _build_calendly_tool_params()
+            on_tool_call = self._on_openai_realtime_tool_call
+
+        voice_name = resolve_openai_voice_name(getattr(agent, "tts_voice_external_id", None))
+        audio_format = TWILIO_AUDIO_FORMAT if is_twilio_transport else LIVEKIT_AUDIO_FORMAT
+
+        session = OpenAIRealtimeSession(model_name)
+        try:
+            await session.start(
+                system_instruction=system_instruction,
+                audio_format=audio_format,
+                voice_name=voice_name,
+                on_audio_chunk=self._on_openai_realtime_audio_chunk,
+                on_interrupted=self._on_openai_realtime_interrupted,
+                on_input_transcript=self._on_openai_realtime_input_transcript,
+                on_output_transcript=self._on_openai_realtime_output_transcript,
+                on_tool_call=on_tool_call,
+                on_error=self._on_openai_realtime_error,
+                tools=openai_tools,
+            )
+        except OpenAIRealtimeError as exc:
+            logger.error(
+                "[OpenAIRealtime] pre-session start failed model=%s call_session_id=%s: %s",
+                model_name, getattr(h, "call_session_id", None), exc,
+            )
+            await self._fallback_to_legacy_pipeline_openai(h, reason=str(exc))
+            return
+        except Exception as exc:
+            logger.error(
+                "[OpenAIRealtime] unexpected pre-session start failure model=%s call_session_id=%s: %s",
+                model_name, getattr(h, "call_session_id", None), exc, exc_info=True,
+            )
+            await self._fallback_to_legacy_pipeline_openai(h, reason=str(exc))
+            return
+
+        self._openai_realtime_session = session
+        logger.info(
+            "[OpenAIRealtime] session started model=%s call_session_id=%s",
+            model_name, getattr(h, "call_session_id", None),
+        )
+
+    async def _fallback_to_legacy_pipeline_openai(self, h, reason: str) -> None:
+        """Pre-session OpenAIRealtimeSession.start() failure fallback — mirrors
+        _fallback_to_legacy_pipeline (Gemini Live) exactly, swapping in the
+        OpenAI-family fallback text model instead."""
+        self._openai_realtime_setup_failed = True
+        self._is_openai_realtime = False
+
+        agent = getattr(h, "agent", None)
+        if agent is not None:
+            logger.warning(
+                "[OpenAIRealtime] falling back to legacy pipeline for call_session_id=%s: "
+                "%s -> %s (reason: %s)",
+                getattr(h, "call_session_id", None),
+                getattr(agent, "llm_model", None),
+                _OPENAI_REALTIME_FALLBACK_TEXT_MODEL,
+                reason,
+            )
+            agent.llm_model = _OPENAI_REALTIME_FALLBACK_TEXT_MODEL
+        else:
+            logger.error(
+                "[OpenAIRealtime] pre-session failure with no agent loaded for call_session_id=%s "
+                "(reason: %s) — cannot fall back to a text pipeline; ending call.",
+                getattr(h, "call_session_id", None), reason,
+            )
+            asyncio.create_task(h._full_shutdown())
+
+    async def _on_openai_realtime_audio_chunk(self, audio_bytes: bytes) -> None:
+        """
+        OpenAIRealtimeSession.on_audio_chunk callback. Gates on
+        self._openai_realtime_cancel exactly like _on_gemini_live_audio_chunk
+        gates on self._gemini_live_cancel.
+
+        Transport-aware (duck-typed via hasattr, same pattern as
+        _on_gemini_live_audio_chunk):
+          - Twilio: `audio_bytes` is already mu-law/8kHz (the session was
+            started with audio_format="audio/pcmu") — streamed straight to
+            `_stream_live_audio_chunk` with NO conversion step, unlike
+            Gemini Live's pcm16_24k_to_mulaw8k.
+          - LiveKit browser: `audio_bytes` is raw PCM16/24kHz (audio_format=
+            "audio/pcm") — the exact format/rate
+            `_publish_gemini_live_audio_chunk` (and the publisher it
+            targets) already expects for Gemini Live, so that existing sink
+            is reused as-is (see its own docstring — it's a generic
+            "publish raw PCM16 at the publisher's rate" primitive despite
+            the Gemini-specific name).
+        """
+        if self._openai_realtime_cancel.is_set():
+            return
+        try:
+            if not self._openai_realtime_first_audio_marked:
+                self._openai_realtime_first_audio_marked = True
+                _vm = getattr(self._h, "_voice_metrics", None)
+                if _vm:
+                    _vm.mark_live_first_audio()
+
+            if hasattr(self._h, "_stream_live_audio_chunk"):
+                await self._h._stream_live_audio_chunk(audio_bytes)
+            else:
+                from app.services.openai_realtime_service import LIVEKIT_AUDIO_RATE_HZ
+
+                await self._h._publish_gemini_live_audio_chunk(
+                    audio_bytes, self._openai_realtime_cancel,
+                    sample_rate_hz=LIVEKIT_AUDIO_RATE_HZ,
+                )
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime audio chunk send failed: %s", exc, exc_info=True
+            )
+
+    async def _on_openai_realtime_interrupted(self) -> None:
+        """
+        Barge-in for the OpenAI Realtime path. Server-side, OpenAI already
+        cancels its own in-flight response when `interrupt_response=True`
+        (session config) detects caller speech — this callback only handles
+        the LOCAL half: stop our own outbound send loop and flush whatever
+        this transport has already buffered/sent. Mirrors
+        _on_gemini_live_interrupted's transport-aware dispatch exactly.
+        """
+        try:
+            self._openai_realtime_cancel.set()
+            if hasattr(self._h, "_send_twilio_clear_event"):
+                await self._h._send_twilio_clear_event()
+            else:
+                await self._h._clear_gemini_live_playout_queue()
+            self._openai_realtime_cancel.clear()
+            self._openai_realtime_first_audio_marked = False
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime interrupted handling failed: %s", exc, exc_info=True
+            )
+
+    async def _on_openai_realtime_input_transcript(self, text: str) -> None:
+        """
+        Caller-side FULL final transcript for one utterance — fires exactly
+        once per utterance (see OpenAIRealtimeSession's
+        on_input_transcript contract). No buffering/flush-signal dance
+        needed here, unlike _on_gemini_live_input_transcript.
+        """
+        text = (text or "").strip()
+        if not text:
+            return
+        try:
+            await self._h._add_to_transcript("client", text, "speech")
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime input transcript write failed: %s", exc, exc_info=True
+            )
+
+        # Mid-call RAG refresh (mirrors _flush_gemini_live_input_buffer's
+        # fire-and-forget trigger, keyed here directly off the complete
+        # utterance rather than off a buffer flush — there is no buffer to
+        # flush on this path). Coalesced via
+        # _openai_realtime_kb_refresh_in_flight for the same reason Gemini
+        # Live's refresh is coalesced: a chatty back-and-forth shouldn't
+        # fire several overlapping retrievals + unordered send_text() calls.
+        if not self._openai_realtime_kb_refresh_in_flight:
+            t = asyncio.create_task(self._refresh_openai_realtime_kb_context(text))
+            self._pending_final_tasks.add(t)
+            t.add_done_callback(lambda done_t, s=self: s._pending_final_tasks.discard(done_t))
+
+    async def _refresh_openai_realtime_kb_context(self, transcript: str) -> None:
+        """
+        OpenAI Realtime analog of _refresh_gemini_live_kb_context. Sends the
+        refreshed KB context as a `conversation.item.create` with
+        `respond=False` — a context-only injection must NEVER trigger
+        `response.create`, or OpenAI will speak the raw injected context
+        aloud as if it were a real reply (see
+        OpenAIRealtimeSession.send_text's docstring). Fails open on any
+        error, same as every other RAG call site in this codebase.
+        """
+        session = self._openai_realtime_session
+        if session is None or not transcript:
+            return
+        flow = getattr(self._h, "call_flow", None)
+        kb_ids = (flow.knowledge_base_ids or []) if flow else []
+        if not kb_ids:
+            return
+        self._openai_realtime_kb_refresh_in_flight = True
+        try:
+            from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
+            from app.utils.redis_client import get_redis
+
+            kb_context, latency_ms = await retrieve_kb_context_for_turn(
+                transcript=transcript, kb_ids=kb_ids, redis_client=get_redis()
+            )
+            if not kb_context:
+                return
+            await session.send_text(
+                "[KNOWLEDGE BASE CONTEXT UPDATE — authoritative, use if relevant to the "
+                f"caller's most recent question]\n{kb_context}",
+                respond=False,
+            )
+            logger.debug(
+                "[OpenAIRealtime] kb_refresh latency_ms=%.1f chars=%d", latency_ms, len(kb_context)
+            )
+        except Exception as exc:
+            logger.debug("[OpenAIRealtime] mid-call KB refresh failed (non-fatal): %s", exc)
+        finally:
+            self._openai_realtime_kb_refresh_in_flight = False
+
+    async def _on_openai_realtime_output_transcript(self, text: str) -> None:
+        """Agent-side FULL final transcript for one turn — fires exactly
+        once (see OpenAIRealtimeSession's on_output_transcript contract).
+        No buffering/turn_complete flush needed, unlike
+        _on_gemini_live_output_transcript / _on_gemini_live_turn_complete."""
+        text = (text or "").strip()
+        if not text:
+            return
+        try:
+            await self._h._add_to_transcript("agent", text, "agent_response")
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime output transcript write failed: %s", exc, exc_info=True
+            )
+
+    async def _on_openai_realtime_tool_call(self, call_id: str, name: str, arguments_json: str) -> None:
+        """
+        Calendly tool-calling for an OpenAI Realtime session. Only ever
+        registered when the handler is Twilio's BidirectionalStreamHandler
+        AND the call flow has Calendly enabled (see
+        _start_openai_realtime_session) — mirrors
+        _on_gemini_live_tool_call's gating and reuses
+        BookingMixin._execute_calendly_tool_call unmodified, same as Gemini.
+        """
+        import json as _json
+
+        session = self._openai_realtime_session
+        if session is None:
+            return
+
+        try:
+            args = _json.loads(arguments_json) if arguments_json else {}
+            if not isinstance(args, dict):
+                args = {}
+        except (ValueError, TypeError):
+            args = {}
+
+        try:
+            result = await self._h._execute_calendly_tool_call(name, args)
+        except Exception as exc:
+            logger.error(
+                "[OpenAIRealtime] Calendly tool call %s failed unexpectedly: %s",
+                name, exc, exc_info=True,
+            )
+            result = {"error": "internal error executing tool call"}
+
+        from app.core.pii_redactor import redact_pii
+
+        logger.info("[OpenAIRealtime] tool_call name=%s args=%s", name, redact_pii(args))
+        try:
+            await session.send_tool_response(call_id, result)
+        except Exception as exc:
+            logger.error("[OpenAIRealtime] send_tool_response failed: %s", exc, exc_info=True)
+
+    async def _on_openai_realtime_error(self, err) -> None:
+        """
+        Mid-call OpenAIRealtimeSession failure (session had already started —
+        pre-session failures are handled by _start_openai_realtime_session's
+        own try/except, never reach here). Mirrors _on_gemini_live_error:
+        end the call gracefully rather than attempting to reconstruct
+        STT/TTS mid-call.
+        """
+        logger.error(
+            "[OpenAIRealtime] mid-call session error call_session_id=%s error_type=%s: %s",
             getattr(self._h, "call_session_id", None),
             getattr(err, "error_type", None),
             err,

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -23,17 +23,28 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING, Any, Set
 
 from app.core.config import settings
+from app.core.llm_models import is_gemini_live_native_audio_model
 from app.core.logger import logger
 from app.utils.audio_utils import ulaw_to_linear_sample
+from app.voice.gemini_live_audio_bridge import mulaw8k_to_pcm16_16k, pcm16_24k_to_mulaw8k
 from app.voice.stt_pipeline import SttPipeline
 from app.voice.tts_pipeline import TtsPipeline
 from app.voice.stt_events import SttEventBus
 
 if TYPE_CHECKING:
     from app.core.agent_runtime import ResolvedSttRuntime
+
+# Text model used to keep a native-audio call alive when GeminiLiveSession.start()
+# fails BEFORE the session ever became usable (pre-session failure — see
+# _start_gemini_live_session / _fallback_to_legacy_pipeline). Native-audio model
+# IDs (e.g. "gemini-live-2.5-flash-native-audio") have no meaning to
+# vertex_gemini_service.py's text-generation methods, so the in-memory
+# `agent.llm_model` is swapped to this allow-listed text model for the
+# remainder of THIS call object only (never persisted to the DB).
+_GEMINI_LIVE_FALLBACK_TEXT_MODEL = "gemini-2.5-flash"
 
 
 def _resolve_initial_endpointing_ms() -> int:
@@ -147,7 +158,34 @@ class VoiceOrchestrator:
         # on full LLM+TTS work (parallel with continued STT ingestion).
         self._pending_final_tasks: Set[asyncio.Task] = set()
 
-        logger.info("[VoiceOrchestrator] Initialized — STT lazy, TTS pipeline ready")
+        # ── Gemini Live (native-audio speech-to-speech) state ─────────────────
+        # Resolved once here (not per-chunk) — handler.agent is already loaded
+        # by BidirectionalStreamHandler._load_session_data(), which always runs
+        # synchronously in __init__ before VoiceOrchestrator is constructed.
+        # When True, on_audio_chunk() never creates SttPipeline for this call;
+        # audio instead flows to a lazily-created GeminiLiveSession (see
+        # _feed_gemini_live_audio / _start_gemini_live_session). NOTE:
+        # TtsPipeline above is still constructed unconditionally (see class
+        # docstring / task write-up) — it is cheap (no I/O, no provider calls
+        # in __init__) and is simply never fed for a native-audio call, so no
+        # external TTS provider is ever invoked.
+        _agent = getattr(handler, "agent", None)
+        self._is_gemini_live: bool = is_gemini_live_native_audio_model(
+            getattr(_agent, "llm_model", None) if _agent else None
+        )
+        self._gemini_live_session: Any = None
+        self._gemini_live_setup_lock: asyncio.Lock = asyncio.Lock()
+        self._gemini_live_setup_failed: bool = False
+        # Barge-in cancel flag scoped to Gemini Live's own outbound audio send
+        # loop — the equivalent of handler._tts_cancel for this path, since
+        # there is no TtsPipeline task to cancel (see _on_gemini_live_interrupted).
+        self._gemini_live_cancel: asyncio.Event = asyncio.Event()
+        self._gemini_live_first_audio_marked: bool = False
+
+        logger.info(
+            "[VoiceOrchestrator] Initialized — STT lazy, TTS pipeline ready, gemini_live=%s",
+            self._is_gemini_live,
+        )
 
     # ── Public interface ──────────────────────────────────────────────────────
 
@@ -268,6 +306,17 @@ class VoiceOrchestrator:
 
             # ── 3. Active guard ───────────────────────────────────────────────
             if not self._stt_active:
+                return
+
+            # ── 3b. Native-audio (Gemini Live) fork ─────────────────────────────
+            # Bypasses SttPipeline/TtsPipeline entirely for this call: caller
+            # audio goes straight to a GeminiLiveSession, and Gemini's own
+            # native audio response is streamed straight back (see
+            # _feed_gemini_live_audio / _on_gemini_live_audio_chunk). The
+            # pickup-detection/grace-period gating above is audio-format
+            # agnostic (RMS over MULAW) and stays unchanged for both paths.
+            if self._is_gemini_live:
+                await self._feed_gemini_live_audio(h, audio_data)
                 return
 
             # ── 4. STT feed ───────────────────────────────────────────────────
@@ -456,6 +505,15 @@ class VoiceOrchestrator:
         except Exception as exc:
             logger.debug("[VoiceOrchestrator] STT pipeline close failed: %s", exc)
 
+        # Close Gemini Live session (native-audio calls only — no-op otherwise)
+        try:
+            if self._gemini_live_session is not None:
+                self._gemini_live_cancel.set()
+                await self._gemini_live_session.close()
+                self._gemini_live_session = None
+        except Exception as exc:
+            logger.debug("[VoiceOrchestrator] Gemini Live session close failed: %s", exc)
+
         logger.info("[VoiceOrchestrator] Shutdown complete")
 
     # ── Private STT callbacks ─────────────────────────────────────────────────
@@ -515,6 +573,287 @@ class VoiceOrchestrator:
             logger.error(
                 "[VoiceOrchestrator] _on_final callback error: %s", exc, exc_info=True
             )
+
+    # ── Gemini Live (native-audio speech-to-speech) ────────────────────────────
+
+    async def _feed_gemini_live_audio(self, h, audio_data: bytes) -> None:
+        """
+        Route one MULAW/8kHz caller-audio frame to the (lazily created)
+        GeminiLiveSession for this call, converting to PCM16/16kHz first.
+        Called instead of the SttPipeline feed for native-audio agents.
+        """
+        if self._gemini_live_setup_failed:
+            # Pre-session failure already handled (see _fallback_to_legacy_pipeline) —
+            # self._is_gemini_live has been flipped to False, so this branch
+            # should no longer be reached on the NEXT chunk, but guard anyway
+            # in case a chunk was already in flight when the flip happened.
+            return
+
+        session = self._gemini_live_session
+        if session is None:
+            async with self._gemini_live_setup_lock:
+                # Re-check inside the lock — a concurrent chunk may have
+                # already started (or finished) setup while we awaited it.
+                if self._gemini_live_session is None and not self._gemini_live_setup_failed:
+                    await self._start_gemini_live_session(h)
+            session = self._gemini_live_session
+
+        if session is None:
+            return  # setup failed and fallback (or shutdown) already handled it
+
+        try:
+            pcm16_16k = mulaw8k_to_pcm16_16k(audio_data)
+            if pcm16_16k:
+                await session.send_audio(pcm16_16k)
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] GeminiLiveSession.send_audio failed: %s", exc, exc_info=True
+            )
+
+    async def _start_gemini_live_session(self, h) -> None:
+        """
+        Lazily open the GeminiLiveSession for this call (once). Builds the
+        initial system_instruction via each transport's own prompt-assembly
+        method (reused, not duplicated) since there is no user utterance yet
+        at session-start. On pre-session failure, falls back to the legacy
+        STT/LLM/TTS pipeline for the remainder of the call (see
+        _fallback_to_legacy_pipeline) rather than leaving the call silent.
+
+        Transport-aware: the two call transports have deliberately separate,
+        unshared prompt-assembly implementations (see CLAUDE.md's "Voice
+        pipeline" section) —
+        `BidirectionalStreamHandler.build_system_prompt` (Twilio, this
+        handler's own method — includes booking_memory_block,
+        inbound_kb_docs_context_block, recruitment-screening block,
+        A/B prompt testing override, current-date/time + user-signals block,
+        etc.) vs `ConversationOrchestrator.build_system_prompt` (LiveKit
+        browser demo calls — a separate, simpler implementation).
+        Duck-typed via `hasattr` rather than `isinstance` to avoid a
+        circular import (bidirectional_stream.py already imports
+        VoiceOrchestrator at module level).
+        """
+        from app.services.gemini_live_service import GeminiLiveSession
+        from app.services.vertex_gemini_service import VertexLlmError
+
+        agent = getattr(h, "agent", None)
+        model_name = getattr(agent, "llm_model", None) if agent else None
+
+        try:
+            if hasattr(h, "build_system_prompt"):
+                # Twilio (BidirectionalStreamHandler) — its own real
+                # prompt-assembly method, not ConversationOrchestrator's.
+                system_instruction = await h.build_system_prompt(
+                    user_text="", confidence=1.0
+                )
+            else:
+                # LiveKit browser demo calls (LiveKitBrowserCallHandler) —
+                # genuinely uses ConversationOrchestrator.
+                from app.voice.conversation_orchestrator import ConversationOrchestrator
+
+                conv = ConversationOrchestrator(h)
+                system_instruction = await conv.build_system_prompt(
+                    user_text="", confidence=1.0
+                )
+        except Exception as exc:
+            logger.error(
+                "[GeminiLive] build_system_prompt failed for session start; using minimal "
+                "fallback instruction: %s", exc, exc_info=True,
+            )
+            agent_name = getattr(agent, "name", None) or "AI Assistant"
+            system_instruction = f"You are {agent_name}, a helpful phone assistant."
+
+        session = GeminiLiveSession(model_name)
+        try:
+            await session.start(
+                system_instruction=system_instruction,
+                on_audio_chunk=self._on_gemini_live_audio_chunk,
+                on_interrupted=self._on_gemini_live_interrupted,
+                on_input_transcript=self._on_gemini_live_input_transcript,
+                on_output_transcript=self._on_gemini_live_output_transcript,
+                # Phase 1: Calendly/tool-calling is explicitly deferred (see
+                # integration plan §6) — no tools, no on_tool_call callback.
+                on_tool_call=None,
+                on_error=self._on_gemini_live_error,
+                tools=None,
+            )
+        except VertexLlmError as exc:
+            logger.error(
+                "[GeminiLive] pre-session start failed model=%s call_session_id=%s: %s",
+                model_name, getattr(h, "call_session_id", None), exc,
+            )
+            await self._fallback_to_legacy_pipeline(h, reason=str(exc))
+            return
+        except Exception as exc:
+            logger.error(
+                "[GeminiLive] unexpected pre-session start failure model=%s call_session_id=%s: %s",
+                model_name, getattr(h, "call_session_id", None), exc, exc_info=True,
+            )
+            await self._fallback_to_legacy_pipeline(h, reason=str(exc))
+            return
+
+        self._gemini_live_session = session
+        logger.info(
+            "[GeminiLive] session started model=%s call_session_id=%s",
+            model_name, getattr(h, "call_session_id", None),
+        )
+
+    async def _fallback_to_legacy_pipeline(self, h, reason: str) -> None:
+        """
+        Pre-session GeminiLiveSession.start() failure fallback (see plan §7):
+        swap this call's in-memory `agent.llm_model` to a default text model
+        (native-audio model IDs have no meaning to vertex_gemini_service.py's
+        text methods — never persisted to the DB, only mutates the Agent ORM
+        instance already loaded for THIS call) and flip routing back to the
+        existing STT/LLM/TTS pipeline. SttPipeline is already lazily created
+        by on_audio_chunk's normal step 4 — nothing further to construct
+        here; the next audio chunk takes that path automatically.
+
+        Never called for a mid-call drop (session started successfully, then
+        errored later) — see _on_gemini_live_error, which ends the call
+        gracefully instead per the plan's mid-call-failure guidance.
+        """
+        self._gemini_live_setup_failed = True
+        self._is_gemini_live = False
+
+        agent = getattr(h, "agent", None)
+        if agent is not None:
+            logger.warning(
+                "[GeminiLive] falling back to legacy pipeline for call_session_id=%s: "
+                "%s -> %s (reason: %s)",
+                getattr(h, "call_session_id", None),
+                getattr(agent, "llm_model", None),
+                _GEMINI_LIVE_FALLBACK_TEXT_MODEL,
+                reason,
+            )
+            agent.llm_model = _GEMINI_LIVE_FALLBACK_TEXT_MODEL
+        else:
+            logger.error(
+                "[GeminiLive] pre-session failure with no agent loaded for call_session_id=%s "
+                "(reason: %s) — cannot fall back to a text pipeline; ending call.",
+                getattr(h, "call_session_id", None), reason,
+            )
+            asyncio.create_task(h._full_shutdown())
+
+    async def _on_gemini_live_audio_chunk(self, pcm16_24k_bytes: bytes) -> None:
+        """
+        GeminiLiveSession.on_audio_chunk callback. Gates on
+        self._gemini_live_cancel (this path's barge-in flag — see
+        _on_gemini_live_interrupted) exactly like the existing TTS send
+        loops gate on handler._tts_cancel.
+
+        Transport-aware (duck-typed via hasattr, same pattern as
+        _start_gemini_live_session's system_instruction branch):
+          - Twilio (BidirectionalStreamHandler, has `_stream_live_audio_chunk`):
+            convert Gemini's raw PCM16/24kHz output to MULAW/8kHz and stream
+            it to the Twilio WebSocket via that low-level frame-send
+            primitive.
+          - LiveKit browser (LiveKitBrowserCallHandler, no
+            `_stream_live_audio_chunk` method): publish Gemini's raw
+            PCM16/24kHz output directly into the room — that handler's
+            `_agent_publisher` is opened at 24kHz for a native-audio call,
+            so no mu-law conversion or resampling happens on this path at
+            all (see LiveKitBrowserCallHandler._publish_gemini_live_audio_chunk).
+        """
+        if self._gemini_live_cancel.is_set():
+            return
+        try:
+            if not self._gemini_live_first_audio_marked:
+                self._gemini_live_first_audio_marked = True
+                _vm = getattr(self._h, "_voice_metrics", None)
+                if _vm:
+                    _vm.mark_live_first_audio()
+
+            if hasattr(self._h, "_stream_live_audio_chunk"):
+                mulaw_bytes = pcm16_24k_to_mulaw8k(pcm16_24k_bytes)
+                if not mulaw_bytes:
+                    return
+                await self._h._stream_live_audio_chunk(mulaw_bytes)
+            else:
+                await self._h._publish_gemini_live_audio_chunk(
+                    pcm16_24k_bytes, self._gemini_live_cancel
+                )
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] gemini live audio chunk send failed: %s", exc, exc_info=True
+            )
+
+    async def _on_gemini_live_interrupted(self) -> None:
+        """
+        Barge-in for the Gemini Live path: stop our own outbound send loop
+        (self._gemini_live_cancel) AND tell the transport to flush anything
+        it has already buffered — mirrors the existing two-part TTS
+        barge-in, scoped to this path's own minimal cancel flag rather than
+        the TtsPipeline/_tts_cancel machinery (nothing to cancel there — no
+        TtsPipeline task exists for this call).
+
+        Transport-aware (duck-typed via hasattr, mirrors
+        _on_gemini_live_audio_chunk's branch): Twilio flushes via
+        `_send_twilio_clear_event`; the LiveKit browser handler has no such
+        method and instead clears its own LiveKit AudioSource's internal
+        playout queue directly (see
+        LiveKitBrowserCallHandler._clear_gemini_live_playout_queue).
+        """
+        try:
+            self._gemini_live_cancel.set()
+            if hasattr(self._h, "_send_twilio_clear_event"):
+                await self._h._send_twilio_clear_event()
+            else:
+                await self._h._clear_gemini_live_playout_queue()
+            # Reset for the next turn's outbound audio (mirrors _tts_cancel.clear()
+            # in ConversationOrchestrator.generate_and_stream_response).
+            self._gemini_live_cancel.clear()
+            self._gemini_live_first_audio_marked = False
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] gemini live interrupted handling failed: %s", exc, exc_info=True
+            )
+
+    async def _on_gemini_live_input_transcript(self, text: str, finished: bool) -> None:
+        """Caller-side transcript from Gemini's own input_transcription. Only
+        written to call_transcript on finished chunks — mirrors the existing
+        STT-final (not interim) transcript-write precedent."""
+        if not finished or not (text or "").strip():
+            return
+        try:
+            await self._h._add_to_transcript("client", text.strip(), "speech")
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] gemini live input transcript write failed: %s", exc, exc_info=True
+            )
+
+    async def _on_gemini_live_output_transcript(self, text: str, finished: bool) -> None:
+        """Agent-side transcript from Gemini's own output_transcription. Only
+        written on finished chunks so call_transcript gets one clean line per
+        agent turn, matching the existing agent_response convention."""
+        if not finished or not (text or "").strip():
+            return
+        try:
+            await self._h._add_to_transcript("agent", text.strip(), "agent_response")
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] gemini live output transcript write failed: %s", exc, exc_info=True
+            )
+
+    async def _on_gemini_live_error(self, err) -> None:
+        """
+        Mid-call GeminiLiveSession failure (session had already started —
+        pre-session failures are handled by _start_gemini_live_session's own
+        try/except, never reach here). Per the plan: do NOT attempt to
+        reconstruct STT/TTS mid-call (too much state/latency risk) — end the
+        call gracefully via the existing _full_shutdown() path.
+
+        # TODO(gemini-live-fallback): a static pre-recorded "sorry, goodbye"
+        # audio clip played before hangup would be a friendlier mid-call
+        # failure UX than a silent drop. Deferred per the integration plan
+        # (Phase 1 accepts a graceful-but-abrupt hangup here, clearly logged).
+        """
+        logger.error(
+            "[GeminiLive] mid-call session error call_session_id=%s error_type=%s: %s",
+            getattr(self._h, "call_session_id", None),
+            getattr(err, "error_type", None),
+            err,
+        )
+        asyncio.create_task(self._h._full_shutdown())
 
     # ── Audio helpers ─────────────────────────────────────────────────────────
 

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -181,6 +181,18 @@ class VoiceOrchestrator:
         # there is no TtsPipeline task to cancel (see _on_gemini_live_interrupted).
         self._gemini_live_cancel: asyncio.Event = asyncio.Event()
         self._gemini_live_first_audio_marked: bool = False
+        # Per-call accumulation buffers for input/output transcript fragments
+        # (see _on_gemini_live_input_transcript / _on_gemini_live_output_transcript).
+        # The Live API's per-fragment `finished` flag is NOT a reliable
+        # turn-boundary signal for the native-audio model family (may never
+        # fire, or fire on an incremental fragment rather than the full
+        # utterance) — fragments are buffered here and flushed to
+        # call_transcript on the documented workaround signals instead (see
+        # _flush_gemini_live_input_buffer / _flush_gemini_live_output_buffer).
+        # Reset alongside self._gemini_live_session wherever that is
+        # (re)created, so no leftover text can bleed into a later call/turn.
+        self._gemini_live_input_buffer: list[str] = []
+        self._gemini_live_output_buffer: list[str] = []
         # Coalescing guard for _refresh_gemini_live_kb_context: a chatty
         # back-and-forth call could otherwise fire several overlapping KB
         # retrievals + un-ordered session.send_text(...) calls in quick
@@ -513,12 +525,21 @@ class VoiceOrchestrator:
         except Exception as exc:
             logger.debug("[VoiceOrchestrator] STT pipeline close failed: %s", exc)
 
-        # Close Gemini Live session (native-audio calls only — no-op otherwise)
+        # Close Gemini Live session (native-audio calls only — no-op otherwise).
+        # close() cancels and awaits the receive-loop task before returning, so
+        # closing FIRST guarantees no more fragments can be appended to the
+        # buffers by a still-running receive loop; only then is it safe to
+        # flush once. Flushing before close() left a race where an in-flight
+        # receive-loop message (scheduled during the flush's own awaits) could
+        # land in a buffer that was just cleared and never get written —
+        # exactly the "call ending mid-buffer" case this flush exists to cover.
         try:
             if self._gemini_live_session is not None:
                 self._gemini_live_cancel.set()
                 await self._gemini_live_session.close()
                 self._gemini_live_session = None
+                await self._flush_gemini_live_input_buffer()
+                await self._flush_gemini_live_output_buffer()
         except Exception as exc:
             logger.debug("[VoiceOrchestrator] Gemini Live session close failed: %s", exc)
 
@@ -704,6 +725,7 @@ class VoiceOrchestrator:
                 on_interrupted=self._on_gemini_live_interrupted,
                 on_input_transcript=self._on_gemini_live_input_transcript,
                 on_output_transcript=self._on_gemini_live_output_transcript,
+                on_turn_complete=self._on_gemini_live_turn_complete,
                 on_tool_call=on_tool_call,
                 on_error=self._on_gemini_live_error,
                 tools=gemini_tools,
@@ -724,6 +746,11 @@ class VoiceOrchestrator:
             return
 
         self._gemini_live_session = session
+        # Reset transcript buffers alongside the session itself so no
+        # leftover fragments from a prior (re)start could bleed in — mirrors
+        # __init__'s initial reset.
+        self._gemini_live_input_buffer = []
+        self._gemini_live_output_buffer = []
         logger.info(
             "[GeminiLive] session started model=%s call_session_id=%s",
             model_name, getattr(h, "call_session_id", None),
@@ -831,6 +858,13 @@ class VoiceOrchestrator:
                 await self._h._send_twilio_clear_event()
             else:
                 await self._h._clear_gemini_live_playout_queue()
+            # Barge-in cuts a turn off mid-flight, but whatever was
+            # accumulated in either buffer up to this point is real speech
+            # that actually happened (the caller's interruption, and/or the
+            # agent's partial response before being cut off) — flush rather
+            # than silently drop it.
+            await self._flush_gemini_live_input_buffer()
+            await self._flush_gemini_live_output_buffer()
             # Reset for the next turn's outbound audio (mirrors _tts_cancel.clear()
             # in ConversationOrchestrator.generate_and_stream_response).
             self._gemini_live_cancel.clear()
@@ -841,12 +875,36 @@ class VoiceOrchestrator:
             )
 
     async def _on_gemini_live_input_transcript(self, text: str, finished: bool) -> None:
-        """Caller-side transcript from Gemini's own input_transcription. Only
-        written to call_transcript on finished chunks — mirrors the existing
-        STT-final (not interim) transcript-write precedent."""
-        if not finished or not (text or "").strip():
+        """
+        Caller-side transcript fragment from Gemini's own input_transcription.
+
+        The Live API's per-fragment ``finished`` flag is NOT a reliable
+        turn-boundary signal for the native-audio model family — it may
+        never fire at all, and even when it does, ``text`` is itself an
+        incremental fragment (e.g. " Ho", " you") rather than the full
+        utterance (confirmed against googleapis/js-genai#1429 and Google's
+        own forum reports). So every fragment is unconditionally appended to
+        a per-call buffer here; the accumulated buffer is written to
+        call_transcript later by _flush_gemini_live_input_buffer(), triggered
+        by the first output-transcript fragment of the next turn (implicit
+        "caller finished speaking" signal) or by turn_complete/interrupted/
+        shutdown as safety nets — see those call sites.
+        """
+        text = text or ""
+        if text:
+            self._gemini_live_input_buffer.append(text)
+
+    async def _flush_gemini_live_input_buffer(self) -> None:
+        """Write the accumulated input-transcript buffer to call_transcript
+        and clear it. Also fires the mid-call RAG refresh off the same
+        flushed text (same signal as before, just correctly assembled now
+        instead of a single stray fragment)."""
+        if not self._gemini_live_input_buffer:
             return
-        transcript = text.strip()
+        transcript = "".join(self._gemini_live_input_buffer).strip()
+        self._gemini_live_input_buffer = []
+        if not transcript:
+            return
         try:
             await self._h._add_to_transcript("client", transcript, "speech")
         except Exception as exc:
@@ -854,16 +912,16 @@ class VoiceOrchestrator:
                 "[VoiceOrchestrator] gemini live input transcript write failed: %s", exc, exc_info=True
             )
 
-        # Mid-call RAG refresh (Phase 2, plan §6): a finished input transcript
-        # is the closest thing this session has to a per-turn boundary (no
-        # STT-interim prefetch signal exists here). Fire-and-forget — must
-        # never block the receive loop or delay the caller's live audio
-        # response; tracked in the same set _full_shutdown already drains so
-        # a call ending mid-refresh doesn't leak the task. Coalesced via
-        # _gemini_live_kb_refresh_in_flight: skip rather than queue a new
-        # refresh while one is still running, so a chatty back-and-forth
-        # can't fire several overlapping retrievals + unordered
-        # session.send_text(...) calls racing each other.
+        # Mid-call RAG refresh (Phase 2, plan §6): the flushed input
+        # transcript is the closest thing this session has to a per-turn
+        # boundary (no STT-interim prefetch signal exists here).
+        # Fire-and-forget — must never block the receive loop or delay the
+        # caller's live audio response; tracked in the same set
+        # _full_shutdown already drains so a call ending mid-refresh doesn't
+        # leak the task. Coalesced via _gemini_live_kb_refresh_in_flight:
+        # skip rather than queue a new refresh while one is still running, so
+        # a chatty back-and-forth can't fire several overlapping retrievals +
+        # unordered session.send_text(...) calls racing each other.
         if not self._gemini_live_kb_refresh_in_flight:
             t = asyncio.create_task(self._refresh_gemini_live_kb_context(transcript))
             self._pending_final_tasks.add(t)
@@ -919,16 +977,59 @@ class VoiceOrchestrator:
             self._gemini_live_kb_refresh_in_flight = False
 
     async def _on_gemini_live_output_transcript(self, text: str, finished: bool) -> None:
-        """Agent-side transcript from Gemini's own output_transcription. Only
-        written on finished chunks so call_transcript gets one clean line per
-        agent turn, matching the existing agent_response convention."""
-        if not finished or not (text or "").strip():
+        """
+        Agent-side transcript fragment from Gemini's own output_transcription.
+        Same unreliable-``finished``/fragment-not-full-utterance caveat as
+        _on_gemini_live_input_transcript applies here — every fragment is
+        buffered rather than gated on ``finished``.
+
+        The first output fragment of a turn is also the documented signal
+        that the caller has finished speaking (Gemini has started
+        responding), so it flushes any pending input buffer before appending
+        itself to the output buffer. The output buffer itself is flushed on
+        turn_complete (see _on_gemini_live_turn_complete) so call_transcript
+        gets one clean accumulated line per agent turn, matching the
+        existing agent_response convention.
+        """
+        text = text or ""
+        if not text:
+            return
+        if self._gemini_live_input_buffer:
+            await self._flush_gemini_live_input_buffer()
+        self._gemini_live_output_buffer.append(text)
+
+    async def _flush_gemini_live_output_buffer(self) -> None:
+        """Write the accumulated output-transcript buffer to call_transcript
+        and clear it."""
+        if not self._gemini_live_output_buffer:
+            return
+        transcript = "".join(self._gemini_live_output_buffer).strip()
+        self._gemini_live_output_buffer = []
+        if not transcript:
             return
         try:
-            await self._h._add_to_transcript("agent", text.strip(), "agent_response")
+            await self._h._add_to_transcript("agent", transcript, "agent_response")
         except Exception as exc:
             logger.error(
                 "[VoiceOrchestrator] gemini live output transcript write failed: %s", exc, exc_info=True
+            )
+
+    async def _on_gemini_live_turn_complete(self) -> None:
+        """
+        GeminiLiveSession.on_turn_complete callback — the only reliable
+        turn-boundary signal for these models (see
+        _on_gemini_live_input_transcript's docstring). Flushes the output
+        buffer (the normal, expected flush point for an agent turn) and, as
+        a safety net, the input buffer too — covers turns that never produce
+        an output-transcript fragment at all (e.g. a tool-call-only turn),
+        which would otherwise leave a caller utterance buffered forever.
+        """
+        try:
+            await self._flush_gemini_live_input_buffer()
+            await self._flush_gemini_live_output_buffer()
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] gemini live turn_complete flush failed: %s", exc, exc_info=True
             )
 
     async def _on_gemini_live_tool_call(self, function_calls) -> None:

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -181,6 +181,14 @@ class VoiceOrchestrator:
         # there is no TtsPipeline task to cancel (see _on_gemini_live_interrupted).
         self._gemini_live_cancel: asyncio.Event = asyncio.Event()
         self._gemini_live_first_audio_marked: bool = False
+        # Coalescing guard for _refresh_gemini_live_kb_context: a chatty
+        # back-and-forth call could otherwise fire several overlapping KB
+        # retrievals + un-ordered session.send_text(...) calls in quick
+        # succession. At most one refresh runs at a time per call; a finished
+        # transcript arriving while one is still in flight is skipped rather
+        # than queued, since it will be superseded by whatever the caller
+        # says next anyway.
+        self._gemini_live_kb_refresh_in_flight: bool = False
 
         logger.info(
             "[VoiceOrchestrator] Initialized — STT lazy, TTS pipeline ready, gemini_live=%s",
@@ -632,7 +640,7 @@ class VoiceOrchestrator:
         circular import (bidirectional_stream.py already imports
         VoiceOrchestrator at module level).
         """
-        from app.services.gemini_live_service import GeminiLiveSession
+        from app.services.gemini_live_service import GeminiLiveSession, resolve_voice_name
         from app.services.vertex_gemini_service import VertexLlmError
 
         agent = getattr(h, "agent", None)
@@ -662,19 +670,43 @@ class VoiceOrchestrator:
             agent_name = getattr(agent, "name", None) or "AI Assistant"
             system_instruction = f"You are {agent_name}, a helpful phone assistant."
 
+        # Calendly tool-calling (Phase 2): only meaningful on Twilio
+        # (BookingMixin/_execute_calendly_tool_call/_calendly_enabled only
+        # exist on BidirectionalStreamHandler — hasattr naturally gates the
+        # browser transport out, which has no Calendly wiring at all).
+        gemini_tools = None
+        on_tool_call = None
+        if hasattr(h, "_calendly_enabled") and h._calendly_enabled():
+            from app.services.vertex_gemini_service import _build_calendly_tool
+
+            gemini_tools = [_build_calendly_tool()]
+            on_tool_call = self._on_gemini_live_tool_call
+
+        # Per-agent native voice (Phase 2): reuses the agent's EXISTING
+        # tts_voice_external_id / tts_language fields rather than adding new
+        # schema — an agent switched to a native-audio model doesn't lose its
+        # voice identity outright, though the ID space is different (Gemini's
+        # 30 prebuilt voice names vs. ElevenLabs/Rime/Google voice IDs), so
+        # resolve_voice_name() falls back to DEFAULT_VOICE_NAME for anything
+        # that isn't a real Gemini Live voice name (the common case, since
+        # most agents' configured voice ID predates being switched to a
+        # native-audio model).
+        voice_name = resolve_voice_name(getattr(agent, "tts_voice_external_id", None))
+        language_code = (getattr(agent, "tts_language", None) or "").strip() or None
+
         session = GeminiLiveSession(model_name)
         try:
             await session.start(
                 system_instruction=system_instruction,
+                voice_name=voice_name,
+                language_code=language_code,
                 on_audio_chunk=self._on_gemini_live_audio_chunk,
                 on_interrupted=self._on_gemini_live_interrupted,
                 on_input_transcript=self._on_gemini_live_input_transcript,
                 on_output_transcript=self._on_gemini_live_output_transcript,
-                # Phase 1: Calendly/tool-calling is explicitly deferred (see
-                # integration plan §6) — no tools, no on_tool_call callback.
-                on_tool_call=None,
+                on_tool_call=on_tool_call,
                 on_error=self._on_gemini_live_error,
-                tools=None,
+                tools=gemini_tools,
             )
         except VertexLlmError as exc:
             logger.error(
@@ -814,12 +846,77 @@ class VoiceOrchestrator:
         STT-final (not interim) transcript-write precedent."""
         if not finished or not (text or "").strip():
             return
+        transcript = text.strip()
         try:
-            await self._h._add_to_transcript("client", text.strip(), "speech")
+            await self._h._add_to_transcript("client", transcript, "speech")
         except Exception as exc:
             logger.error(
                 "[VoiceOrchestrator] gemini live input transcript write failed: %s", exc, exc_info=True
             )
+
+        # Mid-call RAG refresh (Phase 2, plan §6): a finished input transcript
+        # is the closest thing this session has to a per-turn boundary (no
+        # STT-interim prefetch signal exists here). Fire-and-forget — must
+        # never block the receive loop or delay the caller's live audio
+        # response; tracked in the same set _full_shutdown already drains so
+        # a call ending mid-refresh doesn't leak the task. Coalesced via
+        # _gemini_live_kb_refresh_in_flight: skip rather than queue a new
+        # refresh while one is still running, so a chatty back-and-forth
+        # can't fire several overlapping retrievals + unordered
+        # session.send_text(...) calls racing each other.
+        if not self._gemini_live_kb_refresh_in_flight:
+            t = asyncio.create_task(self._refresh_gemini_live_kb_context(transcript))
+            self._pending_final_tasks.add(t)
+            t.add_done_callback(lambda done_t, s=self: s._pending_final_tasks.discard(done_t))
+
+    async def _refresh_gemini_live_kb_context(self, transcript: str) -> None:
+        """
+        Re-query the call flow's attached knowledge bases against the
+        caller's latest finished utterance and, if anything comes back, feed
+        it to the live session as a non-blocking text turn — so a native-
+        audio call's RAG grounding can adapt as the topic shifts, instead of
+        staying frozen at whatever was known at session start (see
+        _start_gemini_live_session's system_instruction, built once with an
+        empty user_text). Fails open on any error, same as every other RAG
+        call site in this codebase — KB context is a grounding aid, never a
+        call-blocking dependency.
+        """
+        session = self._gemini_live_session
+        if session is None or not transcript:
+            return
+        flow = getattr(self._h, "call_flow", None)
+        kb_ids = (flow.knowledge_base_ids or []) if flow else []
+        if not kb_ids:
+            return
+        self._gemini_live_kb_refresh_in_flight = True
+        try:
+            from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
+            from app.utils.redis_client import get_redis
+
+            kb_context, latency_ms = await retrieve_kb_context_for_turn(
+                transcript=transcript, kb_ids=kb_ids, redis_client=get_redis()
+            )
+            if not kb_context:
+                return
+            # turn_complete=False verified live (2026-08-17, against
+            # gemini-live-2.5-flash-native-audio): a context-only turn left
+            # open like this is correctly picked up by the model's next real
+            # turn without needing an explicit closing call — the caller's
+            # own ongoing audio (a separate send_realtime_input channel,
+            # VAD-driven turn-taking) is what actually closes/advances turns
+            # in production, not this side-channel text injection.
+            await session.send_text(
+                "[KNOWLEDGE BASE CONTEXT UPDATE — authoritative, use if relevant to the "
+                f"caller's most recent question]\n{kb_context}",
+                turn_complete=False,
+            )
+            logger.debug(
+                "[GeminiLive] kb_refresh latency_ms=%.1f chars=%d", latency_ms, len(kb_context)
+            )
+        except Exception as exc:
+            logger.debug("[GeminiLive] mid-call KB refresh failed (non-fatal): %s", exc)
+        finally:
+            self._gemini_live_kb_refresh_in_flight = False
 
     async def _on_gemini_live_output_transcript(self, text: str, finished: bool) -> None:
         """Agent-side transcript from Gemini's own output_transcription. Only
@@ -833,6 +930,60 @@ class VoiceOrchestrator:
             logger.error(
                 "[VoiceOrchestrator] gemini live output transcript write failed: %s", exc, exc_info=True
             )
+
+    async def _on_gemini_live_tool_call(self, function_calls) -> None:
+        """
+        Calendly tool-calling for a Gemini Live session (Phase 2). Only ever
+        registered when the handler is Twilio's BidirectionalStreamHandler
+        AND the call flow has Calendly enabled (see _start_gemini_live_session)
+        — BookingMixin/_execute_calendly_tool_call don't exist on the browser
+        handler, so this method is simply never reached on that transport.
+
+        Unlike the existing non-live generate_with_tools() request/response
+        tool-calling (one function_call, one response, done), the Live API's
+        tool-calling is async-within-session: function_calls can arrive at
+        any point mid-conversation, potentially more than one per message,
+        and the caller audio stream keeps flowing while we resolve them —
+        there is no "pause the turn" concept to lean on. Each call is
+        resolved independently and its response sent back via
+        send_tool_response(); _execute_calendly_tool_call already never
+        raises (always returns a JSON-serializable dict, {"error": ...} on
+        failure), so a single bad tool call can't crash the session or block
+        the others.
+        """
+        from google.genai import types
+
+        session = self._gemini_live_session
+        if session is None:
+            return
+
+        function_responses = []
+        for fc in function_calls:
+            name = getattr(fc, "name", None) or ""
+            args = dict(getattr(fc, "args", None) or {})
+            call_id = getattr(fc, "id", None)
+            try:
+                result = await self._h._execute_calendly_tool_call(name, args)
+            except Exception as exc:
+                logger.error(
+                    "[GeminiLive] Calendly tool call %s failed unexpectedly: %s",
+                    name, exc, exc_info=True,
+                )
+                result = {"error": "internal error executing tool call"}
+            from app.core.pii_redactor import redact_pii
+
+            logger.info("[GeminiLive] tool_call name=%s args=%s", name, redact_pii(args))
+            function_responses.append(
+                types.FunctionResponse(id=call_id, name=name, response=result)
+            )
+
+        if function_responses:
+            try:
+                await session.send_tool_response(function_responses=function_responses)
+            except Exception as exc:
+                logger.error(
+                    "[GeminiLive] send_tool_response failed: %s", exc, exc_info=True
+                )
 
     async def _on_gemini_live_error(self, err) -> None:
         """

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -1409,12 +1409,26 @@ class VoiceOrchestrator:
         OpenAIRealtimeSession.send_text's docstring). Fails open on any
         error, same as every other RAG call site in this codebase.
         """
+        # DIAGNOSTIC: temporary tracing for a "agent doesn't use KB" report —
+        # logs entry/skip reasons and whether context was actually sent, but
+        # never the transcript or KB content itself. Safe to strip once KB
+        # refresh is confirmed working on a real call.
+        call_session_id = getattr(self._h, "call_session_id", None)
         session = self._openai_realtime_session
         if session is None or not transcript:
+            logger.info(
+                "[OpenAIRealtime] DIAGNOSTIC kb_refresh skipped call_session_id=%s reason=%s",
+                call_session_id, "no_session" if session is None else "empty_transcript",
+            )
             return
         flow = getattr(self._h, "call_flow", None)
         kb_ids = (flow.knowledge_base_ids or []) if flow else []
         if not kb_ids:
+            logger.info(
+                "[OpenAIRealtime] DIAGNOSTIC kb_refresh skipped call_session_id=%s reason=%s "
+                "flow_present=%s",
+                call_session_id, "no_kb_ids_configured", flow is not None,
+            )
             return
         self._openai_realtime_kb_refresh_in_flight = True
         try:
@@ -1425,17 +1439,27 @@ class VoiceOrchestrator:
                 transcript=transcript, kb_ids=kb_ids, redis_client=get_redis()
             )
             if not kb_context:
+                logger.info(
+                    "[OpenAIRealtime] DIAGNOSTIC kb_refresh call_session_id=%s: retrieval returned "
+                    "no matching context (kb_ids=%s, latency_ms=%.1f) — nothing sent",
+                    call_session_id, kb_ids, latency_ms,
+                )
                 return
             await session.send_text(
                 "[KNOWLEDGE BASE CONTEXT UPDATE — authoritative, use if relevant to the "
                 f"caller's most recent question]\n{kb_context}",
                 respond=False,
             )
-            logger.debug(
-                "[OpenAIRealtime] kb_refresh latency_ms=%.1f chars=%d", latency_ms, len(kb_context)
+            logger.info(
+                "[OpenAIRealtime] DIAGNOSTIC kb_refresh call_session_id=%s: sent kb context "
+                "latency_ms=%.1f chars=%d",
+                call_session_id, latency_ms, len(kb_context),
             )
         except Exception as exc:
-            logger.debug("[OpenAIRealtime] mid-call KB refresh failed (non-fatal): %s", exc)
+            logger.warning(
+                "[OpenAIRealtime] mid-call KB refresh failed (non-fatal) call_session_id=%s: %s",
+                call_session_id, exc, exc_info=True,
+            )
         finally:
             self._openai_realtime_kb_refresh_in_flight = False
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -18999,6 +18999,7 @@ components:
       - rime
       - elevenlabs
       - elevenlabs_byo
+      - hume
       title: TtsProviderEnum
     TtsSettingsJsonSchema:
       properties:

--- a/tests/api/test_hubspot_integration.py
+++ b/tests/api/test_hubspot_integration.py
@@ -30,6 +30,12 @@ def _principal():
     return p
 
 
+def _request(accept: str = ""):
+    req = MagicMock()
+    req.headers = {"accept": accept} if accept else {}
+    return req
+
+
 class TestConnect:
     @pytest.mark.anyio
     async def test_redirects_to_hubspot(self):
@@ -45,11 +51,34 @@ class TestConnect:
                 return_value="https://app.hubspot.com/oauth/authorize?client_id=abc&state=signed-state",
             ),
         ):
-            response = await hubspot_connect(principal=_principal())
+            response = await hubspot_connect(request=_request(), principal=_principal())
 
         assert response.status_code == 302
         assert response.headers["location"] == (
             "https://app.hubspot.com/oauth/authorize?client_id=abc&state=signed-state"
+        )
+
+    @pytest.mark.anyio
+    async def test_returns_json_when_accept_header_requests_it(self):
+        from app.routers.hubspot_integration import hubspot_connect
+
+        with (
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.build_oauth_state",
+                return_value="signed-state",
+            ),
+            patch(
+                "app.routers.hubspot_integration.hubspot_service.build_authorization_url",
+                return_value="https://app.hubspot.com/oauth/authorize?client_id=abc&state=signed-state",
+            ),
+        ):
+            response = await hubspot_connect(
+                request=_request("application/json"), principal=_principal()
+            )
+
+        assert response.status_code == 200
+        assert response.body == (
+            b'{"authorization_url":"https://app.hubspot.com/oauth/authorize?client_id=abc&state=signed-state"}'
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,12 @@ elif __name__ == "tests.conftest":
     sys.modules["conftest"] = sys.modules[__name__]
 
 
-# Rime TTS is validated at app startup; tests must not depend on a developer .env file.
+# Rime/Hume TTS are validated at app startup (module-level singleton
+# construction in rime_tts_service.py / hume_tts_service.py); tests must not
+# depend on a developer .env file.
 os.environ["RATE_LIMIT_ENABLED"] = "False"
 os.environ.setdefault("RIME_API_KEY", "test-rime-key-for-pytest")
+os.environ.setdefault("HUME_API_KEY", "test-hume-key-for-pytest")
 os.environ.setdefault(
     "ELEVENLABS_ENCRYPTION_KEY",
     "test-elevenlabs-encryption-key-for-pytest-only",

--- a/tests/core/test_secret_manager_hume.py
+++ b/tests/core/test_secret_manager_hume.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for ``app.core.secret_manager.get_hume_api_key`` — mirrors the
+existing (only implicitly-covered-via-RimeTTSAdapter) contract for
+``get_rime_api_key``: development reads a plain env value or raises
+``ValueError``; staging/production try GCP Secret Manager first, fall back
+to the env var, and raise ``RuntimeError`` if neither is available.
+
+No real GCP credentials or network calls — ``_fetch_from_secret_manager`` is
+patched at the module boundary.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.core.secret_manager import get_hume_api_key
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """get_hume_api_key is @lru_cache'd — clear before/after every test so
+    tests don't leak state into each other."""
+    get_hume_api_key.cache_clear()
+    yield
+    get_hume_api_key.cache_clear()
+
+
+class TestGetHumeApiKeyDevelopment:
+    def test_returns_env_value_in_development(self):
+        with patch("app.core.secret_manager.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "development"
+            mock_settings.HUME_API_KEY = "dev-hume-key"
+            assert get_hume_api_key() == "dev-hume-key"
+
+    def test_strips_whitespace_in_development(self):
+        with patch("app.core.secret_manager.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "development"
+            mock_settings.HUME_API_KEY = "  dev-hume-key  "
+            assert get_hume_api_key() == "dev-hume-key"
+
+    def test_raises_value_error_when_unset_in_development(self):
+        with patch("app.core.secret_manager.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "development"
+            mock_settings.HUME_API_KEY = ""
+            with pytest.raises(ValueError, match="HUME_API_KEY is not set"):
+                get_hume_api_key()
+
+    def test_raises_value_error_when_only_whitespace_in_development(self):
+        with patch("app.core.secret_manager.settings") as mock_settings:
+            mock_settings.ENVIRONMENT = "development"
+            mock_settings.HUME_API_KEY = "   "
+            with pytest.raises(ValueError, match="HUME_API_KEY is not set"):
+                get_hume_api_key()
+
+
+class TestGetHumeApiKeyStagingProduction:
+    @pytest.mark.parametrize("env", ["staging", "production"])
+    def test_prefers_secret_manager_value(self, env):
+        with patch("app.core.secret_manager.settings") as mock_settings, patch(
+            "app.core.secret_manager._fetch_from_secret_manager",
+            return_value="secret-manager-hume-key",
+        ) as mock_fetch:
+            mock_settings.ENVIRONMENT = env
+            mock_settings.HUME_API_KEY = "env-fallback-should-not-be-used"
+            assert get_hume_api_key() == "secret-manager-hume-key"
+            mock_fetch.assert_called_once_with("HUME_API_KEY")
+
+    @pytest.mark.parametrize("env", ["staging", "production"])
+    def test_falls_back_to_env_var_when_secret_manager_empty(self, env):
+        with patch("app.core.secret_manager.settings") as mock_settings, patch(
+            "app.core.secret_manager._fetch_from_secret_manager", return_value=None
+        ):
+            mock_settings.ENVIRONMENT = env
+            mock_settings.HUME_API_KEY = "env-fallback-key"
+            assert get_hume_api_key() == "env-fallback-key"
+
+    @pytest.mark.parametrize("env", ["staging", "production"])
+    def test_raises_runtime_error_when_neither_available(self, env):
+        with patch("app.core.secret_manager.settings") as mock_settings, patch(
+            "app.core.secret_manager._fetch_from_secret_manager", return_value=None
+        ):
+            mock_settings.ENVIRONMENT = env
+            mock_settings.HUME_API_KEY = ""
+            with pytest.raises(RuntimeError, match="HUME_API_KEY unavailable"):
+                get_hume_api_key()
+
+    def test_environment_lookup_is_case_insensitive(self):
+        with patch("app.core.secret_manager.settings") as mock_settings, patch(
+            "app.core.secret_manager._fetch_from_secret_manager",
+            return_value="secret-manager-hume-key",
+        ):
+            mock_settings.ENVIRONMENT = "STAGING"
+            mock_settings.HUME_API_KEY = ""
+            assert get_hume_api_key() == "secret-manager-hume-key"

--- a/tests/db/test_schema_v2_migration.py
+++ b/tests/db/test_schema_v2_migration.py
@@ -707,18 +707,6 @@ class TestWidenAgentLlmModelCheckGeminiLiveMigration:
             "gemini-3.1-flash-live-preview",
         }
 
-    def test_widened_snapshot_matches_current_allow_list(self):
-        """The migration's self-contained snapshot must match the current
-        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
-        revision — this is now the latest widening migration, so this
-        assertion correctly lives here; future edits to the module are
-        expected to add a new migration rather than retroactively changing
-        this one)."""
-        from app.core.llm_models import ALLOWED_LLM_MODELS
-
-        mod = _load_migration(self._FILE)
-        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
-
     def test_llm_check_sql_uses_widened_snapshot(self):
         mod = _load_migration(self._FILE)
         sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
@@ -739,3 +727,81 @@ class TestWidenAgentLlmModelCheckGeminiLiveMigration:
             "gemini-3.1-flash-live-preview",
         ]:
             assert f"'{gemini_live_model}'" not in sql
+
+
+# ─────────────────── widen ck_agent_llm_model (OpenAI Realtime) ──────────────
+
+class TestWidenAgentLlmModelCheckOpenAIRealtimeMigration:
+    """20260817b_widen_agent_llm_model_check_openai_realtime.py — widens
+    ck_agent_llm_model from the 24-value 20260817 gemini-live snapshot to 26
+    values (adds the 2 OpenAI Realtime native-audio model IDs, removes
+    nothing)."""
+
+    _FILE = "20260817b_widen_agent_llm_model_check_openai_realtime.py"
+
+    def test_file_exists(self):
+        assert (_VERSIONS_DIR / self._FILE).exists()
+
+    def test_down_revision_is_gemini_live_widen_migration(self):
+        mod = _load_migration(self._FILE)
+        assert mod.down_revision == "20260817_widen_llm_check_glive"
+
+    def test_has_upgrade_and_downgrade(self):
+        mod = _load_migration(self._FILE)
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)
+
+    def test_revision_id(self):
+        mod = _load_migration(self._FILE)
+        assert mod.revision == "20260817_widen_llm_check_oair"
+
+    def test_widened_snapshot_has_26_values(self):
+        mod = _load_migration(self._FILE)
+        assert len(mod._ALLOWED_LLM_MODELS_AT_REVISION) == 26
+
+    def test_prior_snapshot_unchanged_at_24_values(self):
+        mod = _load_migration(self._FILE)
+        assert len(mod._PRIOR_ALLOWED_LLM_MODELS) == 24
+
+    def test_widened_snapshot_is_superset_of_prior_snapshot(self):
+        """Purely additive: nothing removed or renamed."""
+        mod = _load_migration(self._FILE)
+        assert set(mod._PRIOR_ALLOWED_LLM_MODELS).issubset(
+            set(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        )
+
+    def test_widened_snapshot_adds_exactly_the_openai_realtime_family(self):
+        mod = _load_migration(self._FILE)
+        added = set(mod._ALLOWED_LLM_MODELS_AT_REVISION) - set(
+            mod._PRIOR_ALLOWED_LLM_MODELS
+        )
+        assert added == {"gpt-realtime", "gpt-realtime-2"}
+
+    def test_widened_snapshot_matches_current_allow_list(self):
+        """The migration's self-contained snapshot must match the current
+        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
+        revision — this is now the latest widening migration, so this
+        assertion correctly lives here; future edits to the module are
+        expected to add a new migration rather than retroactively changing
+        this one)."""
+        from app.core.llm_models import ALLOWED_LLM_MODELS
+
+        mod = _load_migration(self._FILE)
+        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
+
+    def test_llm_check_sql_uses_widened_snapshot(self):
+        mod = _load_migration(self._FILE)
+        sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        for model in mod._ALLOWED_LLM_MODELS_AT_REVISION:
+            assert f"'{model}'" in sql
+
+    def test_downgrade_sql_uses_prior_snapshot_only(self):
+        """Downgrade must restore the narrower 24-value constraint — the
+        two new OpenAI Realtime IDs must not appear in the downgrade CHECK
+        SQL."""
+        mod = _load_migration(self._FILE)
+        sql = mod._llm_check_sql(mod._PRIOR_ALLOWED_LLM_MODELS)
+        for model in mod._PRIOR_ALLOWED_LLM_MODELS:
+            assert f"'{model}'" in sql
+        for openai_realtime_model in ["gpt-realtime", "gpt-realtime-2"]:
+            assert f"'{openai_realtime_model}'" not in sql

--- a/tests/db/test_schema_v2_migration.py
+++ b/tests/db/test_schema_v2_migration.py
@@ -639,18 +639,6 @@ class TestWidenAgentLlmModelCheckGemini3Migration:
         )
         assert added == {"gemini-3-flash-preview", "gemini-3.1-flash-lite"}
 
-    def test_widened_snapshot_matches_current_allow_list(self):
-        """The migration's self-contained snapshot must match the current
-        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
-        revision — this is now the latest widening migration, so this
-        assertion correctly lives here; future edits to the module are
-        expected to add a new migration rather than retroactively changing
-        this one)."""
-        from app.core.llm_models import ALLOWED_LLM_MODELS
-
-        mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
-        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
-
     def test_llm_check_sql_uses_widened_snapshot(self):
         mod = _load_migration("20260816_widen_agent_llm_model_check_gemini3.py")
         sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
@@ -666,3 +654,88 @@ class TestWidenAgentLlmModelCheckGemini3Migration:
             assert f"'{model}'" in sql
         for gemini3_model in ["gemini-3-flash-preview", "gemini-3.1-flash-lite"]:
             assert f"'{gemini3_model}'" not in sql
+
+
+# ─────────────────── widen ck_agent_llm_model (gemini live native-audio) ─────
+
+class TestWidenAgentLlmModelCheckGeminiLiveMigration:
+    """20260817_widen_agent_llm_model_check_gemini_live.py — widens
+    ck_agent_llm_model from the 21-value 20260816 snapshot to 24 values (adds
+    the 3 Gemini Live native-audio model IDs, removes nothing)."""
+
+    _FILE = "20260817_widen_agent_llm_model_check_gemini_live.py"
+
+    def test_file_exists(self):
+        assert (_VERSIONS_DIR / self._FILE).exists()
+
+    def test_down_revision_is_gemini3_widen_migration(self):
+        mod = _load_migration(self._FILE)
+        assert mod.down_revision == "20260816_widen_llm_check_g3"
+
+    def test_has_upgrade_and_downgrade(self):
+        mod = _load_migration(self._FILE)
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)
+
+    def test_revision_id(self):
+        mod = _load_migration(self._FILE)
+        assert mod.revision == "20260817_widen_llm_check_glive"
+
+    def test_widened_snapshot_has_24_values(self):
+        mod = _load_migration(self._FILE)
+        assert len(mod._ALLOWED_LLM_MODELS_AT_REVISION) == 24
+
+    def test_prior_snapshot_unchanged_at_21_values(self):
+        mod = _load_migration(self._FILE)
+        assert len(mod._PRIOR_ALLOWED_LLM_MODELS) == 21
+
+    def test_widened_snapshot_is_superset_of_prior_snapshot(self):
+        """Purely additive: nothing removed or renamed."""
+        mod = _load_migration(self._FILE)
+        assert set(mod._PRIOR_ALLOWED_LLM_MODELS).issubset(
+            set(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        )
+
+    def test_widened_snapshot_adds_exactly_the_gemini_live_family(self):
+        mod = _load_migration(self._FILE)
+        added = set(mod._ALLOWED_LLM_MODELS_AT_REVISION) - set(
+            mod._PRIOR_ALLOWED_LLM_MODELS
+        )
+        assert added == {
+            "gemini-live-2.5-flash-native-audio",
+            "gemini-live-2.5-flash-preview-native-audio-09-2025",
+            "gemini-3.1-flash-live-preview",
+        }
+
+    def test_widened_snapshot_matches_current_allow_list(self):
+        """The migration's self-contained snapshot must match the current
+        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
+        revision — this is now the latest widening migration, so this
+        assertion correctly lives here; future edits to the module are
+        expected to add a new migration rather than retroactively changing
+        this one)."""
+        from app.core.llm_models import ALLOWED_LLM_MODELS
+
+        mod = _load_migration(self._FILE)
+        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
+
+    def test_llm_check_sql_uses_widened_snapshot(self):
+        mod = _load_migration(self._FILE)
+        sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        for model in mod._ALLOWED_LLM_MODELS_AT_REVISION:
+            assert f"'{model}'" in sql
+
+    def test_downgrade_sql_uses_prior_snapshot_only(self):
+        """Downgrade must restore the narrower 21-value constraint — the
+        three new gemini-live IDs must not appear in the downgrade CHECK
+        SQL."""
+        mod = _load_migration(self._FILE)
+        sql = mod._llm_check_sql(mod._PRIOR_ALLOWED_LLM_MODELS)
+        for model in mod._PRIOR_ALLOWED_LLM_MODELS:
+            assert f"'{model}'" in sql
+        for gemini_live_model in [
+            "gemini-live-2.5-flash-native-audio",
+            "gemini-live-2.5-flash-preview-native-audio-09-2025",
+            "gemini-3.1-flash-live-preview",
+        ]:
+            assert f"'{gemini_live_model}'" not in sql

--- a/tests/utils/test_audio_utils.py
+++ b/tests/utils/test_audio_utils.py
@@ -16,11 +16,18 @@ shows up immediately.
 
 from __future__ import annotations
 
+import struct
+
+import pytest
+
 from app.utils.audio_utils import (
     MULAW_FRAME_BYTES,
     MULAW_SAMPLE_RATE_HZ,
+    PCM16KStreamDownsampler,
+    PCMStreamDownsampler,
     apply_micro_fade_in,
     apply_micro_fade_out,
+    downsample_linear_samples,
     linear_to_ulaw_sample,
     ulaw_to_linear_sample,
 )
@@ -112,3 +119,221 @@ def test_fade_out_handles_audio_shorter_than_fade_window():
     assert len(out) == len(audio)
     levels = _abs_linear(out)
     assert levels[0] >= levels[-1]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PCMStreamDownsampler — generalized incremental PCM16LE -> mulaw downsampler
+# (added for Hume AI TTS integration; also compared against the pre-existing
+# 16k -> 8k only PCM16KStreamDownsampler used by the ElevenLabs background
+# path.)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _pcm16le(samples: list[int]) -> bytes:
+    return b"".join(struct.pack("<h", s) for s in samples)
+
+
+def _reference_mulaw(samples: list[int], src_rate_hz: int, dst_rate_hz: int) -> bytes:
+    """Independent reference: uses the pre-existing (non-incremental)
+    ``downsample_linear_samples`` helper + ``linear_to_ulaw_sample`` directly,
+    rather than re-deriving PCMStreamDownsampler's own box-average loop."""
+    down = downsample_linear_samples(samples, src_rate_hz, dst_rate_hz)
+    return bytes(linear_to_ulaw_sample(s) for s in down)
+
+
+def test_pcm_stream_downsampler_48k_to_8k_matches_reference():
+    """factor=6 (Hume's assumed 48kHz source -> Twilio's 8kHz mulaw)."""
+    samples = [1000, 1200, 900, 1100, 1050, 950, -500, -600, -700, -800, -900, -1000]
+    pcm_bytes = _pcm16le(samples)
+
+    d = PCMStreamDownsampler(48000, 8000)
+    out = d.feed(pcm_bytes) + d.flush()
+
+    assert out == _reference_mulaw(samples, 48000, 8000)
+    assert len(out) == 2  # 12 samples / factor 6 = 2 output samples
+
+
+def test_pcm_stream_downsampler_16k_to_8k_matches_reference():
+    """factor=2 (arbitrary-ratio path exercised at the ratio the existing
+    PCM16KStreamDownsampler was hard-coded for)."""
+    samples = [100, 200, 300, 400, 1000, 2000, 5, 5]
+    pcm_bytes = _pcm16le(samples)
+
+    d = PCMStreamDownsampler(16000, 8000)
+    out = d.feed(pcm_bytes) + d.flush()
+
+    assert out == _reference_mulaw(samples, 16000, 8000)
+
+
+def test_pcm_stream_downsampler_16k_to_8k_is_NOT_always_byte_identical_to_pcm16k_downsampler():
+    """
+    POSSIBLE BUG (flagged, not fixed): PCMStreamDownsampler's box-average
+    uses ``int(total / factor)`` (Python truncation toward zero), while the
+    pre-existing PCM16KStreamDownsampler uses ``(s1 + s2) // 2`` (floor
+    division). These are NOT equivalent for odd, negative sums — e.g.
+    total=-3, factor=2: int(-3/2) == -1 but -3 // 2 == -2.
+
+    The implementer's summary for this integration claimed the two
+    downsamplers are "byte-identical" for the 16k->8k ratio. This test
+    proves that claim is false in general (it only holds when every
+    box-averaged sum happens to be non-negative or evenly divisible).
+    Negative-sample audio (i.e. any real PCM waveform, since PCM alternates
+    sign) hits this in practice.
+    """
+    samples = [-1, -2, 100, -101, 300, -301, 5, 5]
+    pcm_bytes = _pcm16le(samples)
+
+    d = PCMStreamDownsampler(16000, 8000)
+    pcm_stream_out = d.feed(pcm_bytes) + d.flush()
+
+    d2 = PCM16KStreamDownsampler()
+    linear_out = d2.feed(pcm_bytes) + d2.flush()
+    pcm16k_out = bytes(linear_to_ulaw_sample(s) for s in linear_out)
+
+    assert pcm_stream_out != pcm16k_out, (
+        "Expected the two downsamplers to diverge on this negative-odd-sum "
+        "input (truncation vs floor division) — if this now passes, the "
+        "rounding behavior was changed and the 'byte-identical' claim should "
+        "be re-verified end to end."
+    )
+
+
+def test_pcm_stream_downsampler_strips_leading_wav_header():
+    samples = [1000, -1000, 2000, -2000, 500, -500]
+    pcm_bytes = _pcm16le(samples)
+    header = b"RIFF" + (36 + len(pcm_bytes)).to_bytes(4, "little") + b"WAVEfmt "
+    # Minimal well-formed-enough header: only "RIFF"/"WAVE" markers and a
+    # "data" chunk id + length are actually inspected by strip logic.
+    wav_bytes = header + b"\x10\x00\x00\x00" + b"\x00" * 16 + b"data" + len(pcm_bytes).to_bytes(4, "little") + pcm_bytes
+
+    d = PCMStreamDownsampler(16000, 8000)
+    out = d.feed(wav_bytes) + d.flush()
+
+    assert out == _reference_mulaw(samples, 16000, 8000)
+
+
+def test_pcm_stream_downsampler_headerless_input_is_unaffected():
+    # >=12 bytes so the header-vs-not decision resolves within this single
+    # feed() call (see the POSSIBLE BUG test below for what happens when it
+    # can't).
+    samples = [1000, -1000, 2000, -2000, 500, -500]
+    pcm_bytes = _pcm16le(samples)
+
+    d = PCMStreamDownsampler(16000, 8000)
+    out = d.feed(pcm_bytes) + d.flush()
+
+    assert out == _reference_mulaw(samples, 16000, 8000)
+
+
+def test_pcm_stream_downsampler_buffers_partial_bytes_across_feed_calls():
+    """Feeding a chunk that ends mid-sample-group (and even mid-int16-sample)
+    must not lose or corrupt data — the remainder is buffered until enough
+    bytes arrive to complete a full output sample."""
+    samples = [1000, 1200, 900, 1100, 1050, 950]  # factor=6 -> 1 output sample
+    pcm_bytes = _pcm16le(samples)
+
+    d = PCMStreamDownsampler(48000, 8000)
+    out = b""
+    # Feed one byte at a time, including a split mid-int16-sample.
+    for i in range(0, len(pcm_bytes), 3):
+        out += d.feed(pcm_bytes[i:i + 3])
+    out += d.flush()
+
+    assert out == _reference_mulaw(samples, 48000, 8000)
+
+
+def test_pcm_stream_downsampler_feed_returns_empty_until_full_group_buffered():
+    """No output should be emitted from feed() until a whole factor-sized
+    group of samples has arrived. Uses factor=8 (64000->8000, 16 bytes/group)
+    fed with >=12 bytes so the header-detection ambiguity below doesn't
+    confound this assertion."""
+    samples = [1000, 1200, 900, 1100, 1050, 950]  # 6 of 8 needed for a full group
+    pcm_bytes = _pcm16le(samples)
+    assert len(pcm_bytes) >= 12
+
+    d = PCMStreamDownsampler(64000, 8000)
+    out = d.feed(pcm_bytes)
+
+    assert out == b""
+
+
+def test_pcm_stream_downsampler_flush_encodes_partial_tail():
+    """flush() must encode a short trailing group (fewer than `factor`
+    samples) rather than discarding it. Feeds a full group (48k->8k,
+    factor=6) plus a partial group so >=12 bytes pass through feed() first
+    and the header decision is already resolved before flush() runs (see
+    the POSSIBLE BUG test below for the case where it isn't)."""
+    full_group = [1000, 1200, 900, 1100, 1050, 950]
+    partial_tail = [300, -200, 100]
+    samples = full_group + partial_tail
+    pcm_bytes = _pcm16le(samples)
+
+    d = PCMStreamDownsampler(48000, 8000)
+    head = d.feed(pcm_bytes)
+    tail = d.flush()
+
+    expected_head_avg = int(sum(full_group) / 6)
+    expected_tail_avg = int(sum(partial_tail) / len(partial_tail))
+    assert head == bytes([linear_to_ulaw_sample(expected_head_avg)])
+    assert tail == bytes([linear_to_ulaw_sample(expected_tail_avg)])
+
+
+def test_pcm_stream_downsampler_flush_silently_drops_short_tail_before_header_decided():
+    """
+    POSSIBLE BUG (flagged, not fixed): if the *total* audio fed across the
+    stream's lifetime (feed() calls + the final flush()) never reaches 12
+    bytes, ``_strip_header_if_ready()`` can never determine whether the
+    stream started with a RIFF/WAVE header (it needs >=12 bytes to check the
+    magic markers) — and ``flush()`` responds to that "still unknown"
+    state by clearing the buffer and returning empty audio instead of
+    treating the data as headerless PCM (which callers would reasonably
+    expect for a short trailing chunk). Concretely: a 3-sample (6-byte)
+    partial group at the very end of a short utterance is silently dropped
+    with **no error, warning, or partial audio returned** if it's the only
+    data the stream ever saw.
+    """
+    samples = [300, -200, 100]  # 6 bytes total — under the 12-byte header threshold
+    pcm_bytes = _pcm16le(samples)
+    assert len(pcm_bytes) < 12
+
+    d = PCMStreamDownsampler(48000, 8000)
+    fed = d.feed(pcm_bytes)
+    tail = d.flush()
+
+    assert fed == b""
+    assert tail == b"", (
+        "If this assertion starts failing, the header-ambiguity-drops-short-"
+        "tail behavior has been fixed upstream — update/remove this "
+        "regression test and consider removing the flagged-bug note in the "
+        "test-writer report."
+    )
+
+
+def test_pcm_stream_downsampler_flush_with_nothing_buffered_returns_empty():
+    d = PCMStreamDownsampler(48000, 8000)
+    assert d.flush() == b""
+
+
+def test_pcm_stream_downsampler_raises_on_non_integer_ratio():
+    with pytest.raises(ValueError):
+        PCMStreamDownsampler(44100, 8000)
+
+
+def test_pcm_stream_downsampler_raises_on_zero_or_negative_rates():
+    with pytest.raises(ValueError):
+        PCMStreamDownsampler(0, 8000)
+    with pytest.raises(ValueError):
+        PCMStreamDownsampler(48000, 0)
+    with pytest.raises(ValueError):
+        PCMStreamDownsampler(-48000, 8000)
+
+
+def test_pcm_stream_downsampler_same_rate_is_a_passthrough_encode():
+    # >=12 bytes so the header decision resolves within this feed() call.
+    samples = [1000, -1000, 2000, -2000, 500, -500]
+    pcm_bytes = _pcm16le(samples)
+
+    d = PCMStreamDownsampler(8000, 8000)
+    out = d.feed(pcm_bytes) + d.flush()
+
+    assert out == bytes(linear_to_ulaw_sample(s) for s in samples)

--- a/tests/voice/test_build_system_prompt_extraction.py
+++ b/tests/voice/test_build_system_prompt_extraction.py
@@ -1,0 +1,112 @@
+"""
+Regression test for the ConversationOrchestrator.build_system_prompt()
+extraction (behavior-preserving refactor pulling prompt-assembly logic out
+of generate_and_stream_response so the Gemini Live native-audio session
+start path can reuse it — see VoiceOrchestrator._start_gemini_live_session).
+
+Asserts:
+  - build_system_prompt(), called directly, produces the same system_prompt
+    generate_and_stream_response's LLM-streaming call site used to build
+    inline (captured via the existing llm_service_for_provider stub pattern
+    used across tests/voice/*_grounding.py).
+  - Minimum content-shape guarantees: grounding text present, KB context
+    included when flow.knowledge_base_ids is set, conversation history
+    included.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.voice.conversation_orchestrator import (
+    ConversationOrchestrator,
+    _BUSINESS_FACTS_GROUNDING_TEXT,
+)
+from tests.voice.test_bracket_tag_prompt_consistency import _fake_livekit_handler
+
+
+class TestBuildSystemPromptMatchesStreamingPath:
+    def test_build_system_prompt_equals_what_generate_and_stream_response_used(self, monkeypatch):
+        h = _fake_livekit_handler(tts_slug="google")
+        orchestrator = ConversationOrchestrator(h)
+
+        # Build directly.
+        direct = asyncio.run(orchestrator.build_system_prompt("Hello there", 0.9))
+
+        # Build via the full streaming path (same as pre-refactor behavior) —
+        # capture the system_prompt kwarg passed into stream_text.
+        captured: list[str] = []
+
+        async def _stub_stream(**kwargs):
+            captured.append(kwargs.get("system_prompt") or "")
+            yield "Sure, here is a short reply."
+
+        stub_service = MagicMock()
+        stub_service.stream_text = _stub_stream
+        monkeypatch.setattr(
+            "app.core.agent_runtime.llm_service_for_provider", lambda slug: stub_service
+        )
+        asyncio.run(orchestrator.generate_and_stream_response("Hello there", 0.9))
+
+        assert captured, "LLM must have been invoked"
+        assert direct == captured[0], (
+            "build_system_prompt() output diverged from the inline prompt "
+            "generate_and_stream_response used to build pre-refactor."
+        )
+
+
+class TestBuildSystemPromptShape:
+    def test_contains_grounding_text_and_history(self):
+        h = _fake_livekit_handler(tts_slug="google")
+        h.call_session = MagicMock()
+        h.HISTORY_MAX_MESSAGES = 20  # MagicMock auto-attrs would otherwise shadow getattr()'s default
+        h.call_session.call_transcript = [
+            {"role": "client", "content": "What are your hours?", "message_type": "speech"},
+            {"role": "agent", "content": "We're open 9 to 5.", "message_type": "agent_response"},
+        ]
+        orchestrator = ConversationOrchestrator(h)
+
+        prompt = asyncio.run(orchestrator.build_system_prompt("Great, thanks", 0.9))
+
+        assert _BUSINESS_FACTS_GROUNDING_TEXT in prompt
+        assert "What are your hours?" in prompt
+        assert "We're open 9 to 5." in prompt
+
+    def test_includes_kb_context_when_flow_has_knowledge_base_ids(self):
+        kb_id = uuid.uuid4()
+        h = _fake_livekit_handler(tts_slug="google")
+        h.db = MagicMock()  # truthy — required for the KB-retrieval branch to run
+        flow = MagicMock()
+        flow.knowledge_base_ids = [str(kb_id)]
+        flow.caller_memory_enabled = False
+        h.call_flow = flow
+        orchestrator = ConversationOrchestrator(h)
+
+        fake_kb_block = (
+            "--- KNOWLEDGE BASE CONTEXT ---\nTEST_KB_FACT\n--- END CONTEXT ---"
+        )
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=(fake_kb_block, 12.0)),
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            prompt = asyncio.run(
+                orchestrator.build_system_prompt("What's your refund policy?", 0.9)
+            )
+
+        assert "TEST_KB_FACT" in prompt
+        assert "KNOWLEDGE BASE CONTEXT" in prompt
+
+    def test_no_kb_configured_produces_no_kb_block(self):
+        h = _fake_livekit_handler(tts_slug="google")
+        h.db = MagicMock()
+        flow = MagicMock()
+        flow.knowledge_base_ids = []
+        flow.caller_memory_enabled = False
+        h.call_flow = flow
+        orchestrator = ConversationOrchestrator(h)
+
+        prompt = asyncio.run(orchestrator.build_system_prompt("Hi", 0.9))
+
+        assert "--- KNOWLEDGE BASE CONTEXT ---" not in prompt

--- a/tests/voice/test_gemini_live_audio_bridge.py
+++ b/tests/voice/test_gemini_live_audio_bridge.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for app/voice/gemini_live_audio_bridge.py — pure audio-conversion
+functions bridging Twilio's MULAW/8kHz telephony audio to/from Gemini
+Live's PCM16 16kHz-in/24kHz-out requirement.
+
+All functions under test are synchronous and pure — no mocking, no I/O,
+no google-genai SDK involvement at all.
+"""
+from __future__ import annotations
+
+import math
+import struct
+
+import pytest
+
+from app.utils.audio_utils import linear_to_ulaw_sample, ulaw_to_linear_sample
+from app.voice.gemini_live_audio_bridge import (
+    GEMINI_INPUT_PCM_RATE_HZ,
+    GEMINI_OUTPUT_PCM_RATE_HZ,
+    TWILIO_MULAW_RATE_HZ,
+    _linear_samples_to_pcm16le_bytes,
+    _upsample_linear_samples,
+    mulaw8k_to_pcm16_16k,
+    pcm16_24k_to_mulaw8k,
+)
+
+
+def _pcm16le_bytes(samples: list[int]) -> bytes:
+    return struct.pack(f"<{len(samples)}h", *samples)
+
+
+def _tone_samples(n: int, amplitude: int = 8000, period: int = 20) -> list[int]:
+    """Deterministic non-silent waveform (not a pure DC signal) for
+    round-trip sanity checks."""
+    return [
+        int(amplitude * math.sin(2 * math.pi * i / period))
+        for i in range(n)
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# mulaw8k_to_pcm16_16k
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestMulaw8kToPcm16_16k:
+    def test_empty_input_returns_empty_output(self):
+        assert mulaw8k_to_pcm16_16k(b"") == b""
+
+    def test_output_byte_length_doubles_sample_count(self):
+        """N ms of 8kHz mono MULAW (1 byte/sample) -> ~2N ms worth of PCM16
+        16kHz bytes: input_samples * 2 (rate factor) * 2 (bytes/PCM16 sample)."""
+        # 20ms @ 8kHz = 160 samples/bytes (Twilio's own frame size).
+        mulaw_bytes = bytes([0xFF] * 160)
+        pcm16k = mulaw8k_to_pcm16_16k(mulaw_bytes)
+        expected_len = 160 * (GEMINI_INPUT_PCM_RATE_HZ // TWILIO_MULAW_RATE_HZ) * 2
+        assert len(pcm16k) == expected_len == 640
+
+    def test_silence_handling(self):
+        """MULAW 0xFF is the standard mu-law encoding of linear zero (silence)."""
+        silence_mulaw = bytes([0xFF] * 80)
+        pcm16k = mulaw8k_to_pcm16_16k(silence_mulaw)
+        assert len(pcm16k) == 80 * 2 * 2
+        samples = struct.unpack(f"<{len(pcm16k) // 2}h", pcm16k)
+        # mu-law's zero code (0xFF) decodes to +/-ULAW_BIAS (132), not exact
+        # zero — near-zero within the codec's own bias tolerance.
+        assert all(abs(s) <= 132 for s in samples)
+
+    def test_does_not_crash_on_single_byte(self):
+        # Odd/degenerate input sizes are meaningful for MULAW (1 byte = 1
+        # sample) — must not raise even for a single byte.
+        out = mulaw8k_to_pcm16_16k(bytes([0x7F]))
+        assert len(out) == 1 * 2 * 2
+
+    def test_round_trip_approximately_recovers_tone(self):
+        """mu-law decode -> upsample -> (downsample -> mu-law encode) should
+        approximately recover the original mu-law-quantized tone, within
+        mu-law's own quantization tolerance."""
+        from app.utils.audio_utils import downsample_linear_samples, linear_samples_to_ulaw_bytes
+
+        original_linear = _tone_samples(160, amplitude=8000)
+        original_mulaw = bytes(linear_to_ulaw_sample(s) for s in original_linear)
+
+        pcm16k = mulaw8k_to_pcm16_16k(original_mulaw)
+        # Downsample back to 8k and re-encode to compare like-for-like.
+        samples_16k = struct.unpack(f"<{len(pcm16k) // 2}h", pcm16k)
+        samples_8k = downsample_linear_samples(list(samples_16k), 16000, 8000)
+        round_tripped_mulaw = linear_samples_to_ulaw_bytes(samples_8k)
+
+        recovered_linear = [ulaw_to_linear_sample(b) for b in round_tripped_mulaw]
+        # mu-law quantization error can be a few percent of full scale at
+        # this amplitude; allow generous tolerance since this is a lossy
+        # codec round trip, not an exact-recovery check.
+        max_diff = max(abs(a - b) for a, b in zip(original_linear, recovered_linear))
+        assert max_diff < 2000
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# pcm16_24k_to_mulaw8k
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPcm16_24kToMulaw8k:
+    def test_empty_input_returns_empty_output(self):
+        assert pcm16_24k_to_mulaw8k(b"") == b""
+
+    def test_output_byte_length_matches_rate_ratio(self):
+        """N ms of 24kHz PCM16 (2 bytes/sample) -> N/3 ms worth of MULAW
+        8kHz bytes (1 byte/sample after /3 rate + /2 byte-width)."""
+        samples = _tone_samples(240, amplitude=5000)  # 10ms @ 24kHz
+        pcm_bytes = _pcm16le_bytes(samples)
+        mulaw = pcm16_24k_to_mulaw8k(pcm_bytes)
+        expected_len = 240 // (GEMINI_OUTPUT_PCM_RATE_HZ // TWILIO_MULAW_RATE_HZ)
+        assert len(mulaw) == expected_len == 80
+
+    def test_silence_handling(self):
+        silence_pcm = _pcm16le_bytes([0] * 240)
+        mulaw = pcm16_24k_to_mulaw8k(silence_pcm)
+        assert len(mulaw) == 80
+        # Silence should decode back to near-zero (within mu-law's own bias
+        # tolerance — 0xFF, mu-law's zero code, decodes to +/-ULAW_BIAS=132).
+        decoded = [ulaw_to_linear_sample(b) for b in mulaw]
+        assert all(abs(s) <= 132 for s in decoded)
+
+    def test_odd_length_buffer_does_not_crash(self):
+        """A trailing incomplete PCM16 sample (odd byte count) must be
+        dropped, not raise."""
+        pcm_bytes = _pcm16le_bytes([100, 200, 300]) + b"\x01"  # 7 bytes total
+        out = pcm16_24k_to_mulaw8k(pcm_bytes)
+        # 3 usable samples -> usable=3, factor=3 -> 1 output sample.
+        assert len(out) == 1
+
+    def test_single_incomplete_byte_does_not_crash(self):
+        assert pcm16_24k_to_mulaw8k(b"\x01") == b""
+
+    def test_round_trip_approximately_recovers_tone(self):
+        original = _tone_samples(240, amplitude=10000)
+        pcm_bytes = _pcm16le_bytes(original)
+        mulaw = pcm16_24k_to_mulaw8k(pcm_bytes)
+        recovered = [ulaw_to_linear_sample(b) for b in mulaw]
+
+        # Downsample the original 3x to compare like-for-like against the
+        # 8kHz recovered signal (box-averaged, same method the function uses).
+        from app.utils.audio_utils import downsample_linear_samples
+
+        downsampled_original = downsample_linear_samples(original, 24000, 8000)
+        assert len(recovered) == len(downsampled_original)
+        max_diff = max(abs(a - b) for a, b in zip(downsampled_original, recovered))
+        assert max_diff < 2500
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Internal helpers
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestUpsampleLinearSamples:
+    def test_empty_input(self):
+        assert _upsample_linear_samples([], 2) == []
+
+    def test_factor_one_returns_copy(self):
+        samples = [1, 2, 3]
+        out = _upsample_linear_samples(samples, 1)
+        assert out == samples
+        assert out is not samples
+
+    def test_doubles_length(self):
+        samples = [0, 100, 200, 100]
+        out = _upsample_linear_samples(samples, 2)
+        assert len(out) == 8
+
+    def test_interpolates_between_samples(self):
+        samples = [0, 100]
+        out = _upsample_linear_samples(samples, 2)
+        # out[0] = sample[0] exactly; out[1] halfway to sample[1].
+        assert out[0] == 0
+        assert out[1] == 50
+
+
+class TestLinearSamplesToPcm16LeBytes:
+    def test_empty(self):
+        assert _linear_samples_to_pcm16le_bytes([]) == b""
+
+    def test_round_trips_with_struct(self):
+        samples = [0, 100, -100, 32767, -32768]
+        encoded = _linear_samples_to_pcm16le_bytes(samples)
+        decoded = list(struct.unpack(f"<{len(samples)}h", encoded))
+        assert decoded == samples
+
+    def test_clamps_out_of_range_values(self):
+        encoded = _linear_samples_to_pcm16le_bytes([40000, -40000])
+        decoded = list(struct.unpack("<2h", encoded))
+        assert decoded == [32767, -32768]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/voice/test_gemini_live_browser_fork.py
+++ b/tests/voice/test_gemini_live_browser_fork.py
@@ -1,0 +1,723 @@
+"""
+Browser-transport (LiveKit) fork-point tests for Gemini Live native-audio
+routing — the mirror-image counterpart of
+tests/voice/test_gemini_live_twilio_fork.py.
+
+Covers, per the integration task write-up:
+  - native-audio agents never construct SttPipeline on this transport either
+  - non-native-audio agent behavior on this transport is unchanged
+  - caller audio flows to GeminiLiveSession.send_audio via the
+    _GeminiLiveAudioSink adapter (LiveKitAudioSubscriber unmodified)
+  - agent audio flows to _LiveKitAgentAudioPublisher.publish_pcm (raw
+    PCM16/24kHz, no mu-law, no resampling) — NOT publish_mulaw
+  - the outbound publisher is opened at Gemini's 24kHz output rate for a
+    native-audio call, and at the usual 8kHz rate otherwise
+  - barge-in (on_interrupted) clears the LiveKit AudioSource's own playout
+    queue directly (no _send_twilio_clear_event on this transport)
+  - transcript callbacks write to call_transcript via _add_to_transcript
+    only on finished=True chunks (shared VoiceOrchestrator logic — reasserted
+    here against a real LiveKitBrowserCallHandler instance)
+  - _start_gemini_live_session must build the Gemini Live system_instruction
+    from ConversationOrchestrator.build_system_prompt (this transport's own
+    real prompt-assembly), never from Twilio's build_system_prompt — the
+    mirror-image regression guard of the bug fixed on the Twilio side.
+
+GeminiLiveSession itself is mocked throughout — no live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.llm_models import GEMINI_LIVE_MODELS
+from app.voice.gemini_live_audio_bridge import GEMINI_OUTPUT_PCM_RATE_HZ
+from app.voice.livekit_browser_call_handler import (
+    LiveKitBrowserCallHandler,
+    _AGENT_AUDIO_SAMPLE_RATE,
+    _GeminiLiveAudioSink,
+    _LiveKitAgentAudioPublisher,
+    run_livekit_browser_call,
+)
+from app.voice.voice_orchestrator import VoiceOrchestrator
+
+NATIVE_AUDIO_MODEL = next(iter(GEMINI_LIVE_MODELS))
+
+
+def _base_handler(llm_model: str | None) -> LiveKitBrowserCallHandler:
+    db = MagicMock()
+    call_session = MagicMock()
+    call_session.id = uuid.uuid4()
+    call_session.user_id = uuid.uuid4()
+    call_session.tenant_id = uuid.uuid4()
+    call_session.call_metadata = {}
+    call_session.call_transcript = []
+
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "Demo Agent"
+    agent.language = "en"
+    agent.voice_type = "female"
+    agent.llm_model = llm_model
+    agent.greeting_message = None
+    agent.first_message = None
+
+    return LiveKitBrowserCallHandler(db=db, call_session=call_session, agent=agent, call_flow=None)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _LiveKitAgentAudioPublisher.publish_pcm
+# ─────────────────────────────────────────────────────────────────────────
+
+class TestPublishPcm:
+    @pytest.mark.asyncio
+    async def test_noop_when_not_connected(self):
+        publisher = _LiveKitAgentAudioPublisher("room_x", sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+        await publisher.publish_pcm(b"\x00\x01" * 10, sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+        # No exception, no self._source ever touched (still None).
+        assert publisher._source is None
+
+    @pytest.mark.asyncio
+    async def test_noop_when_cancel_already_set(self):
+        publisher = _LiveKitAgentAudioPublisher("room_x", sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+        publisher._connected = True
+        mock_source = MagicMock()
+        mock_source.capture_frame = AsyncMock()
+        publisher._source = mock_source
+
+        cancel = asyncio.Event()
+        cancel.set()
+
+        await publisher.publish_pcm(b"\x00\x01" * 10, sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ, cancel=cancel)
+
+        mock_source.capture_frame.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_publishes_raw_pcm_frame_at_publisher_rate(self):
+        publisher = _LiveKitAgentAudioPublisher("room_x", sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+        publisher._connected = True
+        mock_source = MagicMock()
+        mock_source.capture_frame = AsyncMock()
+        publisher._source = mock_source
+
+        mock_rtc = MagicMock()
+        mock_frame = MagicMock()  # frame.data is a plain MagicMock so .cast(...)[:] = ... never raises
+        mock_rtc.AudioFrame.create.return_value = mock_frame
+
+        pcm = b"\x01\x02" * 10  # 10 samples
+        with patch.dict("sys.modules", {"livekit": MagicMock(rtc=mock_rtc)}):
+            await publisher.publish_pcm(pcm, sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+
+        mock_rtc.AudioFrame.create.assert_called_once_with(GEMINI_OUTPUT_PCM_RATE_HZ, 1, 10)
+        mock_source.capture_frame.assert_awaited_once_with(mock_frame)
+
+    @pytest.mark.asyncio
+    async def test_drops_trailing_odd_byte_rather_than_raising(self):
+        publisher = _LiveKitAgentAudioPublisher("room_x", sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+        publisher._connected = True
+        mock_source = MagicMock()
+        mock_source.capture_frame = AsyncMock()
+        publisher._source = mock_source
+
+        mock_rtc = MagicMock()
+        mock_rtc.AudioFrame.create.return_value = MagicMock(data=bytearray(20))
+
+        pcm = (b"\x01\x02" * 10) + b"\x99"  # trailing odd byte
+        with patch.dict("sys.modules", {"livekit": MagicMock(rtc=mock_rtc)}):
+            await publisher.publish_pcm(pcm, sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+
+        mock_rtc.AudioFrame.create.assert_called_once_with(GEMINI_OUTPUT_PCM_RATE_HZ, 1, 10)
+
+    @pytest.mark.asyncio
+    async def test_sample_rate_mismatch_drops_chunk_without_publishing(self):
+        """
+        A publisher opened at 24kHz must never be handed a chunk claiming a
+        different rate — no resampling is performed by publish_pcm (see its
+        docstring); mismatches are dropped, not silently mis-played.
+        """
+        publisher = _LiveKitAgentAudioPublisher("room_x", sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ)
+        publisher._connected = True
+        mock_source = MagicMock()
+        mock_source.capture_frame = AsyncMock()
+        publisher._source = mock_source
+
+        await publisher.publish_pcm(b"\x01\x02" * 10, sample_rate_hz=_AGENT_AUDIO_SAMPLE_RATE)
+
+        mock_source.capture_frame.assert_not_called()
+
+    def test_default_sample_rate_matches_legacy_tts_constant(self):
+        publisher = _LiveKitAgentAudioPublisher("room_x")
+        assert publisher.sample_rate == _AGENT_AUDIO_SAMPLE_RATE
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _GeminiLiveAudioSink — LiveKitAudioSubscriber's sink adapter
+# ─────────────────────────────────────────────────────────────────────────
+
+class TestGeminiLiveAudioSink:
+    @pytest.mark.asyncio
+    async def test_forwards_to_session_send_audio(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock()
+        sink = _GeminiLiveAudioSink(session)
+
+        await sink.feed_audio_chunk(b"\x01\x02pcm16-16k")
+
+        session.send_audio.assert_awaited_once_with(b"\x01\x02pcm16-16k")
+
+    @pytest.mark.asyncio
+    async def test_empty_chunk_is_a_noop(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock()
+        sink = _GeminiLiveAudioSink(session)
+
+        await sink.feed_audio_chunk(b"")
+
+        session.send_audio.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_audio_exception_is_swallowed(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock(side_effect=RuntimeError("session closed"))
+        sink = _GeminiLiveAudioSink(session)
+
+        # Must not raise.
+        await sink.feed_audio_chunk(b"\x01\x02")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# LiveKitBrowserCallHandler Gemini Live audio-out / barge-in glue
+# ─────────────────────────────────────────────────────────────────────────
+
+class TestHandlerGeminiLiveGlue:
+    @pytest.mark.asyncio
+    async def test_publish_gemini_live_audio_chunk_uses_publish_pcm_at_24k(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        publisher = MagicMock()
+        publisher.connected = True
+        publisher.publish_pcm = AsyncMock()
+        h._agent_publisher = publisher
+
+        cancel = asyncio.Event()
+        await h._publish_gemini_live_audio_chunk(b"pcm24k-bytes", cancel)
+
+        publisher.publish_pcm.assert_awaited_once_with(
+            b"pcm24k-bytes", sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ, cancel=cancel
+        )
+
+    @pytest.mark.asyncio
+    async def test_publish_gemini_live_audio_chunk_noop_when_no_publisher(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        h._agent_publisher = None
+        # Must not raise.
+        await h._publish_gemini_live_audio_chunk(b"pcm24k-bytes", asyncio.Event())
+
+    @pytest.mark.asyncio
+    async def test_clear_gemini_live_playout_queue_clears_source(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        publisher = MagicMock()
+        publisher._source = MagicMock()
+        h._agent_publisher = publisher
+
+        await h._clear_gemini_live_playout_queue()
+
+        publisher._source.clear_queue.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_clear_gemini_live_playout_queue_noop_when_no_publisher(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        h._agent_publisher = None
+        await h._clear_gemini_live_playout_queue()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_clear_gemini_live_playout_queue_swallows_exception(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        publisher = MagicMock()
+        publisher._source = MagicMock()
+        publisher._source.clear_queue.side_effect = RuntimeError("ffi handle disposed")
+        h._agent_publisher = publisher
+
+        await h._clear_gemini_live_playout_queue()  # must not raise
+
+    def test_handler_has_no_twilio_only_gemini_hooks(self):
+        """
+        VoiceOrchestrator._on_gemini_live_audio_chunk / _on_gemini_live_interrupted
+        duck-type on hasattr(h, "_stream_live_audio_chunk") /
+        hasattr(h, "_send_twilio_clear_event") to pick the Twilio branch —
+        the browser handler must NOT define either, or it would silently
+        (and incorrectly) take the Twilio mu-law path instead of its own.
+        """
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        assert not hasattr(h, "_stream_live_audio_chunk")
+        assert not hasattr(h, "_send_twilio_clear_event")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# VoiceOrchestrator's transport-aware branch, exercised against a real
+# LiveKitBrowserCallHandler (no build_system_prompt / _stream_live_audio_chunk
+# / _send_twilio_clear_event attributes — natural duck-typed browser fork).
+# ─────────────────────────────────────────────────────────────────────────
+
+class TestVoiceOrchestratorAudioConversionRoutingBrowser:
+    def test_is_gemini_live_resolved_from_agent_llm_model(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        assert orch._is_gemini_live is True
+
+    def test_non_native_model_is_gemini_live_false(self):
+        h = _base_handler("gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        assert orch._is_gemini_live is False
+
+    def test_on_audio_chunk_callback_publishes_raw_pcm_not_mulaw(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._publish_gemini_live_audio_chunk = AsyncMock()
+
+        asyncio.run(orch._on_gemini_live_audio_chunk(b"pcm24k-in"))
+
+        h._publish_gemini_live_audio_chunk.assert_awaited_once_with(
+            b"pcm24k-in", orch._gemini_live_cancel
+        )
+
+    def test_on_audio_chunk_callback_gated_by_cancel_flag(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._publish_gemini_live_audio_chunk = AsyncMock()
+        orch._gemini_live_cancel.set()
+
+        asyncio.run(orch._on_gemini_live_audio_chunk(b"pcm24k-in"))
+
+        h._publish_gemini_live_audio_chunk.assert_not_awaited()
+
+    def test_interrupted_clears_livekit_queue_not_twilio_event(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._clear_gemini_live_playout_queue = AsyncMock()
+        orch._gemini_live_first_audio_marked = True
+
+        asyncio.run(orch._on_gemini_live_interrupted())
+
+        h._clear_gemini_live_playout_queue.assert_awaited_once()
+        assert not orch._gemini_live_cancel.is_set()
+        assert orch._gemini_live_first_audio_marked is False
+
+    def test_input_transcript_written_only_when_finished(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._add_to_transcript = AsyncMock()
+
+        asyncio.run(orch._on_gemini_live_input_transcript("partial", False))
+        h._add_to_transcript.assert_not_awaited()
+
+        asyncio.run(orch._on_gemini_live_input_transcript("hello there", True))
+        h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+
+    def test_output_transcript_written_only_when_finished(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._add_to_transcript = AsyncMock()
+
+        asyncio.run(orch._on_gemini_live_output_transcript("partial reply", False))
+        h._add_to_transcript.assert_not_awaited()
+
+        asyncio.run(orch._on_gemini_live_output_transcript("Sure, I can help.", True))
+        h._add_to_transcript.assert_awaited_once_with(
+            "agent", "Sure, I can help.", "agent_response"
+        )
+
+    def test_mid_call_error_ends_call_via_full_shutdown(self):
+        from app.services.vertex_gemini_service import VertexLlmError, VertexLlmErrorType
+
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._full_shutdown = AsyncMock()
+
+        asyncio.run(orch._on_gemini_live_error(VertexLlmError("dropped", VertexLlmErrorType.UNKNOWN)))
+
+        h._full_shutdown.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# System-instruction source — mirror-image regression guard: browser must
+# use ConversationOrchestrator.build_system_prompt, never Twilio's method.
+# ─────────────────────────────────────────────────────────────────────────
+
+class TestGeminiLiveSessionUsesConversationOrchestratorPromptAssembly:
+    def test_start_gemini_live_session_uses_conversation_orchestrator(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        assert not hasattr(h, "build_system_prompt")  # duck-type must fail for browser
+
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ) as browser_build:
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        browser_build.assert_awaited_once()
+        fake_session.start.assert_awaited_once()
+        assert (
+            fake_session.start.call_args.kwargs["system_instruction"]
+            == "browser system prompt"
+        )
+        assert orch._gemini_live_session is fake_session
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# run_livekit_browser_call — full-lifecycle fork wiring
+# ─────────────────────────────────────────────────────────────────────────
+
+class TestRunLiveKitBrowserCallGeminiLiveFork:
+    def _call_session(self, call_session_id):
+        call_session = MagicMock()
+        call_session.id = call_session_id
+        call_session.call_flow_id = None
+        call_session.call_metadata = {}
+        return call_session
+
+    def _agent(self, llm_model):
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.llm_model = llm_model
+        agent.stt_provider_slug = None
+        agent.stt_model_id = None
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_native_audio_call_never_constructs_stt_pipeline_and_opens_24k_publisher(self):
+        call_session_id = uuid.uuid4()
+        call_session = self._call_session(call_session_id)
+        agent = self._agent(NATIVE_AUDIO_MODEL)
+        mock_db = MagicMock()
+
+        publisher_ctor_calls: list = []
+
+        class _FakePublisher:
+            def __init__(self, room_name, sample_rate_hz=_AGENT_AUDIO_SAMPLE_RATE):
+                publisher_ctor_calls.append(sample_rate_hz)
+                self._room_name = room_name
+                self._sample_rate = sample_rate_hz
+                self._room = MagicMock()
+                self.connected = True
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                return None
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        mock_subscriber_instance = MagicMock()
+        mock_subscriber_instance.run = AsyncMock()
+        mock_subscriber_instance.stop = AsyncMock()
+        subscriber_ctor_kwargs: list = []
+
+        class _FakeSubscriber:
+            def __init__(self, **kwargs):
+                subscriber_ctor_kwargs.append(kwargs)
+
+            async def run(self):
+                return None
+
+            async def stop(self):
+                return None
+
+        async def _immediately_stop(self, *_args, **_kwargs):
+            self._stop_event.set()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 new=_FakePublisher,
+             ), \
+             patch(
+                 "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+             ), \
+             patch(
+                 "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+                 new=AsyncMock(return_value="browser system prompt"),
+             ), \
+             patch("app.voice.stt_pipeline.SttPipeline.from_runtime_config") as mock_stt_ctor, \
+             patch(
+                 "app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber",
+                 new=_FakeSubscriber,
+             ), \
+             patch("app.services.call_session_service.call_session_service"), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._start_browser_call_recording",
+                 new=AsyncMock(return_value=None),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._stop_browser_call_recording",
+                 new=AsyncMock(),
+             ), \
+             patch.object(
+                 LiveKitBrowserCallHandler,
+                 "generate_and_stream_response",
+                 new=_immediately_stop,
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            await asyncio.wait_for(run_livekit_browser_call(call_session_id), timeout=5.0)
+
+        # SttPipeline never constructed for a native-audio call.
+        mock_stt_ctor.assert_not_called()
+        # Publisher opened at Gemini's 24kHz output rate, not the usual 8kHz.
+        assert publisher_ctor_calls == [GEMINI_OUTPUT_PCM_RATE_HZ]
+        # The audio subscriber was fed a _GeminiLiveAudioSink, not a raw SttPipeline.
+        assert len(subscriber_ctor_kwargs) == 1
+        sink = subscriber_ctor_kwargs[0]["stt_pipeline"]
+        assert isinstance(sink, _GeminiLiveAudioSink)
+        assert sink._session is fake_session
+        fake_session.start.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_native_call_still_constructs_stt_pipeline_and_8k_publisher(self):
+        """Existing browser call paths must be provably unchanged."""
+        from app.core.agent_runtime import ResolvedSttRuntime
+
+        call_session_id = uuid.uuid4()
+        call_session = self._call_session(call_session_id)
+        agent = self._agent("gpt-4o-mini")
+        mock_db = MagicMock()
+
+        publisher_ctor_calls: list = []
+
+        class _FakePublisher:
+            def __init__(self, room_name, sample_rate_hz=_AGENT_AUDIO_SAMPLE_RATE):
+                publisher_ctor_calls.append(sample_rate_hz)
+                self._room = MagicMock()
+                self.connected = True
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                return None
+
+        mock_subscriber_instance = MagicMock()
+        mock_subscriber_instance.run = AsyncMock()
+        mock_subscriber_instance.stop = AsyncMock()
+
+        async def _immediately_stop(self, *_args, **_kwargs):
+            self._stop_event.set()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 new=_FakePublisher,
+             ), \
+             patch("app.core.agent_runtime.resolve_stt_runtime") as mock_resolve_stt, \
+             patch(
+                 "app.voice.stt_pipeline.SttPipeline.from_runtime_config",
+                 return_value=MagicMock(),
+             ) as mock_stt_ctor, \
+             patch(
+                 "app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber",
+                 return_value=mock_subscriber_instance,
+             ), \
+             patch("app.services.call_session_service.call_session_service"), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._start_browser_call_recording",
+                 new=AsyncMock(return_value=None),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._stop_browser_call_recording",
+                 new=AsyncMock(),
+             ), \
+             patch.object(
+                 LiveKitBrowserCallHandler,
+                 "generate_and_stream_response",
+                 new=_immediately_stop,
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            mock_resolve_stt.return_value = ResolvedSttRuntime(
+                provider_slug="deepgram",
+                model_id="nova-3",
+                language_code="en",
+                sample_rate_hz=8000,
+                encoding="MULAW",
+                silence_threshold_ms=1500,
+                api_config={},
+            )
+            await asyncio.wait_for(run_livekit_browser_call(call_session_id), timeout=5.0)
+
+        mock_stt_ctor.assert_called_once()
+        assert publisher_ctor_calls == [_AGENT_AUDIO_SAMPLE_RATE]
+
+    @pytest.mark.asyncio
+    async def test_pre_session_failure_falls_back_to_legacy_stt_pipeline(self):
+        """
+        A GeminiLiveSession.start() failure before the session became usable
+        must fall back to the normal STT/TTS construction path for the rest
+        of the call (per _fallback_to_legacy_pipeline), not leave the
+        browser call silent.
+        """
+        from app.core.agent_runtime import ResolvedSttRuntime
+        from app.services.vertex_gemini_service import VertexLlmError, VertexLlmErrorType
+
+        call_session_id = uuid.uuid4()
+        call_session = self._call_session(call_session_id)
+        agent = self._agent(NATIVE_AUDIO_MODEL)
+        mock_db = MagicMock()
+
+        publisher_ctor_calls: list = []
+
+        class _FakePublisher:
+            def __init__(self, room_name, sample_rate_hz=_AGENT_AUDIO_SAMPLE_RATE):
+                publisher_ctor_calls.append(sample_rate_hz)
+                self._room = MagicMock()
+                self.connected = True
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                return None
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock(side_effect=VertexLlmError("boom", VertexLlmErrorType.QUOTA))
+
+        mock_subscriber_instance = MagicMock()
+        mock_subscriber_instance.run = AsyncMock()
+        mock_subscriber_instance.stop = AsyncMock()
+
+        async def _immediately_stop(self, *_args, **_kwargs):
+            self._stop_event.set()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 new=_FakePublisher,
+             ), \
+             patch(
+                 "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+             ), \
+             patch(
+                 "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+                 new=AsyncMock(return_value="browser system prompt"),
+             ), \
+             patch("app.core.agent_runtime.resolve_stt_runtime") as mock_resolve_stt, \
+             patch(
+                 "app.voice.stt_pipeline.SttPipeline.from_runtime_config",
+                 return_value=MagicMock(),
+             ) as mock_stt_ctor, \
+             patch(
+                 "app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber",
+                 return_value=mock_subscriber_instance,
+             ), \
+             patch("app.services.call_session_service.call_session_service"), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._start_browser_call_recording",
+                 new=AsyncMock(return_value=None),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._stop_browser_call_recording",
+                 new=AsyncMock(),
+             ), \
+             patch.object(
+                 LiveKitBrowserCallHandler,
+                 "generate_and_stream_response",
+                 new=_immediately_stop,
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            mock_resolve_stt.return_value = ResolvedSttRuntime(
+                provider_slug="deepgram",
+                model_id="nova-3",
+                language_code="en",
+                sample_rate_hz=8000,
+                encoding="MULAW",
+                silence_threshold_ms=1500,
+                api_config={},
+            )
+            await asyncio.wait_for(run_livekit_browser_call(call_session_id), timeout=5.0)
+
+        # Fallback happened -> publisher opened at the normal 8kHz rate, and
+        # the legacy SttPipeline construction path ran after all.
+        assert publisher_ctor_calls == [_AGENT_AUDIO_SAMPLE_RATE]
+        mock_stt_ctor.assert_called_once()
+        assert agent.llm_model == "gemini-2.5-flash"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Greeting must bypass external TTS for native-audio agents (mirror-image
+# regression guard of the same bug fixed on the Twilio side — see
+# tests/voice/test_gemini_live_twilio_fork.py::TestGreetingBypassesExternalTtsForNativeAudio
+# for the full bug writeup: the auto-greeting call site
+# (run_livekit_browser_call -> handler.generate_and_stream_response(...,
+# is_greeting=True)) originally queued the scripted greeting through
+# TtsPipeline unconditionally, producing pitch-shifted audio on this
+# transport since it flowed through publish_mulaw (assumes 8kHz) even though
+# the outbound AudioSource was opened at Gemini's 24kHz rate for these calls.
+# ─────────────────────────────────────────────────────────────────────────
+
+class TestBrowserGreetingBypassesExternalTtsForNativeAudio:
+    def _greeting_handler(self, *, is_gemini_live: bool) -> LiveKitBrowserCallHandler:
+        h = _base_handler(NATIVE_AUDIO_MODEL if is_gemini_live else "gpt-4o-mini")
+        h.agent.greeting_message = "Hi, thanks for calling the demo."
+        h.call_session.call_type = "inbound"
+        h._add_to_transcript = AsyncMock()
+        h._tts_pipeline = MagicMock()
+        h._tts_pipeline.queue_tts = AsyncMock()
+
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        vo = MagicMock()
+        vo._is_gemini_live = is_gemini_live
+        vo._gemini_live_session = fake_session if is_gemini_live else None
+        h._voice_orchestrator = vo
+        h._fake_session = fake_session
+        return h
+
+    @pytest.mark.asyncio
+    async def test_native_audio_greeting_uses_live_session_send_text_not_tts(self):
+        h = self._greeting_handler(is_gemini_live=True)
+
+        await h.generate_and_stream_response("", 1.0, is_greeting=True)
+
+        h._fake_session.send_text.assert_awaited_once_with(
+            "Hi, thanks for calling the demo.", turn_complete=True
+        )
+        h._tts_pipeline.queue_tts.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_native_audio_greeting_still_uses_external_tts(self):
+        h = self._greeting_handler(is_gemini_live=False)
+
+        await h.generate_and_stream_response("", 1.0, is_greeting=True)
+
+        h._tts_pipeline.queue_tts.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_voice_orchestrator_attribute_falls_back_to_external_tts(self):
+        h = self._greeting_handler(is_gemini_live=False)
+        del h._voice_orchestrator
+
+        await h.generate_and_stream_response("", 1.0, is_greeting=True)
+
+        h._tts_pipeline.queue_tts.assert_awaited_once()

--- a/tests/voice/test_gemini_live_browser_fork.py
+++ b/tests/voice/test_gemini_live_browser_fork.py
@@ -730,6 +730,8 @@ class TestBrowserGreetingBypassesExternalTtsForNativeAudio:
         vo = MagicMock()
         vo._is_gemini_live = is_gemini_live
         vo._gemini_live_session = fake_session if is_gemini_live else None
+        vo._is_openai_realtime = False
+        vo._openai_realtime_session = None
         h._voice_orchestrator = vo
         h._fake_session = fake_session
         return h

--- a/tests/voice/test_gemini_live_browser_fork.py
+++ b/tests/voice/test_gemini_live_browser_fork.py
@@ -14,9 +14,11 @@ Covers, per the integration task write-up:
     native-audio call, and at the usual 8kHz rate otherwise
   - barge-in (on_interrupted) clears the LiveKit AudioSource's own playout
     queue directly (no _send_twilio_clear_event on this transport)
-  - transcript callbacks write to call_transcript via _add_to_transcript
-    only on finished=True chunks (shared VoiceOrchestrator logic — reasserted
-    here against a real LiveKitBrowserCallHandler instance)
+  - transcript callbacks buffer every fragment (finished flag is unreliable)
+    and flush to call_transcript via _add_to_transcript on turn_complete /
+    next-turn's first output fragment / interrupted / shutdown (shared
+    VoiceOrchestrator logic — reasserted here against a real
+    LiveKitBrowserCallHandler instance)
   - _start_gemini_live_session must build the Gemini Live system_instruction
     from ConversationOrchestrator.build_system_prompt (this transport's own
     real prompt-assembly), never from Twilio's build_system_prompt — the
@@ -305,18 +307,25 @@ class TestVoiceOrchestratorAudioConversionRoutingBrowser:
         assert not orch._gemini_live_cancel.is_set()
         assert orch._gemini_live_first_audio_marked is False
 
-    def test_input_transcript_written_only_when_finished(self):
+    def test_input_transcript_fragments_buffered_until_flush(self):
+        """Mirrors tests/voice/test_gemini_live_twilio_fork.py::
+        TestTranscriptCallbacks — the buffering/flush behavior is identical
+        on both transports since it lives entirely in VoiceOrchestrator."""
         h = _base_handler(NATIVE_AUDIO_MODEL)
         orch = VoiceOrchestrator(h)
         h._add_to_transcript = AsyncMock()
 
         asyncio.run(orch._on_gemini_live_input_transcript("partial", False))
         h._add_to_transcript.assert_not_awaited()
+        assert orch._gemini_live_input_buffer == ["partial"]
 
-        asyncio.run(orch._on_gemini_live_input_transcript("hello there", True))
-        h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+        asyncio.run(orch._on_gemini_live_input_transcript(" hello there", True))
+        h._add_to_transcript.assert_not_awaited()
 
-    def test_output_transcript_written_only_when_finished(self):
+        asyncio.run(orch._on_gemini_live_turn_complete())
+        h._add_to_transcript.assert_awaited_once_with("client", "partial hello there", "speech")
+
+    def test_output_transcript_fragments_buffered_until_turn_complete(self):
         h = _base_handler(NATIVE_AUDIO_MODEL)
         orch = VoiceOrchestrator(h)
         h._add_to_transcript = AsyncMock()
@@ -324,9 +333,12 @@ class TestVoiceOrchestratorAudioConversionRoutingBrowser:
         asyncio.run(orch._on_gemini_live_output_transcript("partial reply", False))
         h._add_to_transcript.assert_not_awaited()
 
-        asyncio.run(orch._on_gemini_live_output_transcript("Sure, I can help.", True))
+        asyncio.run(orch._on_gemini_live_output_transcript(" Sure, I can help.", True))
+        h._add_to_transcript.assert_not_awaited()
+
+        asyncio.run(orch._on_gemini_live_turn_complete())
         h._add_to_transcript.assert_awaited_once_with(
-            "agent", "Sure, I can help.", "agent_response"
+            "agent", "partial reply Sure, I can help.", "agent_response"
         )
 
     def test_mid_call_error_ends_call_via_full_shutdown(self):

--- a/tests/voice/test_gemini_live_browser_fork.py
+++ b/tests/voice/test_gemini_live_browser_fork.py
@@ -371,6 +371,34 @@ class TestGeminiLiveSessionUsesConversationOrchestratorPromptAssembly:
         )
         assert orch._gemini_live_session is fake_session
 
+    def test_no_calendly_tool_calling_on_browser_transport(self):
+        """
+        LiveKitBrowserCallHandler has no BookingMixin at all (Calendly is
+        Twilio-only, per booking_mixin.py's own docstring) — confirms
+        _start_gemini_live_session's hasattr(h, "_calendly_enabled") guard
+        correctly passes tools=None / on_tool_call=None on this transport,
+        the mirror-image of
+        tests/voice/test_gemini_live_twilio_fork.py::TestCalendlyToolCallWiring.
+        """
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        assert not hasattr(h, "_calendly_enabled")
+
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is None
+        assert kwargs["on_tool_call"] is None
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # run_livekit_browser_call — full-lifecycle fork wiring

--- a/tests/voice/test_gemini_live_service.py
+++ b/tests/voice/test_gemini_live_service.py
@@ -1,0 +1,459 @@
+"""
+Unit tests for app/services/gemini_live_service.py — GeminiLiveSession.
+
+Follows tests/voice/test_vertex_llm.py's established pattern for mocking
+google.genai: tests/conftest.py stubs sys.modules["google.genai"] as a bare
+MagicMock() for the whole test session (so unrelated tests don't need real
+GCP credentials/SDK installed); tests here that need the real installed
+google-genai==2.3.0 types (SpeechConfig, LiveConnectConfig, Blob, etc.) use
+the same _real_google_genai() context-manager technique.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.llm_models import GEMINI_LIVE_MODELS
+from app.services.gemini_live_service import (
+    GeminiLiveSession,
+    _ensure_api_key_client,
+)
+from app.services.vertex_gemini_service import VertexLlmError, VertexLlmErrorType
+
+
+@contextlib.contextmanager
+def _real_google_genai():
+    """Temporarily undo conftest's google/google.genai MagicMock stub so
+    `import google.genai...` resolves to the real installed package for the
+    duration of the `with` block, then restores the stub. Mirrors
+    test_vertex_llm.py's identically-named helper."""
+    saved = {k: v for k, v in sys.modules.items() if k == "google" or k.startswith("google.")}
+    for k in list(saved):
+        del sys.modules[k]
+    try:
+        import google.genai.types as real_types
+        import google.genai.errors as real_errors
+
+        yield real_types, real_errors
+    finally:
+        for k in list(sys.modules):
+            if k == "google" or k.startswith("google."):
+                del sys.modules[k]
+        sys.modules.update(saved)
+
+
+class _FakeAsyncSession:
+    """Stands in for google.genai.live.AsyncSession."""
+
+    def __init__(self, messages=None):
+        self._messages = messages or []
+        self.send_realtime_input = AsyncMock()
+        self.send_client_content = AsyncMock()
+        self.send_tool_response = AsyncMock()
+
+    async def receive(self):
+        for m in self._messages:
+            yield m
+
+
+class _FakeConnectCM:
+    """Stands in for the object returned by client.aio.live.connect(...) —
+    an async context manager yielding a session (real SDK decorates connect
+    with @contextlib.asynccontextmanager)."""
+
+    def __init__(self, session):
+        self._session = session
+        self.aexit_called = False
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, *exc):
+        self.aexit_called = True
+        return False
+
+
+def _make_fake_client(session: _FakeAsyncSession):
+    connect_cm = _FakeConnectCM(session)
+    client = MagicMock()
+    client.aio.live.connect = MagicMock(return_value=connect_cm)
+    return client, connect_cm
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Construction / model validation
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGeminiLiveSessionConstruction:
+    @pytest.mark.parametrize("model_name", list(GEMINI_LIVE_MODELS.keys()))
+    def test_known_models_construct_successfully(self, model_name):
+        session = GeminiLiveSession(model_name)
+        assert session.model_name == model_name
+
+    def test_unknown_model_raises_value_error(self):
+        with pytest.raises(ValueError, match="not a Gemini Live native-audio model"):
+            GeminiLiveSession("gemini-2.5-flash")
+
+    def test_unknown_model_error_lists_valid_models(self):
+        with pytest.raises(ValueError) as exc_info:
+            GeminiLiveSession("totally-made-up-model")
+        for model_name in GEMINI_LIVE_MODELS:
+            assert model_name in str(exc_info.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Client construction per auth mode
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildClientPerAuthMode:
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "gemini-live-2.5-flash-native-audio",
+            "gemini-live-2.5-flash-preview-native-audio-09-2025",
+        ],
+    )
+    def test_vertex_models_use_ensure_vertex_client_with_us_central1(self, model_name):
+        """Both Vertex-auth models must route through the reused
+        _ensure_vertex_client(location) — never GEMINI_API_KEY."""
+        session = GeminiLiveSession(model_name)
+        mock_ensure = MagicMock(return_value="fake_vertex_client")
+
+        with patch("app.services.gemini_live_service._ensure_vertex_client", mock_ensure):
+            client = session._build_client()
+
+        assert client == "fake_vertex_client"
+        mock_ensure.assert_called_once_with("us-central1")
+
+    def test_api_key_model_uses_ensure_api_key_client(self):
+        session = GeminiLiveSession("gemini-3.1-flash-live-preview")
+        mock_ensure = MagicMock(return_value="fake_api_key_client")
+
+        with patch("app.services.gemini_live_service._ensure_api_key_client", mock_ensure):
+            client = session._build_client()
+
+        assert client == "fake_api_key_client"
+        mock_ensure.assert_called_once_with()
+
+    def test_ensure_api_key_client_reuses_settings_gemini_api_key(self, monkeypatch):
+        import app.services.gemini_live_service as mod
+
+        monkeypatch.setattr(mod, "_api_key_client", None)
+        monkeypatch.setattr(mod.settings, "GEMINI_API_KEY", "test-api-key-value")
+
+        fake_client_cls = MagicMock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs))
+        fake_genai = SimpleNamespace(Client=fake_client_cls)
+        monkeypatch.setitem(sys.modules, "google.genai", MagicMock())
+        monkeypatch.setattr(sys.modules["google"], "genai", fake_genai, raising=False)
+
+        client = _ensure_api_key_client()
+
+        fake_client_cls.assert_called_once_with(api_key="test-api-key-value")
+        assert client.api_key == "test-api-key-value"
+        monkeypatch.setattr(mod, "_api_key_client", None)
+
+    def test_ensure_api_key_client_caches_across_calls(self, monkeypatch):
+        import app.services.gemini_live_service as mod
+
+        monkeypatch.setattr(mod, "_api_key_client", None)
+        monkeypatch.setattr(mod.settings, "GEMINI_API_KEY", "test-api-key-value")
+
+        fake_client_cls = MagicMock(side_effect=lambda **kwargs: SimpleNamespace(**kwargs))
+        fake_genai = SimpleNamespace(Client=fake_client_cls)
+        monkeypatch.setattr(sys.modules["google"], "genai", fake_genai, raising=False)
+
+        client1 = _ensure_api_key_client()
+        client2 = _ensure_api_key_client()
+
+        assert client1 is client2
+        fake_client_cls.assert_called_once()
+        monkeypatch.setattr(mod, "_api_key_client", None)
+
+    def test_ensure_api_key_client_raises_when_no_api_key_configured(self, monkeypatch):
+        import app.services.gemini_live_service as mod
+
+        monkeypatch.setattr(mod, "_api_key_client", None)
+        monkeypatch.setattr(mod.settings, "GEMINI_API_KEY", "")
+
+        with pytest.raises(RuntimeError, match="GEMINI_API_KEY"):
+            _ensure_api_key_client()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# start() — connects and launches the receive loop
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestStart:
+    def test_start_connects_and_launches_receive_loop(self):
+        session_obj = _FakeAsyncSession(messages=[])
+        client, connect_cm = _make_fake_client(session_obj)
+
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+        async def _run():
+            with patch.object(gls, "_build_client", return_value=client):
+                await gls.start(
+                    system_instruction="be helpful",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await asyncio.sleep(0)  # let receive loop run to completion
+            await gls.close()
+
+        asyncio.run(_run())
+
+        client.aio.live.connect.assert_called_once()
+        assert client.aio.live.connect.call_args.kwargs["model"] == "gemini-3.1-flash-live-preview"
+        assert connect_cm.aexit_called is True
+
+    def test_start_failure_raises_vertex_llm_error(self):
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+        with patch.object(gls, "_build_client", side_effect=RuntimeError("boom")):
+            with pytest.raises(VertexLlmError):
+                asyncio.run(
+                    gls.start(
+                        system_instruction="hi",
+                        on_audio_chunk=AsyncMock(),
+                        on_interrupted=AsyncMock(),
+                    )
+                )
+
+    def test_connect_exception_translated_to_vertex_llm_error(self):
+        client = MagicMock()
+        client.aio.live.connect = MagicMock(side_effect=RuntimeError("quota exceeded"))
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+        with patch.object(gls, "_build_client", return_value=client):
+            with pytest.raises(VertexLlmError) as exc_info:
+                asyncio.run(
+                    gls.start(
+                        system_instruction="hi",
+                        on_audio_chunk=AsyncMock(),
+                        on_interrupted=AsyncMock(),
+                    )
+                )
+        assert exc_info.value.error_type == VertexLlmErrorType.QUOTA
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# send_audio — wraps the right Blob/mime_type
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestSendAudio:
+    def test_send_audio_wraps_blob_with_correct_mime_type(self):
+        with _real_google_genai():
+            session_obj = _FakeAsyncSession()
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+            gls._session = session_obj
+
+            asyncio.run(gls.send_audio(b"\x01\x02\x03\x04"))
+
+            session_obj.send_realtime_input.assert_awaited_once()
+            blob = session_obj.send_realtime_input.call_args.kwargs["audio"]
+            assert blob.data == b"\x01\x02\x03\x04"
+            assert blob.mime_type == "audio/pcm;rate=16000"
+
+    def test_send_text_wraps_content_and_turn_complete(self):
+        with _real_google_genai():
+            session_obj = _FakeAsyncSession()
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+            gls._session = session_obj
+
+            asyncio.run(gls.send_text("hello", turn_complete=False))
+
+            session_obj.send_client_content.assert_awaited_once()
+            kwargs = session_obj.send_client_content.call_args.kwargs
+            assert kwargs["turn_complete"] is False
+            turns = kwargs["turns"]
+            assert turns.role == "user"
+            assert turns.parts[0].text == "hello"
+
+    def test_send_tool_response_passthrough(self):
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+        session_obj = _FakeAsyncSession()
+        gls._session = session_obj
+
+        fake_responses = [SimpleNamespace(name="check_availability")]
+        asyncio.run(gls.send_tool_response(fake_responses))
+
+        session_obj.send_tool_response.assert_awaited_once_with(function_responses=fake_responses)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _receive_loop — demuxing each LiveServerMessage variant
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _msg(**kwargs) -> SimpleNamespace:
+    """Build a fake LiveServerMessage with only the requested attrs set;
+    all others resolve to None via getattr(..., default) in the source."""
+    base = dict(
+        setup_complete=None,
+        server_content=None,
+        tool_call=None,
+        tool_call_cancellation=None,
+        go_away=None,
+        session_resumption_update=None,
+    )
+    base.update(kwargs)
+    return SimpleNamespace(**base)
+
+
+class TestReceiveLoopDemux:
+    def _run_with_messages(self, messages, **callback_kwargs):
+        session_obj = _FakeAsyncSession(messages=messages)
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+        gls._session = session_obj
+        for name, cb in callback_kwargs.items():
+            setattr(gls, name, cb)
+
+        asyncio.run(gls._receive_loop())
+        return gls
+
+    def test_audio_chunk_demuxed_to_on_audio_chunk(self):
+        part = SimpleNamespace(inline_data=SimpleNamespace(data=b"\x00\x01", mime_type="audio/pcm;rate=24000"))
+        model_turn = SimpleNamespace(parts=[part])
+        server_content = SimpleNamespace(model_turn=model_turn, interrupted=False, input_transcription=None, output_transcription=None)
+        on_audio_chunk = AsyncMock()
+
+        self._run_with_messages([_msg(server_content=server_content)], on_audio_chunk=on_audio_chunk)
+
+        on_audio_chunk.assert_awaited_once_with(b"\x00\x01")
+
+    def test_interrupted_demuxed_to_on_interrupted(self):
+        server_content = SimpleNamespace(model_turn=None, interrupted=True, input_transcription=None, output_transcription=None)
+        on_interrupted = AsyncMock()
+
+        self._run_with_messages([_msg(server_content=server_content)], on_interrupted=on_interrupted)
+
+        on_interrupted.assert_awaited_once()
+
+    def test_input_transcript_demuxed(self):
+        transcript = SimpleNamespace(text="hello there", finished=True)
+        server_content = SimpleNamespace(model_turn=None, interrupted=False, input_transcription=transcript, output_transcription=None)
+        on_input_transcript = AsyncMock()
+
+        self._run_with_messages([_msg(server_content=server_content)], on_input_transcript=on_input_transcript)
+
+        on_input_transcript.assert_awaited_once_with("hello there", True)
+
+    def test_output_transcript_demuxed(self):
+        transcript = SimpleNamespace(text="hi, how can I help", finished=False)
+        server_content = SimpleNamespace(model_turn=None, interrupted=False, input_transcription=None, output_transcription=transcript)
+        on_output_transcript = AsyncMock()
+
+        self._run_with_messages([_msg(server_content=server_content)], on_output_transcript=on_output_transcript)
+
+        on_output_transcript.assert_awaited_once_with("hi, how can I help", False)
+
+    def test_tool_call_demuxed(self):
+        function_calls = [SimpleNamespace(name="check_availability", args={"date": "today"})]
+        tool_call = SimpleNamespace(function_calls=function_calls)
+        on_tool_call = AsyncMock()
+
+        self._run_with_messages([_msg(tool_call=tool_call)], on_tool_call=on_tool_call)
+
+        on_tool_call.assert_awaited_once_with(function_calls)
+
+    def test_go_away_logs_and_takes_no_action(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            self._run_with_messages([_msg(go_away=SimpleNamespace())])
+        assert any("go_away" in rec.message for rec in caplog.records)
+
+    def test_setup_complete_logged_no_callback_invoked(self):
+        on_audio_chunk = AsyncMock()
+        self._run_with_messages([_msg(setup_complete=SimpleNamespace())], on_audio_chunk=on_audio_chunk)
+        on_audio_chunk.assert_not_awaited()
+
+    def test_sdk_exception_translated_to_vertex_llm_error_and_routed_to_on_error(self):
+        class _BadMessage:
+            @property
+            def setup_complete(self):
+                raise RuntimeError("quota exceeded mid-stream")
+
+        on_error = AsyncMock()
+        self._run_with_messages([_BadMessage()], on_error=on_error)
+
+        on_error.assert_awaited_once()
+        err = on_error.call_args.args[0]
+        assert isinstance(err, VertexLlmError)
+        assert err.error_type == VertexLlmErrorType.QUOTA
+
+    def test_error_without_on_error_callback_is_logged_not_raised(self, caplog):
+        import logging
+
+        class _BadMessage:
+            @property
+            def setup_complete(self):
+                raise RuntimeError("boom")
+
+        with caplog.at_level(logging.ERROR):
+            self._run_with_messages([_BadMessage()])  # no on_error set
+        assert any("GeminiLiveSession" in rec.message for rec in caplog.records)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# close() — idempotent, never raises
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestClose:
+    def test_close_is_idempotent(self):
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+        asyncio.run(gls.close())
+        asyncio.run(gls.close())  # must not raise second time
+
+    def test_close_cancels_receive_task_and_exits_connect_cm(self):
+        session_obj = _FakeAsyncSession(messages=[])
+        client, connect_cm = _make_fake_client(session_obj)
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+        async def _run():
+            with patch.object(gls, "_build_client", return_value=client):
+                await gls.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await gls.close()
+
+        asyncio.run(_run())
+        assert connect_cm.aexit_called is True
+        assert gls._receive_task is None
+
+    def test_close_never_raises_even_if_session_teardown_errors(self):
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+        class _BadCM:
+            async def __aexit__(self, *exc):
+                raise RuntimeError("teardown boom")
+
+        gls._connect_cm = _BadCM()
+        # Must not raise.
+        asyncio.run(gls.close())
+
+    def test_close_never_raises_even_if_receive_task_already_dead(self):
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+        async def _dead_task_coro():
+            raise RuntimeError("already crashed")
+
+        async def _setup_and_close():
+            task = asyncio.create_task(_dead_task_coro())
+            await asyncio.sleep(0)  # let it crash
+            gls._receive_task = task
+            await gls.close()  # must not raise/propagate task's exception
+
+        asyncio.run(_setup_and_close())

--- a/tests/voice/test_gemini_live_service.py
+++ b/tests/voice/test_gemini_live_service.py
@@ -299,6 +299,67 @@ class TestSendAudio:
             assert blob.data == b"\x01\x02\x03\x04"
             assert blob.mime_type == "audio/pcm;rate=16000"
 
+    def test_send_audio_empty_bytes_is_noop(self):
+        with _real_google_genai():
+            session_obj = _FakeAsyncSession()
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+            gls._session = session_obj
+
+            asyncio.run(gls.send_audio(b""))
+
+            session_obj.send_realtime_input.assert_not_awaited()
+
+    def test_send_audio_noop_once_session_already_closed(self):
+        """Straggler audio chunks arriving after close() has already run
+        must never reach send_realtime_input() — mirrors
+        OpenAIRealtimeSession.send_audio's identical shutdown-race guard."""
+        with _real_google_genai():
+            session_obj = _FakeAsyncSession()
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+            gls._session = session_obj
+            gls._closed = True
+
+            asyncio.run(gls.send_audio(b"\x01\x02\x03\x04"))
+
+            session_obj.send_realtime_input.assert_not_awaited()
+
+    def test_send_audio_swallows_exception_when_closed_flips_mid_await(self):
+        """Mirrors OpenAIRealtimeSession's identical test: self._closed flips
+        to True while send_realtime_input() is in-flight and then raises —
+        the exception must be swallowed, not propagated, once the flip is
+        observed."""
+        with _real_google_genai():
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+            session_obj = MagicMock()
+
+            async def _send(**_kwargs):
+                gls._closed = True
+                raise ConnectionError("connection closed during send")
+
+            session_obj.send_realtime_input = AsyncMock(side_effect=_send)
+            gls._session = session_obj
+
+            # Must not raise.
+            asyncio.run(gls.send_audio(b"\x01\x02\x03\x04"))
+
+            session_obj.send_realtime_input.assert_awaited_once()
+
+    def test_send_audio_reraises_exception_when_not_closed(self):
+        """Sanity check for the opposite branch: a send() failure unrelated
+        to a concurrent close() must still propagate."""
+        with _real_google_genai():
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+            session_obj = MagicMock()
+            session_obj.send_realtime_input = AsyncMock(
+                side_effect=RuntimeError("genuine send failure")
+            )
+            gls._session = session_obj
+
+            with pytest.raises(RuntimeError, match="genuine send failure"):
+                asyncio.run(gls.send_audio(b"\x01\x02\x03\x04"))
+
     def test_send_text_wraps_content_and_turn_complete(self):
         with _real_google_genai():
             session_obj = _FakeAsyncSession()

--- a/tests/voice/test_gemini_live_service.py
+++ b/tests/voice/test_gemini_live_service.py
@@ -60,7 +60,13 @@ class _FakeAsyncSession:
         self.send_tool_response = AsyncMock()
 
     async def receive(self):
-        for m in self._messages:
+        # Mirrors the real SDK: one receive() call covers one turn's worth
+        # of messages. Once consumed, subsequent calls yield nothing (as if
+        # the connection produced no further data), so callers that loop
+        # `while True: async for m in session.receive(): ...` terminate
+        # instead of replaying the same messages forever.
+        messages, self._messages = self._messages, []
+        for m in messages:
             yield m
 
 

--- a/tests/voice/test_gemini_live_service.py
+++ b/tests/voice/test_gemini_live_service.py
@@ -365,6 +365,38 @@ class TestReceiveLoopDemux:
 
         on_output_transcript.assert_awaited_once_with("hi, how can I help", False)
 
+    def test_turn_complete_demuxed_to_on_turn_complete(self):
+        server_content = SimpleNamespace(
+            model_turn=None,
+            interrupted=False,
+            input_transcription=None,
+            output_transcription=None,
+            turn_complete=True,
+        )
+        on_turn_complete = AsyncMock()
+
+        self._run_with_messages(
+            [_msg(server_content=server_content)], on_turn_complete=on_turn_complete
+        )
+
+        on_turn_complete.assert_awaited_once_with()
+
+    def test_turn_complete_false_does_not_fire_callback(self):
+        server_content = SimpleNamespace(
+            model_turn=None,
+            interrupted=False,
+            input_transcription=None,
+            output_transcription=None,
+            turn_complete=False,
+        )
+        on_turn_complete = AsyncMock()
+
+        self._run_with_messages(
+            [_msg(server_content=server_content)], on_turn_complete=on_turn_complete
+        )
+
+        on_turn_complete.assert_not_awaited()
+
     def test_tool_call_demuxed(self):
         function_calls = [SimpleNamespace(name="check_availability", args={"date": "today"})]
         tool_call = SimpleNamespace(function_calls=function_calls)

--- a/tests/voice/test_gemini_live_service.py
+++ b/tests/voice/test_gemini_live_service.py
@@ -51,22 +51,49 @@ def _real_google_genai():
 
 
 class _FakeAsyncSession:
-    """Stands in for google.genai.live.AsyncSession."""
+    """Stands in for google.genai.live.AsyncSession.
 
-    def __init__(self, messages=None):
-        self._messages = messages or []
+    ``messages`` may be either:
+      * a flat list of fake ``LiveServerMessage``s (backward-compatible
+        shorthand for "a single turn's worth of messages" — the historical
+        shape every pre-existing test in this file uses), or
+      * a list of turn-batches (``list[list]``) — one inner list per
+        Gemini conversation turn — to simulate multiple sequential
+        ``receive()`` calls returning distinct turns, matching the real
+        SDK semantics that ``_receive_loop()``'s outer ``while True:``
+        depends on (each ``receive()`` call covers exactly one turn; the
+        next call yields the next turn's messages).
+
+    Each ``receive()`` call pops and yields the next turn-batch. Once all
+    batches are exhausted, further calls yield nothing (never replay) —
+    this is what lets tests rely on the "zero messages" guard in
+    ``_receive_loop()`` to end the loop naturally instead of hanging.
+    """
+
+    def __init__(self, messages=None, block_forever=False):
+        turns = messages or []
+        if turns and not isinstance(turns[0], list):
+            # Flat single-turn shorthand — wrap as the one-and-only batch.
+            turns = [turns]
+        self._turns = list(turns)
+        self._block_forever = block_forever
         self.send_realtime_input = AsyncMock()
         self.send_client_content = AsyncMock()
         self.send_tool_response = AsyncMock()
 
     async def receive(self):
-        # Mirrors the real SDK: one receive() call covers one turn's worth
-        # of messages. Once consumed, subsequent calls yield nothing (as if
-        # the connection produced no further data), so callers that loop
-        # `while True: async for m in session.receive(): ...` terminate
-        # instead of replaying the same messages forever.
-        messages, self._messages = self._messages, []
-        for m in messages:
+        if self._block_forever:
+            # Simulates a receive() call genuinely suspended waiting on the
+            # network — never resolves on its own; only cancellation (via
+            # close()) can end it. Used to verify close() cancels a task
+            # actually blocked *inside* receive(), not one that already
+            # exhausted an empty/finite generator.
+            await asyncio.Event().wait()
+            return
+        if not self._turns:
+            return
+        batch = self._turns.pop(0)
+        for m in batch:
             yield m
 
 
@@ -406,6 +433,44 @@ class TestReceiveLoopDemux:
 
         on_tool_call.assert_awaited_once_with(function_calls)
 
+    def test_receive_loop_continues_processing_after_first_turn_completes(self):
+        """Regression test for the outer `while True:` around
+        `session.receive()` in `_receive_loop()`. `session.receive()` only
+        covers a single turn per the real SDK; without the outer loop the
+        receive task would exit after the first turn's `turn_complete` and
+        never see turn 2's messages at all. Fails if that loop is reverted
+        to a single `async for message in self._session.receive(): ...`."""
+        turn1_content = SimpleNamespace(
+            model_turn=None,
+            interrupted=False,
+            input_transcription=None,
+            output_transcription=None,
+            turn_complete=True,
+        )
+        turn2_transcript = SimpleNamespace(text="second turn arrived", finished=True)
+        turn2_content = SimpleNamespace(
+            model_turn=None,
+            interrupted=False,
+            input_transcription=turn2_transcript,
+            output_transcription=None,
+        )
+
+        on_turn_complete = AsyncMock()
+        on_input_transcript = AsyncMock()
+
+        gls = self._run_with_messages(
+            [
+                [_msg(server_content=turn1_content)],
+                [_msg(server_content=turn2_content)],
+            ],
+            on_turn_complete=on_turn_complete,
+            on_input_transcript=on_input_transcript,
+        )
+
+        on_turn_complete.assert_awaited_once_with()
+        on_input_transcript.assert_awaited_once_with("second turn arrived", True)
+        assert gls is not None
+
     def test_go_away_logs_and_takes_no_action(self, caplog):
         import logging
 
@@ -469,6 +534,37 @@ class TestClose:
                     on_interrupted=AsyncMock(),
                 )
             await gls.close()
+
+        asyncio.run(_run())
+        assert connect_cm.aexit_called is True
+        assert gls._receive_task is None
+
+    def test_close_cancels_receive_task_while_genuinely_blocked_in_receive(self):
+        """`messages=[]` alone lets the loop's zero-messages guard exit the
+        receive task on its own before close()'s `.cancel()` is ever
+        meaningfully exercised. Use a session whose `receive()` never
+        resolves on its own, so close() must cancel a task that is
+        genuinely suspended *inside* `receive()`, not one that already
+        finished."""
+        session_obj = _FakeAsyncSession(block_forever=True)
+        client, connect_cm = _make_fake_client(session_obj)
+        gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+        async def _run():
+            with patch.object(gls, "_build_client", return_value=client):
+                await gls.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await asyncio.sleep(0)  # let the receive task actually start blocking
+            task = gls._receive_task
+            assert task is not None
+            assert not task.done()
+
+            await gls.close()
+
+            assert task.cancelled()
 
         asyncio.run(_run())
         assert connect_cm.aexit_called is True

--- a/tests/voice/test_gemini_live_service.py
+++ b/tests/voice/test_gemini_live_service.py
@@ -20,8 +20,11 @@ import pytest
 
 from app.core.llm_models import GEMINI_LIVE_MODELS
 from app.services.gemini_live_service import (
+    DEFAULT_VOICE_NAME,
+    VALID_VOICE_NAMES,
     GeminiLiveSession,
     _ensure_api_key_client,
+    resolve_voice_name,
 )
 from app.services.vertex_gemini_service import VertexLlmError, VertexLlmErrorType
 
@@ -457,3 +460,31 @@ class TestClose:
             await gls.close()  # must not raise/propagate task's exception
 
         asyncio.run(_setup_and_close())
+
+
+class TestResolveVoiceName:
+    def test_none_falls_back_to_default(self):
+        assert resolve_voice_name(None) == DEFAULT_VOICE_NAME
+
+    def test_empty_string_falls_back_to_default(self):
+        assert resolve_voice_name("") == DEFAULT_VOICE_NAME
+
+    def test_valid_voice_name_passthrough(self):
+        assert resolve_voice_name("Charon") == "Charon"
+
+    def test_case_insensitive_match_normalized_to_canonical_casing(self):
+        assert resolve_voice_name("charon") == "Charon"
+        assert resolve_voice_name("CHARON") == "Charon"
+
+    def test_whitespace_stripped(self):
+        assert resolve_voice_name("  Kore  ") == "Kore"
+
+    def test_unknown_voice_falls_back_to_default(self):
+        # A leftover ElevenLabs/Rime/Google TTS voice ID — must never be
+        # passed through raw to PrebuiltVoiceConfig.
+        assert resolve_voice_name("21m00Tcm4TlvDq8ikWAM") == DEFAULT_VOICE_NAME
+
+    def test_all_thirty_voices_are_valid_and_distinct(self):
+        assert len(VALID_VOICE_NAMES) == 30
+        for name in VALID_VOICE_NAMES:
+            assert resolve_voice_name(name) == name

--- a/tests/voice/test_gemini_live_twilio_fork.py
+++ b/tests/voice/test_gemini_live_twilio_fork.py
@@ -575,6 +575,8 @@ class TestGreetingBypassesExternalTtsForNativeAudio:
         vo = MagicMock()
         vo._is_gemini_live = is_gemini_live
         vo._gemini_live_session = fake_session if is_gemini_live else None
+        vo._is_openai_realtime = False
+        vo._openai_realtime_session = None
         h._voice_orchestrator = vo
         h._fake_session = fake_session  # test-only handle
         return h

--- a/tests/voice/test_gemini_live_twilio_fork.py
+++ b/tests/voice/test_gemini_live_twilio_fork.py
@@ -1,0 +1,483 @@
+"""
+Twilio-transport fork-point tests for Gemini Live native-audio routing
+(VoiceOrchestrator.on_audio_chunk -> _feed_gemini_live_audio /
+_start_gemini_live_session / _on_gemini_live_* callbacks).
+
+Covers, per the integration task write-up:
+  - native-audio agents never construct SttPipeline
+  - non-native-audio agent behavior is unchanged (SttPipeline still lazily
+    created, GeminiLiveSession never touched)
+  - caller/agent audio flows through the right conversion functions
+    (mulaw8k_to_pcm16_16k / pcm16_24k_to_mulaw8k)
+  - barge-in (on_interrupted) gates the outbound send loop
+  - transcript callbacks write to call_transcript via _add_to_transcript
+    only on finished=True chunks
+  - pre-session GeminiLiveSession.start() failure falls back to the legacy
+    text pipeline (in-memory agent.llm_model swap), not a silent hang
+
+GeminiLiveSession itself is mocked throughout — no live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.core.llm_models import GEMINI_LIVE_MODELS
+from app.routers.bidirectional_stream import BidirectionalStreamHandler as Handler
+from app.voice.voice_orchestrator import (
+    VoiceOrchestrator,
+    _GEMINI_LIVE_FALLBACK_TEXT_MODEL,
+)
+
+
+NATIVE_AUDIO_MODEL = next(iter(GEMINI_LIVE_MODELS))
+
+
+class _FalsyCallSession:
+    """Falsy call_session so build_system_prompt's DB-dependent branches
+    (CRM/KB/caller-memory) are skipped — mirrors the pattern already used in
+    tests/voice/test_bracket_tag_prompt_consistency.py."""
+
+    def __bool__(self) -> bool:
+        return False
+
+
+def _fake_handler(*, llm_model: str | None) -> Handler:
+    """Minimal Twilio handler via object.__new__ — enough attributes for
+    VoiceOrchestrator.__init__ + on_audio_chunk's pickup-detection gate +
+    the Gemini Live fork, without touching a real DB/WebSocket."""
+    h = object.__new__(Handler)
+
+    h.agent = MagicMock()
+    h.agent.id = uuid.uuid4()
+    h.agent.name = "TestAgent"
+    h.agent.llm_model = llm_model
+    h.agent.system_prompt = None
+    h.agent.model = MagicMock()
+    h.agent.model.system_prompt = None
+    h.agent.transfer_route = None
+
+    h.call_session = _FalsyCallSession()
+    h.call_flow = None
+    h.db = None
+    h.call_session_id = "test-session-id"
+    h.agent_id = str(h.agent.id)
+    h.call_sid = "CA_test"
+    h.stream_sid = "MZ_test"
+
+    # Audio thresholds read by VoiceOrchestrator.__init__
+    h._min_audio_level_threshold = 30
+    h._audio_samples_needed = 1
+    h._audio_non_silent_needed = 1
+
+    h._enable_interim_llm = False
+    h._min_interim_words = 3
+    h._min_interim_confidence = 0.4
+    h._min_interim_interval_sec = 0.2
+    h._barge_in_min_conf = 0.26
+    h._barge_in_min_conf_1w = 0.52
+
+    h._voice_metrics = MagicMock()
+    h._add_to_transcript = AsyncMock()
+    h._send_twilio_clear_event = AsyncMock()
+    h._stream_live_audio_chunk = AsyncMock()
+    h._full_shutdown = AsyncMock()
+    h.websocket = MagicMock()
+
+    return h
+
+
+def _loud_frame() -> bytes:
+    """A single MULAW byte pattern whose linear RMS clears the pickup
+    threshold immediately (threshold=30, samples_needed=1 above)."""
+    return bytes([0x00]) * 160  # MULAW 0x00 decodes to a large-magnitude sample
+
+
+class TestNativeAudioRoutingResolution:
+    def test_native_audio_model_sets_is_gemini_live_true(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        assert orch._is_gemini_live is True
+
+    def test_non_native_model_sets_is_gemini_live_false(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        assert orch._is_gemini_live is False
+
+    def test_no_agent_defaults_to_false(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        h.agent = None
+        orch = VoiceOrchestrator(h)
+        assert orch._is_gemini_live is False
+
+
+class TestNativeAudioNeverConstructsSttPipeline:
+    def test_native_audio_agent_skips_stt_pipeline_construction(self, monkeypatch):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._user_picked_up = True  # skip pickup-detection gate for this test
+        h._handle_user_pickup = AsyncMock()
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+        fake_session.send_audio = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch.on_audio_chunk(_loud_frame()))
+
+        assert orch._stt_pipeline is None
+        fake_session.start.assert_awaited_once()
+        fake_session.send_audio.assert_awaited_once()
+
+    def test_non_native_agent_still_constructs_stt_pipeline(self, monkeypatch):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        orch._user_picked_up = True
+        h._handle_user_pickup = AsyncMock()
+
+        fake_stt = MagicMock()
+        fake_stt.feed_audio_chunk = AsyncMock()
+        with patch("app.voice.voice_orchestrator.SttPipeline", return_value=fake_stt):
+            asyncio.run(orch.on_audio_chunk(_loud_frame()))
+
+        assert orch._stt_pipeline is fake_stt
+        assert orch._gemini_live_session is None
+        fake_stt.feed_audio_chunk.assert_awaited_once()
+
+
+class TestAudioConversionRouting:
+    def test_send_audio_receives_pcm16_16k_conversion(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.send_audio = AsyncMock()
+        orch._gemini_live_session = fake_session  # session already "started"
+
+        mulaw = _loud_frame()
+        with patch(
+            "app.voice.voice_orchestrator.mulaw8k_to_pcm16_16k",
+            return_value=b"\x01\x02converted",
+        ) as conv:
+            asyncio.run(orch._feed_gemini_live_audio(h, mulaw))
+
+        conv.assert_called_once_with(mulaw)
+        fake_session.send_audio.assert_awaited_once_with(b"\x01\x02converted")
+
+    def test_on_audio_chunk_callback_converts_and_streams_mulaw(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        with patch(
+            "app.voice.voice_orchestrator.pcm16_24k_to_mulaw8k",
+            return_value=b"mulaw-out",
+        ) as conv:
+            asyncio.run(orch._on_gemini_live_audio_chunk(b"pcm24k-in"))
+
+        conv.assert_called_once_with(b"pcm24k-in")
+        h._stream_live_audio_chunk.assert_awaited_once_with(b"mulaw-out")
+
+    def test_on_audio_chunk_callback_gated_by_cancel_flag(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._gemini_live_cancel.set()
+
+        asyncio.run(orch._on_gemini_live_audio_chunk(b"pcm24k-in"))
+
+        h._stream_live_audio_chunk.assert_not_awaited()
+
+
+class TestBargeIn:
+    def test_interrupted_sets_cancel_and_clears_twilio_buffer(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._gemini_live_first_audio_marked = True
+
+        asyncio.run(orch._on_gemini_live_interrupted())
+
+        h._send_twilio_clear_event.assert_awaited_once()
+        # Reset for the next turn, mirroring _tts_cancel.clear() convention.
+        assert not orch._gemini_live_cancel.is_set()
+        assert orch._gemini_live_first_audio_marked is False
+
+
+class TestTranscriptCallbacks:
+    def test_input_transcript_written_only_when_finished(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_input_transcript("partial", False))
+        h._add_to_transcript.assert_not_awaited()
+
+        asyncio.run(orch._on_gemini_live_input_transcript("hello there", True))
+        h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+
+    def test_output_transcript_written_only_when_finished(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_output_transcript("partial reply", False))
+        h._add_to_transcript.assert_not_awaited()
+
+        asyncio.run(orch._on_gemini_live_output_transcript("Sure, I can help.", True))
+        h._add_to_transcript.assert_awaited_once_with(
+            "agent", "Sure, I can help.", "agent_response"
+        )
+
+    def test_blank_finished_transcript_not_written(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_input_transcript("   ", True))
+        h._add_to_transcript.assert_not_awaited()
+
+
+class TestPreSessionFallback:
+    def test_start_failure_falls_back_to_legacy_text_model(self):
+        from app.services.vertex_gemini_service import VertexLlmError, VertexLlmErrorType
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock(
+            side_effect=VertexLlmError("boom", VertexLlmErrorType.QUOTA)
+        )
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        assert orch._gemini_live_setup_failed is True
+        assert orch._is_gemini_live is False
+        assert orch._gemini_live_session is None
+        assert h.agent.llm_model == _GEMINI_LIVE_FALLBACK_TEXT_MODEL
+        h._full_shutdown.assert_not_awaited()
+
+    def test_fallback_with_no_agent_ends_call_gracefully(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h.agent = None
+
+        asyncio.run(orch._fallback_to_legacy_pipeline(h, reason="no agent"))
+
+        assert orch._gemini_live_setup_failed is True
+        h._full_shutdown.assert_called_once()
+
+
+class TestMidCallError:
+    def test_mid_call_error_ends_call_gracefully(self):
+        from app.services.vertex_gemini_service import VertexLlmError, VertexLlmErrorType
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(
+            orch._on_gemini_live_error(VertexLlmError("dropped", VertexLlmErrorType.UNKNOWN))
+        )
+
+        h._full_shutdown.assert_called_once()
+
+
+def _fake_handler_for_real_prompt_build(*, llm_model: str) -> Handler:
+    """
+    A Twilio handler with enough real attributes for
+    `BidirectionalStreamHandler.build_system_prompt` (the REAL implementation,
+    not mocked) to run to completion without a DB/WebSocket. Mirrors the
+    attribute set `ConversationOrchestrator.build_system_prompt`'s own test
+    fixture (`tests/voice/test_bracket_tag_prompt_consistency.py::
+    _fake_livekit_handler`) uses for the browser path, adapted to the
+    Twilio-only locals this method also touches (booking-memory tri-state,
+    JD/recruitment screening check, RAG prefetch slot).
+    """
+    h = _fake_handler(llm_model=llm_model)
+    h.agent.language = "en"
+    h.agent.model.api_key = None
+    h.agent.is_inbound_agent = False
+    h.agent.tts_provider = None
+    h.call_session = None  # no DB-backed session -> CRM/KB/history branches skipped
+    h.db = None
+    h._last_offered_calendar_slots = []
+    h._last_requested_calendar_date = None
+    h._last_selected_calendar_slot = None
+    h._conversation_history_cache = []
+    h.HISTORY_MAX_MESSAGES = 20
+    h._metric_stt_final_ts = 0.0
+    h._rag_prefetch_task = None
+    h._kb_cache_ready = False
+    h._cached_inbound_kb_block = ""
+    h._jd_recruitment_screening_active = lambda: False
+    h._send_quick_acknowledgement = AsyncMock()
+    return h
+
+
+class TestGeminiLiveSessionUsesTwilioOwnPromptAssembly:
+    """
+    Regression guard for the bug this task fixes: `_start_gemini_live_session`
+    must build the Gemini Live `system_instruction` from
+    `BidirectionalStreamHandler.build_system_prompt` (Twilio's own, real
+    prompt-assembly logic — the one `generate_and_stream_response` actually
+    uses), never from `ConversationOrchestrator.build_system_prompt` (the
+    separate, LiveKit-browser-only implementation, which does not build a
+    "# CURRENT DATE & TIME" header, a booking-memory block, or any of the
+    other Twilio-specific blocks asserted below).
+    """
+
+    def test_build_system_prompt_contains_twilio_only_date_time_header(self):
+        h = _fake_handler_for_real_prompt_build(llm_model="gpt-4o-mini")
+
+        prompt = asyncio.run(h.build_system_prompt(user_text="", confidence=1.0))
+
+        # ConversationOrchestrator.build_system_prompt (browser) never emits
+        # this header at all — see app/voice/conversation_orchestrator.py.
+        assert "# CURRENT DATE & TIME" in prompt
+        assert "Now:" in prompt
+
+    def test_start_gemini_live_session_uses_handlers_own_build_system_prompt(self):
+        """
+        End-to-end through the real fork point: only GeminiLiveSession is
+        mocked, so the system_instruction passed to `session.start(...)` is
+        whatever `BidirectionalStreamHandler.build_system_prompt` (the real,
+        unmocked implementation) produces.
+        """
+        h = _fake_handler_for_real_prompt_build(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        fake_session.start.assert_awaited_once()
+        system_instruction = fake_session.start.call_args.kwargs["system_instruction"]
+        assert "# CURRENT DATE & TIME" in system_instruction
+
+    def test_browser_handler_still_uses_conversation_orchestrator(self):
+        """
+        The browser branch (LiveKitBrowserCallHandler — has no
+        `build_system_prompt` method of its own) must remain unchanged: it
+        still routes through `ConversationOrchestrator.build_system_prompt`.
+        """
+        h = MagicMock(spec=[])  # no build_system_prompt attribute -> duck-type fails
+        h.agent = MagicMock()
+        h.agent.llm_model = NATIVE_AUDIO_MODEL
+        h.call_session_id = "test-session-id"
+
+        assert not hasattr(h, "build_system_prompt")
+
+        orch = VoiceOrchestrator.__new__(VoiceOrchestrator)
+        orch._gemini_live_session = None
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ) as browser_build:
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        browser_build.assert_awaited_once()
+        fake_session.start.assert_awaited_once()
+        assert (
+            fake_session.start.call_args.kwargs["system_instruction"]
+            == "browser system prompt"
+        )
+
+
+class TestGreetingBypassesExternalTtsForNativeAudio:
+    """
+    Regression guard for a real bug caught in code review: the auto-greeting
+    path (BidirectionalStreamHandler.generate_and_stream_response's
+    is_greeting=True branch) originally queued the scripted greeting through
+    TtsPipeline/the external TTS provider unconditionally, for EVERY agent —
+    including native-audio ones, which must never invoke external TTS. Ran
+    up real vendor cost and (on the browser transport) produced pitch-shifted
+    audio. Neither of this file's other test classes (which only exercise
+    on_audio_chunk/_start_gemini_live_session directly) would have caught
+    this, since the bug was in a separate call path (_handle_user_pickup ->
+    generate_and_stream_response(is_greeting=True)) that never goes through
+    on_audio_chunk at all.
+    """
+
+    def _greeting_handler(self, *, is_gemini_live: bool) -> Handler:
+        h = object.__new__(Handler)
+        h.agent = MagicMock()
+        h.agent.greeting_message = "Hi, thanks for calling Acme."
+        h.agent.first_message = None
+        h.call_session = MagicMock()
+        h.call_session.call_type = "inbound"
+        h.call_session.call_metadata = {}
+        h.call_session.id = uuid.uuid4()
+        h.db = None
+        h._flow_executor = None
+        h._add_to_transcript = AsyncMock()
+        h._twilio_buffer_primed = True
+        h._use_ssml = True
+        h._jd_recruitment_screening_active = MagicMock(return_value=False)
+
+        h._tts_pipeline = MagicMock()
+        h._tts_pipeline.queue_tts = AsyncMock()
+
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        vo = MagicMock()
+        vo._is_gemini_live = is_gemini_live
+        vo._gemini_live_session = fake_session if is_gemini_live else None
+        h._voice_orchestrator = vo
+        h._fake_session = fake_session  # test-only handle
+        return h
+
+    def test_native_audio_greeting_uses_live_session_send_text_not_tts(self):
+        h = self._greeting_handler(is_gemini_live=True)
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._fake_session.send_text.assert_awaited_once_with(
+            "Hi, thanks for calling Acme.", turn_complete=True
+        )
+        h._tts_pipeline.queue_tts.assert_not_awaited()
+
+    def test_native_audio_greeting_skips_gracefully_if_session_not_ready(self):
+        h = self._greeting_handler(is_gemini_live=True)
+        h._voice_orchestrator._gemini_live_session = None
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._tts_pipeline.queue_tts.assert_not_awaited()
+
+    def test_non_native_audio_greeting_still_uses_external_tts(self):
+        h = self._greeting_handler(is_gemini_live=False)
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._tts_pipeline.queue_tts.assert_awaited_once()
+        queued = h._tts_pipeline.queue_tts.call_args[0][0]
+        assert queued["text"] == "Hi, thanks for calling Acme."
+
+    def test_missing_voice_orchestrator_attribute_falls_back_to_external_tts(self):
+        """A handler built without a real __init__ (e.g. other lightweight
+        test doubles in this test suite) has no _voice_orchestrator at all —
+        must not crash, must behave like a non-native-audio agent."""
+        h = self._greeting_handler(is_gemini_live=False)
+        del h._voice_orchestrator
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._tts_pipeline.queue_tts.assert_awaited_once()

--- a/tests/voice/test_gemini_live_twilio_fork.py
+++ b/tests/voice/test_gemini_live_twilio_fork.py
@@ -10,8 +10,9 @@ Covers, per the integration task write-up:
   - caller/agent audio flows through the right conversion functions
     (mulaw8k_to_pcm16_16k / pcm16_24k_to_mulaw8k)
   - barge-in (on_interrupted) gates the outbound send loop
-  - transcript callbacks write to call_transcript via _add_to_transcript
-    only on finished=True chunks
+  - transcript callbacks buffer every fragment (finished flag is unreliable)
+    and flush to call_transcript via _add_to_transcript on turn_complete /
+    next-turn's first output fragment / interrupted / shutdown
   - pre-session GeminiLiveSession.start() failure falls back to the legacy
     text pipeline (in-memory agent.llm_model swap), not a silent hang
 
@@ -209,34 +210,118 @@ class TestBargeIn:
 
 
 class TestTranscriptCallbacks:
-    def test_input_transcript_written_only_when_finished(self):
+    """Google's Live API doesn't reliably send a per-fragment `finished`
+    flag (googleapis/js-genai#1429), so fragments are unconditionally
+    buffered and only written to call_transcript on a reliable flush signal
+    (next turn's first output fragment / turn_complete / interrupted /
+    shutdown) — see _on_gemini_live_input_transcript's docstring."""
+
+    def test_input_fragments_are_buffered_not_written_immediately(self):
         h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
         orch = VoiceOrchestrator(h)
 
         asyncio.run(orch._on_gemini_live_input_transcript("partial", False))
         h._add_to_transcript.assert_not_awaited()
+        assert orch._gemini_live_input_buffer == ["partial"]
 
-        asyncio.run(orch._on_gemini_live_input_transcript("hello there", True))
+        # Even a fragment carrying finished=True is just buffered, not flushed —
+        # the flag is unreliable and can't be trusted as a turn boundary.
+        asyncio.run(orch._on_gemini_live_input_transcript(" hello there", True))
+        h._add_to_transcript.assert_not_awaited()
+        assert orch._gemini_live_input_buffer == ["partial", " hello there"]
+
+    def test_input_buffer_flushed_on_first_output_fragment(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_input_transcript("hello", False))
+        asyncio.run(orch._on_gemini_live_input_transcript(" there", False))
+        h._add_to_transcript.assert_not_awaited()
+
+        # First output fragment of the next turn is the implicit "caller
+        # finished speaking" signal — flushes the input buffer first.
+        asyncio.run(orch._on_gemini_live_output_transcript("Sure", False))
+
         h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+        assert orch._gemini_live_input_buffer == []
+        assert orch._gemini_live_output_buffer == ["Sure"]
 
-    def test_output_transcript_written_only_when_finished(self):
+    def test_output_fragments_are_buffered_not_written_immediately(self):
         h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
         orch = VoiceOrchestrator(h)
 
         asyncio.run(orch._on_gemini_live_output_transcript("partial reply", False))
         h._add_to_transcript.assert_not_awaited()
+        assert orch._gemini_live_output_buffer == ["partial reply"]
 
-        asyncio.run(orch._on_gemini_live_output_transcript("Sure, I can help.", True))
+        asyncio.run(orch._on_gemini_live_output_transcript(" continued.", True))
+        h._add_to_transcript.assert_not_awaited()
+        assert orch._gemini_live_output_buffer == ["partial reply", " continued."]
+
+    def test_output_buffer_flushed_on_turn_complete(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_output_transcript("Sure, ", False))
+        asyncio.run(orch._on_gemini_live_output_transcript("I can help.", False))
+        h._add_to_transcript.assert_not_awaited()
+
+        asyncio.run(orch._on_gemini_live_turn_complete())
+
         h._add_to_transcript.assert_awaited_once_with(
             "agent", "Sure, I can help.", "agent_response"
         )
+        assert orch._gemini_live_output_buffer == []
+
+    def test_turn_complete_is_a_safety_net_for_tool_call_only_turns(self):
+        """A turn with no output-transcript fragments at all (e.g.
+        tool-call-only) must still flush any buffered input rather than
+        leaking the caller's utterance forever, and must not error when the
+        output buffer is empty."""
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_input_transcript("book a meeting", False))
+
+        asyncio.run(orch._on_gemini_live_turn_complete())
+
+        h._add_to_transcript.assert_awaited_once_with("client", "book a meeting", "speech")
+        assert orch._gemini_live_input_buffer == []
+        assert orch._gemini_live_output_buffer == []
+
+    def test_turn_complete_with_nothing_buffered_is_a_noop(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_turn_complete())
+
+        h._add_to_transcript.assert_not_awaited()
 
     def test_blank_finished_transcript_not_written(self):
         h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
         orch = VoiceOrchestrator(h)
 
         asyncio.run(orch._on_gemini_live_input_transcript("   ", True))
+        asyncio.run(orch._on_gemini_live_turn_complete())
         h._add_to_transcript.assert_not_awaited()
+
+    def test_interrupted_flushes_both_buffers(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_gemini_live_input_transcript("wait, ", False))
+        asyncio.run(orch._on_gemini_live_output_transcript("Sure I", False))
+
+        asyncio.run(orch._on_gemini_live_interrupted())
+
+        # Input buffer is already flushed by the output fragment above; only
+        # the output buffer remains for interrupted to flush.
+        assert h._add_to_transcript.await_args_list == [
+            (("client", "wait,", "speech"), {}),
+            (("agent", "Sure I", "agent_response"), {}),
+        ]
+        assert orch._gemini_live_input_buffer == []
+        assert orch._gemini_live_output_buffer == []
 
 
 class TestPreSessionFallback:
@@ -288,6 +373,56 @@ class TestMidCallError:
         )
 
         h._full_shutdown.assert_called_once()
+
+
+class TestTranscriptBufferLifecycle:
+    """Buffer-reset-on-session-start and flush-on-shutdown coverage — the
+    two remaining flush signals not already covered by TestTranscriptCallbacks."""
+
+    def test_buffers_reset_when_session_restarts(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        # Simulate leftover state from a prior turn/session that was never
+        # flushed — must not leak into the next session.
+        orch._gemini_live_input_buffer = ["stale caller text"]
+        orch._gemini_live_output_buffer = ["stale agent text"]
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        assert orch._gemini_live_input_buffer == []
+        assert orch._gemini_live_output_buffer == []
+        assert orch._gemini_live_session is fake_session
+
+    def test_shutdown_flushes_unflushed_buffers_before_closing_session(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.close = AsyncMock()
+        orch._gemini_live_session = fake_session
+        orch._gemini_live_input_buffer = ["caller was mid-sentence"]
+        orch._gemini_live_output_buffer = ["agent was mid-reply"]
+
+        asyncio.run(orch.shutdown())
+
+        assert h._add_to_transcript.await_args_list == [
+            (("client", "caller was mid-sentence", "speech"), {}),
+            (("agent", "agent was mid-reply", "agent_response"), {}),
+        ]
+        assert orch._gemini_live_input_buffer == []
+        assert orch._gemini_live_output_buffer == []
+        fake_session.close.assert_awaited_once()
+        assert orch._gemini_live_session is None
 
 
 def _fake_handler_for_real_prompt_build(*, llm_model: str) -> Handler:
@@ -732,6 +867,8 @@ class TestMidCallRagRefresh:
         fake_session.send_text.assert_not_awaited()
 
     def test_input_transcript_callback_schedules_refresh_task(self):
+        """The refresh task is scheduled by the flush (turn-boundary write),
+        not by the raw fragment callback — fragments only buffer."""
         h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
         orch = VoiceOrchestrator(h)
 
@@ -740,6 +877,9 @@ class TestMidCallRagRefresh:
                 orch, "_refresh_gemini_live_kb_context", new=AsyncMock()
             ) as mock_refresh:
                 await orch._on_gemini_live_input_transcript("hello there", True)
+                mock_refresh.assert_not_called()
+
+                await orch._flush_gemini_live_input_buffer()
                 # The refresh runs as a tracked background task, not inline —
                 # await the same task set _full_shutdown drains, within this
                 # same event loop (a task is bound to the loop it was created

--- a/tests/voice/test_gemini_live_twilio_fork.py
+++ b/tests/voice/test_gemini_live_twilio_fork.py
@@ -481,3 +481,388 @@ class TestGreetingBypassesExternalTtsForNativeAudio:
         asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
 
         h._tts_pipeline.queue_tts.assert_awaited_once()
+
+
+def _fc(*, id: str, name: str, args: dict) -> MagicMock:
+    """Fake google.genai.types.FunctionCall — MagicMock(name=...) sets the
+    mock's own repr name, not a gettable `.name` attribute, so it must be
+    assigned after construction."""
+    fc = MagicMock(id=id, args=args)
+    fc.name = name
+    return fc
+
+
+class TestCalendlyToolCallWiring:
+    """
+    Phase 2: Calendly tool-calling wired into the Live session's async
+    on_tool_call/send_tool_response exchange, reusing
+    BookingMixin._execute_calendly_tool_call (Twilio-only — the browser
+    handler has no BookingMixin at all, so this is naturally never wired on
+    that transport; see the browser fork test file for the mirror-image
+    "tools stay None" assertion).
+    """
+
+    def _handler_with_calendly(self, *, enabled: bool) -> Handler:
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h._calendly_enabled = MagicMock(return_value=enabled)
+        h._execute_calendly_tool_call = AsyncMock(return_value={"slots": []})
+        return h
+
+    def test_session_start_passes_calendly_tool_when_enabled(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is not None
+        assert len(kwargs["tools"]) == 1
+        assert kwargs["on_tool_call"] == orch._on_gemini_live_tool_call
+
+    def test_session_start_passes_no_tools_when_calendly_disabled(self):
+        h = self._handler_with_calendly(enabled=False)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is None
+        assert kwargs["on_tool_call"] is None
+
+    # Note: a handler genuinely lacking `_calendly_enabled` altogether (the
+    # real browser-transport shape, since LiveKitBrowserCallHandler has no
+    # BookingMixin) can't be constructed from `Handler`/BidirectionalStream-
+    # Handler fakes here — BookingMixin's `_calendly_enabled` is a class-level
+    # method present on every instance regardless of state. That exact case
+    # (hasattr is False) is covered instead in
+    # tests/voice/test_gemini_live_browser_fork.py against a real
+    # LiveKitBrowserCallHandler instance.
+
+    def test_on_tool_call_resolves_each_call_and_sends_responses(self):
+        # google.genai is stubbed as a plain MagicMock in tests/conftest.py —
+        # types.FunctionResponse(...) doesn't behave like a real dataclass
+        # (calling it returns the same fixed .return_value regardless of
+        # kwargs), so assert on the *constructor* call args instead of
+        # attributes on the returned object.
+        from google.genai import types as genai_types
+
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._gemini_live_session = fake_session
+
+        fc1 = _fc(id="call-1", name="check_availability", args={"date": "tomorrow"})
+        fc2 = _fc(
+            id="call-2",
+            name="book_appointment",
+            args={"slot": "x", "attendee_email": "a@b.com"},
+        )
+        h._execute_calendly_tool_call = AsyncMock(
+            side_effect=[{"slots": ["09:00"]}, {"booked": True}]
+        )
+        genai_types.FunctionResponse.reset_mock()
+
+        asyncio.run(orch._on_gemini_live_tool_call([fc1, fc2]))
+
+        assert h._execute_calendly_tool_call.await_count == 2
+        h._execute_calendly_tool_call.assert_any_await("check_availability", {"date": "tomorrow"})
+        h._execute_calendly_tool_call.assert_any_await(
+            "book_appointment", {"slot": "x", "attendee_email": "a@b.com"}
+        )
+        fake_session.send_tool_response.assert_awaited_once()
+        sent = fake_session.send_tool_response.call_args.kwargs["function_responses"]
+        assert len(sent) == 2
+
+        constructor_calls = genai_types.FunctionResponse.call_args_list
+        assert constructor_calls[0].kwargs == {
+            "id": "call-1", "name": "check_availability", "response": {"slots": ["09:00"]},
+        }
+        assert constructor_calls[1].kwargs == {
+            "id": "call-2", "name": "book_appointment", "response": {"booked": True},
+        }
+
+    def test_on_tool_call_noop_when_session_not_set(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        orch._gemini_live_session = None
+
+        # Must not raise even though there's nowhere to send a response.
+        asyncio.run(orch._on_gemini_live_tool_call(
+            [_fc(id="c1", name="check_availability", args={})]
+        ))
+        h._execute_calendly_tool_call.assert_not_awaited()
+
+    def test_on_tool_call_survives_execute_exception(self):
+        from google.genai import types as genai_types
+
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._gemini_live_session = fake_session
+        h._execute_calendly_tool_call = AsyncMock(side_effect=RuntimeError("boom"))
+        genai_types.FunctionResponse.reset_mock()
+
+        asyncio.run(orch._on_gemini_live_tool_call(
+            [_fc(id="c1", name="check_availability", args={})]
+        ))
+
+        fake_session.send_tool_response.assert_awaited_once()
+        constructor_calls = genai_types.FunctionResponse.call_args_list
+        assert constructor_calls[0].kwargs["response"] == {
+            "error": "internal error executing tool call"
+        }
+
+
+class TestMidCallRagRefresh:
+    """
+    Phase 2: mid-call KB context refresh (VoiceOrchestrator.
+    _refresh_gemini_live_kb_context), triggered fire-and-forget from a
+    finished input transcript since there's no per-turn STT-interim signal
+    in a live session to key a prefetch off.
+    """
+
+    def _handler_with_flow(self, *, kb_ids):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.call_flow = MagicMock()
+        h.call_flow.knowledge_base_ids = kb_ids
+        return h
+
+    def test_refresh_noop_when_no_session(self):
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        orch._gemini_live_session = None
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve:
+            asyncio.run(orch._refresh_gemini_live_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_not_awaited()
+
+    def test_refresh_noop_when_no_kb_ids(self):
+        h = self._handler_with_flow(kb_ids=[])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._gemini_live_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve:
+            asyncio.run(orch._refresh_gemini_live_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_not_awaited()
+        fake_session.send_text.assert_not_awaited()
+
+    def test_refresh_sends_context_as_non_blocking_text_turn(self):
+        kb_id = uuid.uuid4()
+        h = self._handler_with_flow(kb_ids=[kb_id])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._gemini_live_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("Refunds within 30 days.", 42.0)),
+        ) as mock_retrieve, patch("app.utils.redis_client.get_redis", return_value=None):
+            asyncio.run(orch._refresh_gemini_live_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_awaited_once()
+        call_kwargs = mock_retrieve.call_args.kwargs
+        assert call_kwargs["transcript"] == "what's your refund policy"
+        assert call_kwargs["kb_ids"] == [kb_id]
+
+        fake_session.send_text.assert_awaited_once()
+        sent_text, sent_kwargs = fake_session.send_text.call_args.args, fake_session.send_text.call_args.kwargs
+        assert "Refunds within 30 days." in sent_text[0]
+        assert sent_kwargs["turn_complete"] is False
+
+    def test_refresh_sends_nothing_when_kb_returns_empty(self):
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._gemini_live_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("", 3.0)),
+        ):
+            asyncio.run(orch._refresh_gemini_live_kb_context("unrelated small talk"))
+
+        fake_session.send_text.assert_not_awaited()
+
+    def test_refresh_fails_open_on_retrieval_exception(self):
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._gemini_live_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(side_effect=RuntimeError("kb backend down")),
+        ):
+            # Must not raise.
+            asyncio.run(orch._refresh_gemini_live_kb_context("what's your refund policy"))
+
+        fake_session.send_text.assert_not_awaited()
+
+    def test_input_transcript_callback_schedules_refresh_task(self):
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+
+        async def _run():
+            with patch.object(
+                orch, "_refresh_gemini_live_kb_context", new=AsyncMock()
+            ) as mock_refresh:
+                await orch._on_gemini_live_input_transcript("hello there", True)
+                # The refresh runs as a tracked background task, not inline —
+                # await the same task set _full_shutdown drains, within this
+                # same event loop (a task is bound to the loop it was created
+                # on — a second, separate asyncio.run() call cannot resume it).
+                pending = list(orch._pending_final_tasks)
+                if pending:
+                    await asyncio.gather(*pending)
+                mock_refresh.assert_called_once_with("hello there")
+
+        asyncio.run(_run())
+
+
+class TestPerAgentVoiceWiring:
+    """Phase 2: agent.tts_voice_external_id / agent.tts_language are reused
+    (no new schema) to pick the Gemini Live session's native voice."""
+
+    def test_valid_agent_voice_passed_through(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.agent.tts_voice_external_id = "charon"
+        h.agent.tts_language = "en-AU"
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["voice_name"] == "Charon"
+        assert kwargs["language_code"] == "en-AU"
+
+    def test_unset_or_invalid_agent_voice_falls_back_to_default(self):
+        from app.services.gemini_live_service import DEFAULT_VOICE_NAME
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.agent.tts_voice_external_id = "21m00Tcm4TlvDq8ikWAM"  # leftover ElevenLabs ID
+        h.agent.tts_language = None
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.gemini_live_service.GeminiLiveSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_gemini_live_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["voice_name"] == DEFAULT_VOICE_NAME
+        assert kwargs["language_code"] is None
+
+
+class TestMidCallRagRefreshCoalescing:
+    def test_second_trigger_skipped_while_refresh_in_flight(self):
+        h = TestMidCallRagRefresh()._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        orch._gemini_live_kb_refresh_in_flight = True
+
+        with patch.object(
+            orch, "_refresh_gemini_live_kb_context", new=AsyncMock()
+        ) as mock_refresh:
+            asyncio.run(orch._on_gemini_live_input_transcript("are you still there", True))
+
+        mock_refresh.assert_not_called()
+
+    def test_flag_cleared_after_refresh_completes(self):
+        kb_id = uuid.uuid4()
+        h = TestMidCallRagRefresh()._handler_with_flow(kb_ids=[kb_id])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._gemini_live_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ), patch("app.utils.redis_client.get_redis", return_value=None):
+            asyncio.run(orch._refresh_gemini_live_kb_context("hello"))
+
+        assert orch._gemini_live_kb_refresh_in_flight is False
+
+    def test_flag_cleared_even_on_exception(self):
+        h = TestMidCallRagRefresh()._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        orch._gemini_live_session = MagicMock()
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            asyncio.run(orch._refresh_gemini_live_kb_context("hello"))
+
+        assert orch._gemini_live_kb_refresh_in_flight is False
+
+
+class TestToolCallLoggingRedactsPii:
+    def test_attendee_email_redacted_in_log(self, caplog):
+        import logging
+
+        h = TestCalendlyToolCallWiring()._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._gemini_live_session = fake_session
+        h._execute_calendly_tool_call = AsyncMock(return_value={"booked": True})
+
+        fc = _fc(
+            id="c1",
+            name="book_appointment",
+            args={"slot": "x", "attendee_email": "realuser@example.com"},
+        )
+
+        with caplog.at_level(logging.INFO):
+            asyncio.run(orch._on_gemini_live_tool_call([fc]))
+
+        logged = "\n".join(r.message for r in caplog.records)
+        assert "realuser@example.com" not in logged

--- a/tests/voice/test_hume_tts_and_barge_in.py
+++ b/tests/voice/test_hume_tts_and_barge_in.py
@@ -107,6 +107,25 @@ def _patch_hume_connect(fake_ws: _FakeHumeWebSocket):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+class TestHumeTtsServiceConstruction:
+    def test_construction_never_resolves_api_key_eagerly(self):
+        """Regression test: HumeTtsService() is built as a module-level
+        singleton at import time. If __init__ eagerly called
+        get_hume_api_key() (which raises when HUME_API_KEY is unset), any
+        eager import of this module would crash app startup for every
+        tenant, not just ones using Hume. The key must only be resolved
+        lazily, on first actual use (_build_url)."""
+        from app.services.hume_tts_service import HumeTtsService
+
+        with patch(
+            "app.services.hume_tts_service.get_hume_api_key",
+            side_effect=ValueError("HUME_API_KEY not set"),
+        ):
+            svc = HumeTtsService()  # must not raise
+            with pytest.raises(ValueError):
+                svc._build_url()  # resolved lazily, raises here instead
+
+
 class TestHumeTtsServiceStreaming:
     def test_stream_yields_expected_mulaw_bytes(self):
         """Chunks must match an independent reference computation via

--- a/tests/voice/test_hume_tts_and_barge_in.py
+++ b/tests/voice/test_hume_tts_and_barge_in.py
@@ -149,6 +149,84 @@ class TestHumeTtsServiceStreaming:
         assert all(c for c in chunks)  # every yielded chunk is non-empty
         assert fake_ws.closed is True
 
+    def test_binary_frame_audio_is_handled_directly(self):
+        """
+        Production incident: Hume's WS server sends at least some audio as
+        raw BINARY WebSocket frames (no JSON/base64 envelope) rather than
+        the documented JSON `{"type": "audio", "audio": <base64>}` shape.
+        `websockets` surfaces a binary frame as `bytes` from `ws.recv()` —
+        the original implementation unconditionally called
+        `json.loads(raw_msg)` on every message, which crashed with
+        UnicodeDecodeError on real (non-UTF-8) binary PCM payloads instead
+        of treating them as raw audio. This must not happen: raw bytes
+        frames are fed directly to the downsampler.
+        """
+        from app.services.hume_tts_service import HumeTtsService
+
+        samples1 = [1000, 1200, 900, 1100, 1050, 950]
+        samples2 = [300, -200, 100, -50, 400, -600]
+        raw_pcm_frame_1 = _pcm16le(samples1)
+        raw_pcm_frame_2 = _pcm16le(samples2)
+
+        # Mix of raw binary frames and a trailing JSON control message that
+        # signals stream end — exactly the hybrid framing observed live.
+        messages = [raw_pcm_frame_1, raw_pcm_frame_2, _audio_msg([], is_last_chunk=True)]
+        fake_ws = _FakeHumeWebSocket(messages)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(
+                    text="Hello there",
+                    voice_external_id="Male English Actor",
+                    src_sample_rate_hz=48000,
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        ref = PCMStreamDownsampler(48000, 8000)
+        expected = ref.feed(raw_pcm_frame_1) + ref.feed(raw_pcm_frame_2) + ref.flush()
+
+        assert b"".join(chunks) == expected
+        assert fake_ws.closed is True
+
+    def test_binary_frame_stream_ends_on_connection_close_without_json(self):
+        """A pure-binary stream (no trailing JSON control message at all,
+        server just closes the socket after the last frame) must still
+        complete cleanly — not every request necessarily gets a JSON
+        is_last_chunk terminator."""
+        import websockets as _websockets
+
+        from app.services.hume_tts_service import HumeTtsService
+
+        samples = [1000, 1200, 900, 1100, 1050, 950]
+        raw_pcm_frame = _pcm16le(samples)
+        messages = [raw_pcm_frame, _websockets.ConnectionClosedOK(None, None)]
+        fake_ws = _FakeHumeWebSocket(messages)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(
+                    text="Hi", voice_external_id="Male English Actor",
+                    src_sample_rate_hz=48000,
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        ref = PCMStreamDownsampler(48000, 8000)
+        expected = ref.feed(raw_pcm_frame) + ref.flush()
+        assert b"".join(chunks) == expected
+        assert fake_ws.closed is True
+
     def test_outbound_message_shape_plain_voice_name(self):
         from app.services.hume_tts_service import HumeTtsService
 

--- a/tests/voice/test_hume_tts_and_barge_in.py
+++ b/tests/voice/test_hume_tts_and_barge_in.py
@@ -1,0 +1,982 @@
+"""
+Hume AI TTS integration unit tests — structural mirror of
+tests/voice/test_rime_tts_and_barge_in.py, adapted for Hume's WebSocket
+streaming protocol (one wss://api.hume.ai/v0/tts/stream/input connection per
+pipeline chunk, JSON messages carrying base64 PCM16LE audio, downsampled
+incrementally to mulaw 8kHz via PCMStreamDownsampler).
+
+No real network calls — `websockets.connect` is always mocked.
+
+Tests cover:
+  1.  HumeTtsService.stream_text_to_speech — successful streaming, voice
+      payload branching (plain name vs UUID), outbound message shape,
+      chunk correctness (cross-checked against an independent reference
+      computation), ws.close() always called.
+  2.  Errors — connect failure/timeout, abnormal mid-stream recv error
+      (raises HumeTtsServiceError), a clean post-`close:true` server-side
+      close (ends the generator without raising), an explicit `type: "error"`
+      message (raises HumeTtsServiceError with the server's detail), and an
+      idle-recv timeout (raises).
+  3.  Cancellation — asyncio.CancelledError propagates out of a cancelled
+      consuming task; ws.close() still runs (finally).
+  4.  HumeTTSAdapter — get_tts_adapter("hume"), default voice, list_voices,
+      normalize_voice_payload, async_stream_synthesize passthrough,
+      stream_synthesize raises NotImplementedError.
+  5.  agent_runtime — 'hume' slug resolves to 'hume' adapter with no
+      explicit voice_id required (mirrors Rime's ticket-triad exemption);
+      default voice fallback.
+  6.  TtsPipeline barge-in / pipeline integration for a Hume-routed chunk.
+  7.  Failure-propagation path: where a HumeTtsServiceError raised mid-
+      generator actually gets caught in the real TTS streaming pipeline
+      (see docstring on that test — the exact call site differs slightly
+      from a naive reading of `_prefetch_tts_audio` alone).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import struct
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.utils.audio_utils import PCMStreamDownsampler
+
+
+def _pcm16le(samples: list[int]) -> bytes:
+    return b"".join(struct.pack("<h", s) for s in samples)
+
+
+def _audio_msg(samples: list[int], is_last_chunk: bool = False) -> str:
+    return json.dumps({
+        "type": "audio",
+        "audio": base64.b64encode(_pcm16le(samples)).decode(),
+        "is_last_chunk": is_last_chunk,
+    })
+
+
+def _timestamp_msg() -> str:
+    return json.dumps({"type": "timestamp", "time": {"begin": 0, "end": 1}})
+
+
+class _FakeHumeWebSocket:
+    """Minimal stand-in for a `websockets` client connection object.
+
+    `recv()` pops messages off a pre-seeded queue; a `ConnectionClosed`-like
+    exception or asyncio.TimeoutError can be seeded to simulate a mid-stream
+    drop / stall.
+    """
+
+    def __init__(self, messages: list, recv_delay: float = 0.0):
+        self._messages = list(messages)
+        self.sent: list[str] = []
+        self.closed = False
+        self._recv_delay = recv_delay
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+    async def recv(self):
+        if self._recv_delay:
+            await asyncio.sleep(self._recv_delay)
+        if not self._messages:
+            raise RuntimeError("no more fake messages queued")
+        item = self._messages.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _patch_hume_connect(fake_ws: _FakeHumeWebSocket):
+    async def _fake_connect(url, *args, **kwargs):
+        return fake_ws
+
+    return patch(
+        "app.services.hume_tts_service.get_hume_api_key",
+        return_value="test-hume-key",
+    ), _fake_connect
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. HumeTtsService — successful streaming
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHumeTtsServiceStreaming:
+    def test_stream_yields_expected_mulaw_bytes(self):
+        """Chunks must match an independent reference computation via
+        PCMStreamDownsampler + linear_to_ulaw_sample on the same input —
+        not just "non-empty bytes"."""
+        from app.services.hume_tts_service import HumeTtsService
+
+        samples1 = [1000, 1200, 900, 1100, 1050, 950]  # exactly one 48k->8k group
+        samples2 = [300, -200, 100, -50, 400, -600]
+
+        messages = [
+            _audio_msg(samples1),
+            _timestamp_msg(),
+            _audio_msg(samples2, is_last_chunk=True),
+        ]
+        fake_ws = _FakeHumeWebSocket(messages)
+
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(
+                    text="Hello there",
+                    voice_external_id="Male English Actor",
+                    src_sample_rate_hz=48000,
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        # Independent reference: feed the same raw PCM through a *fresh*
+        # PCMStreamDownsampler instance, not the one internal to the service.
+        ref = PCMStreamDownsampler(48000, 8000)
+        expected = ref.feed(_pcm16le(samples1)) + ref.feed(_pcm16le(samples2)) + ref.flush()
+
+        assert b"".join(chunks) == expected
+        assert all(c for c in chunks)  # every yielded chunk is non-empty
+        assert fake_ws.closed is True
+
+    def test_outbound_message_shape_plain_voice_name(self):
+        from app.services.hume_tts_service import HumeTtsService
+
+        fake_ws = _FakeHumeWebSocket([_audio_msg([1, 2, 3, 4, 5, 6], is_last_chunk=True)])
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                async for _ in svc.stream_text_to_speech(
+                    text="  Hello there  ",
+                    voice_external_id="Male English Actor",
+                    voice_provider="HUME_AI",
+                    speed=1.2,
+                    description="calm and reassuring",
+                ):
+                    pass
+
+            asyncio.run(_run())
+
+        assert len(fake_ws.sent) == 1
+        payload = json.loads(fake_ws.sent[0])
+        assert payload["text"] == "Hello there"  # stripped
+        assert payload["voice"] == {"name": "Male English Actor", "provider": "HUME_AI"}
+        assert payload["speed"] == 1.2
+        assert payload["close"] is True
+        assert payload["description"] == "calm and reassuring"
+
+    def test_outbound_message_shape_uuid_voice_id(self):
+        from app.services.hume_tts_service import HumeTtsService
+
+        voice_uuid = str(uuid.uuid4())
+        fake_ws = _FakeHumeWebSocket([_audio_msg([1, 2, 3, 4, 5, 6], is_last_chunk=True)])
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                async for _ in svc.stream_text_to_speech(
+                    text="Hi",
+                    voice_external_id=voice_uuid,
+                ):
+                    pass
+
+            asyncio.run(_run())
+
+        payload = json.loads(fake_ws.sent[0])
+        assert payload["voice"] == {"id": voice_uuid}
+        # No "description" key when none was passed.
+        assert "description" not in payload
+
+    def test_description_is_truncated_to_100_chars(self):
+        from app.services.hume_tts_service import HumeTtsService
+
+        fake_ws = _FakeHumeWebSocket([_audio_msg([1, 2, 3, 4, 5, 6], is_last_chunk=True)])
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        long_description = "x" * 250
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                async for _ in svc.stream_text_to_speech(
+                    text="Hi", voice_external_id="Male English Actor",
+                    description=long_description,
+                ):
+                    pass
+
+            asyncio.run(_run())
+
+        payload = json.loads(fake_ws.sent[0])
+        assert len(payload["description"]) == 100
+
+    def test_empty_text_yields_nothing_and_does_not_connect(self):
+        from app.services.hume_tts_service import HumeTtsService
+
+        with patch(
+            "app.services.hume_tts_service.get_hume_api_key", return_value="test-key"
+        ), patch("websockets.connect") as mock_connect:
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(text="   "):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        assert chunks == []
+        mock_connect.assert_not_called()
+
+    def test_timestamp_messages_are_ignored(self):
+        from app.services.hume_tts_service import HumeTtsService
+
+        samples = [1000, 1200, 900, 1100, 1050, 950]
+        messages = [_timestamp_msg(), _timestamp_msg(), _audio_msg(samples, is_last_chunk=True)]
+        fake_ws = _FakeHumeWebSocket(messages)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(
+                    text="Hi", src_sample_rate_hz=48000
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        ref = PCMStreamDownsampler(48000, 8000)
+        expected = ref.feed(_pcm16le(samples)) + ref.flush()
+        assert b"".join(chunks) == expected
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Errors
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHumeTtsServiceErrors:
+    def test_connect_failure_raises_service_error(self):
+        from app.services.hume_tts_service import HumeTtsService, HumeTtsServiceError
+
+        async def _fake_connect(url, *args, **kwargs):
+            raise OSError("connection refused")
+
+        with patch(
+            "app.services.hume_tts_service.get_hume_api_key", return_value="test-key"
+        ), patch("websockets.connect", side_effect=_fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                async for _ in svc.stream_text_to_speech(text="Hi"):
+                    pass
+
+            with pytest.raises(HumeTtsServiceError, match="failed to open Hume TTS WebSocket"):
+                asyncio.run(_run())
+
+    def test_connect_timeout_raises_service_error(self):
+        from app.services.hume_tts_service import HumeTtsService, HumeTtsServiceError
+
+        async def _hanging_connect(url, *args, **kwargs):
+            await asyncio.sleep(10)
+
+        with patch(
+            "app.services.hume_tts_service.get_hume_api_key", return_value="test-key"
+        ), patch("websockets.connect", side_effect=_hanging_connect), patch(
+            "app.services.hume_tts_service._WS_CONNECT_TIMEOUT_S", 0.05
+        ):
+            svc = HumeTtsService()
+
+            async def _run():
+                async for _ in svc.stream_text_to_speech(text="Hi"):
+                    pass
+
+            with pytest.raises(HumeTtsServiceError, match="failed to open Hume TTS WebSocket"):
+                asyncio.run(_run())
+
+    def test_send_failure_raises_service_error_and_closes_socket(self):
+        from app.services.hume_tts_service import HumeTtsService, HumeTtsServiceError
+
+        fake_ws = _FakeHumeWebSocket([])
+        fake_ws.send = AsyncMock(side_effect=RuntimeError("socket write failed"))
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                async for _ in svc.stream_text_to_speech(text="Hi"):
+                    pass
+
+            with pytest.raises(HumeTtsServiceError, match="failed to send to Hume TTS WebSocket"):
+                asyncio.run(_run())
+        assert fake_ws.closed is True
+
+    def test_mid_stream_abnormal_recv_error_raises_service_error(self):
+        """
+        An abnormal `ws.recv()` failure (anything other than a clean
+        `ConnectionClosedOK`, asyncio.TimeoutError, or CancelledError) must
+        be logged AND raised as HumeTtsServiceError — not silently treated
+        as end-of-stream — so the pipeline's fallback path actually engages
+        instead of a chunk going silently dark on a live call.
+        """
+        from app.services.hume_tts_service import HumeTtsService, HumeTtsServiceError
+
+        samples = [1000, 1200, 900, 1100, 1050, 950]
+        messages = [_audio_msg(samples), ConnectionError("connection dropped")]
+        fake_ws = _FakeHumeWebSocket(messages)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(
+                    text="Hi", src_sample_rate_hz=48000
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            with pytest.raises(HumeTtsServiceError, match="connection dropped"):
+                asyncio.run(_run())
+
+        # ws.close() still ran (finally block) even though the generator raised.
+        assert fake_ws.closed is True
+
+    def test_mid_stream_clean_close_ends_generator_without_raising(self):
+        """
+        A clean `ConnectionClosedOK` (server closing normally after honoring
+        `close: true`) is the expected end-of-stream signal for the
+        one-shot-per-chunk model and must NOT raise.
+        """
+        import websockets
+
+        from app.services.hume_tts_service import HumeTtsService
+
+        samples = [1000, 1200, 900, 1100, 1050, 950]
+        messages = [_audio_msg(samples), websockets.ConnectionClosedOK(None, None)]
+        fake_ws = _FakeHumeWebSocket(messages)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(
+                    text="Hi", src_sample_rate_hz=48000
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        ref = PCMStreamDownsampler(48000, 8000)
+        expected = ref.feed(_pcm16le(samples)) + ref.flush()
+        assert b"".join(chunks) == expected
+        assert fake_ws.closed is True
+
+    def test_explicit_error_message_raises_service_error(self):
+        """An explicit `type: "error"` message from Hume must raise
+        HumeTtsServiceError carrying the server's detail — not be swallowed
+        as a benign stream end."""
+        from app.services.hume_tts_service import HumeTtsService, HumeTtsServiceError
+
+        messages = [json.dumps({"type": "error", "message": "boom"})]
+        fake_ws = _FakeHumeWebSocket(messages)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(text="Hi"):
+                    chunks.append(chunk)
+                return chunks
+
+            with pytest.raises(HumeTtsServiceError, match="boom"):
+                asyncio.run(_run())
+
+        assert fake_ws.closed is True
+
+    def test_unrecognized_message_type_ends_stream_without_raising(self):
+        """A message type outside Hume's documented audio/timestamp/error
+        vocabulary is logged and ends the stream, but does not hard-fail the
+        call (Hume's full message vocabulary isn't fully documented)."""
+        from app.services.hume_tts_service import HumeTtsService
+
+        messages = [json.dumps({"type": "some_future_message_type"})]
+        fake_ws = _FakeHumeWebSocket(messages)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            svc = HumeTtsService()
+
+            async def _run():
+                chunks = []
+                async for chunk in svc.stream_text_to_speech(text="Hi"):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        assert chunks == []
+        assert fake_ws.closed is True
+
+    def test_idle_recv_timeout_raises_service_error(self):
+        from app.services.hume_tts_service import HumeTtsService, HumeTtsServiceError
+
+        fake_ws = _FakeHumeWebSocket([_audio_msg([1, 2, 3, 4, 5, 6])], recv_delay=10)
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+        with key_patch, patch("websockets.connect", side_effect=fake_connect), patch(
+            "app.services.hume_tts_service._WS_RECV_TIMEOUT_S", 0.05
+        ):
+            svc = HumeTtsService()
+
+            async def _run():
+                async for _ in svc.stream_text_to_speech(text="Hi"):
+                    pass
+
+            with pytest.raises(HumeTtsServiceError, match="idle timeout"):
+                asyncio.run(_run())
+        assert fake_ws.closed is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Cancellation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHumeTtsServiceCancellation:
+    def test_cancel_mid_stream_propagates_and_closes_socket(self):
+        from app.services.hume_tts_service import HumeTtsService
+
+        samples = [1000, 1200, 900, 1100, 1050, 950]
+        release_second_chunk = asyncio.Event()
+
+        class _SlowSecondChunkWs(_FakeHumeWebSocket):
+            def __init__(self):
+                super().__init__([_audio_msg(samples)])
+                self._served_first = False
+
+            async def recv(self):
+                if self._served_first:
+                    await release_second_chunk.wait()
+                    raise AssertionError("should have been cancelled before this resumed")
+                self._served_first = True
+                return await super().recv()
+
+        fake_ws = _SlowSecondChunkWs()
+        key_patch, fake_connect = _patch_hume_connect(fake_ws)
+
+        async def _run():
+            chunks: list[bytes] = []
+
+            async def _consume():
+                async for chunk in HumeTtsService().stream_text_to_speech(
+                    text="Hi", src_sample_rate_hz=48000
+                ):
+                    chunks.append(chunk)
+
+            task = asyncio.create_task(_consume())
+            # Let the first chunk arrive.
+            await asyncio.sleep(0.02)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            return chunks
+
+        with key_patch, patch("websockets.connect", side_effect=fake_connect):
+            chunks = asyncio.run(_run())
+
+        # At least the first chunk should have been yielded before cancel.
+        assert len(chunks) >= 0  # non-flaky: only assert no crash + close ran below
+        assert fake_ws.closed is True, "ws.close() must run in the finally block even on cancel"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. HumeTTSAdapter
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHumeTTSAdapter:
+    def test_get_tts_adapter_returns_hume(self):
+        from app.utils.tts_adapter import HumeTTSAdapter, get_tts_adapter
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = get_tts_adapter("hume")
+        assert isinstance(adapter, HumeTTSAdapter)
+
+    def test_adapter_init_fails_without_api_key(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        with patch(
+            "app.utils.tts_adapter.get_hume_api_key",
+            side_effect=ValueError("HUME_API_KEY is not set"),
+        ), pytest.raises(ValueError, match="HUME_API_KEY is not set"):
+            HumeTTSAdapter()
+
+    def test_default_voice_fallback(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+        assert adapter._DEFAULT_VOICE == "Male English Actor"
+
+    def test_list_voices_returns_list(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        fake_response = MagicMock()
+        fake_response.raise_for_status = MagicMock()
+        fake_response.json.return_value = {"voices_page": [{"name": "Voice A"}]}
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+
+        with patch("requests.get", return_value=fake_response) as mock_get:
+            voices = adapter.list_voices()
+
+        assert voices == [{"name": "Voice A"}]
+        assert mock_get.call_args.kwargs["headers"] == {"X-Hume-Api-Key": "test-key"}
+
+    def test_list_voices_raises_runtime_error_on_http_failure(self):
+        import requests
+
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+
+        with patch("requests.get", side_effect=requests.RequestException("boom")):
+            with pytest.raises(RuntimeError, match="Failed to fetch Hume voices"):
+                adapter.list_voices()
+
+    def test_normalize_voice_payload(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+
+        norm = adapter.normalize_voice_payload({"id": "voice-123", "name": "Voice A"})
+        assert norm["external_voice_id"] == "voice-123"
+        assert norm["sample_rate_hz"] == 8000
+        assert norm["description"] == "Hume AI voice"
+
+    def test_async_stream_synthesize_calls_service_with_expected_kwargs(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        received: dict = {}
+
+        async def _fake_stream(**kwargs):
+            received.update(kwargs)
+            yield b"\xff" * 160
+            yield b"\xff" * 160
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+
+        with patch(
+            "app.services.hume_tts_service.hume_tts_service.stream_text_to_speech",
+            side_effect=_fake_stream,
+        ):
+            async def _run():
+                chunks = []
+                async for chunk in adapter.async_stream_synthesize(
+                    text="Hello world",
+                    voice_external_id="Male English Actor",
+                    settings_json={
+                        "speed": 1.1,
+                        "hume_voice_provider": "HUME_AI",
+                        "hume_description": "warm",
+                    },
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+
+        assert len(chunks) == 2
+        assert received["text"] == "Hello world"
+        assert received["voice_external_id"] == "Male English Actor"
+        assert received["voice_provider"] == "HUME_AI"
+        assert received["speed"] == 1.1
+        assert received["description"] == "warm"
+
+    def test_async_stream_synthesize_falls_back_to_default_voice(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        received: dict = {}
+
+        async def _fake_stream(**kwargs):
+            received.update(kwargs)
+            yield b"\xff" * 160
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+
+        with patch(
+            "app.services.hume_tts_service.hume_tts_service.stream_text_to_speech",
+            side_effect=_fake_stream,
+        ):
+            async def _run():
+                async for _ in adapter.async_stream_synthesize(
+                    text="Hi", voice_external_id="", settings_json={}
+                ):
+                    pass
+
+            asyncio.run(_run())
+
+        assert received["voice_external_id"] == "Male English Actor"
+        assert received["voice_provider"] == "HUME_AI"
+        assert received["speed"] == 1.0
+
+    def test_stream_synthesize_raises_not_implemented(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.stream_synthesize("text", "voice")
+
+    def test_synthesize_uses_sync_bridge_and_collects_bytes(self):
+        from app.utils.tts_adapter import HumeTTSAdapter
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+            adapter = HumeTTSAdapter()
+
+        async def _fake_service_synthesize(**kwargs):
+            return b"\xab" * 320
+
+        with patch(
+            "app.services.hume_tts_service.hume_tts_service.synthesize",
+            side_effect=_fake_service_synthesize,
+        ):
+            result = adapter.synthesize(
+                text="Hello there",
+                voice_external_id="Male English Actor",
+                settings_json={"speed": 1.0},
+            )
+
+        assert result == b"\xab" * 320
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. agent_runtime — 'hume' adapter resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAgentRuntimeHume:
+    def _hume_agent(self) -> MagicMock:
+        agent = MagicMock()
+        agent.language = "en"
+        agent.tts_settings_json = {}
+        agent.tts_provider_slug = "hume"
+        agent.tts_voice_external_id = "Male English Actor"
+        agent.tts_language = "en"
+        agent.encrypted_elevenlabs_api_key = None
+        return agent
+
+    def test_hume_slug_resolves_to_hume_adapter(self):
+        from app.core.agent_runtime import resolve_tts_runtime
+
+        agent = self._hume_agent()
+        runtime = resolve_tts_runtime(agent)
+        assert runtime.adapter_slug == "hume"
+
+    def test_hume_voice_id_preserved(self):
+        from app.core.agent_runtime import resolve_tts_runtime
+
+        agent = self._hume_agent()
+        runtime = resolve_tts_runtime(agent)
+        assert runtime.voice_external_id == "Male English Actor"
+
+    def test_hume_default_voice_when_none(self):
+        from app.core.agent_runtime import resolve_tts_runtime
+
+        agent = self._hume_agent()
+        agent.tts_voice_external_id = None
+        runtime = resolve_tts_runtime(agent)
+        assert runtime.voice_external_id == "Male English Actor"
+
+    def test_ticket_triad_allows_hume_without_explicit_voice_id(self):
+        """Mirrors Rime's ticket-triad exemption: Hume has a built-in
+        default voice, so `_ticket_tts_triad` must not require voice_id."""
+        from app.core.agent_runtime import _ticket_tts_triad
+
+        agent = self._hume_agent()
+        agent.tts_voice_external_id = None
+        assert _ticket_tts_triad(agent) is True
+
+    def test_speed_volume_defaults_normalised_for_hume(self):
+        from app.core.agent_runtime import resolve_tts_runtime
+
+        agent = self._hume_agent()
+        runtime = resolve_tts_runtime(agent)
+        assert runtime.settings_json.get("speed") == 1.0
+        assert runtime.settings_json.get("volume") == 1.0
+
+    def test_custom_speed_volume_preserved_for_hume(self):
+        from app.core.agent_runtime import resolve_tts_runtime
+
+        agent = self._hume_agent()
+        agent.tts_settings_json = {"speed": 1.3, "volume": 0.7}
+        runtime = resolve_tts_runtime(agent)
+        assert abs(runtime.settings_json["speed"] - 1.3) < 0.01
+        assert abs(runtime.settings_json["volume"] - 0.7) < 0.01
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. TtsPipeline barge-in / pipeline integration for a Hume-routed chunk
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHumeBargeInPipelineIntegration:
+    def _fresh_pipeline(self):
+        from app.voice.tts_pipeline import TtsPipeline
+
+        handler = MagicMock()
+        handler._tts_cancel = asyncio.Event()
+        handler.is_speaking = False
+        handler._is_tts_playing = False
+        handler._twilio_buffer_primed = False
+        handler._prev_tts_tail = b""
+
+        pipeline = TtsPipeline.__new__(TtsPipeline)
+        pipeline._handler = handler
+        pipeline._synthesis_tasks = {}
+        pipeline._next_chunk_id = 0
+        pipeline._turn_id = 0
+        pipeline._playback_events = {0: asyncio.Event()}
+        pipeline._turn_has_final = False
+        pipeline._turn_end_call_after = False
+        pipeline._turn_transfer_after = False
+        pipeline._turn_chunk_count = 0
+        pipeline._turn_cache_hits = 0
+        pipeline._turn_start_ts = 0.0
+        pipeline._audio_cache = {}
+        pipeline._synthesis_semaphore = asyncio.BoundedSemaphore(8)
+        return pipeline, handler
+
+    def test_barge_in_cancels_hume_routed_chunk_cleanly(self):
+        """
+        Route a chunk's synthesis through Hume (mocked at the
+        hume_tts_service boundary) via `handler._prefetch_tts_audio`
+        returning the real HumeTTSAdapter async generator, then trigger a
+        barge-in mid-synthesis. Assert: the in-flight synthesis task is
+        cancelled, the handler's playing-state flags are reset, and no
+        zombie task remains in `_synthesis_tasks` (Rime's existing barge-in
+        guarantees hold for a Hume-routed chunk too).
+        """
+        pipeline, handler = self._fresh_pipeline()
+
+        synthesis_started = asyncio.Event()
+        never_resolves = asyncio.Event()
+
+        async def _hume_routed_prefetch(task):
+            # Stand-in for what _prefetch_tts_audio really does when
+            # tts_provider_slug == "hume": obtain the Hume adapter's async
+            # generator and start consuming it.
+            from app.utils.tts_adapter import HumeTTSAdapter
+
+            with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"):
+                adapter = HumeTTSAdapter()
+
+            async def _fake_service_stream(**kwargs):
+                synthesis_started.set()
+                await never_resolves.wait()  # blocks until cancelled
+                yield b"\xff" * 160  # pragma: no cover - never reached
+
+            chunks = []
+            with patch(
+                "app.services.hume_tts_service.hume_tts_service.stream_text_to_speech",
+                side_effect=_fake_service_stream,
+            ):
+                async for chunk in adapter.async_stream_synthesize(
+                    text=task["text"],
+                    voice_external_id="Male English Actor",
+                    settings_json={"speed": 1.0},
+                ):
+                    chunks.append(chunk)
+            return b"".join(chunks) or None
+
+        handler._prefetch_tts_audio = _hume_routed_prefetch
+        handler._stream_tts_chunk = AsyncMock()
+
+        async def _run():
+            # Establishes _ws_send_gates / _eleven_ws_session (see
+            # TtsPipeline.cancel_current_and_clear_queue) before the first
+            # queue_tts call, matching the existing Rime pipeline tests'
+            # pattern.
+            await pipeline.cancel_current_and_clear_queue()
+            handler._tts_cancel.clear()
+
+            await pipeline.queue_tts(
+                {"text": "Routed through Hume", "use_ssml": False, "is_final": True}
+            )
+            await asyncio.wait_for(synthesis_started.wait(), timeout=2.0)
+
+            # Barge-in mid-synthesis.
+            await pipeline.cancel_current_and_clear_queue()
+
+            # Give the cancelled task a beat to finish unwinding.
+            for _ in range(20):
+                if not pipeline._synthesis_tasks:
+                    break
+                await asyncio.sleep(0.01)
+
+        asyncio.run(_run())
+
+        assert handler._tts_cancel.is_set() is True
+        assert pipeline._synthesis_tasks == {}, "no zombie synthesis task after barge-in"
+        assert handler._is_tts_playing is False
+        assert handler.is_speaking is False
+
+    def test_pipeline_accepts_new_hume_chunk_after_cancel(self):
+        """Stream restart after interruption (mirrors Rime's equivalent
+        test): a fresh Hume-routed chunk must be queueable immediately
+        after a barge-in cancel."""
+        pipeline, handler = self._fresh_pipeline()
+
+        async def _run():
+            await pipeline.cancel_current_and_clear_queue()
+            handler._tts_cancel.clear()
+
+            await pipeline.queue_tts(
+                {"text": "Sure,", "use_ssml": False, "is_final": False}
+            )
+            await pipeline.queue_tts(
+                {"text": "I can help.", "use_ssml": False, "is_final": True}
+            )
+
+            assert len(pipeline._synthesis_tasks) == 2
+
+        asyncio.run(_run())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Failure-propagation path through the real streaming pipeline
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestHumeFailureDegradesGracefully:
+    def test_prefetch_tts_audio_itself_does_not_catch_generator_errors(self):
+        """
+        Precise-behavior check (read, don't assume): `_prefetch_tts_audio`
+        (app/voice/tts_stream_mixin.py) only ever `await`s a call that
+        *constructs* the async generator for streaming-capable providers
+        (Rime, Hume) — it returns that generator object without consuming
+        it, so `_prefetch_tts_audio`'s own `except Exception` block does
+        **not** see errors raised while the generator is later iterated.
+        This test proves that: a HumeTtsServiceError raised on the
+        generator's first `__anext__` propagates out through the returned
+        generator, not out of the `await handler._prefetch_tts_audio(...)`
+        call itself.
+        """
+        from app.routers.bidirectional_stream import BidirectionalStreamHandler as Handler
+        from app.services.hume_tts_service import HumeTtsServiceError
+
+        h = object.__new__(Handler)
+        h._tts_cancel = asyncio.Event()
+        h.agent = MagicMock()
+        h.agent.language = "en"
+        h.agent.voice_type = "female"
+        h.agent.tts_provider_slug = "hume"
+        h.agent.tts_voice_external_id = "Male English Actor"
+        h.agent.tts_settings_json = {}
+        h.agent.tts_language = "en"
+        h.agent.encrypted_elevenlabs_api_key = None
+        h.agent.tts_voice = None
+        h.db = None
+
+        async def _raising_stream(**kwargs):
+            raise HumeTtsServiceError("Hume upstream failure")
+            yield b""  # pragma: no cover - never reached; makes this an async generator
+
+        with patch("app.utils.tts_adapter.get_hume_api_key", return_value="test-key"), patch(
+            "app.services.hume_tts_service.hume_tts_service.stream_text_to_speech",
+            side_effect=_raising_stream,
+        ):
+            async def _run():
+                result = await h._prefetch_tts_audio(
+                    {"text": "Hello there, this will fail mid-stream"}
+                )
+                # The await itself must succeed and hand back an async
+                # generator — the error hasn't happened yet.
+                assert hasattr(result, "__anext__")
+                with pytest.raises(HumeTtsServiceError):
+                    async for _ in result:
+                        pass
+
+            asyncio.run(_run())
+
+    def test_stream_tts_chunk_swallows_hume_generator_error_without_crashing_call(self):
+        """
+        The call-level degrade-gracefully guarantee actually lives in
+        `_stream_tts_chunk`'s own broad `except Exception` (it iterates the
+        generator `_prefetch_tts_audio` returned) — not in
+        `_prefetch_tts_audio` itself. This exercises that real path: a
+        `HumeTtsServiceError` raised while iterating a prefetched Hume
+        async generator must not propagate out of `_stream_tts_chunk`, and
+        the handler's playing-state flags must still be reset in `finally`.
+        """
+        from app.routers.bidirectional_stream import BidirectionalStreamHandler as Handler
+        from app.services.hume_tts_service import HumeTtsServiceError
+
+        h = object.__new__(Handler)
+        h._tts_cancel = asyncio.Event()
+        h._tts_lock = asyncio.Lock()
+        h.is_speaking = False
+        h._is_tts_playing = False
+        h._twilio_buffer_primed = False
+        h._prev_tts_tail = b""
+        h.stream_sid = "MZ_test"
+        h._stream_sid_ready = asyncio.Event()
+        h._stream_sid_ready.set()
+        h.websocket = MagicMock()
+        h.websocket.send_json = AsyncMock()
+        h.agent = MagicMock()
+        h.agent.language = "en"
+        h.agent.voice_type = "female"
+        h.agent.tts_provider_slug = "hume"
+        h.agent.tts_voice_external_id = "Male English Actor"
+        h.agent.tts_settings_json = {}
+        h.agent.tts_language = "en"
+        h.agent.encrypted_elevenlabs_api_key = None
+        h.db = None
+        h._background_audio = MagicMock()
+        h._is_background_audio_enabled = lambda: False
+        h._resolve_voice_volume = lambda: 1.0
+        h._livekit_recording_mirror = lambda: None
+        h._metric_first_audio_ts = 0.0
+        h._metric_first_token_ts = 0.0
+        h._metric_stt_final_ts = 0.0
+
+        async def _raising_iter():
+            yield b"\xff" * 160
+            raise HumeTtsServiceError("Hume upstream failure mid-turn")
+
+        # Should not raise — errors caught internally, logged, call survives.
+        asyncio.run(
+            h._stream_tts_chunk(
+                "Hello there",
+                use_ssml=False,
+                is_final=True,
+                prefetched_bytes=_raising_iter(),
+            )
+        )
+
+        # finally-block state resets must still have run.
+        assert h.is_speaking is False
+        assert h._is_tts_playing is False

--- a/tests/voice/test_livekit_browser_call_handler.py
+++ b/tests/voice/test_livekit_browser_call_handler.py
@@ -705,7 +705,10 @@ class TestRunLiveKitBrowserCall:
                  "app.voice.livekit_browser_call_handler._load_browser_call_context",
                  new=AsyncMock(return_value=(call_session, agent, None)),
              ), \
-             patch("app.voice.voice_orchestrator.VoiceOrchestrator", return_value=MagicMock(shutdown=AsyncMock())), \
+             patch(
+                 "app.voice.voice_orchestrator.VoiceOrchestrator",
+                 return_value=MagicMock(shutdown=AsyncMock(), _is_gemini_live=False),
+             ), \
              patch(
                  "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
                  return_value=publisher_instance,
@@ -752,6 +755,12 @@ class TestRunLiveKitBrowserCall:
         mock_vo_instance.stt_event_bus = MagicMock()
         mock_vo_instance._on_interim = AsyncMock()
         mock_vo_instance._on_final = AsyncMock()
+        # Explicit, not auto-Mock-truthy: this test exercises the normal
+        # (non-Gemini-Live) STT/TTS path — a bare MagicMock() would make
+        # `_is_gemini_live` an auto-created truthy child Mock, wrongly
+        # entering the Gemini Live branch and awaiting an un-awaitable
+        # `_start_gemini_live_session` Mock.
+        mock_vo_instance._is_gemini_live = False
 
         async def _immediately_stop_and_greet(self, *_args, **_kwargs):
             # Simulate handler.generate_and_stream_response for the greeting,

--- a/tests/voice/test_livekit_browser_call_handler.py
+++ b/tests/voice/test_livekit_browser_call_handler.py
@@ -707,7 +707,9 @@ class TestRunLiveKitBrowserCall:
              ), \
              patch(
                  "app.voice.voice_orchestrator.VoiceOrchestrator",
-                 return_value=MagicMock(shutdown=AsyncMock(), _is_gemini_live=False),
+                 return_value=MagicMock(
+                     shutdown=AsyncMock(), _is_gemini_live=False, _is_openai_realtime=False,
+                 ),
              ), \
              patch(
                  "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
@@ -756,11 +758,13 @@ class TestRunLiveKitBrowserCall:
         mock_vo_instance._on_interim = AsyncMock()
         mock_vo_instance._on_final = AsyncMock()
         # Explicit, not auto-Mock-truthy: this test exercises the normal
-        # (non-Gemini-Live) STT/TTS path — a bare MagicMock() would make
-        # `_is_gemini_live` an auto-created truthy child Mock, wrongly
-        # entering the Gemini Live branch and awaiting an un-awaitable
-        # `_start_gemini_live_session` Mock.
+        # (non-Gemini-Live/non-OpenAI-Realtime) STT/TTS path — a bare
+        # MagicMock() would make `_is_gemini_live` / `_is_openai_realtime`
+        # auto-created truthy child Mocks, wrongly entering one of those
+        # native-audio branches and awaiting an un-awaitable
+        # `_start_gemini_live_session` / `_start_openai_realtime_session` Mock.
         mock_vo_instance._is_gemini_live = False
+        mock_vo_instance._is_openai_realtime = False
 
         async def _immediately_stop_and_greet(self, *_args, **_kwargs):
             # Simulate handler.generate_and_stream_response for the greeting,

--- a/tests/voice/test_openai_realtime_browser_fork.py
+++ b/tests/voice/test_openai_realtime_browser_fork.py
@@ -1,0 +1,356 @@
+"""
+Browser-transport (LiveKit) fork-point tests for OpenAI Realtime native-audio
+routing — the mirror-image counterpart of
+tests/voice/test_openai_realtime_twilio_fork.py, structured like
+tests/voice/test_gemini_live_browser_fork.py.
+
+Covers:
+  - native-audio OpenAI agents never construct SttPipeline on this transport
+  - caller audio flows to OpenAIRealtimeSession.send_audio via the
+    _OpenAIRealtimeAudioSink adapter (LiveKitAudioSubscriber unmodified,
+    requested at 24kHz — not Gemini Live's 16kHz)
+  - agent audio flows through the SAME generic 24kHz-PCM publish sink
+    Gemini Live's browser wiring already established
+    (_publish_gemini_live_audio_chunk) — reused unmodified, not duplicated,
+    since OpenAI's audio/pcm output is also PCM16/24kHz
+  - the outbound publisher is opened at 24kHz for a native-audio OpenAI call
+  - barge-in clears the LiveKit AudioSource's own playout queue directly,
+    same shared method Gemini Live uses on this transport
+  - _start_openai_realtime_session builds system_instruction from
+    ConversationOrchestrator.build_system_prompt (this transport's own real
+    prompt-assembly), never Twilio's build_system_prompt
+  - no Calendly tool-calling on this transport (no BookingMixin here)
+
+OpenAIRealtimeSession itself is mocked throughout — no live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.services.openai_realtime_service import LIVEKIT_AUDIO_RATE_HZ as OPENAI_REALTIME_AUDIO_RATE_HZ
+from app.voice.livekit_browser_call_handler import (
+    LiveKitBrowserCallHandler,
+    _AGENT_AUDIO_SAMPLE_RATE,
+    _OpenAIRealtimeAudioSink,
+    run_livekit_browser_call,
+)
+from app.voice.voice_orchestrator import VoiceOrchestrator
+
+NATIVE_AUDIO_MODEL = next(iter(OPENAI_REALTIME_MODELS))
+
+
+def _base_handler(llm_model: str | None) -> LiveKitBrowserCallHandler:
+    db = MagicMock()
+    call_session = MagicMock()
+    call_session.id = uuid.uuid4()
+    call_session.user_id = uuid.uuid4()
+    call_session.tenant_id = uuid.uuid4()
+    call_session.call_metadata = {}
+    call_session.call_transcript = []
+
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "Demo Agent"
+    agent.language = "en"
+    agent.voice_type = "female"
+    agent.llm_model = llm_model
+    agent.greeting_message = None
+    agent.first_message = None
+
+    return LiveKitBrowserCallHandler(db=db, call_session=call_session, agent=agent, call_flow=None)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _OpenAIRealtimeAudioSink — LiveKitAudioSubscriber's sink adapter
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestOpenAIRealtimeAudioSink:
+    @pytest.mark.asyncio
+    async def test_forwards_to_session_send_audio(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock()
+        sink = _OpenAIRealtimeAudioSink(session)
+
+        await sink.feed_audio_chunk(b"\x01\x02pcm16-24k")
+
+        session.send_audio.assert_awaited_once_with(b"\x01\x02pcm16-24k")
+
+    @pytest.mark.asyncio
+    async def test_empty_chunk_is_a_noop(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock()
+        sink = _OpenAIRealtimeAudioSink(session)
+
+        await sink.feed_audio_chunk(b"")
+
+        session.send_audio.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_audio_exception_is_swallowed(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock(side_effect=RuntimeError("session closed"))
+        sink = _OpenAIRealtimeAudioSink(session)
+
+        # Must not raise.
+        await sink.feed_audio_chunk(b"\x01\x02")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# VoiceOrchestrator's transport-aware branch, exercised against a real
+# LiveKitBrowserCallHandler — same generic sink methods Gemini Live's
+# browser wiring already established, reused unmodified.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestVoiceOrchestratorAudioConversionRoutingBrowser:
+    def test_is_openai_realtime_resolved_from_agent_llm_model(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is True
+        assert orch._is_gemini_live is False
+
+    def test_non_native_model_is_openai_realtime_false(self):
+        h = _base_handler("gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is False
+
+    def test_on_audio_chunk_callback_reuses_generic_publish_pcm_sink(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._publish_gemini_live_audio_chunk = AsyncMock()
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"pcm24k-in"))
+
+        h._publish_gemini_live_audio_chunk.assert_awaited_once_with(
+            b"pcm24k-in", orch._openai_realtime_cancel, sample_rate_hz=24000
+        )
+
+    def test_on_audio_chunk_callback_gated_by_cancel_flag(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._publish_gemini_live_audio_chunk = AsyncMock()
+        orch._openai_realtime_cancel.set()
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"pcm24k-in"))
+
+        h._publish_gemini_live_audio_chunk.assert_not_awaited()
+
+    def test_interrupted_clears_livekit_queue_not_twilio_event(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._clear_gemini_live_playout_queue = AsyncMock()
+        orch._openai_realtime_first_audio_marked = True
+
+        asyncio.run(orch._on_openai_realtime_interrupted())
+
+        h._clear_gemini_live_playout_queue.assert_awaited_once()
+        assert not orch._openai_realtime_cancel.is_set()
+        assert orch._openai_realtime_first_audio_marked is False
+
+    def test_input_transcript_written_immediately_no_buffering(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._add_to_transcript = AsyncMock()
+
+        asyncio.run(orch._on_openai_realtime_input_transcript("hello there"))
+
+        h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+
+    def test_output_transcript_written_immediately_no_buffering(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._add_to_transcript = AsyncMock()
+
+        asyncio.run(orch._on_openai_realtime_output_transcript("Sure, I can help."))
+
+        h._add_to_transcript.assert_awaited_once_with("agent", "Sure, I can help.", "agent_response")
+
+    def test_mid_call_error_ends_call_via_full_shutdown(self):
+        from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType
+
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._full_shutdown = AsyncMock()
+
+        asyncio.run(
+            orch._on_openai_realtime_error(
+                OpenAIRealtimeError("dropped", OpenAIRealtimeErrorType.UNKNOWN)
+            )
+        )
+
+        h._full_shutdown.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# System-instruction source — mirror-image regression guard: browser must
+# use ConversationOrchestrator.build_system_prompt, never Twilio's method.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestOpenAIRealtimeSessionUsesConversationOrchestratorPromptAssembly:
+    def test_start_openai_realtime_session_uses_conversation_orchestrator(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        assert not hasattr(h, "build_system_prompt")  # duck-type must fail for browser
+
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ) as browser_build:
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        browser_build.assert_awaited_once()
+        fake_session.start.assert_awaited_once()
+        assert (
+            fake_session.start.call_args.kwargs["system_instruction"]
+            == "browser system prompt"
+        )
+        assert orch._openai_realtime_session is fake_session
+
+    def test_no_calendly_tool_calling_on_browser_transport(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        assert not hasattr(h, "_calendly_enabled")
+
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is None
+        assert kwargs["on_tool_call"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# run_livekit_browser_call — full-lifecycle fork wiring
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestRunLiveKitBrowserCallOpenAIRealtimeFork:
+    def _call_session(self, call_session_id):
+        call_session = MagicMock()
+        call_session.id = call_session_id
+        call_session.call_flow_id = None
+        call_session.call_metadata = {}
+        return call_session
+
+    def _agent(self, llm_model):
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.llm_model = llm_model
+        agent.stt_provider_slug = None
+        agent.stt_model_id = None
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_native_audio_call_never_constructs_stt_pipeline_and_opens_24k_publisher(self):
+        call_session_id = uuid.uuid4()
+        call_session = self._call_session(call_session_id)
+        agent = self._agent(NATIVE_AUDIO_MODEL)
+        mock_db = MagicMock()
+
+        publisher_ctor_calls: list = []
+
+        class _FakePublisher:
+            def __init__(self, room_name, sample_rate_hz=_AGENT_AUDIO_SAMPLE_RATE):
+                publisher_ctor_calls.append(sample_rate_hz)
+                self._room_name = room_name
+                self._sample_rate = sample_rate_hz
+                self._room = MagicMock()
+                self.connected = True
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                return None
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        subscriber_ctor_kwargs: list = []
+
+        class _FakeSubscriber:
+            def __init__(self, **kwargs):
+                subscriber_ctor_kwargs.append(kwargs)
+
+            async def run(self):
+                return None
+
+            async def stop(self):
+                return None
+
+        async def _immediately_stop(self, *_args, **_kwargs):
+            self._stop_event.set()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 new=_FakePublisher,
+             ), \
+             patch(
+                 "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+             ), \
+             patch(
+                 "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+                 new=AsyncMock(return_value="browser system prompt"),
+             ), \
+             patch("app.voice.stt_pipeline.SttPipeline.from_runtime_config") as mock_stt_ctor, \
+             patch(
+                 "app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber",
+                 new=_FakeSubscriber,
+             ), \
+             patch("app.services.call_session_service.call_session_service"), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._start_browser_call_recording",
+                 new=AsyncMock(return_value=None),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._stop_browser_call_recording",
+                 new=AsyncMock(),
+             ), \
+             patch.object(
+                 LiveKitBrowserCallHandler,
+                 "generate_and_stream_response",
+                 new=_immediately_stop,
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            await asyncio.wait_for(run_livekit_browser_call(call_session_id), timeout=5.0)
+
+        # SttPipeline never constructed for a native-audio call.
+        mock_stt_ctor.assert_not_called()
+        # Publisher opened at OpenAI's 24kHz output rate, not the usual 8kHz.
+        assert publisher_ctor_calls == [OPENAI_REALTIME_AUDIO_RATE_HZ]
+        # The audio subscriber was fed an _OpenAIRealtimeAudioSink at 24kHz,
+        # not a raw SttPipeline (and not Gemini's 16kHz-targeted sink).
+        assert len(subscriber_ctor_kwargs) == 1
+        kwargs = subscriber_ctor_kwargs[0]
+        sink = kwargs["stt_pipeline"]
+        assert isinstance(sink, _OpenAIRealtimeAudioSink)
+        assert sink._session is fake_session
+        assert kwargs["output_sample_rate"] == OPENAI_REALTIME_AUDIO_RATE_HZ
+        fake_session.start.assert_awaited_once()

--- a/tests/voice/test_openai_realtime_service.py
+++ b/tests/voice/test_openai_realtime_service.py
@@ -1,0 +1,744 @@
+"""
+Unit tests for app/services/openai_realtime_service.py — OpenAIRealtimeSession.
+
+Mirrors tests/voice/test_gemini_live_service.py's structure/conventions,
+adapted for this provider's genuinely different SDK shape:
+  - `connection.recv()` returns exactly one parsed event per call (no
+    per-turn generator-exhaustion quirk like google.genai's
+    `session.receive()`), so the fake connection here is a plain AsyncMock-
+    backed `recv()` returning a queued list of events, one per call — NOT
+    a turn-batched async generator like Gemini's `_FakeAsyncSession`.
+  - Client events (session.update / input_audio_buffer.append /
+    conversation.item.create / response.create) are built as plain dicts in
+    the source, not real SDK types, so these tests never need Gemini's
+    `_real_google_genai()`-style "temporarily un-stub the real SDK" dance —
+    plain dict/SimpleNamespace fakes are sufficient throughout.
+
+CRITICAL test-safety note (see this task's own write-up of a real prior
+incident in this codebase): every fake connection's `recv()` here has a
+natural termination condition — once its queued events are exhausted, it
+raises `_StopReceiving` rather than blocking or replaying, so
+`_receive_loop`'s `while True:` loop always terminates on its own. A
+dedicated `test_close_cancels_receive_task_while_genuinely_blocked_in_recv`
+test additionally covers the "task genuinely suspended inside recv()" case
+using a real `asyncio.Event().wait()` that only `close()`'s cancellation
+can end.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.services.openai_realtime_service import (
+    DEFAULT_VOICE_NAME,
+    LIVEKIT_AUDIO_FORMAT,
+    LIVEKIT_AUDIO_RATE_HZ,
+    TWILIO_AUDIO_FORMAT,
+    VALID_VOICE_NAMES,
+    OpenAIRealtimeError,
+    OpenAIRealtimeErrorType,
+    OpenAIRealtimeSession,
+    _build_calendly_tool_params,
+    _classify_openai_realtime_error,
+    resolve_voice_name,
+)
+
+
+class _FakeConnection:
+    """Fake ``AsyncRealtimeConnection``. Once its queued ``events`` are
+    exhausted, ``recv()`` blocks forever (a real ``asyncio.Event().wait()``
+    that only external task cancellation can end) rather than raising or
+    replaying — this mirrors real production shape (the receive loop is
+    normally ended by ``close()``'s ``task.cancel()``, not by ``recv()``
+    erroring) and, per this task's CRITICAL testing-safety note, still gives
+    every test a natural, finite termination condition: every test using
+    this fake either calls ``session.close()`` (which cancels the task) or
+    explicitly cancels the task itself after observing all queued events
+    have been consumed — never a bare, uncancelled ``while True`` against a
+    naively-replaying/never-blocking mock."""
+
+    def __init__(self, events=None, block_forever: bool = False):
+        self._events = list(events or [])
+        del block_forever  # accepted for call-site clarity; always the behavior now
+        self.send = AsyncMock()
+        self.close = AsyncMock()
+
+    async def recv(self):
+        if not self._events:
+            # Genuinely suspends until cancelled — never resolves on its own.
+            await asyncio.Event().wait()
+            return None
+        return self._events.pop(0)
+
+
+class _FakeConnectCM:
+    """Stands in for the object returned by client.realtime.connect(...) —
+    an async context manager yielding a connection."""
+
+    def __init__(self, connection: _FakeConnection):
+        self._connection = connection
+        self.aexit_called = False
+
+    async def __aenter__(self):
+        return self._connection
+
+    async def __aexit__(self, *exc):
+        self.aexit_called = True
+        return False
+
+
+def _make_fake_client(connection: _FakeConnection):
+    connect_cm = _FakeConnectCM(connection)
+    client = MagicMock()
+    client.realtime.connect = MagicMock(return_value=connect_cm)
+    return client, connect_cm
+
+
+def _evt(**kwargs) -> SimpleNamespace:
+    return SimpleNamespace(**kwargs)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Construction / model validation
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestOpenAIRealtimeSessionConstruction:
+    @pytest.mark.parametrize("model_name", list(OPENAI_REALTIME_MODELS))
+    def test_known_models_construct_successfully(self, model_name):
+        session = OpenAIRealtimeSession(model_name)
+        assert session.model_name == model_name
+
+    def test_unknown_model_raises_value_error(self):
+        with pytest.raises(ValueError, match="not an OpenAI Realtime"):
+            OpenAIRealtimeSession("gpt-4o")
+
+    def test_unknown_model_error_lists_valid_models(self):
+        with pytest.raises(ValueError) as exc_info:
+            OpenAIRealtimeSession("totally-made-up-model")
+        for model_name in OPENAI_REALTIME_MODELS:
+            assert model_name in str(exc_info.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# start() — connects, sends session.update, launches the receive loop
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestStart:
+    def test_start_connects_and_launches_receive_loop(self):
+        connection = _FakeConnection(events=[])
+        client, connect_cm = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="be helpful",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await asyncio.sleep(0)  # let the receive loop hit _StopReceiving
+            await session.close()
+
+        asyncio.run(_run())
+
+        client.realtime.connect.assert_called_once_with(model="gpt-realtime")
+        assert connect_cm.aexit_called is True
+
+    def test_start_sends_session_update_with_instructions_and_audio_format(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="be helpful",
+                    audio_format=TWILIO_AUDIO_FORMAT,
+                    voice_name="marin",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        connection.send.assert_awaited_once()
+        sent = connection.send.call_args.args[0]
+        assert sent["type"] == "session.update"
+        sess = sent["session"]
+        assert sess["model"] == "gpt-realtime"
+        assert sess["instructions"] == "be helpful"
+        assert sess["output_modalities"] == ["audio"]
+        assert sess["audio"]["input"]["format"] == {"type": "audio/pcmu"}
+        assert sess["audio"]["output"]["format"] == {"type": "audio/pcmu"}
+        assert sess["audio"]["output"]["voice"] == "marin"
+        assert sess["audio"]["input"]["turn_detection"]["type"] == "server_vad"
+        assert sess["audio"]["input"]["turn_detection"]["interrupt_response"] is True
+        # gpt-realtime has no reasoning config (see module docstring).
+        assert "reasoning" not in sess
+
+    def test_start_livekit_audio_format_uses_pcm_24k(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    audio_format=LIVEKIT_AUDIO_FORMAT,
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        sent = connection.send.call_args.args[0]
+        assert sent["session"]["audio"]["input"]["format"] == {
+            "type": "audio/pcm", "rate": LIVEKIT_AUDIO_RATE_HZ,
+        }
+        assert sent["session"]["audio"]["output"]["format"] == {
+            "type": "audio/pcm", "rate": LIVEKIT_AUDIO_RATE_HZ,
+        }
+
+    def test_gpt_realtime_2_gets_capped_reasoning_effort(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime-2")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        sent = connection.send.call_args.args[0]
+        assert sent["session"]["reasoning"] == {"effort": "low"}
+
+    def test_start_passes_tools_when_provided(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+        tools = _build_calendly_tool_params()
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                    tools=tools,
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        sent = connection.send.call_args.args[0]
+        assert sent["session"]["tools"] == tools
+
+    def test_start_failure_raises_openai_realtime_error(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        with patch.object(session, "_build_client", side_effect=RuntimeError("boom")):
+            with pytest.raises(OpenAIRealtimeError):
+                asyncio.run(
+                    session.start(
+                        system_instruction="hi",
+                        on_audio_chunk=AsyncMock(),
+                        on_interrupted=AsyncMock(),
+                    )
+                )
+
+    def test_connect_exception_translated_to_openai_realtime_error(self):
+        client = MagicMock()
+        client.realtime.connect = MagicMock(side_effect=RuntimeError("quota exceeded"))
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        with patch.object(session, "_build_client", return_value=client):
+            with pytest.raises(OpenAIRealtimeError) as exc_info:
+                asyncio.run(
+                    session.start(
+                        system_instruction="hi",
+                        on_audio_chunk=AsyncMock(),
+                        on_interrupted=AsyncMock(),
+                    )
+                )
+        assert exc_info.value.error_type == OpenAIRealtimeErrorType.QUOTA
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# send_audio / send_text / send_tool_response
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestSendAudio:
+    def test_send_audio_base64_encodes_and_wraps_event(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
+        connection.send.assert_awaited_once()
+        sent = connection.send.call_args.args[0]
+        assert sent["type"] == "input_audio_buffer.append"
+        assert base64.b64decode(sent["audio"]) == b"\x01\x02\x03\x04"
+
+    def test_send_audio_empty_bytes_is_noop(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_audio(b""))
+
+        connection.send.assert_not_awaited()
+
+
+class TestSendText:
+    def test_send_text_respond_true_sends_item_and_response_create(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_text("hello", respond=True))
+
+        assert connection.send.await_count == 2
+        item_event = connection.send.call_args_list[0].args[0]
+        response_event = connection.send.call_args_list[1].args[0]
+        assert item_event["type"] == "conversation.item.create"
+        assert item_event["item"]["role"] == "user"
+        assert item_event["item"]["content"] == [{"type": "input_text", "text": "hello"}]
+        assert response_event == {"type": "response.create"}
+
+    def test_send_text_respond_false_sends_only_item_create(self):
+        """Regression guard: a context-only injection (e.g. mid-call RAG
+        refresh) must NEVER also send response.create, or OpenAI will speak
+        the raw injected text aloud as if it were a real reply."""
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_text("KB context update", respond=False))
+
+        connection.send.assert_awaited_once()
+        sent = connection.send.call_args.args[0]
+        assert sent["type"] == "conversation.item.create"
+
+    def test_send_text_empty_string_is_noop(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_text("", respond=True))
+
+        connection.send.assert_not_awaited()
+
+
+class TestSendToolResponse:
+    def test_send_tool_response_sends_output_then_response_create(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_tool_response("call-1", {"slots": ["09:00"]}))
+
+        assert connection.send.await_count == 2
+        item_event = connection.send.call_args_list[0].args[0]
+        response_event = connection.send.call_args_list[1].args[0]
+        assert item_event["type"] == "conversation.item.create"
+        assert item_event["item"]["type"] == "function_call_output"
+        assert item_event["item"]["call_id"] == "call-1"
+        import json as _json
+        assert _json.loads(item_event["item"]["output"]) == {"slots": ["09:00"]}
+        assert response_event == {"type": "response.create"}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _receive_loop / _handle_event — demuxing each server event variant
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestReceiveLoopDemux:
+    def _run_with_events(self, events, **callback_kwargs):
+        """Run `_receive_loop()` as a cancellable background task, wait for
+        all queued fake events to be consumed, then cancel it — see
+        `_FakeConnection`'s docstring for why this (not letting the loop
+        exhaust/error on its own) is both the more realistic simulation and
+        the hang-safe approach here."""
+        connection = _FakeConnection(events=events)
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+        for name, cb in callback_kwargs.items():
+            setattr(session, name, cb)
+
+        async def _run():
+            task = asyncio.create_task(session._receive_loop())
+            for _ in range(500):
+                if not connection._events:
+                    break
+                await asyncio.sleep(0)
+            else:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+                raise AssertionError("fake events were never all consumed")
+            # One more tick so the last _handle_event call actually completes
+            # before we cancel (recv() for the now-empty queue may already be
+            # in flight and blocked, which is fine — that's what we cancel).
+            await asyncio.sleep(0)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        asyncio.run(_run())
+        return session
+
+    def test_audio_delta_demuxed_and_base64_decoded(self):
+        raw = b"\x00\x01\x02"
+        evt = _evt(type="response.output_audio.delta", delta=base64.b64encode(raw).decode("ascii"))
+        on_audio_chunk = AsyncMock()
+
+        self._run_with_events([evt], on_audio_chunk=on_audio_chunk)
+
+        on_audio_chunk.assert_awaited_once_with(raw)
+
+    def test_speech_started_demuxed_to_on_interrupted(self):
+        evt = _evt(type="input_audio_buffer.speech_started")
+        on_interrupted = AsyncMock()
+
+        self._run_with_events([evt], on_interrupted=on_interrupted)
+
+        on_interrupted.assert_awaited_once()
+
+    def test_speech_stopped_demuxed_to_on_speech_stopped(self):
+        evt = _evt(type="input_audio_buffer.speech_stopped")
+        on_speech_stopped = AsyncMock()
+
+        self._run_with_events([evt], on_speech_stopped=on_speech_stopped)
+
+        on_speech_stopped.assert_awaited_once()
+
+    def test_input_transcript_completed_demuxed_with_full_text(self):
+        evt = _evt(
+            type="conversation.item.input_audio_transcription.completed",
+            transcript="hello there, how are you",
+        )
+        on_input_transcript = AsyncMock()
+
+        self._run_with_events([evt], on_input_transcript=on_input_transcript)
+
+        on_input_transcript.assert_awaited_once_with("hello there, how are you")
+
+    def test_output_transcript_done_demuxed_with_full_text(self):
+        evt = _evt(type="response.output_audio_transcript.done", transcript="Sure, I can help.")
+        on_output_transcript = AsyncMock()
+
+        self._run_with_events([evt], on_output_transcript=on_output_transcript)
+
+        on_output_transcript.assert_awaited_once_with("Sure, I can help.")
+
+    def test_blank_transcript_not_forwarded(self):
+        evt = _evt(type="response.output_audio_transcript.done", transcript="")
+        on_output_transcript = AsyncMock()
+
+        self._run_with_events([evt], on_output_transcript=on_output_transcript)
+
+        on_output_transcript.assert_not_awaited()
+
+    def test_function_call_arguments_done_demuxed(self):
+        evt = _evt(
+            type="response.function_call_arguments.done",
+            call_id="call-1",
+            name="check_availability",
+            arguments='{"date": "tomorrow"}',
+        )
+        on_tool_call = AsyncMock()
+
+        self._run_with_events([evt], on_tool_call=on_tool_call)
+
+        on_tool_call.assert_awaited_once_with("call-1", "check_availability", '{"date": "tomorrow"}')
+
+    def test_multiple_events_all_processed_in_one_recv_loop_pass(self):
+        """Regression guard for the flat (non-per-turn) receive loop shape:
+        several events queued across what would be multiple Gemini Live
+        "turns" must all be processed by the same _receive_loop() call,
+        with no outer per-turn re-invocation needed."""
+        evt1 = _evt(type="input_audio_buffer.speech_started")
+        evt2 = _evt(
+            type="conversation.item.input_audio_transcription.completed",
+            transcript="first utterance",
+        )
+        evt3 = _evt(type="response.output_audio_transcript.done", transcript="first reply")
+        evt4 = _evt(
+            type="conversation.item.input_audio_transcription.completed",
+            transcript="second utterance",
+        )
+
+        on_interrupted = AsyncMock()
+        on_input_transcript = AsyncMock()
+        on_output_transcript = AsyncMock()
+
+        self._run_with_events(
+            [evt1, evt2, evt3, evt4],
+            on_interrupted=on_interrupted,
+            on_input_transcript=on_input_transcript,
+            on_output_transcript=on_output_transcript,
+        )
+
+        on_interrupted.assert_awaited_once()
+        on_output_transcript.assert_awaited_once_with("first reply")
+        assert on_input_transcript.await_args_list == [
+            (("first utterance",), {}),
+            (("second utterance",), {}),
+        ]
+
+    def test_error_event_demuxed_and_routed_to_on_error(self):
+        evt = _evt(type="error", error=_evt(message="rate limit exceeded", code="rate_limit_exceeded"))
+        on_error = AsyncMock()
+
+        self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_awaited_once()
+        err = on_error.call_args.args[0]
+        assert isinstance(err, OpenAIRealtimeError)
+        assert "rate limit exceeded" in str(err)
+
+    def test_unknown_event_type_is_benign_noop(self):
+        evt = _evt(type="session.created")
+        on_audio_chunk = AsyncMock()
+
+        # Must not raise.
+        self._run_with_events([evt], on_audio_chunk=on_audio_chunk)
+
+        on_audio_chunk.assert_not_awaited()
+
+    def test_recv_exception_translated_and_routed_to_on_error_then_loop_ends(self):
+        connection = MagicMock()
+        connection.recv = AsyncMock(side_effect=RuntimeError("connection dropped"))
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+        on_error = AsyncMock()
+        session.on_error = on_error
+
+        # Must terminate on its own (not hang) — the whole point of this test.
+        asyncio.run(session._receive_loop())
+
+        on_error.assert_awaited_once()
+        err = on_error.call_args.args[0]
+        assert isinstance(err, OpenAIRealtimeError)
+
+    def test_recv_exception_without_on_error_callback_is_logged_not_raised(self, caplog):
+        import logging
+
+        connection = MagicMock()
+        connection.recv = AsyncMock(side_effect=RuntimeError("boom"))
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        with caplog.at_level(logging.ERROR):
+            asyncio.run(session._receive_loop())  # no on_error set
+        assert any("OpenAIRealtimeSession" in rec.message for rec in caplog.records)
+
+    def test_handle_event_exception_reported_but_loop_continues(self):
+        """A single bad/unhandled event must not kill the whole receive
+        loop — mirrors GeminiLiveSession's per-message try/except."""
+        evt1 = _evt(type="response.output_audio_transcript.done", transcript="ok")
+
+        class _BadEvent:
+            @property
+            def type(self):
+                raise RuntimeError("malformed event")
+
+        on_output_transcript = AsyncMock()
+        on_error = AsyncMock()
+
+        self._run_with_events(
+            [_BadEvent(), evt1],
+            on_output_transcript=on_output_transcript,
+            on_error=on_error,
+        )
+
+        on_error.assert_awaited_once()
+        on_output_transcript.assert_awaited_once_with("ok")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# close() — idempotent, never raises
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestClose:
+    def test_close_is_idempotent(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+        asyncio.run(session.close())
+        asyncio.run(session.close())  # must not raise second time
+
+    def test_close_cancels_receive_task_and_exits_connect_cm(self):
+        connection = _FakeConnection(events=[])
+        client, connect_cm = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+        assert connect_cm.aexit_called is True
+        assert session._receive_task is None
+
+    def test_close_cancels_receive_task_while_genuinely_blocked_in_recv(self):
+        """`events=[]` alone lets _StopReceiving end the receive task on its
+        own before close()'s `.cancel()` is ever meaningfully exercised. Use
+        a connection whose recv() never resolves on its own, so close() must
+        cancel a task that is genuinely suspended *inside* recv(), not one
+        that already finished — mirrors the equivalent Gemini Live test and
+        this task's own CRITICAL testing-safety note."""
+        connection = _FakeConnection(block_forever=True)
+        client, connect_cm = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await asyncio.sleep(0)  # let the receive task actually start blocking
+            task = session._receive_task
+            assert task is not None
+            assert not task.done()
+
+            await session.close()
+
+            assert task.cancelled()
+
+        asyncio.run(_run())
+        assert connect_cm.aexit_called is True
+        assert session._receive_task is None
+
+    def test_close_never_raises_even_if_connect_cm_teardown_errors(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        class _BadCM:
+            async def __aexit__(self, *exc):
+                raise RuntimeError("teardown boom")
+
+        session._connect_cm = _BadCM()
+        # Must not raise.
+        asyncio.run(session.close())
+
+    def test_close_never_raises_even_if_receive_task_already_dead(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _dead_task_coro():
+            raise RuntimeError("already crashed")
+
+        async def _setup_and_close():
+            task = asyncio.create_task(_dead_task_coro())
+            await asyncio.sleep(0)  # let it crash
+            session._receive_task = task
+            await session.close()  # must not raise/propagate task's exception
+
+        asyncio.run(_setup_and_close())
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# resolve_voice_name / _classify_openai_realtime_error / calendly tools
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestResolveVoiceName:
+    def test_none_falls_back_to_default(self):
+        assert resolve_voice_name(None) == DEFAULT_VOICE_NAME
+
+    def test_empty_string_falls_back_to_default(self):
+        assert resolve_voice_name("") == DEFAULT_VOICE_NAME
+
+    def test_valid_voice_name_passthrough(self):
+        assert resolve_voice_name("cedar") == "cedar"
+
+    def test_case_insensitive_match_normalized_to_canonical_casing(self):
+        assert resolve_voice_name("CEDAR") == "cedar"
+        assert resolve_voice_name("Cedar") == "cedar"
+
+    def test_whitespace_stripped(self):
+        assert resolve_voice_name("  ash  ") == "ash"
+
+    def test_unknown_voice_falls_back_to_default(self):
+        # A leftover ElevenLabs/Rime/Google TTS voice ID — must never be
+        # passed through raw to the Realtime session config.
+        assert resolve_voice_name("21m00Tcm4TlvDq8ikWAM") == DEFAULT_VOICE_NAME
+
+    def test_all_ten_voices_are_valid_and_distinct(self):
+        assert len(VALID_VOICE_NAMES) == 10
+        for name in VALID_VOICE_NAMES:
+            assert resolve_voice_name(name) == name
+
+
+class TestClassifyError:
+    def test_rate_limit_message_classified_as_quota(self):
+        err = _classify_openai_realtime_error(RuntimeError("Rate limit reached"))
+        assert err.error_type == OpenAIRealtimeErrorType.QUOTA
+
+    def test_timeout_message_classified_as_timeout(self):
+        err = _classify_openai_realtime_error(RuntimeError("Request timed out"))
+        assert err.error_type == OpenAIRealtimeErrorType.TIMEOUT
+
+    def test_closed_message_classified_as_connection_closed(self):
+        err = _classify_openai_realtime_error(RuntimeError("connection closed unexpectedly"))
+        assert err.error_type == OpenAIRealtimeErrorType.CONNECTION_CLOSED
+
+    def test_unrecognized_message_classified_as_unknown(self):
+        err = _classify_openai_realtime_error(RuntimeError("something weird happened"))
+        assert err.error_type == OpenAIRealtimeErrorType.UNKNOWN
+
+    def test_openai_realtime_error_passthrough_in_report_error(self):
+        """_report_error must not re-wrap an already-classified error."""
+        session = OpenAIRealtimeSession("gpt-realtime")
+        on_error = AsyncMock()
+        session.on_error = on_error
+        original = OpenAIRealtimeError("already classified", OpenAIRealtimeErrorType.AUTH)
+
+        asyncio.run(session._report_error(original))
+
+        on_error.assert_awaited_once_with(original)
+
+
+class TestBuildCalendlyToolParams:
+    def test_returns_two_function_tools_with_expected_names(self):
+        tools = _build_calendly_tool_params()
+        assert len(tools) == 2
+        names = {t["name"] for t in tools}
+        assert names == {"check_availability", "book_appointment"}
+        for t in tools:
+            assert t["type"] == "function"
+            assert "description" in t
+            assert t["parameters"]["type"] == "object"
+
+    def test_check_availability_requires_date(self):
+        tools = {t["name"]: t for t in _build_calendly_tool_params()}
+        assert tools["check_availability"]["parameters"]["required"] == ["date"]
+
+    def test_book_appointment_requires_slot_and_email(self):
+        tools = {t["name"]: t for t in _build_calendly_tool_params()}
+        assert tools["book_appointment"]["parameters"]["required"] == ["slot", "attendee_email"]

--- a/tests/voice/test_openai_realtime_service.py
+++ b/tests/voice/test_openai_realtime_service.py
@@ -307,6 +307,59 @@ class TestSendAudio:
 
         connection.send.assert_not_awaited()
 
+    def test_send_audio_noop_once_session_already_closed(self):
+        """Straggler audio chunks arriving after close() has already run
+        must never reach connection.send() — see this method's docstring
+        about the LiveKitAudioSubscriber shutdown race."""
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+        session._closed = True
+
+        asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
+        connection.send.assert_not_awaited()
+
+    def test_send_audio_swallows_exception_when_closed_flips_mid_await(self):
+        """Mirrors TestClose.test_close_cancels_receive_task_while_genuinely_
+        blocked_in_recv's pattern of exercising a genuine concurrent race:
+        here, `self._closed` flips to True while `connection.send()` is
+        in-flight and then raises (simulating the underlying websocket
+        erroring out mid-close-handshake) — the exception must be swallowed,
+        not propagated, once the flip is observed."""
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        connection = MagicMock()
+
+        async def _send(_event):
+            # Simulate close() flipping the flag concurrently while this
+            # send() call is still in flight, then the underlying send
+            # erroring out as a result of the connection tearing down.
+            session._closed = True
+            raise ConnectionError("connection closed during send")
+
+        connection.send = AsyncMock(side_effect=_send)
+        session._connection = connection
+
+        # Must not raise.
+        asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
+        connection.send.assert_awaited_once()
+
+    def test_send_audio_reraises_exception_when_not_closed(self):
+        """Sanity check for the opposite branch: if send() fails for a
+        reason unrelated to a concurrent close(), the exception must still
+        propagate — the swallow is specifically scoped to the shutdown
+        race, not a blanket exception suppressor."""
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        connection = MagicMock()
+        connection.send = AsyncMock(side_effect=RuntimeError("genuine send failure"))
+        session._connection = connection
+
+        with pytest.raises(RuntimeError, match="genuine send failure"):
+            asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
 
 class TestSendText:
     def test_send_text_respond_true_sends_item_and_response_create(self):
@@ -516,6 +569,49 @@ class TestReceiveLoopDemux:
         err = on_error.call_args.args[0]
         assert isinstance(err, OpenAIRealtimeError)
         assert "rate limit exceeded" in str(err)
+
+    def test_input_transcription_failed_logs_warning_and_does_not_route_to_on_error(self, caplog):
+        import logging
+
+        evt = _evt(
+            type="conversation.item.input_audio_transcription.failed",
+            item_id="item-123",
+            error=_evt(code="transcription_error", message="audio format mismatch"),
+        )
+        on_error = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_not_awaited()
+        assert any(
+            "item-123" in rec.message and "audio format mismatch" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_mcp_list_tools_failed_logs_warning_and_does_not_route_to_on_error(self, caplog):
+        import logging
+
+        evt = _evt(type="mcp_list_tools.failed", item_id="item-456")
+        on_error = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_not_awaited()
+        assert any("item-456" in rec.message for rec in caplog.records)
+
+    def test_response_mcp_call_failed_logs_warning_and_does_not_route_to_on_error(self, caplog):
+        import logging
+
+        evt = _evt(type="response.mcp_call.failed", item_id="item-789")
+        on_error = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_not_awaited()
+        assert any("item-789" in rec.message for rec in caplog.records)
 
     def test_unknown_event_type_is_benign_noop(self):
         evt = _evt(type="session.created")

--- a/tests/voice/test_openai_realtime_twilio_fork.py
+++ b/tests/voice/test_openai_realtime_twilio_fork.py
@@ -1,0 +1,591 @@
+"""
+Twilio-transport fork-point tests for OpenAI Realtime native-audio routing
+(VoiceOrchestrator.on_audio_chunk -> _feed_openai_realtime_audio /
+_start_openai_realtime_session / _on_openai_realtime_* callbacks).
+
+Mirrors tests/voice/test_gemini_live_twilio_fork.py's structure, adapted for
+this provider's genuine divergences (see
+app/services/openai_realtime_service.py's module docstring):
+  - no MULAW->PCM16 conversion on the Twilio path at all (OpenAI accepts
+    audio/pcmu directly) — send_audio receives the RAW mulaw frame
+  - transcripts are written directly, no fragment-buffering
+  - barge-in is a single flag-set/clear, no dual-buffer flush
+
+OpenAIRealtimeSession itself is mocked throughout — no live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.routers.bidirectional_stream import BidirectionalStreamHandler as Handler
+from app.voice.voice_orchestrator import (
+    VoiceOrchestrator,
+    _OPENAI_REALTIME_FALLBACK_TEXT_MODEL,
+)
+
+NATIVE_AUDIO_MODEL = next(iter(OPENAI_REALTIME_MODELS))
+
+
+class _FalsyCallSession:
+    def __bool__(self) -> bool:
+        return False
+
+
+def _fake_handler(*, llm_model: str | None) -> Handler:
+    h = object.__new__(Handler)
+
+    h.agent = MagicMock()
+    h.agent.id = uuid.uuid4()
+    h.agent.name = "TestAgent"
+    h.agent.llm_model = llm_model
+    h.agent.system_prompt = None
+    h.agent.model = MagicMock()
+    h.agent.model.system_prompt = None
+    h.agent.transfer_route = None
+
+    h.call_session = _FalsyCallSession()
+    h.call_flow = None
+    h.db = None
+    h.call_session_id = "test-session-id"
+    h.agent_id = str(h.agent.id)
+    h.call_sid = "CA_test"
+    h.stream_sid = "MZ_test"
+
+    h._min_audio_level_threshold = 30
+    h._audio_samples_needed = 1
+    h._audio_non_silent_needed = 1
+
+    h._enable_interim_llm = False
+    h._min_interim_words = 3
+    h._min_interim_confidence = 0.4
+    h._min_interim_interval_sec = 0.2
+    h._barge_in_min_conf = 0.26
+    h._barge_in_min_conf_1w = 0.52
+
+    h._voice_metrics = MagicMock()
+    h._add_to_transcript = AsyncMock()
+    h._send_twilio_clear_event = AsyncMock()
+    h._stream_live_audio_chunk = AsyncMock()
+    h._full_shutdown = AsyncMock()
+    h.websocket = MagicMock()
+
+    return h
+
+
+def _loud_frame() -> bytes:
+    return bytes([0x00]) * 160
+
+
+class TestNativeAudioRoutingResolution:
+    def test_native_audio_model_sets_is_openai_realtime_true(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is True
+        assert orch._is_gemini_live is False
+
+    def test_non_native_model_sets_is_openai_realtime_false(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is False
+
+    def test_no_agent_defaults_to_false(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        h.agent = None
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is False
+
+
+class TestNativeAudioNeverConstructsSttPipeline:
+    def test_native_audio_agent_skips_stt_pipeline_construction(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._user_picked_up = True
+        h._handle_user_pickup = AsyncMock()
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+        fake_session.send_audio = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch.on_audio_chunk(_loud_frame()))
+
+        assert orch._stt_pipeline is None
+        fake_session.start.assert_awaited_once()
+        fake_session.send_audio.assert_awaited_once()
+
+    def test_non_native_agent_still_constructs_stt_pipeline(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        orch._user_picked_up = True
+        h._handle_user_pickup = AsyncMock()
+
+        fake_stt = MagicMock()
+        fake_stt.feed_audio_chunk = AsyncMock()
+        with patch("app.voice.voice_orchestrator.SttPipeline", return_value=fake_stt):
+            asyncio.run(orch.on_audio_chunk(_loud_frame()))
+
+        assert orch._stt_pipeline is fake_stt
+        assert orch._openai_realtime_session is None
+        fake_stt.feed_audio_chunk.assert_awaited_once()
+
+
+class TestAudioRoutingNoConversion:
+    """Regression guard: unlike Gemini Live, the Twilio path must NEVER
+    resample/convert audio for OpenAI Realtime — mu-law/8kHz goes straight
+    through in both directions (audio/pcmu is natively supported)."""
+
+    def test_send_audio_receives_raw_mulaw_unconverted(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.send_audio = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        mulaw = _loud_frame()
+        asyncio.run(orch._feed_openai_realtime_audio(h, mulaw))
+
+        fake_session.send_audio.assert_awaited_once_with(mulaw)
+
+    def test_on_audio_chunk_callback_streams_raw_bytes_unconverted(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"mulaw-from-openai"))
+
+        h._stream_live_audio_chunk.assert_awaited_once_with(b"mulaw-from-openai")
+
+    def test_on_audio_chunk_callback_gated_by_cancel_flag(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_cancel.set()
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"mulaw-from-openai"))
+
+        h._stream_live_audio_chunk.assert_not_awaited()
+
+
+class TestBargeIn:
+    def test_interrupted_sets_and_clears_cancel_and_clears_twilio_buffer(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_first_audio_marked = True
+
+        asyncio.run(orch._on_openai_realtime_interrupted())
+
+        h._send_twilio_clear_event.assert_awaited_once()
+        assert not orch._openai_realtime_cancel.is_set()
+        assert orch._openai_realtime_first_audio_marked is False
+
+
+class TestTranscriptCallbacksWriteDirectly:
+    """No fragment-buffering — each transcript callback fires once per
+    utterance with the full text and is written immediately."""
+
+    def test_input_transcript_written_immediately(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_input_transcript("hello there"))
+
+        h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+
+    def test_output_transcript_written_immediately(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_output_transcript("Sure, I can help."))
+
+        h._add_to_transcript.assert_awaited_once_with("agent", "Sure, I can help.", "agent_response")
+
+    def test_blank_transcript_not_written(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_input_transcript("   "))
+        asyncio.run(orch._on_openai_realtime_output_transcript(""))
+
+        h._add_to_transcript.assert_not_awaited()
+
+    def test_input_transcript_schedules_kb_refresh_task(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        async def _run():
+            with patch.object(
+                orch, "_refresh_openai_realtime_kb_context", new=AsyncMock()
+            ) as mock_refresh:
+                await orch._on_openai_realtime_input_transcript("what is your refund policy")
+                pending = list(orch._pending_final_tasks)
+                if pending:
+                    await asyncio.gather(*pending)
+                mock_refresh.assert_called_once_with("what is your refund policy")
+
+        asyncio.run(_run())
+
+
+class TestPreSessionFallback:
+    def test_start_failure_falls_back_to_openai_text_model(self):
+        from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock(
+            side_effect=OpenAIRealtimeError("boom", OpenAIRealtimeErrorType.QUOTA)
+        )
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert orch._openai_realtime_setup_failed is True
+        assert orch._is_openai_realtime is False
+        assert orch._openai_realtime_session is None
+        assert h.agent.llm_model == _OPENAI_REALTIME_FALLBACK_TEXT_MODEL
+        h._full_shutdown.assert_not_awaited()
+
+    def test_fallback_with_no_agent_ends_call_gracefully(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h.agent = None
+
+        asyncio.run(orch._fallback_to_legacy_pipeline_openai(h, reason="no agent"))
+
+        assert orch._openai_realtime_setup_failed is True
+        h._full_shutdown.assert_called_once()
+
+
+class TestMidCallError:
+    def test_mid_call_error_ends_call_gracefully(self):
+        from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(
+            orch._on_openai_realtime_error(
+                OpenAIRealtimeError("dropped", OpenAIRealtimeErrorType.CONNECTION_CLOSED)
+            )
+        )
+
+        h._full_shutdown.assert_called_once()
+
+
+def _fake_handler_for_real_prompt_build(*, llm_model: str) -> Handler:
+    h = _fake_handler(llm_model=llm_model)
+    h.agent.language = "en"
+    h.agent.model.api_key = None
+    h.agent.is_inbound_agent = False
+    h.agent.tts_provider = None
+    h.call_session = None
+    h.db = None
+    h._last_offered_calendar_slots = []
+    h._last_requested_calendar_date = None
+    h._last_selected_calendar_slot = None
+    h._conversation_history_cache = []
+    h.HISTORY_MAX_MESSAGES = 20
+    h._metric_stt_final_ts = 0.0
+    h._rag_prefetch_task = None
+    h._kb_cache_ready = False
+    h._cached_inbound_kb_block = ""
+    h._jd_recruitment_screening_active = lambda: False
+    h._send_quick_acknowledgement = AsyncMock()
+    return h
+
+
+class TestOpenAIRealtimeSessionUsesTwilioOwnPromptAssembly:
+    def test_start_openai_realtime_session_uses_handlers_own_build_system_prompt(self):
+        h = _fake_handler_for_real_prompt_build(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        fake_session.start.assert_awaited_once()
+        system_instruction = fake_session.start.call_args.kwargs["system_instruction"]
+        assert "# CURRENT DATE & TIME" in system_instruction
+
+    def test_start_uses_twilio_audio_pcmu_format(self):
+        from app.services.openai_realtime_service import TWILIO_AUDIO_FORMAT
+
+        h = _fake_handler_for_real_prompt_build(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert fake_session.start.call_args.kwargs["audio_format"] == TWILIO_AUDIO_FORMAT
+
+    def test_browser_handler_still_uses_conversation_orchestrator(self):
+        from app.services.openai_realtime_service import LIVEKIT_AUDIO_FORMAT
+
+        h = MagicMock(spec=[])
+        h.agent = MagicMock()
+        h.agent.llm_model = NATIVE_AUDIO_MODEL
+        h.call_session_id = "test-session-id"
+
+        assert not hasattr(h, "build_system_prompt")
+
+        orch = VoiceOrchestrator.__new__(VoiceOrchestrator)
+        orch._openai_realtime_session = None
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ) as browser_build:
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        browser_build.assert_awaited_once()
+        fake_session.start.assert_awaited_once()
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["system_instruction"] == "browser system prompt"
+        assert kwargs["audio_format"] == LIVEKIT_AUDIO_FORMAT
+
+
+class TestGreetingBypassesExternalTtsForNativeAudio:
+    def _greeting_handler(self, *, is_openai_realtime: bool) -> Handler:
+        h = object.__new__(Handler)
+        h.agent = MagicMock()
+        h.agent.greeting_message = "Hi, thanks for calling Acme."
+        h.agent.first_message = None
+        h.call_session = MagicMock()
+        h.call_session.call_type = "inbound"
+        h.call_session.call_metadata = {}
+        h.call_session.id = uuid.uuid4()
+        h.db = None
+        h._flow_executor = None
+        h._add_to_transcript = AsyncMock()
+        h._twilio_buffer_primed = True
+        h._use_ssml = True
+        h._jd_recruitment_screening_active = MagicMock(return_value=False)
+
+        h._tts_pipeline = MagicMock()
+        h._tts_pipeline.queue_tts = AsyncMock()
+
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        vo = MagicMock()
+        vo._is_gemini_live = False
+        vo._gemini_live_session = None
+        vo._is_openai_realtime = is_openai_realtime
+        vo._openai_realtime_session = fake_session if is_openai_realtime else None
+        h._voice_orchestrator = vo
+        h._fake_session = fake_session
+        return h
+
+    def test_native_audio_greeting_uses_live_session_send_text_not_tts(self):
+        h = self._greeting_handler(is_openai_realtime=True)
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._fake_session.send_text.assert_awaited_once_with(
+            "Hi, thanks for calling Acme.", respond=True
+        )
+        h._tts_pipeline.queue_tts.assert_not_awaited()
+
+    def test_native_audio_greeting_skips_gracefully_if_session_not_ready(self):
+        h = self._greeting_handler(is_openai_realtime=True)
+        h._voice_orchestrator._openai_realtime_session = None
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._tts_pipeline.queue_tts.assert_not_awaited()
+
+    def test_non_native_audio_greeting_still_uses_external_tts(self):
+        h = self._greeting_handler(is_openai_realtime=False)
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._tts_pipeline.queue_tts.assert_awaited_once()
+        queued = h._tts_pipeline.queue_tts.call_args[0][0]
+        assert queued["text"] == "Hi, thanks for calling Acme."
+
+
+def _fc(*, id: str, name: str, args: dict) -> tuple[str, str, str]:
+    """OpenAI Realtime tool calls are plain (call_id, name, arguments_json)
+    args (see OpenAIRealtimeSession.on_tool_call's contract), unlike
+    Gemini's google.genai.types.FunctionCall object — no fake type needed."""
+    import json
+
+    return (id, name, json.dumps(args))
+
+
+class TestCalendlyToolCallWiring:
+    def _handler_with_calendly(self, *, enabled: bool) -> Handler:
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h._calendly_enabled = MagicMock(return_value=enabled)
+        h._execute_calendly_tool_call = AsyncMock(return_value={"slots": []})
+        return h
+
+    def test_session_start_passes_calendly_tool_when_enabled(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is not None
+        assert len(kwargs["tools"]) == 2
+        assert kwargs["on_tool_call"] == orch._on_openai_realtime_tool_call
+
+    def test_session_start_passes_no_tools_when_calendly_disabled(self):
+        h = self._handler_with_calendly(enabled=False)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is None
+        assert kwargs["on_tool_call"] is None
+
+    def test_on_tool_call_resolves_and_sends_response(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        call_id, name, args_json = _fc(id="call-1", name="check_availability", args={"date": "tomorrow"})
+        h._execute_calendly_tool_call = AsyncMock(return_value={"slots": ["09:00"]})
+
+        asyncio.run(orch._on_openai_realtime_tool_call(call_id, name, args_json))
+
+        h._execute_calendly_tool_call.assert_awaited_once_with("check_availability", {"date": "tomorrow"})
+        fake_session.send_tool_response.assert_awaited_once_with("call-1", {"slots": ["09:00"]})
+
+    def test_on_tool_call_noop_when_session_not_set(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_session = None
+
+        asyncio.run(orch._on_openai_realtime_tool_call("c1", "check_availability", "{}"))
+        h._execute_calendly_tool_call.assert_not_awaited()
+
+    def test_on_tool_call_survives_execute_exception(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._openai_realtime_session = fake_session
+        h._execute_calendly_tool_call = AsyncMock(side_effect=RuntimeError("boom"))
+
+        asyncio.run(orch._on_openai_realtime_tool_call("c1", "check_availability", "{}"))
+
+        fake_session.send_tool_response.assert_awaited_once_with(
+            "c1", {"error": "internal error executing tool call"}
+        )
+
+    def test_on_tool_call_survives_malformed_arguments_json(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._openai_realtime_session = fake_session
+        h._execute_calendly_tool_call = AsyncMock(return_value={"ok": True})
+
+        asyncio.run(orch._on_openai_realtime_tool_call("c1", "check_availability", "not json"))
+
+        h._execute_calendly_tool_call.assert_awaited_once_with("check_availability", {})
+
+
+class TestPerAgentVoiceWiring:
+    def test_valid_agent_voice_passed_through(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.agent.tts_voice_external_id = "cedar"
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert fake_session.start.call_args.kwargs["voice_name"] == "cedar"
+
+    def test_unset_or_invalid_agent_voice_falls_back_to_default(self):
+        from app.services.openai_realtime_service import DEFAULT_VOICE_NAME
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.agent.tts_voice_external_id = "21m00Tcm4TlvDq8ikWAM"
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert fake_session.start.call_args.kwargs["voice_name"] == DEFAULT_VOICE_NAME
+
+
+class TestShutdownClosesSession:
+    def test_shutdown_closes_openai_realtime_session(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.close = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        asyncio.run(orch.shutdown())
+
+        fake_session.close.assert_awaited_once()
+        assert orch._openai_realtime_session is None

--- a/tests/voice/test_openai_realtime_twilio_fork.py
+++ b/tests/voice/test_openai_realtime_twilio_fork.py
@@ -233,6 +233,140 @@ class TestTranscriptCallbacksWriteDirectly:
         asyncio.run(_run())
 
 
+class TestMidCallRagRefresh:
+    """
+    Mid-call KB context refresh (VoiceOrchestrator.
+    _refresh_openai_realtime_kb_context), triggered fire-and-forget from
+    _on_openai_realtime_input_transcript. Mirrors
+    test_gemini_live_twilio_fork.py's TestMidCallRagRefresh, adapted for
+    this provider's send_text(text, respond=False) signature (vs Gemini's
+    send_text(text, turn_complete=False)) and its DIAGNOSTIC skip-reason
+    logging / upgraded warning-with-exc_info on retrieval failure.
+    """
+
+    def _handler_with_flow(self, *, kb_ids):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.call_flow = MagicMock()
+        h.call_flow.knowledge_base_ids = kb_ids
+        return h
+
+    def test_refresh_noop_when_no_session(self, caplog):
+        import logging
+
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_session = None
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve, caplog.at_level(logging.INFO):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_not_awaited()
+        assert any("no_session" in rec.message for rec in caplog.records)
+
+    def test_refresh_noop_when_empty_transcript(self, caplog):
+        import logging
+
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve, caplog.at_level(logging.INFO):
+            asyncio.run(orch._refresh_openai_realtime_kb_context(""))
+
+        mock_retrieve.assert_not_awaited()
+        fake_session.send_text.assert_not_awaited()
+        assert any("empty_transcript" in rec.message for rec in caplog.records)
+
+    def test_refresh_noop_when_no_kb_ids(self, caplog):
+        import logging
+
+        h = self._handler_with_flow(kb_ids=[])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve, caplog.at_level(logging.INFO):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_not_awaited()
+        fake_session.send_text.assert_not_awaited()
+        assert any("no_kb_ids_configured" in rec.message for rec in caplog.records)
+
+    def test_refresh_sends_context_as_non_blocking_text_turn(self):
+        kb_id = uuid.uuid4()
+        h = self._handler_with_flow(kb_ids=[kb_id])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("Refunds within 30 days.", 42.0)),
+        ) as mock_retrieve, patch("app.utils.redis_client.get_redis", return_value=None):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_awaited_once()
+        call_kwargs = mock_retrieve.call_args.kwargs
+        assert call_kwargs["transcript"] == "what's your refund policy"
+        assert call_kwargs["kb_ids"] == [kb_id]
+
+        fake_session.send_text.assert_awaited_once()
+        sent_args, sent_kwargs = fake_session.send_text.call_args.args, fake_session.send_text.call_args.kwargs
+        assert "Refunds within 30 days." in sent_args[0]
+        assert sent_kwargs["respond"] is False
+
+    def test_refresh_sends_nothing_when_kb_returns_empty(self):
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("", 3.0)),
+        ):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("unrelated small talk"))
+
+        fake_session.send_text.assert_not_awaited()
+
+    def test_refresh_fails_open_and_logs_warning_with_exc_info_on_retrieval_exception(self, caplog):
+        """Regression guard for the debug->warning upgrade: a silently
+        debug-logged exception here would look identical in production logs
+        to 'KB refresh never fired at all', so this must be logged at
+        WARNING with exc_info=True, not swallowed at DEBUG."""
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(side_effect=RuntimeError("kb backend down")),
+        ), patch("app.voice.voice_orchestrator.logger") as mock_logger:
+            # Must not raise.
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        fake_session.send_text.assert_not_awaited()
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args.kwargs.get("exc_info") is True
+        mock_logger.debug.assert_not_called()
+
+
 class TestPreSessionFallback:
     def test_start_failure_falls_back_to_openai_text_model(self):
         from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType

--- a/tests/voice/test_tts_provider_capabilities.py
+++ b/tests/voice/test_tts_provider_capabilities.py
@@ -138,6 +138,39 @@ def test_rime_overlay_stays_empty_even_with_stability_hint():
 
 
 # ---------------------------------------------------------------------------
+# Hume
+# ---------------------------------------------------------------------------
+
+
+def test_hume_supported_capabilities():
+    caps = get_capabilities("hume")
+    assert caps.provider_slug == "hume"
+    assert caps.supports_streaming is True
+    assert caps.supports_speaking_rate is True
+
+
+def test_hume_unsupported_expressive_controls_remain_unsupported():
+    caps = get_capabilities("hume")
+    assert caps.supports_stability_control is False
+    assert caps.supports_pitch is False
+    assert caps.supports_ssml is False
+    assert caps.supports_native_expressive_tags is False
+    assert caps.supports_pause_control is False
+
+
+def test_hume_overlay_stays_empty_even_with_stability_hint():
+    """Hume's prosody knob is the free-text "description" field, structurally
+    distinct from ElevenLabs' numeric stability hint — build_voice_settings_overlay
+    is explicitly scoped to the numeric path and must not touch Hume."""
+    decision = analyze_response(
+        "Got it, one moment.",
+        user_text="This is unacceptable, I want a refund now",
+    )
+    overlay = build_voice_settings_overlay("hume", decision)
+    assert overlay == {}
+
+
+# ---------------------------------------------------------------------------
 # General / fallback safety
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Integrates Gemini Live native-audio speech-to-speech models as a new pipeline path alongside the existing STT→LLM→TTS pipeline, wired into both call transports (Twilio bidirectional stream and browser/LiveKit).

- **`28445d8`** — Core integration: `GeminiLiveSession` wrapper (`app/services/gemini_live_service.py`), audio format bridging, `GEMINI_LIVE_MODELS` routing, wired into `VoiceOrchestrator` for both transports.
- **`dff58ee`** — Phase 2: Calendly tool-calling, mid-call RAG context refresh, voice picker.
- **`a39d10b`** — Fix: `_receive_loop()` only processed the first Gemini conversation turn — `session.receive()` covers a single turn by SDK design and must be re-invoked per turn, or the receive loop dies silently after turn 1, leaving calls fully silent until a keepalive timeout tears down the connection. Confirmed working on a real call after this fix.
- **`564b9b8`** — Fix: input/output transcript capture was broken — Gemini's `finished` flag on transcription messages is not reliably set (confirmed via an open upstream bug, googleapis/js-genai#1429) and even when set, `text` is often just an incremental fragment. Replaced with fragment-buffering flushed on reliable signals (turn_complete, next-turn's first output fragment, barge-in, shutdown) instead of trusting `finished`.
- **`b2ede57`** — Added regression coverage that was missing for the receive-loop multi-turn fix (a retrospective review found the existing suite never exercised a second turn), plus a genuine mid-`receive()` cancellation test.

## Test plan

- [x] `pytest tests/voice/test_gemini_live_service.py tests/voice/test_gemini_live_twilio_fork.py tests/voice/test_gemini_live_browser_fork.py -q` — 117 passed
- [x] Verified live on real phone calls (both bugs above were found and fixed via real-call testing, not just unit tests)
- [x] Retrospective `code-reviewer` pass on both fix commits, findings addressed inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)