### PR TITLE
feat(voice): integrate OpenAI Realtime native-audio speech-to-speech models

### DIFF
--- a/alembic/versions/20260817b_widen_agent_llm_model_check_openai_realtime.py
+++ b/alembic/versions/20260817b_widen_agent_llm_model_check_openai_realtime.py
@@ -1,0 +1,151 @@
+"""widen ck_agent_llm_model to include OpenAI Realtime speech-to-speech models
+
+Revision ID: 20260817_widen_llm_check_oair
+Revises: 20260817_widen_llm_check_glive
+Create Date: 2026-08-17
+
+Purpose
+-------
+``app/core/llm_models.py`` now includes two new OpenAI Realtime
+speech-to-speech native-audio models: ``gpt-realtime`` and
+``gpt-realtime-2``. The DB-level ``ck_agent_llm_model`` CHECK constraint —
+most recently widened by ``20260817_widen_llm_check_glive`` to a 24-value
+snapshot — was never widened to match, so inserting/updating an agent with
+either of these new model IDs would violate the CHECK even though the
+application layer accepts them.
+
+This migration is purely additive: it drops and recreates
+``ck_agent_llm_model`` with the union of the prior 24-value snapshot plus
+the 2 new OpenAI Realtime IDs (26 total). No values are removed or renamed,
+so no existing row can violate the widened constraint — safe to apply
+without a backfill on a live multi-tenant table. Same additive-CHECK-
+widening pattern used by ``20260817_widen_llm_check_glive``,
+``20260816_widen_llm_check_g3``, ``20260815_widen_llm_check``, and, before
+them, ``20260602_schema_v2_completion``.
+
+Note: these two model IDs select an entirely different call pipeline
+(speech-to-speech via OpenAI's Realtime API, no external STT/TTS) — this
+migration only widens the CHECK so the value is storable; it does not
+change any pipeline behavior.
+
+Snapshot strategy
+------------------
+Per the same rationale as the prior widening migrations, the allow-list
+used to build the CHECK SQL is a self-contained snapshot tuple in *this*
+file, not an import from ``app.core.llm_models`` — so future edits to that
+module (renames, removals) do not retroactively change what this historical
+migration replays during ``alembic upgrade``.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260817_widen_llm_check_oair"
+down_revision: Union[str, Sequence[str], None] = "20260817_widen_llm_check_glive"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Union of the 20260817_widen_llm_check_glive 24-value snapshot plus the 2
+# new OpenAI Realtime model IDs added to
+# app.core.llm_models.ALLOWED_LLM_MODELS. Self-contained — do not import
+# app.core.llm_models (future renames there must not retroactively change
+# this migration's replay behavior).
+_ALLOWED_LLM_MODELS_AT_REVISION: tuple[str, ...] = (
+    # --- prior 24-value snapshot (20260817_widen_llm_check_glive), unchanged ---
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+    "gemini-live-2.5-flash-native-audio",
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "gemini-3.1-flash-live-preview",
+    # --- new: OpenAI Realtime speech-to-speech native-audio family ---
+    "gpt-realtime",
+    "gpt-realtime-2",
+)
+
+# The exact 24-value snapshot from 20260817_widen_llm_check_glive, needed to
+# restore the narrower constraint on downgrade.
+_PRIOR_ALLOWED_LLM_MODELS: tuple[str, ...] = (
+    "gpt-4o-mini",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4-turbo",
+    "gemini-2.5-flash",
+    "gemini-2.0-flash-001",
+    "gemini-2.0-flash",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "claude-3-5-sonnet",
+    "claude-3-haiku",
+    "llama-3.1-70b-versatile",
+    "llama-3.1-8b-instant",
+    "gpt-5",
+    "gpt-5-mini",
+    "gpt-5.1",
+    "gpt-5.2",
+    "gpt-5.4",
+    "gemini-3-flash-preview",
+    "gemini-3.1-flash-lite",
+    "gemini-live-2.5-flash-native-audio",
+    "gemini-live-2.5-flash-preview-native-audio-09-2025",
+    "gemini-3.1-flash-live-preview",
+)
+
+
+def _llm_check_sql(models: tuple[str, ...]) -> str:
+    """Build ck_agent_llm_model CHECK SQL from a given model snapshot."""
+    return "llm_model IS NULL OR llm_model IN (%s)" % ", ".join(
+        f"'{m}'" for m in models
+    )
+
+
+def _has_constraint(conn, table: str, constraint: str) -> bool:
+    return conn.execute(
+        sa.text(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.table_constraints "
+            "WHERE table_schema = 'public' AND table_name = :tbl AND constraint_name = :con)"
+        ),
+        {"tbl": table, "con": constraint},
+    ).scalar()
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_ALLOWED_LLM_MODELS_AT_REVISION)
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    if _has_constraint(conn, "agent", "ck_agent_llm_model"):
+        op.drop_constraint("ck_agent_llm_model", "agent", type_="check")
+    op.create_check_constraint(
+        "ck_agent_llm_model", "agent", _llm_check_sql(_PRIOR_ALLOWED_LLM_MODELS)
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -93,6 +93,9 @@ class LlmSettings(BaseModel):
     openai_api_key: str = Field(default="", validation_alias="OPENAI_API_KEY")
     openai_base_url: str = Field(default="", validation_alias="OPENAI_BASE_URL")
     openai_api_version: str = Field(default="", validation_alias="OPENAI_API_VERSION")
+    openai_realtime_transcription_model: str = Field(
+        default="whisper-1", validation_alias="OPENAI_REALTIME_TRANSCRIPTION_MODEL"
+    )
     # Gemini / Vertex
     gemini_api_key: str = Field(default="", validation_alias="GEMINI_API_KEY")
     google_application_credentials: str = Field(
@@ -449,6 +452,15 @@ class Settings(BaseSettings):
     DEFAULT_LLM_PROVIDER: str = "gemini"
     # OpenAI Configuration
     OPENAI_API_KEY: str = ""
+    # Input-audio transcription model for OpenAI Realtime sessions (separate
+    # from the main gpt-realtime*/gpt-realtime-2 model itself). Defaults to
+    # whisper-1 — OpenAI's oldest, most universally-enabled transcription
+    # model — since newer options like gpt-4o-mini-transcribe require
+    # per-project access that isn't guaranteed to be enabled (confirmed via
+    # a real call: model_not_found for gpt-4o-mini-transcribe on a project
+    # that otherwise has full Realtime API access). Override per-environment
+    # if a project has access to a better model.
+    OPENAI_REALTIME_TRANSCRIPTION_MODEL: str = "whisper-1"
 
     # Rime Labs TTS Configuration
     RIME_API_KEY: str = ""
@@ -1069,6 +1081,7 @@ class Settings(BaseSettings):
             openai_api_key=self.OPENAI_API_KEY,
             openai_base_url=self.OPENAI_BASE_URL,
             openai_api_version=self.OPENAI_API_VERSION,
+            openai_realtime_transcription_model=self.OPENAI_REALTIME_TRANSCRIPTION_MODEL,
             gemini_api_key=self.GEMINI_API_KEY,
             google_application_credentials=self.GOOGLE_APPLICATION_CREDENTIALS,
             google_cloud_project_id=self.GOOGLE_CLOUD_PROJECT_ID,

--- a/app/core/llm_models.py
+++ b/app/core/llm_models.py
@@ -48,6 +48,15 @@ ALLOWED_LLM_MODELS: Final[tuple[str, ...]] = (
     "gemini-live-2.5-flash-native-audio",
     "gemini-live-2.5-flash-preview-native-audio-09-2025",
     "gemini-3.1-flash-live-preview",
+    # OpenAI — Realtime speech-to-speech native-audio models (new). Same
+    # "NOT a text model" caveat as the Gemini Live family above: selecting
+    # one of these routes the whole call through OpenAI's Realtime API
+    # (caller audio in, OpenAI's native audio out, no external STT/TTS). See
+    # OPENAI_REALTIME_MODELS below and is_openai_realtime_model() for the
+    # routing predicate. `infer_llm_provider` already returns "openai" for
+    # any "gpt"-prefixed model — no change needed there.
+    "gpt-realtime",
+    "gpt-realtime-2",
     # Anthropic — existing
     "claude-3-5-sonnet",
     "claude-3-haiku",
@@ -107,6 +116,42 @@ def is_gemini_live_native_audio_model(model_name: str) -> bool:
     native-audio.
     """
     return (model_name or "") in GEMINI_LIVE_MODELS
+
+
+#: Per-model config for the OpenAI Realtime speech-to-speech family.
+#: Confirmed against the installed openai==2.36.0 SDK's own generated types
+#: (openai.types.realtime.call_accept_params's model Literal enum) — see
+#: app/services/openai_realtime_service.py for the session wrapper.
+#:
+#: - ``gpt-realtime``: the original flagship Realtime model (GA Aug 2025).
+#:   No `reasoning` config — the Realtime API's reasoning_effort knob is
+#:   documented as only applying to reasoning-capable Realtime models.
+#: - ``gpt-realtime-2``: newer reasoning-capable generation. Capped to a low
+#:   reasoning effort by default (see openai_realtime_service.py's
+#:   _REASONING_EFFORT_BY_MODEL) for the same voice-turn-latency reason
+#:   gpt-5/gpt-5-mini's Chat Completions reasoning_effort is capped in
+#:   app/services/openai_service.py — an uncapped reasoning budget on a
+#:   live voice turn risks noticeable dead air before the model starts
+#:   speaking.
+#:
+#: Both models use plain API-key auth (settings.OPENAI_API_KEY via
+#: app.core.openai_client.get_async_openai_client) — no ephemeral-token
+#: dance, since this backend always proxies rather than handing a token to
+#: a browser/mobile client directly.
+OPENAI_REALTIME_MODELS: Final[tuple[str, ...]] = ("gpt-realtime", "gpt-realtime-2")
+
+
+def is_openai_realtime_model(model_name: str) -> bool:
+    """
+    Return True if ``model_name`` is one of the OpenAI Realtime
+    speech-to-speech native-audio models (:data:`OPENAI_REALTIME_MODELS`).
+
+    Exact-match check, mirroring is_gemini_live_native_audio_model()'s
+    reasoning — these models require a completely different call pipeline
+    (caller audio in, OpenAI's own native audio out, no external STT/TTS),
+    not just another text-generation ``gpt-*`` model.
+    """
+    return (model_name or "") in OPENAI_REALTIME_MODELS
 
 
 def infer_llm_provider(model_name: str) -> str:

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -2025,6 +2025,28 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                     self._twilio_buffer_primed = False
                     return
 
+                # Mirror-image bypass for OpenAI Realtime native-audio calls —
+                # same rationale as the Gemini Live branch above, routed
+                # through OpenAIRealtimeSession.send_text(respond=True) so
+                # OpenAI actually speaks the greeting (unlike the mid-call KB
+                # refresh's respond=False, this scripted greeting SHOULD be
+                # spoken as a real turn).
+                if _vo is not None and getattr(_vo, "_is_openai_realtime", False):
+                    session = _vo._openai_realtime_session
+                    if session is not None:
+                        try:
+                            await session.send_text(greeting_text, respond=True)
+                        except Exception as exc:
+                            logger.warning(
+                                "[OpenAIRealtime] failed to send greeting via live session: %s", exc
+                            )
+                    else:
+                        logger.debug(
+                            "[OpenAIRealtime] skipping scripted greeting — live session not ready yet"
+                        )
+                    self._twilio_buffer_primed = False
+                    return
+
                 # Queue greeting TTS directly (skip LLM!)
                 if not self._tts_pipeline:
                     return

--- a/app/services/gemini_live_service.py
+++ b/app/services/gemini_live_service.py
@@ -241,12 +241,30 @@ class GeminiLiveSession:
         """Send one chunk of raw PCM16/16kHz/mono caller audio. Caller must
         have already converted to this format (e.g. via
         ``gemini_live_audio_bridge.mulaw8k_to_pcm16_16k``) — this module has
-        zero telephony-format knowledge."""
+        zero telephony-format knowledge.
+
+        Safe no-op once the session is closed/closing — the audio-forwarding
+        background task (``LiveKitAudioSubscriber`` / Twilio's media-stream
+        loop) is stopped independently of this session's teardown, so a few
+        straggler chunks arriving after ``close()`` has already fired are
+        expected, not exceptional. Without this guard those stragglers hit
+        the underlying websocket mid-close-handshake and raise
+        ``ConnectionClosedError``/``TimeoutError``, which the caller then
+        logs at ERROR level for what is actually a benign shutdown race."""
+        if not pcm16_16k_bytes or self._closed:
+            return
         from google.genai import types
 
-        await self._session.send_realtime_input(
-            audio=types.Blob(data=pcm16_16k_bytes, mime_type="audio/pcm;rate=16000")
-        )
+        try:
+            await self._session.send_realtime_input(
+                audio=types.Blob(data=pcm16_16k_bytes, mime_type="audio/pcm;rate=16000")
+            )
+        except Exception:
+            if self._closed:
+                # Lost the race: close() ran concurrently with this send.
+                # Benign — swallow rather than surface as an error.
+                return
+            raise
 
     async def send_text(self, text: str, turn_complete: bool = True) -> None:
         from google.genai import types

--- a/app/services/openai_realtime_service.py
+++ b/app/services/openai_realtime_service.py
@@ -57,6 +57,7 @@ import enum
 import json
 from typing import Any, Awaitable, Callable
 
+from app.core.config import settings
 from app.core.llm_models import OPENAI_REALTIME_MODELS
 from app.core.logger import logger
 from app.core.openai_client import get_async_openai_client
@@ -324,7 +325,14 @@ class OpenAIRealtimeSession:
             "audio": {
                 "input": {
                     "format": _audio_format_dict(audio_format),
-                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    # Configurable — see settings.llm.openai_realtime_transcription_model's
+                    # docstring: newer transcription models (gpt-4o-mini-transcribe
+                    # etc.) require per-project OpenAI access that isn't
+                    # guaranteed to be enabled even when the project has full
+                    # Realtime API access for the main model itself (confirmed
+                    # via a real call hitting model_not_found). whisper-1 is
+                    # the safe, universally-available default.
+                    "transcription": {"model": settings.llm.openai_realtime_transcription_model},
                     "turn_detection": {
                         "type": "server_vad",
                         "interrupt_response": True,

--- a/app/services/openai_realtime_service.py
+++ b/app/services/openai_realtime_service.py
@@ -356,13 +356,29 @@ class OpenAIRealtimeSession:
         """Send one chunk of raw caller audio, already encoded in whatever
         format this session was started with (`audio_format` — mu-law 8kHz
         for Twilio, PCM16 24kHz for LiveKit). This module has zero
-        telephony-format knowledge beyond that string."""
-        if not audio_bytes:
+        telephony-format knowledge beyond that string.
+
+        Safe no-op once the session is closed/closing — the audio-forwarding
+        background task (``LiveKitAudioSubscriber`` / Twilio's media-stream
+        loop) is stopped independently of this session's teardown, so a few
+        straggler chunks arriving after ``close()`` has already fired are
+        expected, not exceptional. Without this guard those stragglers hit
+        the underlying websocket mid-close-handshake and raise
+        ``ConnectionClosedError``/``TimeoutError``, which the caller then
+        logs at ERROR level for what is actually a benign shutdown race."""
+        if not audio_bytes or self._closed:
             return
-        await self._connection.send({
-            "type": "input_audio_buffer.append",
-            "audio": base64.b64encode(audio_bytes).decode("ascii"),
-        })
+        try:
+            await self._connection.send({
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(audio_bytes).decode("ascii"),
+            })
+        except Exception:
+            if self._closed:
+                # Lost the race: close() ran concurrently with this send.
+                # Benign — swallow rather than surface as an error.
+                return
+            raise
 
     async def send_text(self, text: str, respond: bool = True) -> None:
         """
@@ -467,6 +483,13 @@ class OpenAIRealtimeSession:
     async def _handle_event(self, event: Any) -> None:
         etype = getattr(event, "type", None)
 
+        # DIAGNOSTIC: temporary, event-type-only tracing to confirm which
+        # Realtime events actually arrive on a real call (added while
+        # investigating a "no transcript captured" report — no raw audio or
+        # transcript text is ever included here). Safe to strip once
+        # transcript capture is confirmed working on a real call.
+        logger.info("[OpenAIRealtimeSession] DIAGNOSTIC event type=%s", etype)
+
         if etype == "response.output_audio.delta":
             delta = getattr(event, "delta", None)
             if delta and self.on_audio_chunk is not None:
@@ -507,6 +530,43 @@ class OpenAIRealtimeSession:
             error_obj = getattr(event, "error", None)
             message = getattr(error_obj, "message", None) or str(error_obj) or "unknown Realtime API error"
             await self._report_error(OpenAIRealtimeError(message, OpenAIRealtimeErrorType.UNKNOWN))
+            return
+
+        if etype == "conversation.item.input_audio_transcription.failed":
+            # A single utterance's transcription failed server-side (e.g. an
+            # issue with the configured `gpt-4o-mini-transcribe` model or an
+            # audio-format mismatch). This is NOT the same as a session-fatal
+            # `error` event — the audio call itself is fine and OpenAI keeps
+            # talking; only this one utterance's transcript is lost. Log
+            # loudly (previously this fell through to the silent "benign
+            # chatter" branch below with zero visibility) but do not treat it
+            # as fatal / route through on_error, matching this codebase's
+            # fail-open philosophy for per-turn transcript/RAG failures.
+            error_obj = getattr(event, "error", None)
+            message = getattr(error_obj, "message", None) or str(error_obj) or "unknown transcription error"
+            code = getattr(error_obj, "code", None)
+            item_id = getattr(event, "item_id", None)
+            logger.warning(
+                "[OpenAIRealtimeSession] input audio transcription FAILED "
+                "(model=%s item_id=%s code=%s): %s",
+                self.model_name, item_id, code, message,
+            )
+            return
+
+        if etype in ("mcp_list_tools.failed", "response.mcp_call.failed"):
+            # Not currently used by this integration (no MCP tools are wired
+            # up here — only the Calendly function tools), but logged
+            # explicitly rather than silently dropped in case that changes,
+            # or in case the SDK reports one of these unexpectedly. Neither
+            # event type carries its own error payload (confirmed against
+            # the SDK's generated fields — just event_id/item_id); the
+            # underlying reason, if any, arrives separately via the generic
+            # "error" event handled above.
+            item_id = getattr(event, "item_id", None)
+            logger.warning(
+                "[OpenAIRealtimeSession] %s event (model=%s item_id=%s)",
+                etype, self.model_name, item_id,
+            )
             return
 
         # All other event types (session.created, response.created,

--- a/app/services/openai_realtime_service.py
+++ b/app/services/openai_realtime_service.py
@@ -1,0 +1,515 @@
+"""
+OpenAI Realtime (speech-to-speech native-audio) session wrapper.
+
+Mirrors ``app/services/gemini_live_service.py``'s module shape/callback
+contract (``GeminiLiveSession``) so ``VoiceOrchestrator`` can wire either
+provider into the same transport handlers with parallel, not shared, code
+paths (per this repo's convention of keeping the two Twilio/LiveKit
+transport handlers "deliberately parallel, not shared via inheritance" —
+same idea applied one layer down, at the provider level).
+
+This module has ZERO knowledge of Twilio/LiveKit/telephony framing — it
+only speaks whatever raw audio bytes the caller tells it to use via
+``audio_format`` (``"audio/pcmu"`` — mu-law 8kHz, a direct match for
+Twilio's own wire format, so the Twilio transport needs NO resampling
+bridge at all; or ``"audio/pcm"`` — PCM16 24kHz, symmetric in both
+directions, which is what the LiveKit browser transport's publisher speaks
+for Gemini Live too). See ``app/core/llm_models.py``'s
+``OPENAI_REALTIME_MODELS``/``is_openai_realtime_model`` for the routing
+predicate used by transport handlers.
+
+Deliberate divergences from ``GeminiLiveSession`` (do not "fix" these to
+match Gemini — they are correct as written; see each divergence's own
+docstring for the evidence):
+
+  * ``_receive_loop`` is a single flat ``while True: recv(); handle()``
+    loop — ``AsyncRealtimeConnection.recv()`` returns exactly one parsed
+    server event per call with no per-turn generator-exhaustion quirk,
+    unlike ``google.genai``'s ``session.receive()`` (whose per-turn
+    re-invocation requirement was the root cause of a real "silent after
+    turn 1" bug this repo shipped and then fixed for Gemini Live — see
+    that module's ``_receive_loop`` docstring for the incident). Wrapping
+    this loop in Gemini's outer per-turn ``while True`` here would be
+    solving a problem this SDK doesn't have.
+  * Transcripts are captured directly off
+    ``conversation.item.input_audio_transcription.completed`` /
+    ``response.output_audio_transcript.done`` — each fires exactly once
+    per utterance with the FULL final text in ``.transcript``. No
+    fragment-buffering/reassembly workaround is needed (unlike Gemini
+    Live's per-fragment ``finished``-flag unreliability) — do not port that
+    buffering pattern here, it would be solving a problem this API
+    contract doesn't have either.
+  * Barge-in is largely server-driven: session config sets
+    ``turn_detection.interrupt_response=True``, so OpenAI cancels its own
+    in-flight response server-side the moment it detects caller speech.
+    ``on_interrupted`` (wired to ``input_audio_buffer.speech_started``) is
+    still surfaced so the transport can locally clear whatever audio it
+    has already buffered/sent (mirrors Gemini Live's ``on_interrupted``
+    contract at the VoiceOrchestrator layer, even though the server-side
+    half of the interruption is automatic here and manual for Gemini).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+import enum
+import json
+from typing import Any, Awaitable, Callable
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.core.logger import logger
+from app.core.openai_client import get_async_openai_client
+
+DEFAULT_VOICE_NAME = "marin"
+
+# Confirmed via the installed openai==2.36.0 SDK
+# (openai.types.realtime.realtime_audio_output.RealtimeAudioConfigOutput's
+# `voice` field / OpenAI's Realtime voices list). OpenAI recommends `marin`/
+# `cedar` for best quality on the newer Realtime models — used as the
+# default here rather than a legacy voice like `alloy`.
+VALID_VOICE_NAMES: frozenset[str] = frozenset(
+    {
+        "alloy", "ash", "ballad", "coral", "echo", "sage", "shimmer",
+        "verse", "marin", "cedar",
+    }
+)
+
+# gpt-realtime-2 is documented (SDK-side, via RealtimeReasoning/
+# reasoning_effort) as "reasoning-capable" — an uncapped reasoning budget on
+# a live voice turn risks noticeable dead air before the model starts
+# speaking, same rationale as app.services.openai_service.py's
+# _REASONING_EFFORT_BY_MODEL cap for the gpt-5.x Chat Completions family
+# (see that module's docstring for the full incident writeup this pattern
+# is modeled on). `gpt-realtime` (the original, non-"-2" model) has no
+# reasoning config at all, so it is deliberately absent from this map —
+# sending a `reasoning` block to a non-reasoning-capable model is not
+# something this integration has verified is safe, so it is simply never
+# sent for that model.
+_REASONING_EFFORT_BY_MODEL: dict[str, str] = {
+    "gpt-realtime-2": "low",
+}
+
+# Twilio's own wire format (mu-law 8kHz) — passed straight through with NO
+# conversion, unlike Gemini Live's forced PCM16 resample round-trip (see
+# app/voice/gemini_live_audio_bridge.py). Confirmed via
+# openai.types.realtime.realtime_audio_formats.AudioPCMU: `audio/pcmu` is a
+# natively supported input AND output format.
+TWILIO_AUDIO_FORMAT = "audio/pcmu"
+# LiveKit browser transport's publisher format — PCM16, 24kHz only
+# (confirmed via AudioPCM: `rate` is `Literal[24000]`), symmetric for both
+# input and output (unlike Gemini Live's asymmetric 16kHz-in/24kHz-out).
+LIVEKIT_AUDIO_FORMAT = "audio/pcm"
+LIVEKIT_AUDIO_RATE_HZ = 24000
+
+
+def resolve_voice_name(requested: str | None) -> str:
+    """
+    Map an agent's configured voice to a valid OpenAI Realtime voice name,
+    falling back to DEFAULT_VOICE_NAME when unset or not a real Realtime
+    voice (e.g. an ElevenLabs/Rime/Google TTS voice ID left over from before
+    the agent was switched to a native-audio model). Mirrors
+    gemini_live_service.resolve_voice_name's fallback-and-log-on-mismatch
+    pattern exactly.
+    """
+    if not requested:
+        return DEFAULT_VOICE_NAME
+    for valid in VALID_VOICE_NAMES:
+        if valid.lower() == requested.strip().lower():
+            return valid
+    logger.info(
+        "[OpenAIRealtime] agent voice '%s' is not a valid OpenAI Realtime voice name — "
+        "falling back to %s",
+        requested, DEFAULT_VOICE_NAME,
+    )
+    return DEFAULT_VOICE_NAME
+
+
+class OpenAIRealtimeErrorType(str, enum.Enum):
+    QUOTA = "quota"
+    TIMEOUT = "timeout"
+    AUTH = "auth"
+    CONNECTION_CLOSED = "connection_closed"
+    UNKNOWN = "unknown"
+
+
+class OpenAIRealtimeError(Exception):
+    def __init__(
+        self, message: str, error_type: OpenAIRealtimeErrorType = OpenAIRealtimeErrorType.UNKNOWN
+    ) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+
+
+def _classify_openai_realtime_error(exc: Exception) -> OpenAIRealtimeError:
+    """Mirrors gemini_live_service._classify_vertex_error's shape/intent,
+    against the openai-python SDK's own exception hierarchy instead of
+    google.genai's."""
+    import openai as openai_sdk
+
+    msg = str(exc)
+    if isinstance(exc, openai_sdk.RateLimitError):
+        return OpenAIRealtimeError(f"OpenAI Realtime quota exceeded: {msg}", OpenAIRealtimeErrorType.QUOTA)
+    if isinstance(exc, openai_sdk.APITimeoutError):
+        return OpenAIRealtimeError(f"OpenAI Realtime timeout: {msg}", OpenAIRealtimeErrorType.TIMEOUT)
+    if isinstance(exc, openai_sdk.AuthenticationError):
+        return OpenAIRealtimeError(f"OpenAI Realtime auth failed: {msg}", OpenAIRealtimeErrorType.AUTH)
+    if isinstance(exc, getattr(openai_sdk, "WebSocketConnectionClosedError", ())):
+        return OpenAIRealtimeError(f"OpenAI Realtime connection closed: {msg}", OpenAIRealtimeErrorType.CONNECTION_CLOSED)
+
+    name = type(exc).__name__
+    lowered = msg.lower()
+    if "quota" in lowered or ("rate" in lowered and "limit" in lowered):
+        return OpenAIRealtimeError(f"OpenAI Realtime quota: {msg}", OpenAIRealtimeErrorType.QUOTA)
+    if "timeout" in lowered or "timed out" in lowered:
+        return OpenAIRealtimeError(f"OpenAI Realtime timeout: {msg}", OpenAIRealtimeErrorType.TIMEOUT)
+    if "closed" in lowered or "ConnectionClosed" in name:
+        return OpenAIRealtimeError(f"OpenAI Realtime connection closed: {msg}", OpenAIRealtimeErrorType.CONNECTION_CLOSED)
+    return OpenAIRealtimeError(f"OpenAI Realtime error: {msg}", OpenAIRealtimeErrorType.UNKNOWN)
+
+
+def _build_calendly_tool_params() -> list[dict]:
+    """
+    OpenAI Realtime function-tool declarations for the Calendly booking
+    flow — same two tools/parameter shapes as
+    ``vertex_gemini_service._build_calendly_tool()``, translated to the
+    Realtime API's flat ``{type: "function", name, description,
+    parameters}`` tool shape (confirmed via
+    ``openai.types.realtime.RealtimeFunctionToolParam``) instead of
+    google.genai's ``FunctionDeclaration`` wrapper.
+    """
+    return [
+        {
+            "type": "function",
+            "name": "check_availability",
+            "description": (
+                "Check available appointment slots on the connected Calendly calendar. "
+                "Slot length is fixed by the connected Calendly event type — it cannot "
+                "be requested per-call."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "date": {
+                        "type": "string",
+                        "description": "Date to check availability for, as YYYY-MM-DD (or 'today'/'tomorrow').",
+                    },
+                },
+                "required": ["date"],
+            },
+        },
+        {
+            "type": "function",
+            "name": "book_appointment",
+            "description": "Schedule an appointment on Calendly for a previously offered slot.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "slot": {
+                        "type": "string",
+                        "description": "The chosen slot start time, ISO-8601 (UTC).",
+                    },
+                    "attendee_email": {
+                        "type": "string",
+                        "description": "The caller's email address to send the Calendly confirmation to.",
+                    },
+                },
+                "required": ["slot", "attendee_email"],
+            },
+        },
+    ]
+
+
+def _audio_format_dict(audio_format: str) -> dict:
+    if audio_format == LIVEKIT_AUDIO_FORMAT:
+        return {"type": LIVEKIT_AUDIO_FORMAT, "rate": LIVEKIT_AUDIO_RATE_HZ}
+    return {"type": audio_format}
+
+
+class OpenAIRealtimeSession:
+    """
+    Transport-agnostic wrapper around one OpenAI Realtime API connection.
+
+    Usage (mirrors GeminiLiveSession):
+      session = OpenAIRealtimeSession(agent.llm_model)
+      await session.start(system_instruction=..., audio_format="audio/pcmu",
+                           on_audio_chunk=..., on_interrupted=...)
+      await session.send_audio(mulaw_or_pcm16_bytes)   # per caller-audio chunk
+      ...
+      await session.close()
+    """
+
+    def __init__(self, model_name: str) -> None:
+        if model_name not in OPENAI_REALTIME_MODELS:
+            raise ValueError(
+                f"'{model_name}' is not an OpenAI Realtime speech-to-speech model. "
+                f"Valid models: {sorted(OPENAI_REALTIME_MODELS)}"
+            )
+        self.model_name = model_name
+
+        self._client: Any = None
+        self._connect_cm: Any = None
+        self._connection: Any = None
+        self._receive_task: asyncio.Task | None = None
+        self._closed = False
+
+        # Registered by start(); consumed by _receive_loop.
+        self.on_audio_chunk: Callable[[bytes], Awaitable[None]] | None = None
+        self.on_interrupted: Callable[[], Awaitable[None]] | None = None
+        # Demuxed from OpenAI's own input_audio_buffer.speech_stopped event
+        # (see _handle_message). Not currently wired by VoiceOrchestrator —
+        # nothing there needs a "caller stopped talking" signal yet — but the
+        # session-level plumbing is here and tested so a future turn-boundary
+        # or analytics consumer doesn't have to add wire-protocol handling.
+        self.on_speech_stopped: Callable[[], Awaitable[None]] | None = None
+        # Fires once per utterance with the FULL final transcript text — no
+        # `finished`-flag/fragment-buffering dance (see module docstring).
+        self.on_input_transcript: Callable[[str], Awaitable[None]] | None = None
+        self.on_output_transcript: Callable[[str], Awaitable[None]] | None = None
+        self.on_tool_call: Callable[[str, str, str], Awaitable[None]] | None = None
+        self.on_error: Callable[[OpenAIRealtimeError], Awaitable[None]] | None = None
+
+    def _build_client(self):
+        return get_async_openai_client()
+
+    async def start(
+        self,
+        *,
+        system_instruction: str,
+        audio_format: str = LIVEKIT_AUDIO_FORMAT,
+        voice_name: str = DEFAULT_VOICE_NAME,
+        on_audio_chunk: Callable[[bytes], Awaitable[None]],
+        on_interrupted: Callable[[], Awaitable[None]],
+        on_speech_stopped: Callable[[], Awaitable[None]] | None = None,
+        on_input_transcript: Callable[[str], Awaitable[None]] | None = None,
+        on_output_transcript: Callable[[str], Awaitable[None]] | None = None,
+        on_tool_call: Callable[[str, str, str], Awaitable[None]] | None = None,
+        on_error: Callable[[OpenAIRealtimeError], Awaitable[None]] | None = None,
+        tools: list[dict] | None = None,
+    ) -> None:
+        """
+        Open the Realtime connection, send the initial `session.update`, and
+        start the background receive loop. Raises ``OpenAIRealtimeError`` on
+        any setup failure (bad model, missing credentials, SDK/connect
+        errors) — mirrors GeminiLiveSession.start()'s contract exactly so
+        VoiceOrchestrator's pre-session-failure fallback handling can stay
+        provider-agnostic at the call site.
+        """
+        self.on_audio_chunk = on_audio_chunk
+        self.on_interrupted = on_interrupted
+        self.on_speech_stopped = on_speech_stopped
+        self.on_input_transcript = on_input_transcript
+        self.on_output_transcript = on_output_transcript
+        self.on_tool_call = on_tool_call
+        self.on_error = on_error
+
+        try:
+            self._client = self._build_client()
+        except Exception as exc:
+            raise OpenAIRealtimeError(
+                f"OpenAI Realtime client init failed: {exc}", OpenAIRealtimeErrorType.UNKNOWN
+            ) from exc
+
+        try:
+            self._connect_cm = self._client.realtime.connect(model=self.model_name)
+            self._connection = await self._connect_cm.__aenter__()
+        except Exception as exc:
+            self._connect_cm = None
+            raise _classify_openai_realtime_error(exc) from exc
+
+        session_config: dict[str, Any] = {
+            "type": "realtime",
+            "model": self.model_name,
+            "output_modalities": ["audio"],
+            "audio": {
+                "input": {
+                    "format": _audio_format_dict(audio_format),
+                    "transcription": {"model": "gpt-4o-mini-transcribe"},
+                    "turn_detection": {
+                        "type": "server_vad",
+                        "interrupt_response": True,
+                        "create_response": True,
+                    },
+                },
+                "output": {
+                    "format": _audio_format_dict(audio_format),
+                    "voice": voice_name,
+                },
+            },
+        }
+        if system_instruction:
+            session_config["instructions"] = system_instruction
+        if tools:
+            session_config["tools"] = tools
+        effort = _REASONING_EFFORT_BY_MODEL.get(self.model_name)
+        if effort:
+            session_config["reasoning"] = {"effort": effort}
+
+        try:
+            await self._connection.send({"type": "session.update", "session": session_config})
+        except Exception as exc:
+            raise _classify_openai_realtime_error(exc) from exc
+
+        self._receive_task = asyncio.create_task(self._receive_loop())
+
+    async def send_audio(self, audio_bytes: bytes) -> None:
+        """Send one chunk of raw caller audio, already encoded in whatever
+        format this session was started with (`audio_format` — mu-law 8kHz
+        for Twilio, PCM16 24kHz for LiveKit). This module has zero
+        telephony-format knowledge beyond that string."""
+        if not audio_bytes:
+            return
+        await self._connection.send({
+            "type": "input_audio_buffer.append",
+            "audio": base64.b64encode(audio_bytes).decode("ascii"),
+        })
+
+    async def send_text(self, text: str, respond: bool = True) -> None:
+        """
+        Inject a text turn into the conversation via
+        `conversation.item.create` (role="user"). Unlike GeminiLiveSession's
+        single `send_client_content(turn_complete=...)` call, the Realtime
+        API separates "add this item to the conversation" from "generate a
+        response" — a context-only injection (e.g. mid-call RAG refresh)
+        must send ONLY the item-create event, never a following
+        `response.create`, or OpenAI will speak the raw injected text as if
+        it were a real reply. `respond=True` (the default — used for e.g.
+        the scripted greeting, which SHOULD be spoken) sends both.
+        """
+        if not text:
+            return
+        await self._connection.send({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": text}],
+            },
+        })
+        if respond:
+            await self._connection.send({"type": "response.create"})
+
+    async def send_tool_response(self, call_id: str, output: dict) -> None:
+        """
+        Resolve a function call: `conversation.item.create` with a
+        `function_call_output` item, then an explicit `response.create` to
+        prompt the model to continue — unlike GeminiLiveSession's single
+        `send_tool_response(function_responses=...)` call, the Realtime API
+        requires this second event to actually resume generation.
+        """
+        await self._connection.send({
+            "type": "conversation.item.create",
+            "item": {
+                "type": "function_call_output",
+                "call_id": call_id,
+                "output": json.dumps(output),
+            },
+        })
+        await self._connection.send({"type": "response.create"})
+
+    async def close(self) -> None:
+        """Idempotent teardown — safe to call multiple times, and safe to
+        call from a finally/shutdown path. Never raises: all teardown
+        errors are swallowed and logged. Mirrors GeminiLiveSession.close()."""
+        if self._closed:
+            return
+        self._closed = True
+
+        if self._receive_task is not None:
+            self._receive_task.cancel()
+            with contextlib.suppress(Exception, asyncio.CancelledError):
+                await self._receive_task
+            self._receive_task = None
+
+        if self._connect_cm is not None:
+            try:
+                await self._connect_cm.__aexit__(None, None, None)
+            except Exception as exc:
+                logger.debug("[OpenAIRealtimeSession] close: teardown error (ignored): %s", exc)
+            self._connect_cm = None
+
+        self._connection = None
+
+    async def _receive_loop(self) -> None:
+        """
+        Flat receive loop — see module docstring for why this is NOT
+        shaped like GeminiLiveSession's per-turn outer loop.
+        `connection.recv()` raising (connection genuinely dropped, or any
+        SDK-level error) ends the loop after routing to on_error/logging —
+        there is no "zero messages, retry" case to guard against here since
+        each recv() call either returns exactly one event or raises.
+        """
+        try:
+            while True:
+                try:
+                    event = await self._connection.recv()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    await self._report_error(exc)
+                    return
+                try:
+                    await self._handle_event(event)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    await self._report_error(exc)
+        except asyncio.CancelledError:
+            raise
+
+    async def _report_error(self, exc: Exception) -> None:
+        err = exc if isinstance(exc, OpenAIRealtimeError) else _classify_openai_realtime_error(exc)
+        if self.on_error is not None:
+            await self.on_error(err)
+        else:
+            logger.error("[OpenAIRealtimeSession] %s (model=%s): %s", err.error_type, self.model_name, err)
+
+    async def _handle_event(self, event: Any) -> None:
+        etype = getattr(event, "type", None)
+
+        if etype == "response.output_audio.delta":
+            delta = getattr(event, "delta", None)
+            if delta and self.on_audio_chunk is not None:
+                await self.on_audio_chunk(base64.b64decode(delta))
+            return
+
+        if etype == "input_audio_buffer.speech_started":
+            if self.on_interrupted is not None:
+                await self.on_interrupted()
+            return
+
+        if etype == "input_audio_buffer.speech_stopped":
+            if self.on_speech_stopped is not None:
+                await self.on_speech_stopped()
+            return
+
+        if etype == "conversation.item.input_audio_transcription.completed":
+            transcript = getattr(event, "transcript", "") or ""
+            if transcript and self.on_input_transcript is not None:
+                await self.on_input_transcript(transcript)
+            return
+
+        if etype == "response.output_audio_transcript.done":
+            transcript = getattr(event, "transcript", "") or ""
+            if transcript and self.on_output_transcript is not None:
+                await self.on_output_transcript(transcript)
+            return
+
+        if etype == "response.function_call_arguments.done":
+            if self.on_tool_call is not None:
+                call_id = getattr(event, "call_id", None) or ""
+                name = getattr(event, "name", None) or ""
+                arguments = getattr(event, "arguments", None) or "{}"
+                await self.on_tool_call(call_id, name, arguments)
+            return
+
+        if etype == "error":
+            error_obj = getattr(event, "error", None)
+            message = getattr(error_obj, "message", None) or str(error_obj) or "unknown Realtime API error"
+            await self._report_error(OpenAIRealtimeError(message, OpenAIRealtimeErrorType.UNKNOWN))
+            return
+
+        # All other event types (session.created, response.created,
+        # conversation.item.created, rate_limits.updated, delta variants we
+        # deliberately don't consume, etc.) are expected, benign chatter —
+        # no action needed.

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -805,6 +805,24 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                     self._h._twilio_buffer_primed = False
                     return
 
+                # Mirror-image bypass for OpenAI Realtime native-audio calls —
+                # same rationale as the Gemini Live branch above.
+                if _vo is not None and getattr(_vo, "_is_openai_realtime", False):
+                    session = _vo._openai_realtime_session
+                    if session is not None:
+                        try:
+                            await session.send_text(greeting_text, respond=True)
+                        except Exception as exc:
+                            logger.warning(
+                                "[OpenAIRealtime] failed to send greeting via live session: %s", exc
+                            )
+                    else:
+                        logger.debug(
+                            "[OpenAIRealtime] skipping scripted greeting — live session not ready yet"
+                        )
+                    self._h._twilio_buffer_primed = False
+                    return
+
                 # Queue greeting TTS directly (skip LLM!)
                 if not self._h._tts_pipeline:
                     return

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -57,6 +57,7 @@ from app.utils.audio_utils import MULAW_FRAME_BYTES, ulaw_to_linear_sample
 from app.utils.ssml_utils import strip_ssml_tags
 from app.voice.conversation_orchestrator import ConversationOrchestrator, VOICE_TUNABLES
 from app.voice.gemini_live_audio_bridge import GEMINI_OUTPUT_PCM_RATE_HZ
+from app.services.openai_realtime_service import LIVEKIT_AUDIO_RATE_HZ as OPENAI_REALTIME_AUDIO_RATE_HZ
 from app.voice.humanization_engine import pause_frames_for_chunk
 
 if TYPE_CHECKING:
@@ -353,6 +354,32 @@ class _GeminiLiveAudioSink:
             )
 
 
+class _OpenAIRealtimeAudioSink:
+    """
+    OpenAI Realtime analog of ``_GeminiLiveAudioSink`` — same
+    ``stt_pipeline``-shaped adapter pattern, targeting an
+    ``OpenAIRealtimeSession`` instead. ``LiveKitAudioSubscriber`` is opened
+    with ``output_sample_rate=OPENAI_REALTIME_AUDIO_RATE_HZ`` (24kHz) for a
+    native-audio OpenAI call (see ``run_livekit_browser_call``) — exactly
+    the rate ``OpenAIRealtimeSession.send_audio`` expects when the session
+    was started with ``audio_format="audio/pcm"``, so no conversion happens
+    here either.
+    """
+
+    def __init__(self, session: Any) -> None:
+        self._session = session
+
+    async def feed_audio_chunk(self, pcm_bytes: bytes) -> None:
+        if not pcm_bytes:
+            return
+        try:
+            await self._session.send_audio(pcm_bytes)
+        except Exception as exc:
+            logger.error(
+                "[LiveKitBrowserCall] OpenAIRealtimeSession.send_audio failed: %s", exc, exc_info=True
+            )
+
+
 class LiveKitBrowserCallHandler:
     """
     Transport adapter: implements exactly the attribute/method surface that
@@ -513,21 +540,32 @@ class LiveKitBrowserCallHandler:
     # module for the branch).
 
     async def _publish_gemini_live_audio_chunk(
-        self, pcm16_24k_bytes: bytes, cancel: asyncio.Event
+        self,
+        pcm16_24k_bytes: bytes,
+        cancel: asyncio.Event,
+        sample_rate_hz: int = GEMINI_OUTPUT_PCM_RATE_HZ,
     ) -> None:
         """
-        GeminiLiveSession audio-out sink for this transport (native-audio
-        calls only). Publishes Gemini's raw PCM16/24kHz output directly via
-        `_agent_publisher.publish_pcm` — `_agent_publisher` is opened at
-        24kHz for a native-audio call (see run_livekit_browser_call), so
-        unlike the Twilio path's `_stream_live_audio_chunk` (mu-law/8kHz),
+        Native-audio-S2S audio-out sink for this transport, shared by both
+        Gemini Live and OpenAI Realtime (see the Gemini-specific name's note
+        below). Publishes raw PCM16 output directly via
+        `_agent_publisher.publish_pcm` — `_agent_publisher` is opened at the
+        matching rate for a native-audio call (see run_livekit_browser_call),
+        so unlike the Twilio path's `_stream_live_audio_chunk` (mu-law/8kHz),
         no resampling or codec conversion happens here at all.
+
+        `sample_rate_hz` defaults to Gemini's own output rate for the
+        original Gemini call site; OpenAI Realtime's call site passes its own
+        rate explicitly instead of relying on the two providers' rates
+        happening to both be 24kHz today — a future rate change to either
+        provider must not silently mismatch the other and get audio dropped
+        by `publish_pcm`'s rate-mismatch guard.
         """
         publisher = self._agent_publisher
         if publisher is None or not publisher.connected:
             return
         await publisher.publish_pcm(
-            pcm16_24k_bytes, sample_rate_hz=GEMINI_OUTPUT_PCM_RATE_HZ, cancel=cancel
+            pcm16_24k_bytes, sample_rate_hz=sample_rate_hz, cancel=cancel
         )
 
     async def _clear_gemini_live_playout_queue(self) -> None:
@@ -1346,12 +1384,30 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
             await voice_orchestrator._start_gemini_live_session(handler)
             is_gemini_live = voice_orchestrator._is_gemini_live
 
-        # ── Connect agent audio-out (TTS / Gemini Live) ──────────────────────
-        # A native-audio call opens the publisher at Gemini's own 24kHz PCM
-        # output rate (no mu-law, no resampling on this path — see
+        # ── OpenAI Realtime (native-audio speech-to-speech) fork ─────────────
+        # Parallel to the Gemini Live fork above, not shared/refactored code
+        # (per this task's "strictly additive, don't touch Gemini-Live-
+        # specific code" constraint) — mutually exclusive with is_gemini_live
+        # since VoiceOrchestrator.__init__ resolves each provider from a
+        # disjoint model-ID allow-list.
+        is_openai_realtime = voice_orchestrator._is_openai_realtime
+        if is_openai_realtime:
+            await voice_orchestrator._start_openai_realtime_session(handler)
+            is_openai_realtime = voice_orchestrator._is_openai_realtime
+
+        # ── Connect agent audio-out (TTS / Gemini Live / OpenAI Realtime) ────
+        # A native-audio call opens the publisher at the provider's own 24kHz
+        # PCM output rate (no mu-law, no resampling on this path — see
         # _LiveKitAgentAudioPublisher.publish_pcm); every other call keeps the
-        # existing 8kHz mu-law-derived rate.
-        publisher_sample_rate = GEMINI_OUTPUT_PCM_RATE_HZ if is_gemini_live else _AGENT_AUDIO_SAMPLE_RATE
+        # existing 8kHz mu-law-derived rate. Gemini Live and OpenAI Realtime
+        # both happen to use 24kHz PCM16 for this transport, so the same
+        # publisher/sink plumbing serves either provider unmodified.
+        if is_gemini_live:
+            publisher_sample_rate = GEMINI_OUTPUT_PCM_RATE_HZ
+        elif is_openai_realtime:
+            publisher_sample_rate = OPENAI_REALTIME_AUDIO_RATE_HZ
+        else:
+            publisher_sample_rate = _AGENT_AUDIO_SAMPLE_RATE
         publisher = _LiveKitAgentAudioPublisher(room_name, sample_rate_hz=publisher_sample_rate)
         connected = await publisher.connect()
         if not connected:
@@ -1393,6 +1449,19 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
                 room_name=room_name,
                 stt_pipeline=_GeminiLiveAudioSink(session),
                 output_sample_rate=_STT_INPUT_SAMPLE_RATE,
+            )
+        elif is_openai_realtime:
+            # Native-audio OpenAI agents skip STT entirely too. Unlike the
+            # Gemini Live branch above, this requests LiveKitAudioSubscriber
+            # resample caller audio to 24kHz (not 16kHz) — the rate
+            # OpenAIRealtimeSession.send_audio expects when the session was
+            # started with audio_format="audio/pcm" (symmetric 24kHz in/out,
+            # unlike Gemini Live's asymmetric 16kHz-in/24kHz-out).
+            session = voice_orchestrator._openai_realtime_session
+            audio_subscriber = LiveKitAudioSubscriber(
+                room_name=room_name,
+                stt_pipeline=_OpenAIRealtimeAudioSink(session),
+                output_sample_rate=OPENAI_REALTIME_AUDIO_RATE_HZ,
             )
         else:
             from app.core.agent_runtime import resolve_stt_runtime

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -700,14 +700,26 @@ class TtsStreamMixin:
         so Twilio's 20ms/160-byte MULAW framing/message format is not
         reimplemented here.
 
-        Cancellation is gated on ``self._voice_orchestrator._gemini_live_cancel``
-        — this path's own minimal barge-in flag (see
-        VoiceOrchestrator._on_gemini_live_interrupted) — never on
-        ``self._tts_cancel``, since no TtsPipeline task exists for this call.
+        Cancellation is gated on whichever native-audio provider's own
+        minimal barge-in flag is active for this call —
+        ``self._voice_orchestrator._gemini_live_cancel`` (see
+        VoiceOrchestrator._on_gemini_live_interrupted) or
+        ``self._voice_orchestrator._openai_realtime_cancel`` (see
+        VoiceOrchestrator._on_openai_realtime_interrupted) — never on
+        ``self._tts_cancel``, since no TtsPipeline task exists for either of
+        these calls. Both cancel Events are always constructed
+        unconditionally in ``VoiceOrchestrator.__init__`` regardless of
+        which (if either) provider is active for this call, so resolving by
+        ``_is_openai_realtime`` here is safe even before either provider's
+        session has actually started.
         """
         if not mulaw_bytes or not self.stream_sid:
             return
-        cancel = getattr(self._voice_orchestrator, "_gemini_live_cancel", None)
+        vo = self._voice_orchestrator
+        if getattr(vo, "_is_openai_realtime", False):
+            cancel = getattr(vo, "_openai_realtime_cancel", None)
+        else:
+            cancel = getattr(vo, "_gemini_live_cancel", None)
         if cancel is not None and cancel.is_set():
             return
         try:

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -26,7 +26,7 @@ import time
 from typing import TYPE_CHECKING, Any, Set
 
 from app.core.config import settings
-from app.core.llm_models import is_gemini_live_native_audio_model
+from app.core.llm_models import is_gemini_live_native_audio_model, is_openai_realtime_model
 from app.core.logger import logger
 from app.utils.audio_utils import ulaw_to_linear_sample
 from app.voice.gemini_live_audio_bridge import mulaw8k_to_pcm16_16k, pcm16_24k_to_mulaw8k
@@ -45,6 +45,14 @@ if TYPE_CHECKING:
 # `agent.llm_model` is swapped to this allow-listed text model for the
 # remainder of THIS call object only (never persisted to the DB).
 _GEMINI_LIVE_FALLBACK_TEXT_MODEL = "gemini-2.5-flash"
+
+# Same idea as _GEMINI_LIVE_FALLBACK_TEXT_MODEL above, for OpenAI Realtime
+# ("gpt-realtime"/"gpt-realtime-2") pre-session failures — see
+# _start_openai_realtime_session / _fallback_to_legacy_pipeline_openai. Kept
+# in the same provider family (OpenAI) rather than falling back cross-
+# provider to a Gemini text model, since the tenant/agent is already
+# configured for an OpenAI API key.
+_OPENAI_REALTIME_FALLBACK_TEXT_MODEL = "gpt-4o-mini"
 
 
 def _resolve_initial_endpointing_ms() -> int:
@@ -202,9 +210,32 @@ class VoiceOrchestrator:
         # says next anyway.
         self._gemini_live_kb_refresh_in_flight: bool = False
 
+        # ── OpenAI Realtime (native-audio speech-to-speech) state ─────────────
+        # Parallel to the Gemini Live block above, not a shared/refactored
+        # implementation (per this task's "strictly additive, don't touch
+        # Gemini-Live-specific code" constraint) — see
+        # app/services/openai_realtime_service.py's module docstring for the
+        # deliberate behavioral divergences (no per-turn receive loop, no
+        # transcript-fragment buffering, mostly-server-driven barge-in).
+        self._is_openai_realtime: bool = is_openai_realtime_model(
+            getattr(_agent, "llm_model", None) if _agent else None
+        )
+        self._openai_realtime_session: Any = None
+        self._openai_realtime_setup_lock: asyncio.Lock = asyncio.Lock()
+        self._openai_realtime_setup_failed: bool = False
+        self._openai_realtime_cancel: asyncio.Event = asyncio.Event()
+        self._openai_realtime_first_audio_marked: bool = False
+        # No input/output transcript buffers needed here — unlike Gemini
+        # Live, OpenAI's transcription events each fire exactly once per
+        # utterance with the full final text (see
+        # openai_realtime_service.OpenAIRealtimeSession's on_input_transcript/
+        # on_output_transcript contract).
+        self._openai_realtime_kb_refresh_in_flight: bool = False
+
         logger.info(
-            "[VoiceOrchestrator] Initialized — STT lazy, TTS pipeline ready, gemini_live=%s",
-            self._is_gemini_live,
+            "[VoiceOrchestrator] Initialized — STT lazy, TTS pipeline ready, "
+            "gemini_live=%s openai_realtime=%s",
+            self._is_gemini_live, self._is_openai_realtime,
         )
 
     # ── Public interface ──────────────────────────────────────────────────────
@@ -337,6 +368,16 @@ class VoiceOrchestrator:
             # agnostic (RMS over MULAW) and stays unchanged for both paths.
             if self._is_gemini_live:
                 await self._feed_gemini_live_audio(h, audio_data)
+                return
+
+            # ── 3c. Native-audio (OpenAI Realtime) fork ─────────────────────────
+            # Same idea as 3b above, for OpenAI's Realtime speech-to-speech
+            # models. Twilio's own MULAW/8kHz wire format is sent straight
+            # through with NO conversion (see _feed_openai_realtime_audio /
+            # app.services.openai_realtime_service's module docstring) —
+            # unlike Gemini Live, which forces a PCM16 resample round-trip.
+            if self._is_openai_realtime:
+                await self._feed_openai_realtime_audio(h, audio_data)
                 return
 
             # ── 4. STT feed ───────────────────────────────────────────────────
@@ -542,6 +583,19 @@ class VoiceOrchestrator:
                 await self._flush_gemini_live_output_buffer()
         except Exception as exc:
             logger.debug("[VoiceOrchestrator] Gemini Live session close failed: %s", exc)
+
+        # Close OpenAI Realtime session (native-audio calls only — no-op
+        # otherwise). No buffer-flush step needed here (unlike the Gemini
+        # Live block above) — OpenAI's transcripts are written to
+        # call_transcript synchronously as each complete utterance arrives,
+        # never buffered.
+        try:
+            if self._openai_realtime_session is not None:
+                self._openai_realtime_cancel.set()
+                await self._openai_realtime_session.close()
+                self._openai_realtime_session = None
+        except Exception as exc:
+            logger.debug("[VoiceOrchestrator] OpenAI Realtime session close failed: %s", exc)
 
         logger.info("[VoiceOrchestrator] Shutdown complete")
 
@@ -1101,6 +1155,354 @@ class VoiceOrchestrator:
         """
         logger.error(
             "[GeminiLive] mid-call session error call_session_id=%s error_type=%s: %s",
+            getattr(self._h, "call_session_id", None),
+            getattr(err, "error_type", None),
+            err,
+        )
+        asyncio.create_task(self._h._full_shutdown())
+
+    # ── OpenAI Realtime (native-audio speech-to-speech) ─────────────────────────
+    # Parallel to the "Gemini Live" section above — see
+    # app/services/openai_realtime_service.py's module docstring for the
+    # deliberate behavioral divergences from Gemini Live (no per-turn
+    # receive loop, no transcript-fragment buffering, mostly-server-driven
+    # barge-in via turn_detection.interrupt_response).
+
+    async def _feed_openai_realtime_audio(self, h, audio_data: bytes) -> None:
+        """
+        Route one MULAW/8kHz Twilio caller-audio frame to the (lazily
+        created) OpenAIRealtimeSession for this call. Called instead of the
+        SttPipeline feed for native-audio OpenAI agents. Unlike
+        _feed_gemini_live_audio, no format conversion happens here — the
+        session is started with audio_format="audio/pcmu" for a Twilio
+        call, which OpenAI accepts natively (see
+        openai_realtime_service.TWILIO_AUDIO_FORMAT).
+        """
+        if self._openai_realtime_setup_failed:
+            return
+
+        session = self._openai_realtime_session
+        if session is None:
+            async with self._openai_realtime_setup_lock:
+                if self._openai_realtime_session is None and not self._openai_realtime_setup_failed:
+                    await self._start_openai_realtime_session(h)
+            session = self._openai_realtime_session
+
+        if session is None:
+            return  # setup failed and fallback (or shutdown) already handled it
+
+        try:
+            await session.send_audio(audio_data)
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] OpenAIRealtimeSession.send_audio failed: %s", exc, exc_info=True
+            )
+
+    async def _start_openai_realtime_session(self, h) -> None:
+        """
+        Lazily open the OpenAIRealtimeSession for this call (once). Mirrors
+        _start_gemini_live_session's transport-aware system_instruction /
+        Calendly-tool wiring exactly — only the session class, audio format,
+        and voice-resolution helper differ.
+        """
+        from app.services.openai_realtime_service import (
+            OpenAIRealtimeError,
+            OpenAIRealtimeSession,
+            LIVEKIT_AUDIO_FORMAT,
+            TWILIO_AUDIO_FORMAT,
+            resolve_voice_name as resolve_openai_voice_name,
+        )
+
+        agent = getattr(h, "agent", None)
+        model_name = getattr(agent, "llm_model", None) if agent else None
+        is_twilio_transport = hasattr(h, "build_system_prompt")
+
+        try:
+            if is_twilio_transport:
+                system_instruction = await h.build_system_prompt(user_text="", confidence=1.0)
+            else:
+                from app.voice.conversation_orchestrator import ConversationOrchestrator
+
+                conv = ConversationOrchestrator(h)
+                system_instruction = await conv.build_system_prompt(user_text="", confidence=1.0)
+        except Exception as exc:
+            logger.error(
+                "[OpenAIRealtime] build_system_prompt failed for session start; using minimal "
+                "fallback instruction: %s", exc, exc_info=True,
+            )
+            agent_name = getattr(agent, "name", None) or "AI Assistant"
+            system_instruction = f"You are {agent_name}, a helpful phone assistant."
+
+        openai_tools = None
+        on_tool_call = None
+        if hasattr(h, "_calendly_enabled") and h._calendly_enabled():
+            from app.services.openai_realtime_service import _build_calendly_tool_params
+
+            openai_tools = _build_calendly_tool_params()
+            on_tool_call = self._on_openai_realtime_tool_call
+
+        voice_name = resolve_openai_voice_name(getattr(agent, "tts_voice_external_id", None))
+        audio_format = TWILIO_AUDIO_FORMAT if is_twilio_transport else LIVEKIT_AUDIO_FORMAT
+
+        session = OpenAIRealtimeSession(model_name)
+        try:
+            await session.start(
+                system_instruction=system_instruction,
+                audio_format=audio_format,
+                voice_name=voice_name,
+                on_audio_chunk=self._on_openai_realtime_audio_chunk,
+                on_interrupted=self._on_openai_realtime_interrupted,
+                on_input_transcript=self._on_openai_realtime_input_transcript,
+                on_output_transcript=self._on_openai_realtime_output_transcript,
+                on_tool_call=on_tool_call,
+                on_error=self._on_openai_realtime_error,
+                tools=openai_tools,
+            )
+        except OpenAIRealtimeError as exc:
+            logger.error(
+                "[OpenAIRealtime] pre-session start failed model=%s call_session_id=%s: %s",
+                model_name, getattr(h, "call_session_id", None), exc,
+            )
+            await self._fallback_to_legacy_pipeline_openai(h, reason=str(exc))
+            return
+        except Exception as exc:
+            logger.error(
+                "[OpenAIRealtime] unexpected pre-session start failure model=%s call_session_id=%s: %s",
+                model_name, getattr(h, "call_session_id", None), exc, exc_info=True,
+            )
+            await self._fallback_to_legacy_pipeline_openai(h, reason=str(exc))
+            return
+
+        self._openai_realtime_session = session
+        logger.info(
+            "[OpenAIRealtime] session started model=%s call_session_id=%s",
+            model_name, getattr(h, "call_session_id", None),
+        )
+
+    async def _fallback_to_legacy_pipeline_openai(self, h, reason: str) -> None:
+        """Pre-session OpenAIRealtimeSession.start() failure fallback — mirrors
+        _fallback_to_legacy_pipeline (Gemini Live) exactly, swapping in the
+        OpenAI-family fallback text model instead."""
+        self._openai_realtime_setup_failed = True
+        self._is_openai_realtime = False
+
+        agent = getattr(h, "agent", None)
+        if agent is not None:
+            logger.warning(
+                "[OpenAIRealtime] falling back to legacy pipeline for call_session_id=%s: "
+                "%s -> %s (reason: %s)",
+                getattr(h, "call_session_id", None),
+                getattr(agent, "llm_model", None),
+                _OPENAI_REALTIME_FALLBACK_TEXT_MODEL,
+                reason,
+            )
+            agent.llm_model = _OPENAI_REALTIME_FALLBACK_TEXT_MODEL
+        else:
+            logger.error(
+                "[OpenAIRealtime] pre-session failure with no agent loaded for call_session_id=%s "
+                "(reason: %s) — cannot fall back to a text pipeline; ending call.",
+                getattr(h, "call_session_id", None), reason,
+            )
+            asyncio.create_task(h._full_shutdown())
+
+    async def _on_openai_realtime_audio_chunk(self, audio_bytes: bytes) -> None:
+        """
+        OpenAIRealtimeSession.on_audio_chunk callback. Gates on
+        self._openai_realtime_cancel exactly like _on_gemini_live_audio_chunk
+        gates on self._gemini_live_cancel.
+
+        Transport-aware (duck-typed via hasattr, same pattern as
+        _on_gemini_live_audio_chunk):
+          - Twilio: `audio_bytes` is already mu-law/8kHz (the session was
+            started with audio_format="audio/pcmu") — streamed straight to
+            `_stream_live_audio_chunk` with NO conversion step, unlike
+            Gemini Live's pcm16_24k_to_mulaw8k.
+          - LiveKit browser: `audio_bytes` is raw PCM16/24kHz (audio_format=
+            "audio/pcm") — the exact format/rate
+            `_publish_gemini_live_audio_chunk` (and the publisher it
+            targets) already expects for Gemini Live, so that existing sink
+            is reused as-is (see its own docstring — it's a generic
+            "publish raw PCM16 at the publisher's rate" primitive despite
+            the Gemini-specific name).
+        """
+        if self._openai_realtime_cancel.is_set():
+            return
+        try:
+            if not self._openai_realtime_first_audio_marked:
+                self._openai_realtime_first_audio_marked = True
+                _vm = getattr(self._h, "_voice_metrics", None)
+                if _vm:
+                    _vm.mark_live_first_audio()
+
+            if hasattr(self._h, "_stream_live_audio_chunk"):
+                await self._h._stream_live_audio_chunk(audio_bytes)
+            else:
+                from app.services.openai_realtime_service import LIVEKIT_AUDIO_RATE_HZ
+
+                await self._h._publish_gemini_live_audio_chunk(
+                    audio_bytes, self._openai_realtime_cancel,
+                    sample_rate_hz=LIVEKIT_AUDIO_RATE_HZ,
+                )
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime audio chunk send failed: %s", exc, exc_info=True
+            )
+
+    async def _on_openai_realtime_interrupted(self) -> None:
+        """
+        Barge-in for the OpenAI Realtime path. Server-side, OpenAI already
+        cancels its own in-flight response when `interrupt_response=True`
+        (session config) detects caller speech — this callback only handles
+        the LOCAL half: stop our own outbound send loop and flush whatever
+        this transport has already buffered/sent. Mirrors
+        _on_gemini_live_interrupted's transport-aware dispatch exactly.
+        """
+        try:
+            self._openai_realtime_cancel.set()
+            if hasattr(self._h, "_send_twilio_clear_event"):
+                await self._h._send_twilio_clear_event()
+            else:
+                await self._h._clear_gemini_live_playout_queue()
+            self._openai_realtime_cancel.clear()
+            self._openai_realtime_first_audio_marked = False
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime interrupted handling failed: %s", exc, exc_info=True
+            )
+
+    async def _on_openai_realtime_input_transcript(self, text: str) -> None:
+        """
+        Caller-side FULL final transcript for one utterance — fires exactly
+        once per utterance (see OpenAIRealtimeSession's
+        on_input_transcript contract). No buffering/flush-signal dance
+        needed here, unlike _on_gemini_live_input_transcript.
+        """
+        text = (text or "").strip()
+        if not text:
+            return
+        try:
+            await self._h._add_to_transcript("client", text, "speech")
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime input transcript write failed: %s", exc, exc_info=True
+            )
+
+        # Mid-call RAG refresh (mirrors _flush_gemini_live_input_buffer's
+        # fire-and-forget trigger, keyed here directly off the complete
+        # utterance rather than off a buffer flush — there is no buffer to
+        # flush on this path). Coalesced via
+        # _openai_realtime_kb_refresh_in_flight for the same reason Gemini
+        # Live's refresh is coalesced: a chatty back-and-forth shouldn't
+        # fire several overlapping retrievals + unordered send_text() calls.
+        if not self._openai_realtime_kb_refresh_in_flight:
+            t = asyncio.create_task(self._refresh_openai_realtime_kb_context(text))
+            self._pending_final_tasks.add(t)
+            t.add_done_callback(lambda done_t, s=self: s._pending_final_tasks.discard(done_t))
+
+    async def _refresh_openai_realtime_kb_context(self, transcript: str) -> None:
+        """
+        OpenAI Realtime analog of _refresh_gemini_live_kb_context. Sends the
+        refreshed KB context as a `conversation.item.create` with
+        `respond=False` — a context-only injection must NEVER trigger
+        `response.create`, or OpenAI will speak the raw injected context
+        aloud as if it were a real reply (see
+        OpenAIRealtimeSession.send_text's docstring). Fails open on any
+        error, same as every other RAG call site in this codebase.
+        """
+        session = self._openai_realtime_session
+        if session is None or not transcript:
+            return
+        flow = getattr(self._h, "call_flow", None)
+        kb_ids = (flow.knowledge_base_ids or []) if flow else []
+        if not kb_ids:
+            return
+        self._openai_realtime_kb_refresh_in_flight = True
+        try:
+            from app.services.kb_retrieval_service import retrieve_kb_context_for_turn
+            from app.utils.redis_client import get_redis
+
+            kb_context, latency_ms = await retrieve_kb_context_for_turn(
+                transcript=transcript, kb_ids=kb_ids, redis_client=get_redis()
+            )
+            if not kb_context:
+                return
+            await session.send_text(
+                "[KNOWLEDGE BASE CONTEXT UPDATE — authoritative, use if relevant to the "
+                f"caller's most recent question]\n{kb_context}",
+                respond=False,
+            )
+            logger.debug(
+                "[OpenAIRealtime] kb_refresh latency_ms=%.1f chars=%d", latency_ms, len(kb_context)
+            )
+        except Exception as exc:
+            logger.debug("[OpenAIRealtime] mid-call KB refresh failed (non-fatal): %s", exc)
+        finally:
+            self._openai_realtime_kb_refresh_in_flight = False
+
+    async def _on_openai_realtime_output_transcript(self, text: str) -> None:
+        """Agent-side FULL final transcript for one turn — fires exactly
+        once (see OpenAIRealtimeSession's on_output_transcript contract).
+        No buffering/turn_complete flush needed, unlike
+        _on_gemini_live_output_transcript / _on_gemini_live_turn_complete."""
+        text = (text or "").strip()
+        if not text:
+            return
+        try:
+            await self._h._add_to_transcript("agent", text, "agent_response")
+        except Exception as exc:
+            logger.error(
+                "[VoiceOrchestrator] openai realtime output transcript write failed: %s", exc, exc_info=True
+            )
+
+    async def _on_openai_realtime_tool_call(self, call_id: str, name: str, arguments_json: str) -> None:
+        """
+        Calendly tool-calling for an OpenAI Realtime session. Only ever
+        registered when the handler is Twilio's BidirectionalStreamHandler
+        AND the call flow has Calendly enabled (see
+        _start_openai_realtime_session) — mirrors
+        _on_gemini_live_tool_call's gating and reuses
+        BookingMixin._execute_calendly_tool_call unmodified, same as Gemini.
+        """
+        import json as _json
+
+        session = self._openai_realtime_session
+        if session is None:
+            return
+
+        try:
+            args = _json.loads(arguments_json) if arguments_json else {}
+            if not isinstance(args, dict):
+                args = {}
+        except (ValueError, TypeError):
+            args = {}
+
+        try:
+            result = await self._h._execute_calendly_tool_call(name, args)
+        except Exception as exc:
+            logger.error(
+                "[OpenAIRealtime] Calendly tool call %s failed unexpectedly: %s",
+                name, exc, exc_info=True,
+            )
+            result = {"error": "internal error executing tool call"}
+
+        from app.core.pii_redactor import redact_pii
+
+        logger.info("[OpenAIRealtime] tool_call name=%s args=%s", name, redact_pii(args))
+        try:
+            await session.send_tool_response(call_id, result)
+        except Exception as exc:
+            logger.error("[OpenAIRealtime] send_tool_response failed: %s", exc, exc_info=True)
+
+    async def _on_openai_realtime_error(self, err) -> None:
+        """
+        Mid-call OpenAIRealtimeSession failure (session had already started —
+        pre-session failures are handled by _start_openai_realtime_session's
+        own try/except, never reach here). Mirrors _on_gemini_live_error:
+        end the call gracefully rather than attempting to reconstruct
+        STT/TTS mid-call.
+        """
+        logger.error(
+            "[OpenAIRealtime] mid-call session error call_session_id=%s error_type=%s: %s",
             getattr(self._h, "call_session_id", None),
             getattr(err, "error_type", None),
             err,

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -1409,12 +1409,26 @@ class VoiceOrchestrator:
         OpenAIRealtimeSession.send_text's docstring). Fails open on any
         error, same as every other RAG call site in this codebase.
         """
+        # DIAGNOSTIC: temporary tracing for a "agent doesn't use KB" report —
+        # logs entry/skip reasons and whether context was actually sent, but
+        # never the transcript or KB content itself. Safe to strip once KB
+        # refresh is confirmed working on a real call.
+        call_session_id = getattr(self._h, "call_session_id", None)
         session = self._openai_realtime_session
         if session is None or not transcript:
+            logger.info(
+                "[OpenAIRealtime] DIAGNOSTIC kb_refresh skipped call_session_id=%s reason=%s",
+                call_session_id, "no_session" if session is None else "empty_transcript",
+            )
             return
         flow = getattr(self._h, "call_flow", None)
         kb_ids = (flow.knowledge_base_ids or []) if flow else []
         if not kb_ids:
+            logger.info(
+                "[OpenAIRealtime] DIAGNOSTIC kb_refresh skipped call_session_id=%s reason=%s "
+                "flow_present=%s",
+                call_session_id, "no_kb_ids_configured", flow is not None,
+            )
             return
         self._openai_realtime_kb_refresh_in_flight = True
         try:
@@ -1425,17 +1439,27 @@ class VoiceOrchestrator:
                 transcript=transcript, kb_ids=kb_ids, redis_client=get_redis()
             )
             if not kb_context:
+                logger.info(
+                    "[OpenAIRealtime] DIAGNOSTIC kb_refresh call_session_id=%s: retrieval returned "
+                    "no matching context (kb_ids=%s, latency_ms=%.1f) — nothing sent",
+                    call_session_id, kb_ids, latency_ms,
+                )
                 return
             await session.send_text(
                 "[KNOWLEDGE BASE CONTEXT UPDATE — authoritative, use if relevant to the "
                 f"caller's most recent question]\n{kb_context}",
                 respond=False,
             )
-            logger.debug(
-                "[OpenAIRealtime] kb_refresh latency_ms=%.1f chars=%d", latency_ms, len(kb_context)
+            logger.info(
+                "[OpenAIRealtime] DIAGNOSTIC kb_refresh call_session_id=%s: sent kb context "
+                "latency_ms=%.1f chars=%d",
+                call_session_id, latency_ms, len(kb_context),
             )
         except Exception as exc:
-            logger.debug("[OpenAIRealtime] mid-call KB refresh failed (non-fatal): %s", exc)
+            logger.warning(
+                "[OpenAIRealtime] mid-call KB refresh failed (non-fatal) call_session_id=%s: %s",
+                call_session_id, exc, exc_info=True,
+            )
         finally:
             self._openai_realtime_kb_refresh_in_flight = False
 

--- a/tests/db/test_schema_v2_migration.py
+++ b/tests/db/test_schema_v2_migration.py
@@ -707,18 +707,6 @@ class TestWidenAgentLlmModelCheckGeminiLiveMigration:
             "gemini-3.1-flash-live-preview",
         }
 
-    def test_widened_snapshot_matches_current_allow_list(self):
-        """The migration's self-contained snapshot must match the current
-        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
-        revision — this is now the latest widening migration, so this
-        assertion correctly lives here; future edits to the module are
-        expected to add a new migration rather than retroactively changing
-        this one)."""
-        from app.core.llm_models import ALLOWED_LLM_MODELS
-
-        mod = _load_migration(self._FILE)
-        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
-
     def test_llm_check_sql_uses_widened_snapshot(self):
         mod = _load_migration(self._FILE)
         sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
@@ -739,3 +727,81 @@ class TestWidenAgentLlmModelCheckGeminiLiveMigration:
             "gemini-3.1-flash-live-preview",
         ]:
             assert f"'{gemini_live_model}'" not in sql
+
+
+# ─────────────────── widen ck_agent_llm_model (OpenAI Realtime) ──────────────
+
+class TestWidenAgentLlmModelCheckOpenAIRealtimeMigration:
+    """20260817b_widen_agent_llm_model_check_openai_realtime.py — widens
+    ck_agent_llm_model from the 24-value 20260817 gemini-live snapshot to 26
+    values (adds the 2 OpenAI Realtime native-audio model IDs, removes
+    nothing)."""
+
+    _FILE = "20260817b_widen_agent_llm_model_check_openai_realtime.py"
+
+    def test_file_exists(self):
+        assert (_VERSIONS_DIR / self._FILE).exists()
+
+    def test_down_revision_is_gemini_live_widen_migration(self):
+        mod = _load_migration(self._FILE)
+        assert mod.down_revision == "20260817_widen_llm_check_glive"
+
+    def test_has_upgrade_and_downgrade(self):
+        mod = _load_migration(self._FILE)
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)
+
+    def test_revision_id(self):
+        mod = _load_migration(self._FILE)
+        assert mod.revision == "20260817_widen_llm_check_oair"
+
+    def test_widened_snapshot_has_26_values(self):
+        mod = _load_migration(self._FILE)
+        assert len(mod._ALLOWED_LLM_MODELS_AT_REVISION) == 26
+
+    def test_prior_snapshot_unchanged_at_24_values(self):
+        mod = _load_migration(self._FILE)
+        assert len(mod._PRIOR_ALLOWED_LLM_MODELS) == 24
+
+    def test_widened_snapshot_is_superset_of_prior_snapshot(self):
+        """Purely additive: nothing removed or renamed."""
+        mod = _load_migration(self._FILE)
+        assert set(mod._PRIOR_ALLOWED_LLM_MODELS).issubset(
+            set(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        )
+
+    def test_widened_snapshot_adds_exactly_the_openai_realtime_family(self):
+        mod = _load_migration(self._FILE)
+        added = set(mod._ALLOWED_LLM_MODELS_AT_REVISION) - set(
+            mod._PRIOR_ALLOWED_LLM_MODELS
+        )
+        assert added == {"gpt-realtime", "gpt-realtime-2"}
+
+    def test_widened_snapshot_matches_current_allow_list(self):
+        """The migration's self-contained snapshot must match the current
+        app.core.llm_models.ALLOWED_LLM_MODELS allow-list (as of this
+        revision — this is now the latest widening migration, so this
+        assertion correctly lives here; future edits to the module are
+        expected to add a new migration rather than retroactively changing
+        this one)."""
+        from app.core.llm_models import ALLOWED_LLM_MODELS
+
+        mod = _load_migration(self._FILE)
+        assert set(mod._ALLOWED_LLM_MODELS_AT_REVISION) == set(ALLOWED_LLM_MODELS)
+
+    def test_llm_check_sql_uses_widened_snapshot(self):
+        mod = _load_migration(self._FILE)
+        sql = mod._llm_check_sql(mod._ALLOWED_LLM_MODELS_AT_REVISION)
+        for model in mod._ALLOWED_LLM_MODELS_AT_REVISION:
+            assert f"'{model}'" in sql
+
+    def test_downgrade_sql_uses_prior_snapshot_only(self):
+        """Downgrade must restore the narrower 24-value constraint — the
+        two new OpenAI Realtime IDs must not appear in the downgrade CHECK
+        SQL."""
+        mod = _load_migration(self._FILE)
+        sql = mod._llm_check_sql(mod._PRIOR_ALLOWED_LLM_MODELS)
+        for model in mod._PRIOR_ALLOWED_LLM_MODELS:
+            assert f"'{model}'" in sql
+        for openai_realtime_model in ["gpt-realtime", "gpt-realtime-2"]:
+            assert f"'{openai_realtime_model}'" not in sql

--- a/tests/voice/test_gemini_live_browser_fork.py
+++ b/tests/voice/test_gemini_live_browser_fork.py
@@ -730,6 +730,8 @@ class TestBrowserGreetingBypassesExternalTtsForNativeAudio:
         vo = MagicMock()
         vo._is_gemini_live = is_gemini_live
         vo._gemini_live_session = fake_session if is_gemini_live else None
+        vo._is_openai_realtime = False
+        vo._openai_realtime_session = None
         h._voice_orchestrator = vo
         h._fake_session = fake_session
         return h

--- a/tests/voice/test_gemini_live_service.py
+++ b/tests/voice/test_gemini_live_service.py
@@ -299,6 +299,67 @@ class TestSendAudio:
             assert blob.data == b"\x01\x02\x03\x04"
             assert blob.mime_type == "audio/pcm;rate=16000"
 
+    def test_send_audio_empty_bytes_is_noop(self):
+        with _real_google_genai():
+            session_obj = _FakeAsyncSession()
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+            gls._session = session_obj
+
+            asyncio.run(gls.send_audio(b""))
+
+            session_obj.send_realtime_input.assert_not_awaited()
+
+    def test_send_audio_noop_once_session_already_closed(self):
+        """Straggler audio chunks arriving after close() has already run
+        must never reach send_realtime_input() — mirrors
+        OpenAIRealtimeSession.send_audio's identical shutdown-race guard."""
+        with _real_google_genai():
+            session_obj = _FakeAsyncSession()
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+            gls._session = session_obj
+            gls._closed = True
+
+            asyncio.run(gls.send_audio(b"\x01\x02\x03\x04"))
+
+            session_obj.send_realtime_input.assert_not_awaited()
+
+    def test_send_audio_swallows_exception_when_closed_flips_mid_await(self):
+        """Mirrors OpenAIRealtimeSession's identical test: self._closed flips
+        to True while send_realtime_input() is in-flight and then raises —
+        the exception must be swallowed, not propagated, once the flip is
+        observed."""
+        with _real_google_genai():
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+            session_obj = MagicMock()
+
+            async def _send(**_kwargs):
+                gls._closed = True
+                raise ConnectionError("connection closed during send")
+
+            session_obj.send_realtime_input = AsyncMock(side_effect=_send)
+            gls._session = session_obj
+
+            # Must not raise.
+            asyncio.run(gls.send_audio(b"\x01\x02\x03\x04"))
+
+            session_obj.send_realtime_input.assert_awaited_once()
+
+    def test_send_audio_reraises_exception_when_not_closed(self):
+        """Sanity check for the opposite branch: a send() failure unrelated
+        to a concurrent close() must still propagate."""
+        with _real_google_genai():
+            gls = GeminiLiveSession("gemini-3.1-flash-live-preview")
+
+            session_obj = MagicMock()
+            session_obj.send_realtime_input = AsyncMock(
+                side_effect=RuntimeError("genuine send failure")
+            )
+            gls._session = session_obj
+
+            with pytest.raises(RuntimeError, match="genuine send failure"):
+                asyncio.run(gls.send_audio(b"\x01\x02\x03\x04"))
+
     def test_send_text_wraps_content_and_turn_complete(self):
         with _real_google_genai():
             session_obj = _FakeAsyncSession()

--- a/tests/voice/test_gemini_live_twilio_fork.py
+++ b/tests/voice/test_gemini_live_twilio_fork.py
@@ -575,6 +575,8 @@ class TestGreetingBypassesExternalTtsForNativeAudio:
         vo = MagicMock()
         vo._is_gemini_live = is_gemini_live
         vo._gemini_live_session = fake_session if is_gemini_live else None
+        vo._is_openai_realtime = False
+        vo._openai_realtime_session = None
         h._voice_orchestrator = vo
         h._fake_session = fake_session  # test-only handle
         return h

--- a/tests/voice/test_livekit_browser_call_handler.py
+++ b/tests/voice/test_livekit_browser_call_handler.py
@@ -707,7 +707,9 @@ class TestRunLiveKitBrowserCall:
              ), \
              patch(
                  "app.voice.voice_orchestrator.VoiceOrchestrator",
-                 return_value=MagicMock(shutdown=AsyncMock(), _is_gemini_live=False),
+                 return_value=MagicMock(
+                     shutdown=AsyncMock(), _is_gemini_live=False, _is_openai_realtime=False,
+                 ),
              ), \
              patch(
                  "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
@@ -756,11 +758,13 @@ class TestRunLiveKitBrowserCall:
         mock_vo_instance._on_interim = AsyncMock()
         mock_vo_instance._on_final = AsyncMock()
         # Explicit, not auto-Mock-truthy: this test exercises the normal
-        # (non-Gemini-Live) STT/TTS path — a bare MagicMock() would make
-        # `_is_gemini_live` an auto-created truthy child Mock, wrongly
-        # entering the Gemini Live branch and awaiting an un-awaitable
-        # `_start_gemini_live_session` Mock.
+        # (non-Gemini-Live/non-OpenAI-Realtime) STT/TTS path — a bare
+        # MagicMock() would make `_is_gemini_live` / `_is_openai_realtime`
+        # auto-created truthy child Mocks, wrongly entering one of those
+        # native-audio branches and awaiting an un-awaitable
+        # `_start_gemini_live_session` / `_start_openai_realtime_session` Mock.
         mock_vo_instance._is_gemini_live = False
+        mock_vo_instance._is_openai_realtime = False
 
         async def _immediately_stop_and_greet(self, *_args, **_kwargs):
             # Simulate handler.generate_and_stream_response for the greeting,

--- a/tests/voice/test_openai_realtime_browser_fork.py
+++ b/tests/voice/test_openai_realtime_browser_fork.py
@@ -1,0 +1,356 @@
+"""
+Browser-transport (LiveKit) fork-point tests for OpenAI Realtime native-audio
+routing — the mirror-image counterpart of
+tests/voice/test_openai_realtime_twilio_fork.py, structured like
+tests/voice/test_gemini_live_browser_fork.py.
+
+Covers:
+  - native-audio OpenAI agents never construct SttPipeline on this transport
+  - caller audio flows to OpenAIRealtimeSession.send_audio via the
+    _OpenAIRealtimeAudioSink adapter (LiveKitAudioSubscriber unmodified,
+    requested at 24kHz — not Gemini Live's 16kHz)
+  - agent audio flows through the SAME generic 24kHz-PCM publish sink
+    Gemini Live's browser wiring already established
+    (_publish_gemini_live_audio_chunk) — reused unmodified, not duplicated,
+    since OpenAI's audio/pcm output is also PCM16/24kHz
+  - the outbound publisher is opened at 24kHz for a native-audio OpenAI call
+  - barge-in clears the LiveKit AudioSource's own playout queue directly,
+    same shared method Gemini Live uses on this transport
+  - _start_openai_realtime_session builds system_instruction from
+    ConversationOrchestrator.build_system_prompt (this transport's own real
+    prompt-assembly), never Twilio's build_system_prompt
+  - no Calendly tool-calling on this transport (no BookingMixin here)
+
+OpenAIRealtimeSession itself is mocked throughout — no live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.services.openai_realtime_service import LIVEKIT_AUDIO_RATE_HZ as OPENAI_REALTIME_AUDIO_RATE_HZ
+from app.voice.livekit_browser_call_handler import (
+    LiveKitBrowserCallHandler,
+    _AGENT_AUDIO_SAMPLE_RATE,
+    _OpenAIRealtimeAudioSink,
+    run_livekit_browser_call,
+)
+from app.voice.voice_orchestrator import VoiceOrchestrator
+
+NATIVE_AUDIO_MODEL = next(iter(OPENAI_REALTIME_MODELS))
+
+
+def _base_handler(llm_model: str | None) -> LiveKitBrowserCallHandler:
+    db = MagicMock()
+    call_session = MagicMock()
+    call_session.id = uuid.uuid4()
+    call_session.user_id = uuid.uuid4()
+    call_session.tenant_id = uuid.uuid4()
+    call_session.call_metadata = {}
+    call_session.call_transcript = []
+
+    agent = MagicMock()
+    agent.id = uuid.uuid4()
+    agent.name = "Demo Agent"
+    agent.language = "en"
+    agent.voice_type = "female"
+    agent.llm_model = llm_model
+    agent.greeting_message = None
+    agent.first_message = None
+
+    return LiveKitBrowserCallHandler(db=db, call_session=call_session, agent=agent, call_flow=None)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _OpenAIRealtimeAudioSink — LiveKitAudioSubscriber's sink adapter
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestOpenAIRealtimeAudioSink:
+    @pytest.mark.asyncio
+    async def test_forwards_to_session_send_audio(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock()
+        sink = _OpenAIRealtimeAudioSink(session)
+
+        await sink.feed_audio_chunk(b"\x01\x02pcm16-24k")
+
+        session.send_audio.assert_awaited_once_with(b"\x01\x02pcm16-24k")
+
+    @pytest.mark.asyncio
+    async def test_empty_chunk_is_a_noop(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock()
+        sink = _OpenAIRealtimeAudioSink(session)
+
+        await sink.feed_audio_chunk(b"")
+
+        session.send_audio.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_audio_exception_is_swallowed(self):
+        session = MagicMock()
+        session.send_audio = AsyncMock(side_effect=RuntimeError("session closed"))
+        sink = _OpenAIRealtimeAudioSink(session)
+
+        # Must not raise.
+        await sink.feed_audio_chunk(b"\x01\x02")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# VoiceOrchestrator's transport-aware branch, exercised against a real
+# LiveKitBrowserCallHandler — same generic sink methods Gemini Live's
+# browser wiring already established, reused unmodified.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestVoiceOrchestratorAudioConversionRoutingBrowser:
+    def test_is_openai_realtime_resolved_from_agent_llm_model(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is True
+        assert orch._is_gemini_live is False
+
+    def test_non_native_model_is_openai_realtime_false(self):
+        h = _base_handler("gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is False
+
+    def test_on_audio_chunk_callback_reuses_generic_publish_pcm_sink(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._publish_gemini_live_audio_chunk = AsyncMock()
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"pcm24k-in"))
+
+        h._publish_gemini_live_audio_chunk.assert_awaited_once_with(
+            b"pcm24k-in", orch._openai_realtime_cancel, sample_rate_hz=24000
+        )
+
+    def test_on_audio_chunk_callback_gated_by_cancel_flag(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._publish_gemini_live_audio_chunk = AsyncMock()
+        orch._openai_realtime_cancel.set()
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"pcm24k-in"))
+
+        h._publish_gemini_live_audio_chunk.assert_not_awaited()
+
+    def test_interrupted_clears_livekit_queue_not_twilio_event(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._clear_gemini_live_playout_queue = AsyncMock()
+        orch._openai_realtime_first_audio_marked = True
+
+        asyncio.run(orch._on_openai_realtime_interrupted())
+
+        h._clear_gemini_live_playout_queue.assert_awaited_once()
+        assert not orch._openai_realtime_cancel.is_set()
+        assert orch._openai_realtime_first_audio_marked is False
+
+    def test_input_transcript_written_immediately_no_buffering(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._add_to_transcript = AsyncMock()
+
+        asyncio.run(orch._on_openai_realtime_input_transcript("hello there"))
+
+        h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+
+    def test_output_transcript_written_immediately_no_buffering(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._add_to_transcript = AsyncMock()
+
+        asyncio.run(orch._on_openai_realtime_output_transcript("Sure, I can help."))
+
+        h._add_to_transcript.assert_awaited_once_with("agent", "Sure, I can help.", "agent_response")
+
+    def test_mid_call_error_ends_call_via_full_shutdown(self):
+        from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType
+
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h._full_shutdown = AsyncMock()
+
+        asyncio.run(
+            orch._on_openai_realtime_error(
+                OpenAIRealtimeError("dropped", OpenAIRealtimeErrorType.UNKNOWN)
+            )
+        )
+
+        h._full_shutdown.assert_called_once()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# System-instruction source — mirror-image regression guard: browser must
+# use ConversationOrchestrator.build_system_prompt, never Twilio's method.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestOpenAIRealtimeSessionUsesConversationOrchestratorPromptAssembly:
+    def test_start_openai_realtime_session_uses_conversation_orchestrator(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        assert not hasattr(h, "build_system_prompt")  # duck-type must fail for browser
+
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ) as browser_build:
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        browser_build.assert_awaited_once()
+        fake_session.start.assert_awaited_once()
+        assert (
+            fake_session.start.call_args.kwargs["system_instruction"]
+            == "browser system prompt"
+        )
+        assert orch._openai_realtime_session is fake_session
+
+    def test_no_calendly_tool_calling_on_browser_transport(self):
+        h = _base_handler(NATIVE_AUDIO_MODEL)
+        assert not hasattr(h, "_calendly_enabled")
+
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is None
+        assert kwargs["on_tool_call"] is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# run_livekit_browser_call — full-lifecycle fork wiring
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestRunLiveKitBrowserCallOpenAIRealtimeFork:
+    def _call_session(self, call_session_id):
+        call_session = MagicMock()
+        call_session.id = call_session_id
+        call_session.call_flow_id = None
+        call_session.call_metadata = {}
+        return call_session
+
+    def _agent(self, llm_model):
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.llm_model = llm_model
+        agent.stt_provider_slug = None
+        agent.stt_model_id = None
+        return agent
+
+    @pytest.mark.asyncio
+    async def test_native_audio_call_never_constructs_stt_pipeline_and_opens_24k_publisher(self):
+        call_session_id = uuid.uuid4()
+        call_session = self._call_session(call_session_id)
+        agent = self._agent(NATIVE_AUDIO_MODEL)
+        mock_db = MagicMock()
+
+        publisher_ctor_calls: list = []
+
+        class _FakePublisher:
+            def __init__(self, room_name, sample_rate_hz=_AGENT_AUDIO_SAMPLE_RATE):
+                publisher_ctor_calls.append(sample_rate_hz)
+                self._room_name = room_name
+                self._sample_rate = sample_rate_hz
+                self._room = MagicMock()
+                self.connected = True
+
+            async def connect(self):
+                return True
+
+            async def disconnect(self):
+                return None
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        subscriber_ctor_kwargs: list = []
+
+        class _FakeSubscriber:
+            def __init__(self, **kwargs):
+                subscriber_ctor_kwargs.append(kwargs)
+
+            async def run(self):
+                return None
+
+            async def stop(self):
+                return None
+
+        async def _immediately_stop(self, *_args, **_kwargs):
+            self._stop_event.set()
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 new=_FakePublisher,
+             ), \
+             patch(
+                 "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+             ), \
+             patch(
+                 "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+                 new=AsyncMock(return_value="browser system prompt"),
+             ), \
+             patch("app.voice.stt_pipeline.SttPipeline.from_runtime_config") as mock_stt_ctor, \
+             patch(
+                 "app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber",
+                 new=_FakeSubscriber,
+             ), \
+             patch("app.services.call_session_service.call_session_service"), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._start_browser_call_recording",
+                 new=AsyncMock(return_value=None),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._stop_browser_call_recording",
+                 new=AsyncMock(),
+             ), \
+             patch.object(
+                 LiveKitBrowserCallHandler,
+                 "generate_and_stream_response",
+                 new=_immediately_stop,
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            await asyncio.wait_for(run_livekit_browser_call(call_session_id), timeout=5.0)
+
+        # SttPipeline never constructed for a native-audio call.
+        mock_stt_ctor.assert_not_called()
+        # Publisher opened at OpenAI's 24kHz output rate, not the usual 8kHz.
+        assert publisher_ctor_calls == [OPENAI_REALTIME_AUDIO_RATE_HZ]
+        # The audio subscriber was fed an _OpenAIRealtimeAudioSink at 24kHz,
+        # not a raw SttPipeline (and not Gemini's 16kHz-targeted sink).
+        assert len(subscriber_ctor_kwargs) == 1
+        kwargs = subscriber_ctor_kwargs[0]
+        sink = kwargs["stt_pipeline"]
+        assert isinstance(sink, _OpenAIRealtimeAudioSink)
+        assert sink._session is fake_session
+        assert kwargs["output_sample_rate"] == OPENAI_REALTIME_AUDIO_RATE_HZ
+        fake_session.start.assert_awaited_once()

--- a/tests/voice/test_openai_realtime_service.py
+++ b/tests/voice/test_openai_realtime_service.py
@@ -1,0 +1,744 @@
+"""
+Unit tests for app/services/openai_realtime_service.py — OpenAIRealtimeSession.
+
+Mirrors tests/voice/test_gemini_live_service.py's structure/conventions,
+adapted for this provider's genuinely different SDK shape:
+  - `connection.recv()` returns exactly one parsed event per call (no
+    per-turn generator-exhaustion quirk like google.genai's
+    `session.receive()`), so the fake connection here is a plain AsyncMock-
+    backed `recv()` returning a queued list of events, one per call — NOT
+    a turn-batched async generator like Gemini's `_FakeAsyncSession`.
+  - Client events (session.update / input_audio_buffer.append /
+    conversation.item.create / response.create) are built as plain dicts in
+    the source, not real SDK types, so these tests never need Gemini's
+    `_real_google_genai()`-style "temporarily un-stub the real SDK" dance —
+    plain dict/SimpleNamespace fakes are sufficient throughout.
+
+CRITICAL test-safety note (see this task's own write-up of a real prior
+incident in this codebase): every fake connection's `recv()` here has a
+natural termination condition — once its queued events are exhausted, it
+raises `_StopReceiving` rather than blocking or replaying, so
+`_receive_loop`'s `while True:` loop always terminates on its own. A
+dedicated `test_close_cancels_receive_task_while_genuinely_blocked_in_recv`
+test additionally covers the "task genuinely suspended inside recv()" case
+using a real `asyncio.Event().wait()` that only `close()`'s cancellation
+can end.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.services.openai_realtime_service import (
+    DEFAULT_VOICE_NAME,
+    LIVEKIT_AUDIO_FORMAT,
+    LIVEKIT_AUDIO_RATE_HZ,
+    TWILIO_AUDIO_FORMAT,
+    VALID_VOICE_NAMES,
+    OpenAIRealtimeError,
+    OpenAIRealtimeErrorType,
+    OpenAIRealtimeSession,
+    _build_calendly_tool_params,
+    _classify_openai_realtime_error,
+    resolve_voice_name,
+)
+
+
+class _FakeConnection:
+    """Fake ``AsyncRealtimeConnection``. Once its queued ``events`` are
+    exhausted, ``recv()`` blocks forever (a real ``asyncio.Event().wait()``
+    that only external task cancellation can end) rather than raising or
+    replaying — this mirrors real production shape (the receive loop is
+    normally ended by ``close()``'s ``task.cancel()``, not by ``recv()``
+    erroring) and, per this task's CRITICAL testing-safety note, still gives
+    every test a natural, finite termination condition: every test using
+    this fake either calls ``session.close()`` (which cancels the task) or
+    explicitly cancels the task itself after observing all queued events
+    have been consumed — never a bare, uncancelled ``while True`` against a
+    naively-replaying/never-blocking mock."""
+
+    def __init__(self, events=None, block_forever: bool = False):
+        self._events = list(events or [])
+        del block_forever  # accepted for call-site clarity; always the behavior now
+        self.send = AsyncMock()
+        self.close = AsyncMock()
+
+    async def recv(self):
+        if not self._events:
+            # Genuinely suspends until cancelled — never resolves on its own.
+            await asyncio.Event().wait()
+            return None
+        return self._events.pop(0)
+
+
+class _FakeConnectCM:
+    """Stands in for the object returned by client.realtime.connect(...) —
+    an async context manager yielding a connection."""
+
+    def __init__(self, connection: _FakeConnection):
+        self._connection = connection
+        self.aexit_called = False
+
+    async def __aenter__(self):
+        return self._connection
+
+    async def __aexit__(self, *exc):
+        self.aexit_called = True
+        return False
+
+
+def _make_fake_client(connection: _FakeConnection):
+    connect_cm = _FakeConnectCM(connection)
+    client = MagicMock()
+    client.realtime.connect = MagicMock(return_value=connect_cm)
+    return client, connect_cm
+
+
+def _evt(**kwargs) -> SimpleNamespace:
+    return SimpleNamespace(**kwargs)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Construction / model validation
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestOpenAIRealtimeSessionConstruction:
+    @pytest.mark.parametrize("model_name", list(OPENAI_REALTIME_MODELS))
+    def test_known_models_construct_successfully(self, model_name):
+        session = OpenAIRealtimeSession(model_name)
+        assert session.model_name == model_name
+
+    def test_unknown_model_raises_value_error(self):
+        with pytest.raises(ValueError, match="not an OpenAI Realtime"):
+            OpenAIRealtimeSession("gpt-4o")
+
+    def test_unknown_model_error_lists_valid_models(self):
+        with pytest.raises(ValueError) as exc_info:
+            OpenAIRealtimeSession("totally-made-up-model")
+        for model_name in OPENAI_REALTIME_MODELS:
+            assert model_name in str(exc_info.value)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# start() — connects, sends session.update, launches the receive loop
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestStart:
+    def test_start_connects_and_launches_receive_loop(self):
+        connection = _FakeConnection(events=[])
+        client, connect_cm = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="be helpful",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await asyncio.sleep(0)  # let the receive loop hit _StopReceiving
+            await session.close()
+
+        asyncio.run(_run())
+
+        client.realtime.connect.assert_called_once_with(model="gpt-realtime")
+        assert connect_cm.aexit_called is True
+
+    def test_start_sends_session_update_with_instructions_and_audio_format(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="be helpful",
+                    audio_format=TWILIO_AUDIO_FORMAT,
+                    voice_name="marin",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        connection.send.assert_awaited_once()
+        sent = connection.send.call_args.args[0]
+        assert sent["type"] == "session.update"
+        sess = sent["session"]
+        assert sess["model"] == "gpt-realtime"
+        assert sess["instructions"] == "be helpful"
+        assert sess["output_modalities"] == ["audio"]
+        assert sess["audio"]["input"]["format"] == {"type": "audio/pcmu"}
+        assert sess["audio"]["output"]["format"] == {"type": "audio/pcmu"}
+        assert sess["audio"]["output"]["voice"] == "marin"
+        assert sess["audio"]["input"]["turn_detection"]["type"] == "server_vad"
+        assert sess["audio"]["input"]["turn_detection"]["interrupt_response"] is True
+        # gpt-realtime has no reasoning config (see module docstring).
+        assert "reasoning" not in sess
+
+    def test_start_livekit_audio_format_uses_pcm_24k(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    audio_format=LIVEKIT_AUDIO_FORMAT,
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        sent = connection.send.call_args.args[0]
+        assert sent["session"]["audio"]["input"]["format"] == {
+            "type": "audio/pcm", "rate": LIVEKIT_AUDIO_RATE_HZ,
+        }
+        assert sent["session"]["audio"]["output"]["format"] == {
+            "type": "audio/pcm", "rate": LIVEKIT_AUDIO_RATE_HZ,
+        }
+
+    def test_gpt_realtime_2_gets_capped_reasoning_effort(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime-2")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        sent = connection.send.call_args.args[0]
+        assert sent["session"]["reasoning"] == {"effort": "low"}
+
+    def test_start_passes_tools_when_provided(self):
+        connection = _FakeConnection(events=[])
+        client, _ = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+        tools = _build_calendly_tool_params()
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                    tools=tools,
+                )
+            await session.close()
+
+        asyncio.run(_run())
+
+        sent = connection.send.call_args.args[0]
+        assert sent["session"]["tools"] == tools
+
+    def test_start_failure_raises_openai_realtime_error(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        with patch.object(session, "_build_client", side_effect=RuntimeError("boom")):
+            with pytest.raises(OpenAIRealtimeError):
+                asyncio.run(
+                    session.start(
+                        system_instruction="hi",
+                        on_audio_chunk=AsyncMock(),
+                        on_interrupted=AsyncMock(),
+                    )
+                )
+
+    def test_connect_exception_translated_to_openai_realtime_error(self):
+        client = MagicMock()
+        client.realtime.connect = MagicMock(side_effect=RuntimeError("quota exceeded"))
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        with patch.object(session, "_build_client", return_value=client):
+            with pytest.raises(OpenAIRealtimeError) as exc_info:
+                asyncio.run(
+                    session.start(
+                        system_instruction="hi",
+                        on_audio_chunk=AsyncMock(),
+                        on_interrupted=AsyncMock(),
+                    )
+                )
+        assert exc_info.value.error_type == OpenAIRealtimeErrorType.QUOTA
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# send_audio / send_text / send_tool_response
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestSendAudio:
+    def test_send_audio_base64_encodes_and_wraps_event(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
+        connection.send.assert_awaited_once()
+        sent = connection.send.call_args.args[0]
+        assert sent["type"] == "input_audio_buffer.append"
+        assert base64.b64decode(sent["audio"]) == b"\x01\x02\x03\x04"
+
+    def test_send_audio_empty_bytes_is_noop(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_audio(b""))
+
+        connection.send.assert_not_awaited()
+
+
+class TestSendText:
+    def test_send_text_respond_true_sends_item_and_response_create(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_text("hello", respond=True))
+
+        assert connection.send.await_count == 2
+        item_event = connection.send.call_args_list[0].args[0]
+        response_event = connection.send.call_args_list[1].args[0]
+        assert item_event["type"] == "conversation.item.create"
+        assert item_event["item"]["role"] == "user"
+        assert item_event["item"]["content"] == [{"type": "input_text", "text": "hello"}]
+        assert response_event == {"type": "response.create"}
+
+    def test_send_text_respond_false_sends_only_item_create(self):
+        """Regression guard: a context-only injection (e.g. mid-call RAG
+        refresh) must NEVER also send response.create, or OpenAI will speak
+        the raw injected text aloud as if it were a real reply."""
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_text("KB context update", respond=False))
+
+        connection.send.assert_awaited_once()
+        sent = connection.send.call_args.args[0]
+        assert sent["type"] == "conversation.item.create"
+
+    def test_send_text_empty_string_is_noop(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_text("", respond=True))
+
+        connection.send.assert_not_awaited()
+
+
+class TestSendToolResponse:
+    def test_send_tool_response_sends_output_then_response_create(self):
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        asyncio.run(session.send_tool_response("call-1", {"slots": ["09:00"]}))
+
+        assert connection.send.await_count == 2
+        item_event = connection.send.call_args_list[0].args[0]
+        response_event = connection.send.call_args_list[1].args[0]
+        assert item_event["type"] == "conversation.item.create"
+        assert item_event["item"]["type"] == "function_call_output"
+        assert item_event["item"]["call_id"] == "call-1"
+        import json as _json
+        assert _json.loads(item_event["item"]["output"]) == {"slots": ["09:00"]}
+        assert response_event == {"type": "response.create"}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# _receive_loop / _handle_event — demuxing each server event variant
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestReceiveLoopDemux:
+    def _run_with_events(self, events, **callback_kwargs):
+        """Run `_receive_loop()` as a cancellable background task, wait for
+        all queued fake events to be consumed, then cancel it — see
+        `_FakeConnection`'s docstring for why this (not letting the loop
+        exhaust/error on its own) is both the more realistic simulation and
+        the hang-safe approach here."""
+        connection = _FakeConnection(events=events)
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+        for name, cb in callback_kwargs.items():
+            setattr(session, name, cb)
+
+        async def _run():
+            task = asyncio.create_task(session._receive_loop())
+            for _ in range(500):
+                if not connection._events:
+                    break
+                await asyncio.sleep(0)
+            else:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+                raise AssertionError("fake events were never all consumed")
+            # One more tick so the last _handle_event call actually completes
+            # before we cancel (recv() for the now-empty queue may already be
+            # in flight and blocked, which is fine — that's what we cancel).
+            await asyncio.sleep(0)
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+        asyncio.run(_run())
+        return session
+
+    def test_audio_delta_demuxed_and_base64_decoded(self):
+        raw = b"\x00\x01\x02"
+        evt = _evt(type="response.output_audio.delta", delta=base64.b64encode(raw).decode("ascii"))
+        on_audio_chunk = AsyncMock()
+
+        self._run_with_events([evt], on_audio_chunk=on_audio_chunk)
+
+        on_audio_chunk.assert_awaited_once_with(raw)
+
+    def test_speech_started_demuxed_to_on_interrupted(self):
+        evt = _evt(type="input_audio_buffer.speech_started")
+        on_interrupted = AsyncMock()
+
+        self._run_with_events([evt], on_interrupted=on_interrupted)
+
+        on_interrupted.assert_awaited_once()
+
+    def test_speech_stopped_demuxed_to_on_speech_stopped(self):
+        evt = _evt(type="input_audio_buffer.speech_stopped")
+        on_speech_stopped = AsyncMock()
+
+        self._run_with_events([evt], on_speech_stopped=on_speech_stopped)
+
+        on_speech_stopped.assert_awaited_once()
+
+    def test_input_transcript_completed_demuxed_with_full_text(self):
+        evt = _evt(
+            type="conversation.item.input_audio_transcription.completed",
+            transcript="hello there, how are you",
+        )
+        on_input_transcript = AsyncMock()
+
+        self._run_with_events([evt], on_input_transcript=on_input_transcript)
+
+        on_input_transcript.assert_awaited_once_with("hello there, how are you")
+
+    def test_output_transcript_done_demuxed_with_full_text(self):
+        evt = _evt(type="response.output_audio_transcript.done", transcript="Sure, I can help.")
+        on_output_transcript = AsyncMock()
+
+        self._run_with_events([evt], on_output_transcript=on_output_transcript)
+
+        on_output_transcript.assert_awaited_once_with("Sure, I can help.")
+
+    def test_blank_transcript_not_forwarded(self):
+        evt = _evt(type="response.output_audio_transcript.done", transcript="")
+        on_output_transcript = AsyncMock()
+
+        self._run_with_events([evt], on_output_transcript=on_output_transcript)
+
+        on_output_transcript.assert_not_awaited()
+
+    def test_function_call_arguments_done_demuxed(self):
+        evt = _evt(
+            type="response.function_call_arguments.done",
+            call_id="call-1",
+            name="check_availability",
+            arguments='{"date": "tomorrow"}',
+        )
+        on_tool_call = AsyncMock()
+
+        self._run_with_events([evt], on_tool_call=on_tool_call)
+
+        on_tool_call.assert_awaited_once_with("call-1", "check_availability", '{"date": "tomorrow"}')
+
+    def test_multiple_events_all_processed_in_one_recv_loop_pass(self):
+        """Regression guard for the flat (non-per-turn) receive loop shape:
+        several events queued across what would be multiple Gemini Live
+        "turns" must all be processed by the same _receive_loop() call,
+        with no outer per-turn re-invocation needed."""
+        evt1 = _evt(type="input_audio_buffer.speech_started")
+        evt2 = _evt(
+            type="conversation.item.input_audio_transcription.completed",
+            transcript="first utterance",
+        )
+        evt3 = _evt(type="response.output_audio_transcript.done", transcript="first reply")
+        evt4 = _evt(
+            type="conversation.item.input_audio_transcription.completed",
+            transcript="second utterance",
+        )
+
+        on_interrupted = AsyncMock()
+        on_input_transcript = AsyncMock()
+        on_output_transcript = AsyncMock()
+
+        self._run_with_events(
+            [evt1, evt2, evt3, evt4],
+            on_interrupted=on_interrupted,
+            on_input_transcript=on_input_transcript,
+            on_output_transcript=on_output_transcript,
+        )
+
+        on_interrupted.assert_awaited_once()
+        on_output_transcript.assert_awaited_once_with("first reply")
+        assert on_input_transcript.await_args_list == [
+            (("first utterance",), {}),
+            (("second utterance",), {}),
+        ]
+
+    def test_error_event_demuxed_and_routed_to_on_error(self):
+        evt = _evt(type="error", error=_evt(message="rate limit exceeded", code="rate_limit_exceeded"))
+        on_error = AsyncMock()
+
+        self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_awaited_once()
+        err = on_error.call_args.args[0]
+        assert isinstance(err, OpenAIRealtimeError)
+        assert "rate limit exceeded" in str(err)
+
+    def test_unknown_event_type_is_benign_noop(self):
+        evt = _evt(type="session.created")
+        on_audio_chunk = AsyncMock()
+
+        # Must not raise.
+        self._run_with_events([evt], on_audio_chunk=on_audio_chunk)
+
+        on_audio_chunk.assert_not_awaited()
+
+    def test_recv_exception_translated_and_routed_to_on_error_then_loop_ends(self):
+        connection = MagicMock()
+        connection.recv = AsyncMock(side_effect=RuntimeError("connection dropped"))
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+        on_error = AsyncMock()
+        session.on_error = on_error
+
+        # Must terminate on its own (not hang) — the whole point of this test.
+        asyncio.run(session._receive_loop())
+
+        on_error.assert_awaited_once()
+        err = on_error.call_args.args[0]
+        assert isinstance(err, OpenAIRealtimeError)
+
+    def test_recv_exception_without_on_error_callback_is_logged_not_raised(self, caplog):
+        import logging
+
+        connection = MagicMock()
+        connection.recv = AsyncMock(side_effect=RuntimeError("boom"))
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+
+        with caplog.at_level(logging.ERROR):
+            asyncio.run(session._receive_loop())  # no on_error set
+        assert any("OpenAIRealtimeSession" in rec.message for rec in caplog.records)
+
+    def test_handle_event_exception_reported_but_loop_continues(self):
+        """A single bad/unhandled event must not kill the whole receive
+        loop — mirrors GeminiLiveSession's per-message try/except."""
+        evt1 = _evt(type="response.output_audio_transcript.done", transcript="ok")
+
+        class _BadEvent:
+            @property
+            def type(self):
+                raise RuntimeError("malformed event")
+
+        on_output_transcript = AsyncMock()
+        on_error = AsyncMock()
+
+        self._run_with_events(
+            [_BadEvent(), evt1],
+            on_output_transcript=on_output_transcript,
+            on_error=on_error,
+        )
+
+        on_error.assert_awaited_once()
+        on_output_transcript.assert_awaited_once_with("ok")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# close() — idempotent, never raises
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestClose:
+    def test_close_is_idempotent(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+        asyncio.run(session.close())
+        asyncio.run(session.close())  # must not raise second time
+
+    def test_close_cancels_receive_task_and_exits_connect_cm(self):
+        connection = _FakeConnection(events=[])
+        client, connect_cm = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await session.close()
+
+        asyncio.run(_run())
+        assert connect_cm.aexit_called is True
+        assert session._receive_task is None
+
+    def test_close_cancels_receive_task_while_genuinely_blocked_in_recv(self):
+        """`events=[]` alone lets _StopReceiving end the receive task on its
+        own before close()'s `.cancel()` is ever meaningfully exercised. Use
+        a connection whose recv() never resolves on its own, so close() must
+        cancel a task that is genuinely suspended *inside* recv(), not one
+        that already finished — mirrors the equivalent Gemini Live test and
+        this task's own CRITICAL testing-safety note."""
+        connection = _FakeConnection(block_forever=True)
+        client, connect_cm = _make_fake_client(connection)
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _run():
+            with patch.object(session, "_build_client", return_value=client):
+                await session.start(
+                    system_instruction="hi",
+                    on_audio_chunk=AsyncMock(),
+                    on_interrupted=AsyncMock(),
+                )
+            await asyncio.sleep(0)  # let the receive task actually start blocking
+            task = session._receive_task
+            assert task is not None
+            assert not task.done()
+
+            await session.close()
+
+            assert task.cancelled()
+
+        asyncio.run(_run())
+        assert connect_cm.aexit_called is True
+        assert session._receive_task is None
+
+    def test_close_never_raises_even_if_connect_cm_teardown_errors(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        class _BadCM:
+            async def __aexit__(self, *exc):
+                raise RuntimeError("teardown boom")
+
+        session._connect_cm = _BadCM()
+        # Must not raise.
+        asyncio.run(session.close())
+
+    def test_close_never_raises_even_if_receive_task_already_dead(self):
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        async def _dead_task_coro():
+            raise RuntimeError("already crashed")
+
+        async def _setup_and_close():
+            task = asyncio.create_task(_dead_task_coro())
+            await asyncio.sleep(0)  # let it crash
+            session._receive_task = task
+            await session.close()  # must not raise/propagate task's exception
+
+        asyncio.run(_setup_and_close())
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# resolve_voice_name / _classify_openai_realtime_error / calendly tools
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestResolveVoiceName:
+    def test_none_falls_back_to_default(self):
+        assert resolve_voice_name(None) == DEFAULT_VOICE_NAME
+
+    def test_empty_string_falls_back_to_default(self):
+        assert resolve_voice_name("") == DEFAULT_VOICE_NAME
+
+    def test_valid_voice_name_passthrough(self):
+        assert resolve_voice_name("cedar") == "cedar"
+
+    def test_case_insensitive_match_normalized_to_canonical_casing(self):
+        assert resolve_voice_name("CEDAR") == "cedar"
+        assert resolve_voice_name("Cedar") == "cedar"
+
+    def test_whitespace_stripped(self):
+        assert resolve_voice_name("  ash  ") == "ash"
+
+    def test_unknown_voice_falls_back_to_default(self):
+        # A leftover ElevenLabs/Rime/Google TTS voice ID — must never be
+        # passed through raw to the Realtime session config.
+        assert resolve_voice_name("21m00Tcm4TlvDq8ikWAM") == DEFAULT_VOICE_NAME
+
+    def test_all_ten_voices_are_valid_and_distinct(self):
+        assert len(VALID_VOICE_NAMES) == 10
+        for name in VALID_VOICE_NAMES:
+            assert resolve_voice_name(name) == name
+
+
+class TestClassifyError:
+    def test_rate_limit_message_classified_as_quota(self):
+        err = _classify_openai_realtime_error(RuntimeError("Rate limit reached"))
+        assert err.error_type == OpenAIRealtimeErrorType.QUOTA
+
+    def test_timeout_message_classified_as_timeout(self):
+        err = _classify_openai_realtime_error(RuntimeError("Request timed out"))
+        assert err.error_type == OpenAIRealtimeErrorType.TIMEOUT
+
+    def test_closed_message_classified_as_connection_closed(self):
+        err = _classify_openai_realtime_error(RuntimeError("connection closed unexpectedly"))
+        assert err.error_type == OpenAIRealtimeErrorType.CONNECTION_CLOSED
+
+    def test_unrecognized_message_classified_as_unknown(self):
+        err = _classify_openai_realtime_error(RuntimeError("something weird happened"))
+        assert err.error_type == OpenAIRealtimeErrorType.UNKNOWN
+
+    def test_openai_realtime_error_passthrough_in_report_error(self):
+        """_report_error must not re-wrap an already-classified error."""
+        session = OpenAIRealtimeSession("gpt-realtime")
+        on_error = AsyncMock()
+        session.on_error = on_error
+        original = OpenAIRealtimeError("already classified", OpenAIRealtimeErrorType.AUTH)
+
+        asyncio.run(session._report_error(original))
+
+        on_error.assert_awaited_once_with(original)
+
+
+class TestBuildCalendlyToolParams:
+    def test_returns_two_function_tools_with_expected_names(self):
+        tools = _build_calendly_tool_params()
+        assert len(tools) == 2
+        names = {t["name"] for t in tools}
+        assert names == {"check_availability", "book_appointment"}
+        for t in tools:
+            assert t["type"] == "function"
+            assert "description" in t
+            assert t["parameters"]["type"] == "object"
+
+    def test_check_availability_requires_date(self):
+        tools = {t["name"]: t for t in _build_calendly_tool_params()}
+        assert tools["check_availability"]["parameters"]["required"] == ["date"]
+
+    def test_book_appointment_requires_slot_and_email(self):
+        tools = {t["name"]: t for t in _build_calendly_tool_params()}
+        assert tools["book_appointment"]["parameters"]["required"] == ["slot", "attendee_email"]

--- a/tests/voice/test_openai_realtime_service.py
+++ b/tests/voice/test_openai_realtime_service.py
@@ -307,6 +307,59 @@ class TestSendAudio:
 
         connection.send.assert_not_awaited()
 
+    def test_send_audio_noop_once_session_already_closed(self):
+        """Straggler audio chunks arriving after close() has already run
+        must never reach connection.send() — see this method's docstring
+        about the LiveKitAudioSubscriber shutdown race."""
+        connection = _FakeConnection()
+        session = OpenAIRealtimeSession("gpt-realtime")
+        session._connection = connection
+        session._closed = True
+
+        asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
+        connection.send.assert_not_awaited()
+
+    def test_send_audio_swallows_exception_when_closed_flips_mid_await(self):
+        """Mirrors TestClose.test_close_cancels_receive_task_while_genuinely_
+        blocked_in_recv's pattern of exercising a genuine concurrent race:
+        here, `self._closed` flips to True while `connection.send()` is
+        in-flight and then raises (simulating the underlying websocket
+        erroring out mid-close-handshake) — the exception must be swallowed,
+        not propagated, once the flip is observed."""
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        connection = MagicMock()
+
+        async def _send(_event):
+            # Simulate close() flipping the flag concurrently while this
+            # send() call is still in flight, then the underlying send
+            # erroring out as a result of the connection tearing down.
+            session._closed = True
+            raise ConnectionError("connection closed during send")
+
+        connection.send = AsyncMock(side_effect=_send)
+        session._connection = connection
+
+        # Must not raise.
+        asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
+        connection.send.assert_awaited_once()
+
+    def test_send_audio_reraises_exception_when_not_closed(self):
+        """Sanity check for the opposite branch: if send() fails for a
+        reason unrelated to a concurrent close(), the exception must still
+        propagate — the swallow is specifically scoped to the shutdown
+        race, not a blanket exception suppressor."""
+        session = OpenAIRealtimeSession("gpt-realtime")
+
+        connection = MagicMock()
+        connection.send = AsyncMock(side_effect=RuntimeError("genuine send failure"))
+        session._connection = connection
+
+        with pytest.raises(RuntimeError, match="genuine send failure"):
+            asyncio.run(session.send_audio(b"\x01\x02\x03\x04"))
+
 
 class TestSendText:
     def test_send_text_respond_true_sends_item_and_response_create(self):
@@ -516,6 +569,49 @@ class TestReceiveLoopDemux:
         err = on_error.call_args.args[0]
         assert isinstance(err, OpenAIRealtimeError)
         assert "rate limit exceeded" in str(err)
+
+    def test_input_transcription_failed_logs_warning_and_does_not_route_to_on_error(self, caplog):
+        import logging
+
+        evt = _evt(
+            type="conversation.item.input_audio_transcription.failed",
+            item_id="item-123",
+            error=_evt(code="transcription_error", message="audio format mismatch"),
+        )
+        on_error = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_not_awaited()
+        assert any(
+            "item-123" in rec.message and "audio format mismatch" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_mcp_list_tools_failed_logs_warning_and_does_not_route_to_on_error(self, caplog):
+        import logging
+
+        evt = _evt(type="mcp_list_tools.failed", item_id="item-456")
+        on_error = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_not_awaited()
+        assert any("item-456" in rec.message for rec in caplog.records)
+
+    def test_response_mcp_call_failed_logs_warning_and_does_not_route_to_on_error(self, caplog):
+        import logging
+
+        evt = _evt(type="response.mcp_call.failed", item_id="item-789")
+        on_error = AsyncMock()
+
+        with caplog.at_level(logging.WARNING):
+            self._run_with_events([evt], on_error=on_error)
+
+        on_error.assert_not_awaited()
+        assert any("item-789" in rec.message for rec in caplog.records)
 
     def test_unknown_event_type_is_benign_noop(self):
         evt = _evt(type="session.created")

--- a/tests/voice/test_openai_realtime_twilio_fork.py
+++ b/tests/voice/test_openai_realtime_twilio_fork.py
@@ -1,0 +1,591 @@
+"""
+Twilio-transport fork-point tests for OpenAI Realtime native-audio routing
+(VoiceOrchestrator.on_audio_chunk -> _feed_openai_realtime_audio /
+_start_openai_realtime_session / _on_openai_realtime_* callbacks).
+
+Mirrors tests/voice/test_gemini_live_twilio_fork.py's structure, adapted for
+this provider's genuine divergences (see
+app/services/openai_realtime_service.py's module docstring):
+  - no MULAW->PCM16 conversion on the Twilio path at all (OpenAI accepts
+    audio/pcmu directly) — send_audio receives the RAW mulaw frame
+  - transcripts are written directly, no fragment-buffering
+  - barge-in is a single flag-set/clear, no dual-buffer flush
+
+OpenAIRealtimeSession itself is mocked throughout — no live API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.core.llm_models import OPENAI_REALTIME_MODELS
+from app.routers.bidirectional_stream import BidirectionalStreamHandler as Handler
+from app.voice.voice_orchestrator import (
+    VoiceOrchestrator,
+    _OPENAI_REALTIME_FALLBACK_TEXT_MODEL,
+)
+
+NATIVE_AUDIO_MODEL = next(iter(OPENAI_REALTIME_MODELS))
+
+
+class _FalsyCallSession:
+    def __bool__(self) -> bool:
+        return False
+
+
+def _fake_handler(*, llm_model: str | None) -> Handler:
+    h = object.__new__(Handler)
+
+    h.agent = MagicMock()
+    h.agent.id = uuid.uuid4()
+    h.agent.name = "TestAgent"
+    h.agent.llm_model = llm_model
+    h.agent.system_prompt = None
+    h.agent.model = MagicMock()
+    h.agent.model.system_prompt = None
+    h.agent.transfer_route = None
+
+    h.call_session = _FalsyCallSession()
+    h.call_flow = None
+    h.db = None
+    h.call_session_id = "test-session-id"
+    h.agent_id = str(h.agent.id)
+    h.call_sid = "CA_test"
+    h.stream_sid = "MZ_test"
+
+    h._min_audio_level_threshold = 30
+    h._audio_samples_needed = 1
+    h._audio_non_silent_needed = 1
+
+    h._enable_interim_llm = False
+    h._min_interim_words = 3
+    h._min_interim_confidence = 0.4
+    h._min_interim_interval_sec = 0.2
+    h._barge_in_min_conf = 0.26
+    h._barge_in_min_conf_1w = 0.52
+
+    h._voice_metrics = MagicMock()
+    h._add_to_transcript = AsyncMock()
+    h._send_twilio_clear_event = AsyncMock()
+    h._stream_live_audio_chunk = AsyncMock()
+    h._full_shutdown = AsyncMock()
+    h.websocket = MagicMock()
+
+    return h
+
+
+def _loud_frame() -> bytes:
+    return bytes([0x00]) * 160
+
+
+class TestNativeAudioRoutingResolution:
+    def test_native_audio_model_sets_is_openai_realtime_true(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is True
+        assert orch._is_gemini_live is False
+
+    def test_non_native_model_sets_is_openai_realtime_false(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is False
+
+    def test_no_agent_defaults_to_false(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        h.agent = None
+        orch = VoiceOrchestrator(h)
+        assert orch._is_openai_realtime is False
+
+
+class TestNativeAudioNeverConstructsSttPipeline:
+    def test_native_audio_agent_skips_stt_pipeline_construction(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._user_picked_up = True
+        h._handle_user_pickup = AsyncMock()
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+        fake_session.send_audio = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch.on_audio_chunk(_loud_frame()))
+
+        assert orch._stt_pipeline is None
+        fake_session.start.assert_awaited_once()
+        fake_session.send_audio.assert_awaited_once()
+
+    def test_non_native_agent_still_constructs_stt_pipeline(self):
+        h = _fake_handler(llm_model="gpt-4o-mini")
+        orch = VoiceOrchestrator(h)
+        orch._user_picked_up = True
+        h._handle_user_pickup = AsyncMock()
+
+        fake_stt = MagicMock()
+        fake_stt.feed_audio_chunk = AsyncMock()
+        with patch("app.voice.voice_orchestrator.SttPipeline", return_value=fake_stt):
+            asyncio.run(orch.on_audio_chunk(_loud_frame()))
+
+        assert orch._stt_pipeline is fake_stt
+        assert orch._openai_realtime_session is None
+        fake_stt.feed_audio_chunk.assert_awaited_once()
+
+
+class TestAudioRoutingNoConversion:
+    """Regression guard: unlike Gemini Live, the Twilio path must NEVER
+    resample/convert audio for OpenAI Realtime — mu-law/8kHz goes straight
+    through in both directions (audio/pcmu is natively supported)."""
+
+    def test_send_audio_receives_raw_mulaw_unconverted(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.send_audio = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        mulaw = _loud_frame()
+        asyncio.run(orch._feed_openai_realtime_audio(h, mulaw))
+
+        fake_session.send_audio.assert_awaited_once_with(mulaw)
+
+    def test_on_audio_chunk_callback_streams_raw_bytes_unconverted(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"mulaw-from-openai"))
+
+        h._stream_live_audio_chunk.assert_awaited_once_with(b"mulaw-from-openai")
+
+    def test_on_audio_chunk_callback_gated_by_cancel_flag(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_cancel.set()
+
+        asyncio.run(orch._on_openai_realtime_audio_chunk(b"mulaw-from-openai"))
+
+        h._stream_live_audio_chunk.assert_not_awaited()
+
+
+class TestBargeIn:
+    def test_interrupted_sets_and_clears_cancel_and_clears_twilio_buffer(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_first_audio_marked = True
+
+        asyncio.run(orch._on_openai_realtime_interrupted())
+
+        h._send_twilio_clear_event.assert_awaited_once()
+        assert not orch._openai_realtime_cancel.is_set()
+        assert orch._openai_realtime_first_audio_marked is False
+
+
+class TestTranscriptCallbacksWriteDirectly:
+    """No fragment-buffering — each transcript callback fires once per
+    utterance with the full text and is written immediately."""
+
+    def test_input_transcript_written_immediately(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_input_transcript("hello there"))
+
+        h._add_to_transcript.assert_awaited_once_with("client", "hello there", "speech")
+
+    def test_output_transcript_written_immediately(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_output_transcript("Sure, I can help."))
+
+        h._add_to_transcript.assert_awaited_once_with("agent", "Sure, I can help.", "agent_response")
+
+    def test_blank_transcript_not_written(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(orch._on_openai_realtime_input_transcript("   "))
+        asyncio.run(orch._on_openai_realtime_output_transcript(""))
+
+        h._add_to_transcript.assert_not_awaited()
+
+    def test_input_transcript_schedules_kb_refresh_task(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        async def _run():
+            with patch.object(
+                orch, "_refresh_openai_realtime_kb_context", new=AsyncMock()
+            ) as mock_refresh:
+                await orch._on_openai_realtime_input_transcript("what is your refund policy")
+                pending = list(orch._pending_final_tasks)
+                if pending:
+                    await asyncio.gather(*pending)
+                mock_refresh.assert_called_once_with("what is your refund policy")
+
+        asyncio.run(_run())
+
+
+class TestPreSessionFallback:
+    def test_start_failure_falls_back_to_openai_text_model(self):
+        from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock(
+            side_effect=OpenAIRealtimeError("boom", OpenAIRealtimeErrorType.QUOTA)
+        )
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert orch._openai_realtime_setup_failed is True
+        assert orch._is_openai_realtime is False
+        assert orch._openai_realtime_session is None
+        assert h.agent.llm_model == _OPENAI_REALTIME_FALLBACK_TEXT_MODEL
+        h._full_shutdown.assert_not_awaited()
+
+    def test_fallback_with_no_agent_ends_call_gracefully(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+        h.agent = None
+
+        asyncio.run(orch._fallback_to_legacy_pipeline_openai(h, reason="no agent"))
+
+        assert orch._openai_realtime_setup_failed is True
+        h._full_shutdown.assert_called_once()
+
+
+class TestMidCallError:
+    def test_mid_call_error_ends_call_gracefully(self):
+        from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        asyncio.run(
+            orch._on_openai_realtime_error(
+                OpenAIRealtimeError("dropped", OpenAIRealtimeErrorType.CONNECTION_CLOSED)
+            )
+        )
+
+        h._full_shutdown.assert_called_once()
+
+
+def _fake_handler_for_real_prompt_build(*, llm_model: str) -> Handler:
+    h = _fake_handler(llm_model=llm_model)
+    h.agent.language = "en"
+    h.agent.model.api_key = None
+    h.agent.is_inbound_agent = False
+    h.agent.tts_provider = None
+    h.call_session = None
+    h.db = None
+    h._last_offered_calendar_slots = []
+    h._last_requested_calendar_date = None
+    h._last_selected_calendar_slot = None
+    h._conversation_history_cache = []
+    h.HISTORY_MAX_MESSAGES = 20
+    h._metric_stt_final_ts = 0.0
+    h._rag_prefetch_task = None
+    h._kb_cache_ready = False
+    h._cached_inbound_kb_block = ""
+    h._jd_recruitment_screening_active = lambda: False
+    h._send_quick_acknowledgement = AsyncMock()
+    return h
+
+
+class TestOpenAIRealtimeSessionUsesTwilioOwnPromptAssembly:
+    def test_start_openai_realtime_session_uses_handlers_own_build_system_prompt(self):
+        h = _fake_handler_for_real_prompt_build(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        fake_session.start.assert_awaited_once()
+        system_instruction = fake_session.start.call_args.kwargs["system_instruction"]
+        assert "# CURRENT DATE & TIME" in system_instruction
+
+    def test_start_uses_twilio_audio_pcmu_format(self):
+        from app.services.openai_realtime_service import TWILIO_AUDIO_FORMAT
+
+        h = _fake_handler_for_real_prompt_build(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert fake_session.start.call_args.kwargs["audio_format"] == TWILIO_AUDIO_FORMAT
+
+    def test_browser_handler_still_uses_conversation_orchestrator(self):
+        from app.services.openai_realtime_service import LIVEKIT_AUDIO_FORMAT
+
+        h = MagicMock(spec=[])
+        h.agent = MagicMock()
+        h.agent.llm_model = NATIVE_AUDIO_MODEL
+        h.call_session_id = "test-session-id"
+
+        assert not hasattr(h, "build_system_prompt")
+
+        orch = VoiceOrchestrator.__new__(VoiceOrchestrator)
+        orch._openai_realtime_session = None
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.voice.conversation_orchestrator.ConversationOrchestrator.build_system_prompt",
+            new=AsyncMock(return_value="browser system prompt"),
+        ) as browser_build:
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        browser_build.assert_awaited_once()
+        fake_session.start.assert_awaited_once()
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["system_instruction"] == "browser system prompt"
+        assert kwargs["audio_format"] == LIVEKIT_AUDIO_FORMAT
+
+
+class TestGreetingBypassesExternalTtsForNativeAudio:
+    def _greeting_handler(self, *, is_openai_realtime: bool) -> Handler:
+        h = object.__new__(Handler)
+        h.agent = MagicMock()
+        h.agent.greeting_message = "Hi, thanks for calling Acme."
+        h.agent.first_message = None
+        h.call_session = MagicMock()
+        h.call_session.call_type = "inbound"
+        h.call_session.call_metadata = {}
+        h.call_session.id = uuid.uuid4()
+        h.db = None
+        h._flow_executor = None
+        h._add_to_transcript = AsyncMock()
+        h._twilio_buffer_primed = True
+        h._use_ssml = True
+        h._jd_recruitment_screening_active = MagicMock(return_value=False)
+
+        h._tts_pipeline = MagicMock()
+        h._tts_pipeline.queue_tts = AsyncMock()
+
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        vo = MagicMock()
+        vo._is_gemini_live = False
+        vo._gemini_live_session = None
+        vo._is_openai_realtime = is_openai_realtime
+        vo._openai_realtime_session = fake_session if is_openai_realtime else None
+        h._voice_orchestrator = vo
+        h._fake_session = fake_session
+        return h
+
+    def test_native_audio_greeting_uses_live_session_send_text_not_tts(self):
+        h = self._greeting_handler(is_openai_realtime=True)
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._fake_session.send_text.assert_awaited_once_with(
+            "Hi, thanks for calling Acme.", respond=True
+        )
+        h._tts_pipeline.queue_tts.assert_not_awaited()
+
+    def test_native_audio_greeting_skips_gracefully_if_session_not_ready(self):
+        h = self._greeting_handler(is_openai_realtime=True)
+        h._voice_orchestrator._openai_realtime_session = None
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._tts_pipeline.queue_tts.assert_not_awaited()
+
+    def test_non_native_audio_greeting_still_uses_external_tts(self):
+        h = self._greeting_handler(is_openai_realtime=False)
+
+        asyncio.run(h.generate_and_stream_response("", 1.0, is_greeting=True))
+
+        h._tts_pipeline.queue_tts.assert_awaited_once()
+        queued = h._tts_pipeline.queue_tts.call_args[0][0]
+        assert queued["text"] == "Hi, thanks for calling Acme."
+
+
+def _fc(*, id: str, name: str, args: dict) -> tuple[str, str, str]:
+    """OpenAI Realtime tool calls are plain (call_id, name, arguments_json)
+    args (see OpenAIRealtimeSession.on_tool_call's contract), unlike
+    Gemini's google.genai.types.FunctionCall object — no fake type needed."""
+    import json
+
+    return (id, name, json.dumps(args))
+
+
+class TestCalendlyToolCallWiring:
+    def _handler_with_calendly(self, *, enabled: bool) -> Handler:
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h._calendly_enabled = MagicMock(return_value=enabled)
+        h._execute_calendly_tool_call = AsyncMock(return_value={"slots": []})
+        return h
+
+    def test_session_start_passes_calendly_tool_when_enabled(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is not None
+        assert len(kwargs["tools"]) == 2
+        assert kwargs["on_tool_call"] == orch._on_openai_realtime_tool_call
+
+    def test_session_start_passes_no_tools_when_calendly_disabled(self):
+        h = self._handler_with_calendly(enabled=False)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        kwargs = fake_session.start.call_args.kwargs
+        assert kwargs["tools"] is None
+        assert kwargs["on_tool_call"] is None
+
+    def test_on_tool_call_resolves_and_sends_response(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        call_id, name, args_json = _fc(id="call-1", name="check_availability", args={"date": "tomorrow"})
+        h._execute_calendly_tool_call = AsyncMock(return_value={"slots": ["09:00"]})
+
+        asyncio.run(orch._on_openai_realtime_tool_call(call_id, name, args_json))
+
+        h._execute_calendly_tool_call.assert_awaited_once_with("check_availability", {"date": "tomorrow"})
+        fake_session.send_tool_response.assert_awaited_once_with("call-1", {"slots": ["09:00"]})
+
+    def test_on_tool_call_noop_when_session_not_set(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_session = None
+
+        asyncio.run(orch._on_openai_realtime_tool_call("c1", "check_availability", "{}"))
+        h._execute_calendly_tool_call.assert_not_awaited()
+
+    def test_on_tool_call_survives_execute_exception(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._openai_realtime_session = fake_session
+        h._execute_calendly_tool_call = AsyncMock(side_effect=RuntimeError("boom"))
+
+        asyncio.run(orch._on_openai_realtime_tool_call("c1", "check_availability", "{}"))
+
+        fake_session.send_tool_response.assert_awaited_once_with(
+            "c1", {"error": "internal error executing tool call"}
+        )
+
+    def test_on_tool_call_survives_malformed_arguments_json(self):
+        h = self._handler_with_calendly(enabled=True)
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_tool_response = AsyncMock()
+        orch._openai_realtime_session = fake_session
+        h._execute_calendly_tool_call = AsyncMock(return_value={"ok": True})
+
+        asyncio.run(orch._on_openai_realtime_tool_call("c1", "check_availability", "not json"))
+
+        h._execute_calendly_tool_call.assert_awaited_once_with("check_availability", {})
+
+
+class TestPerAgentVoiceWiring:
+    def test_valid_agent_voice_passed_through(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.agent.tts_voice_external_id = "cedar"
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert fake_session.start.call_args.kwargs["voice_name"] == "cedar"
+
+    def test_unset_or_invalid_agent_voice_falls_back_to_default(self):
+        from app.services.openai_realtime_service import DEFAULT_VOICE_NAME
+
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.agent.tts_voice_external_id = "21m00Tcm4TlvDq8ikWAM"
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.start = AsyncMock()
+
+        with patch(
+            "app.services.openai_realtime_service.OpenAIRealtimeSession", return_value=fake_session
+        ), patch(
+            "app.routers.bidirectional_stream.BidirectionalStreamHandler.build_system_prompt",
+            new=AsyncMock(return_value="system prompt"),
+        ):
+            asyncio.run(orch._start_openai_realtime_session(h))
+
+        assert fake_session.start.call_args.kwargs["voice_name"] == DEFAULT_VOICE_NAME
+
+
+class TestShutdownClosesSession:
+    def test_shutdown_closes_openai_realtime_session(self):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        fake_session = MagicMock()
+        fake_session.close = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        asyncio.run(orch.shutdown())
+
+        fake_session.close.assert_awaited_once()
+        assert orch._openai_realtime_session is None

--- a/tests/voice/test_openai_realtime_twilio_fork.py
+++ b/tests/voice/test_openai_realtime_twilio_fork.py
@@ -233,6 +233,140 @@ class TestTranscriptCallbacksWriteDirectly:
         asyncio.run(_run())
 
 
+class TestMidCallRagRefresh:
+    """
+    Mid-call KB context refresh (VoiceOrchestrator.
+    _refresh_openai_realtime_kb_context), triggered fire-and-forget from
+    _on_openai_realtime_input_transcript. Mirrors
+    test_gemini_live_twilio_fork.py's TestMidCallRagRefresh, adapted for
+    this provider's send_text(text, respond=False) signature (vs Gemini's
+    send_text(text, turn_complete=False)) and its DIAGNOSTIC skip-reason
+    logging / upgraded warning-with-exc_info on retrieval failure.
+    """
+
+    def _handler_with_flow(self, *, kb_ids):
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        h.call_flow = MagicMock()
+        h.call_flow.knowledge_base_ids = kb_ids
+        return h
+
+    def test_refresh_noop_when_no_session(self, caplog):
+        import logging
+
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        orch._openai_realtime_session = None
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve, caplog.at_level(logging.INFO):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_not_awaited()
+        assert any("no_session" in rec.message for rec in caplog.records)
+
+    def test_refresh_noop_when_empty_transcript(self, caplog):
+        import logging
+
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve, caplog.at_level(logging.INFO):
+            asyncio.run(orch._refresh_openai_realtime_kb_context(""))
+
+        mock_retrieve.assert_not_awaited()
+        fake_session.send_text.assert_not_awaited()
+        assert any("empty_transcript" in rec.message for rec in caplog.records)
+
+    def test_refresh_noop_when_no_kb_ids(self, caplog):
+        import logging
+
+        h = self._handler_with_flow(kb_ids=[])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("some context", 5.0)),
+        ) as mock_retrieve, caplog.at_level(logging.INFO):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_not_awaited()
+        fake_session.send_text.assert_not_awaited()
+        assert any("no_kb_ids_configured" in rec.message for rec in caplog.records)
+
+    def test_refresh_sends_context_as_non_blocking_text_turn(self):
+        kb_id = uuid.uuid4()
+        h = self._handler_with_flow(kb_ids=[kb_id])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("Refunds within 30 days.", 42.0)),
+        ) as mock_retrieve, patch("app.utils.redis_client.get_redis", return_value=None):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        mock_retrieve.assert_awaited_once()
+        call_kwargs = mock_retrieve.call_args.kwargs
+        assert call_kwargs["transcript"] == "what's your refund policy"
+        assert call_kwargs["kb_ids"] == [kb_id]
+
+        fake_session.send_text.assert_awaited_once()
+        sent_args, sent_kwargs = fake_session.send_text.call_args.args, fake_session.send_text.call_args.kwargs
+        assert "Refunds within 30 days." in sent_args[0]
+        assert sent_kwargs["respond"] is False
+
+    def test_refresh_sends_nothing_when_kb_returns_empty(self):
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(return_value=("", 3.0)),
+        ):
+            asyncio.run(orch._refresh_openai_realtime_kb_context("unrelated small talk"))
+
+        fake_session.send_text.assert_not_awaited()
+
+    def test_refresh_fails_open_and_logs_warning_with_exc_info_on_retrieval_exception(self, caplog):
+        """Regression guard for the debug->warning upgrade: a silently
+        debug-logged exception here would look identical in production logs
+        to 'KB refresh never fired at all', so this must be logged at
+        WARNING with exc_info=True, not swallowed at DEBUG."""
+        h = self._handler_with_flow(kb_ids=[uuid.uuid4()])
+        orch = VoiceOrchestrator(h)
+        fake_session = MagicMock()
+        fake_session.send_text = AsyncMock()
+        orch._openai_realtime_session = fake_session
+
+        with patch(
+            "app.services.kb_retrieval_service.retrieve_kb_context_for_turn",
+            new=AsyncMock(side_effect=RuntimeError("kb backend down")),
+        ), patch("app.voice.voice_orchestrator.logger") as mock_logger:
+            # Must not raise.
+            asyncio.run(orch._refresh_openai_realtime_kb_context("what's your refund policy"))
+
+        fake_session.send_text.assert_not_awaited()
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args.kwargs.get("exc_info") is True
+        mock_logger.debug.assert_not_called()
+
+
 class TestPreSessionFallback:
     def test_start_failure_falls_back_to_openai_text_model(self):
         from app.services.openai_realtime_service import OpenAIRealtimeError, OpenAIRealtimeErrorType


### PR DESCRIPTION
## Summary
This PR integrates OpenAI Realtime native-audio speech-to-speech models (`gpt-realtime` and `gpt-realtime-2`) into the voice pipeline alongside the existing Gemini Live integration.

## Key Changes
- **OpenAI Realtime Service & Models**:
  - Added `gpt-realtime` and `gpt-realtime-2` to `app/core/llm_models.py` (`OPENAI_REALTIME_MODELS`, `is_openai_realtime_model`).
  - Added `OpenAIRealtimeSession` in `app/services/openai_realtime_service.py` to handle WebSocket communication with OpenAI's Realtime API.
  - Defaulted input audio transcription to `whisper-1` for real-time user transcript generation.
- **Voice Orchestration**:
  - Wired parallel OpenAI Realtime handling in `app/voice/voice_orchestrator.py` for Twilio and LiveKit browser call transports.
  - Added greeting-bypass wiring in `app/routers/bidirectional_stream.py` and `app/voice/conversation_orchestrator.py`.
- **Stability & Shutdown Fixes**:
  - Added explicit handling for OpenAI Realtime `.failed` events (`conversation.item.input_audio_transcription.failed`, `mcp_list_tools.failed`, `response.mcp_call.failed`).
  - Fixed audio forwarding shutdown race in `send_audio` for both `OpenAIRealtimeSession` and `GeminiLiveSession`.
- **Database & Migration**:
  - Added Alembic migration (`20260817_widen_agent_llm_model_check_openai_realtime.py`) widening the DB `CHECK` constraint for `llm_model`.
- **Testing**:
  - Added comprehensive test suites covering OpenAI Realtime service unit tests, Twilio integration fork tests, and LiveKit browser fork tests.

## Verification
- Comprehensive unit tests passed: `pytest tests/voice/test_openai_realtime*.py`.