### PR TITLE
feat(voice): add xAI as a real-time streaming TTS provider

### DIFF
--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -28,8 +28,8 @@ _TICKET_TTS_TO_ADAPTER: dict[str, str] = {
     "11labs_byo": "elevenlabs",
     # "rime" now has its own adapter — no longer falls back to google.
     "rime": "rime",
-    # "hume" needs no entry — .get(slug, slug) already falls through unchanged
-    # since the ticket slug and adapter slug are identical.
+    # "hume"/"xai" need no entry — .get(slug, slug) already falls through
+    # unchanged since the ticket slug and adapter slug are identical.
 }
 
 def _coerce_float(value: Any, default: float) -> float:
@@ -117,10 +117,10 @@ def _decrypt_stored_api_key(
 
 
 def _ticket_tts_triad(agent: Agent) -> bool:
-    # Rime and Hume both have a built-in default voice — allow ticket path
-    # even without explicit voice_id.
+    # Rime, Hume, and xAI all have a built-in default voice — allow ticket
+    # path even without explicit voice_id.
     has_voice = bool(agent.tts_voice_external_id) or (
-        (agent.tts_provider_slug or "").lower() in ("rime", "hume")
+        (agent.tts_provider_slug or "").lower() in ("rime", "hume", "xai")
     )
     return bool(agent.tts_provider_slug and agent.tts_language and has_voice)
 
@@ -307,13 +307,17 @@ def resolve_tts_runtime(
                     f"Agent {agent.id}: stored BYO ElevenLabs API key is corrupted or "
                     "unreadable. Re-save the API key in agent settings."
                 ) from exc
-        # For Rime/Hume: ensure default voice when none configured.
+        # For Rime/Hume/xAI: ensure default voice when none configured.
         if adapter_slug == "rime" and not voice_id:
             voice_id = "mistv2_Wildflower"
         elif adapter_slug == "hume" and not voice_id:
             from app.services.hume_tts_service import HUME_DEFAULT_VOICE
 
             voice_id = HUME_DEFAULT_VOICE
+        elif adapter_slug == "xai" and not voice_id:
+            from app.services.xai_tts_service import XAI_DEFAULT_VOICE
+
+            voice_id = XAI_DEFAULT_VOICE
         settings.setdefault("language_code", language)
         return ResolvedTtsRuntime(
             adapter_slug=adapter_slug,

--- a/app/main.py
+++ b/app/main.py
@@ -113,6 +113,25 @@ def create_app() -> FastAPI:
             else:
                 logger.warning("Hume TTS not configured: %s — fine if TTS_PROVIDER is not 'hume'", exc)
 
+        try:
+            from app.services.tts_catalog_service import tts_catalog_service
+
+            tts_catalog_service.verify_xai_api_key_configured()
+            logger.info("xAI TTS API key configured")
+        except ValueError as exc:
+            # xAI TTS is opt-in (not seeded as an always-available platform
+            # default the way Rime is) — only hard-fail startup when it's
+            # actually the configured default provider. Mirrors the Hume
+            # check above. Unlike Hume/Rime, the key is read directly via
+            # settings.XAI_API_KEY (matching xai_grok_stt_service.py's
+            # existing xAI STT integration), not app.core.secret_manager.
+            env = settings.ENVIRONMENT.lower()
+            if env in ("staging", "production") and settings.TTS_PROVIDER == "xai":
+                logger.error("xAI TTS misconfigured: %s", exc)
+                raise
+            else:
+                logger.warning("xAI TTS not configured: %s — fine if TTS_PROVIDER is not 'xai'", exc)
+
         if settings.LIVEKIT_ENABLED:
             from app.core.secret_manager import get_livekit_credentials
 

--- a/app/schemas/agent.py
+++ b/app/schemas/agent.py
@@ -40,6 +40,7 @@ class TtsProviderEnum(str, Enum):
     elevenlabs = "elevenlabs"
     elevenlabs_byo = "elevenlabs_byo"
     hume = "hume"
+    xai = "xai"
 
 
 class AgentStatusEnum(str, Enum):

--- a/app/services/tts_catalog_service.py
+++ b/app/services/tts_catalog_service.py
@@ -4,6 +4,7 @@ import uuid
 
 from sqlalchemy.orm import Session
 
+from app.core.config import settings
 from app.core.secret_manager import get_hume_api_key, get_rime_api_key
 from app.models.tts_provider import TTSProvider
 from app.models.tts_voice import TTSVoice
@@ -20,6 +21,19 @@ class TTSCatalogService:
     def verify_hume_api_key_configured() -> None:
         """Fail fast when Hume is enabled but HUME_API_KEY is missing or invalid."""
         get_hume_api_key()
+
+    @staticmethod
+    def verify_xai_api_key_configured() -> None:
+        """Fail fast when xAI TTS is enabled but XAI_API_KEY is missing.
+
+        Unlike Hume/Rime, xAI's key is read directly via settings.XAI_API_KEY
+        (matching app/services/xai_grok_stt_service.py's existing xAI STT
+        integration in this codebase), not via app.core.secret_manager.
+        """
+        if not (settings.XAI_API_KEY or "").strip():
+            raise ValueError(
+                "XAI_API_KEY is not set. Add it to your environment/.env to use xAI TTS."
+            )
 
     def ensure_default_provider(self, db: Session) -> TTSProvider:
         providers_to_seed = [
@@ -47,6 +61,13 @@ class TTSCatalogService:
             {
                 "slug": "hume",
                 "display_name": "Hume AI",
+                "is_active": True,
+                "supports_streaming": True,
+                "supports_ssml": False,
+            },
+            {
+                "slug": "xai",
+                "display_name": "xAI Grok",
                 "is_active": True,
                 "supports_streaming": True,
                 "supports_ssml": False,

--- a/app/services/tts_catalog_service.py
+++ b/app/services/tts_catalog_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -12,6 +13,47 @@ from app.utils.tts_adapter import get_tts_adapter_for_provider
 
 
 class TTSCatalogService:
+    # Extracted as a class constant (rather than a local var inside
+    # ensure_default_provider) so tests can assert against the actual seed
+    # data directly instead of grepping the method's source text.
+    SEED_PROVIDERS: list[dict[str, Any]] = [
+        {
+            "slug": "elevenlabs",
+            "display_name": "ElevenLabs",
+            "is_active": True,
+            "supports_streaming": True,
+            "supports_ssml": True,
+        },
+        {
+            "slug": "google",
+            "display_name": "Google Cloud TTS",
+            "is_active": True,
+            "supports_streaming": True,
+            "supports_ssml": True,
+        },
+        {
+            "slug": "rime",
+            "display_name": "Rime Labs",
+            "is_active": True,
+            "supports_streaming": True,
+            "supports_ssml": False,
+        },
+        {
+            "slug": "hume",
+            "display_name": "Hume AI",
+            "is_active": True,
+            "supports_streaming": True,
+            "supports_ssml": False,
+        },
+        {
+            "slug": "xai",
+            "display_name": "xAI Grok",
+            "is_active": True,
+            "supports_streaming": True,
+            "supports_ssml": False,
+        },
+    ]
+
     @staticmethod
     def verify_rime_api_key_configured() -> None:
         """Fail fast when Rime is enabled but RIME_API_KEY is missing or invalid."""
@@ -36,47 +78,9 @@ class TTSCatalogService:
             )
 
     def ensure_default_provider(self, db: Session) -> TTSProvider:
-        providers_to_seed = [
-            {
-                "slug": "elevenlabs",
-                "display_name": "ElevenLabs",
-                "is_active": True,
-                "supports_streaming": True,
-                "supports_ssml": True,
-            },
-            {
-                "slug": "google",
-                "display_name": "Google Cloud TTS",
-                "is_active": True,
-                "supports_streaming": True,
-                "supports_ssml": True,
-            },
-            {
-                "slug": "rime",
-                "display_name": "Rime Labs",
-                "is_active": True,
-                "supports_streaming": True,
-                "supports_ssml": False,
-            },
-            {
-                "slug": "hume",
-                "display_name": "Hume AI",
-                "is_active": True,
-                "supports_streaming": True,
-                "supports_ssml": False,
-            },
-            {
-                "slug": "xai",
-                "display_name": "xAI Grok",
-                "is_active": True,
-                "supports_streaming": True,
-                "supports_ssml": False,
-            },
-        ]
-
         selected = None
         changed = False
-        for spec in providers_to_seed:
+        for spec in self.SEED_PROVIDERS:
             provider = db.query(TTSProvider).filter(TTSProvider.slug == spec["slug"]).first()
             if provider is None:
                 provider = TTSProvider(**spec)

--- a/app/services/xai_tts_service.py
+++ b/app/services/xai_tts_service.py
@@ -74,12 +74,17 @@ class XaiTtsServiceError(RuntimeError):
 
 
 def _mask_key(key: str | None) -> str:
-    """Safe, non-reversible preview for diagnostics — never logs the raw key."""
+    """Safe, non-reversible preview for diagnostics — never logs the raw key.
+
+    Only a 4-char prefix is shown (no suffix) — a prefix+suffix reveal on a
+    short key can leak a large fraction of it (flagged in PR #207 for the
+    equivalent AssemblyAI helper).
+    """
     if not key:
         return "<empty>"
     if len(key) <= 8:
         return f"<masked len={len(key)}>"
-    return f"{key[:4]}...{key[-2:]} (len={len(key)})"
+    return f"{key[:4]}{'*' * min(8, len(key) - 4)} (len={len(key)})"
 
 
 class XaiTtsService:
@@ -164,7 +169,8 @@ class XaiTtsService:
             # trace in the logs if that upstream invariant ever breaks.
             logger.warning(
                 "[xAI TTS] text.delta exceeds %d chars (got %d) — truncating",
-                _MAX_TEXT_DELTA_CHARS, len(stripped_text),
+                _MAX_TEXT_DELTA_CHARS,
+                len(stripped_text),
             )
             stripped_text = stripped_text[:_MAX_TEXT_DELTA_CHARS]
 

--- a/app/services/xai_tts_service.py
+++ b/app/services/xai_tts_service.py
@@ -1,0 +1,314 @@
+"""
+xAI Grok TTS service — streaming WebSocket synthesis for real-time calling.
+
+API: wss://api.x.ai/v1/tts
+Auth: Bearer token via the `Authorization` header on the WebSocket upgrade
+request (matches how `app/services/xai_grok_stt_service.py` authenticates
+xAI's STT WebSocket — xAI's TTS endpoint does not document query-string
+auth). Query params configure the session: `language` (required, BCP-47 or
+`auto`), `voice` (default `eve`), `codec` (`mp3`/`wav`/`pcm`/`mulaw`/`ulaw`/
+`alaw`), `sample_rate`, `bit_rate` (mp3 only), `speed` (0.7-1.5),
+`optimize_streaming_latency` (0=off, 1=moderate, 2=aggressive),
+`text_normalization`, `with_timestamps`.
+
+Telephony output: this service always requests `codec=mulaw&sample_rate=8000`
+(matches Twilio MULAW 8000) directly from xAI — unlike Hume (PCM-only,
+requires `PCMStreamDownsampler` to get to mulaw/8kHz), xAI natively emits
+telephony-ready audio, so no resampling step exists in this file.
+
+Client->server JSON messages: `text.delta` (`{"type":"text.delta","delta":
+"..."}`, incremental text, <=15k chars), `text.done` (flush + synthesize the
+accumulated text), `text.clear` (cancel the current utterance without closing
+the connection — xAI's documented mechanism for a persistent, cross-turn
+session). Server->client JSON messages: `audio.delta` (base64 audio chunk),
+`audio.done` (utterance complete, connection may be reused), `audio.clear`
+(ack of `text.clear`), `error` (connection stays open per xAI's docs).
+
+Connection model: this integration deliberately mirrors Hume/Rime's "one
+WebSocket per synthesis chunk" model (open -> text.delta(s) + text.done ->
+drain audio.delta until audio.done -> close) — NOT a persistent, cross-turn
+streaming session (that's ElevenLabs' Phase 6-3-only
+`elevenlabs_ws_session.py` pattern, out of scope here, same as Hume's own
+docstring scopes itself). This is consistent with how cancellation already
+works elsewhere in this codebase: the pipeline layer cancels the consuming
+async generator/task on barge-in, which propagates through `await ws.recv()`
+and closes the socket in a `finally` block below — that alone is a valid
+stop-synthesis mechanism per xAI's docs; nothing requires sending
+`text.clear` before closing. `text.clear`/`audio.clear` are consequently
+unused here but are xAI's documented mechanism for a future persistent-
+session mode, should this integration ever grow one.
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import time
+from typing import Any, AsyncIterator
+from urllib.parse import urlencode
+
+from app.core.config import settings
+from app.core.logger import logger
+
+_XAI_TTS_URL = "wss://api.x.ai/v1/tts"
+# Public — imported by agent_runtime.py / tts_stream_mixin.py /
+# livekit_browser_call_handler.py so the default voice string exists in
+# exactly one place, mirroring HUME_DEFAULT_VOICE's rationale.
+XAI_DEFAULT_VOICE = "eve"
+_DEFAULT_VOICE = XAI_DEFAULT_VOICE
+_DEFAULT_LANGUAGE = "auto"
+
+# Mirrors the connect-timeout budget used elsewhere on the hot TTS path
+# (see app/services/hume_tts_service.py / elevenlabs_ws_session.py).
+_WS_CONNECT_TIMEOUT_S: float = 5.0
+# Idle read timeout per incoming message — guards against a stalled xAI
+# connection hanging a chunk forever.
+_WS_RECV_TIMEOUT_S: float = 15.0
+
+# xAI's documented ceiling on a single text.delta payload.
+_MAX_TEXT_DELTA_CHARS = 15_000
+
+
+class XaiTtsServiceError(RuntimeError):
+    """Connect/auth/send/receive failure talking to xAI's TTS WebSocket."""
+
+
+def _mask_key(key: str | None) -> str:
+    """Safe, non-reversible preview for diagnostics — never logs the raw key."""
+    if not key:
+        return "<empty>"
+    if len(key) <= 8:
+        return f"<masked len={len(key)}>"
+    return f"{key[:4]}...{key[-2:]} (len={len(key)})"
+
+
+class XaiTtsService:
+    """Thin async wrapper around the xAI TTS WebSocket streaming endpoint."""
+
+    def __init__(self) -> None:
+        # Resolved lazily on first call, not here -- this class is
+        # constructed as a module-level singleton at import time, and xAI
+        # TTS is an optional provider most tenants never configure. Eagerly
+        # reading/validating settings.XAI_API_KEY here would surface a
+        # confusing failure mode tied to import order rather than actual use.
+        pass
+
+    def _get_api_key(self) -> str:
+        key = (settings.XAI_API_KEY or "").strip()
+        if not key:
+            raise XaiTtsServiceError(
+                "XAI_API_KEY is not set. Add it to your environment/.env to use xAI TTS."
+            )
+        return key
+
+    def _build_url(
+        self,
+        *,
+        language: str,
+        voice: str,
+        codec: str,
+        sample_rate: int,
+        speed: float,
+        optimize_streaming_latency: int,
+    ) -> str:
+        params: dict[str, Any] = {
+            "language": language,
+            "voice": voice,
+            "codec": codec,
+            "sample_rate": sample_rate,
+            "speed": speed,
+            "optimize_streaming_latency": optimize_streaming_latency,
+        }
+        return f"{_XAI_TTS_URL}?{urlencode(params)}"
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def stream_text_to_speech(
+        self,
+        text: str,
+        voice: str = _DEFAULT_VOICE,
+        language: str = _DEFAULT_LANGUAGE,
+        speed: float = 1.0,
+        codec: str = "mulaw",
+        sample_rate: int = 8000,
+        optimize_streaming_latency: int = 2,
+    ) -> AsyncIterator[bytes]:
+        """
+        Async generator yielding raw audio byte chunks in real-time, decoded
+        as xAI's WebSocket sends `audio.delta` messages. Requests
+        `codec=mulaw&sample_rate=8000` by default — telephony-ready audio,
+        no resampling needed downstream.
+
+        Opens one WebSocket per call (one-shot text.delta + text.done ->
+        drain audio.delta until audio.done -> close) — not a persistent
+        cross-turn session; see module docstring.
+        """
+        if not text or not text.strip():
+            return
+
+        try:
+            from websockets.asyncio.client import connect as websocket_connect
+        except ImportError as exc:  # pragma: no cover - dependency is pinned in requirements.txt
+            raise XaiTtsServiceError(
+                "the 'websockets' package is not installed"
+            ) from exc
+
+        api_key = self._get_api_key()
+        stripped_text = text.strip()
+        if len(stripped_text) > _MAX_TEXT_DELTA_CHARS:
+            # Should not happen in practice — tts_stream_mixin.py chunks LLM
+            # output into short per-turn segments well under this ceiling —
+            # but truncating silently would clip audio mid-word with zero
+            # trace in the logs if that upstream invariant ever breaks.
+            logger.warning(
+                "[xAI TTS] text.delta exceeds %d chars (got %d) — truncating",
+                _MAX_TEXT_DELTA_CHARS, len(stripped_text),
+            )
+            stripped_text = stripped_text[:_MAX_TEXT_DELTA_CHARS]
+
+        url = self._build_url(
+            language=language or _DEFAULT_LANGUAGE,
+            voice=voice or _DEFAULT_VOICE,
+            codec=codec,
+            sample_rate=sample_rate,
+            speed=float(speed),
+            optimize_streaming_latency=optimize_streaming_latency,
+        )
+        t0 = time.perf_counter()
+        first_chunk = True
+
+        try:
+            ws = await asyncio.wait_for(
+                websocket_connect(
+                    url,
+                    additional_headers={"Authorization": f"Bearer {api_key}"},
+                ),
+                timeout=_WS_CONNECT_TIMEOUT_S,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.error(
+                "[xAI TTS] connect failed (api_key=%s): %s", _mask_key(api_key), exc
+            )
+            raise XaiTtsServiceError(
+                f"failed to open xAI TTS WebSocket: {exc}"
+            ) from exc
+
+        try:
+            try:
+                await ws.send(json.dumps({"type": "text.delta", "delta": stripped_text}))
+                await ws.send(json.dumps({"type": "text.done"}))
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                raise XaiTtsServiceError(
+                    f"failed to send to xAI TTS WebSocket: {exc}"
+                ) from exc
+
+            while True:
+                try:
+                    raw_msg = await asyncio.wait_for(ws.recv(), timeout=_WS_RECV_TIMEOUT_S)
+                except asyncio.CancelledError:
+                    raise
+                except asyncio.TimeoutError as exc:
+                    raise XaiTtsServiceError(
+                        f"xAI TTS WebSocket idle timeout after {_WS_RECV_TIMEOUT_S}s"
+                    ) from exc
+                except Exception as exc:
+                    # ConnectionClosed (normal or abnormal) and any other
+                    # protocol-level failure land here. Unlike Hume, xAI's
+                    # documented end-of-utterance signal is the in-band
+                    # `audio.done` JSON message, not a socket close — so a
+                    # closed-before-audio.done connection is treated as a
+                    # real failure (mirrors Hume/Rime's abnormal-close
+                    # handling) so the caller's fallback path engages.
+                    logger.error("[xAI TTS] receive loop failed: %s", exc)
+                    raise XaiTtsServiceError(
+                        f"xAI TTS WebSocket receive failed: {exc}"
+                    ) from exc
+
+                # Defensive: don't assume every server message is JSON text
+                # (lesson from the Hume binary-frame production incident) —
+                # xAI's docs only document JSON envelopes for this endpoint,
+                # but a stray binary frame must not crash the receive loop.
+                if isinstance(raw_msg, (bytes, bytearray)):
+                    logger.warning(
+                        "[xAI TTS] unexpected binary WebSocket frame (%d bytes) — skipped",
+                        len(raw_msg),
+                    )
+                    continue
+
+                try:
+                    msg = json.loads(raw_msg)
+                except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+                    continue
+
+                msg_type = msg.get("type")
+                if msg_type == "audio.delta":
+                    audio_b64 = msg.get("delta")
+                    if audio_b64:
+                        try:
+                            audio_bytes = base64.b64decode(audio_b64)
+                        except Exception as exc:  # noqa: BLE001 - malformed payload must not kill the loop
+                            logger.warning("[xAI TTS] failed to decode audio chunk: %s", exc)
+                            audio_bytes = b""
+                        if audio_bytes:
+                            if first_chunk:
+                                latency_ms = (time.perf_counter() - t0) * 1000
+                                logger.info(
+                                    "[xAI TTS] first audio chunk latency: %.0f ms (voice=%s)",
+                                    latency_ms, voice,
+                                )
+                                first_chunk = False
+                            yield audio_bytes
+                    continue
+                if msg_type == "audio.done":
+                    break
+                if msg_type == "audio.clear":
+                    # Ack of a text.clear we never send in this one-shot
+                    # model; benign if it ever arrives.
+                    continue
+                if msg_type == "error":
+                    error_detail = msg.get("message") or msg
+                    logger.error("[xAI TTS] error response: %s", error_detail)
+                    raise XaiTtsServiceError(f"xAI TTS error: {error_detail}")
+                # Unrecognized message type — log and keep draining; xAI's
+                # message vocabulary beyond the documented set isn't assumed
+                # exhaustive, and an unknown-but-benign message shouldn't
+                # hard-fail a call.
+                logger.debug("[xAI TTS] unrecognized message type %r — ignored", msg_type)
+        finally:
+            try:
+                await ws.close()
+            except Exception as exc:  # noqa: BLE001 - best-effort close, already tearing down
+                logger.debug("[xAI TTS] close() raised during teardown: %s", exc)
+
+    async def synthesize(
+        self,
+        text: str,
+        voice: str = _DEFAULT_VOICE,
+        language: str = _DEFAULT_LANGUAGE,
+        speed: float = 1.0,
+        codec: str = "mulaw",
+        sample_rate: int = 8000,
+        optimize_streaming_latency: int = 2,
+    ) -> bytes:
+        """Collect full audio into memory (used by batch/cache paths)."""
+        chunks: list[bytes] = []
+        async for chunk in self.stream_text_to_speech(
+            text=text,
+            voice=voice,
+            language=language,
+            speed=speed,
+            codec=codec,
+            sample_rate=sample_rate,
+            optimize_streaming_latency=optimize_streaming_latency,
+        ):
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+
+xai_tts_service = XaiTtsService()

--- a/app/utils/tts_adapter.py
+++ b/app/utils/tts_adapter.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, Coroutine
 
 from app.core.config import settings
+from app.core.logger import logger
 from app.core.secret_manager import get_hume_api_key, get_rime_api_key
 from app.models.tts_provider import TTSProvider
 from app.services.elevenlabs_service import elevenlabs_service
@@ -719,18 +720,27 @@ class XaiTTSAdapter(BaseTTSProviderAdapter):
 
         self._DEFAULT_VOICE = XAI_DEFAULT_VOICE
         # Fail at adapter construction — not on first mid-call synthesis request.
-        key = (settings.XAI_API_KEY or "").strip()
-        if not key:
+        # Validated but NOT stored: every synthesis call goes through
+        # xai_tts_service, which re-reads settings.XAI_API_KEY itself via
+        # _get_api_key(). Storing a separate copy here would go stale if the
+        # key changes between construction and a later call, and would
+        # surface as a different exception type (XaiTtsServiceError instead
+        # of this constructor's ValueError) than callers might expect.
+        if not (settings.XAI_API_KEY or "").strip():
             raise ValueError(
                 "XAI_API_KEY is not set. Add it to your environment/.env to use xAI TTS."
             )
-        self._api_key = key
 
     def list_voices(self) -> list[dict[str, Any]]:
         # xAI's GET /v1/tts/voices exists but there is no vendor SDK / prior
         # verified integration for it in this codebase — return a small
         # static list (matches Rime's approach) so the admin voice-picker UI
         # has something to show without depending on an unverified live call.
+        # xAI's documented default voice is "eve"; see
+        # https://docs.x.ai/developers/model-capabilities/audio/text-to-speech
+        # for the current full voice roster if more need to be added here.
+        # A live GET /v1/tts/voices fetch is not wired up yet — add it if the
+        # catalog needs to stay current without manual updates.
         return [
             {"voice_id": "eve", "name": "Eve"},
         ]
@@ -803,7 +813,16 @@ class XaiTTSAdapter(BaseTTSProviderAdapter):
         voice_external_id: str,
         settings_json: dict[str, Any] | None = None,
     ):
-        # Sync streaming is not used for xAI; callers should use async_stream_synthesize.
+        # Sync streaming is not used for xAI; callers should use
+        # async_stream_synthesize. tts_stream_mixin.py's hot path already
+        # dispatches via hasattr(adapter, "async_stream_synthesize") before
+        # ever considering this method, so this should not fire in the live
+        # call path — logged so any other caller that does hit it traces
+        # cleanly back here instead of surfacing a bare NotImplementedError.
+        logger.warning(
+            "[xAI TTS] stream_synthesize (sync) is not implemented — "
+            "callers must use async_stream_synthesize instead"
+        )
         raise NotImplementedError(
             "Use async_stream_synthesize for xAI TTS streaming"
         )

--- a/app/utils/tts_adapter.py
+++ b/app/utils/tts_adapter.py
@@ -5,6 +5,7 @@ import threading
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, Coroutine
 
+from app.core.config import settings
 from app.core.secret_manager import get_hume_api_key, get_rime_api_key
 from app.models.tts_provider import TTSProvider
 from app.services.elevenlabs_service import elevenlabs_service
@@ -137,6 +138,60 @@ class _HumeSyncEventLoopBridge:
 
 
 _hume_sync_bridge = _HumeSyncEventLoopBridge()
+
+
+class _XaiSyncEventLoopBridge:
+    """Same rationale/pattern as `_RimeSyncEventLoopBridge`/`_HumeSyncEventLoopBridge`
+    above, applied to xAI's `websockets`-based streaming client — a websocket
+    connection opened on one event loop cannot be safely driven from a
+    different loop, so XaiTTSAdapter.synthesize() (the sync-bridge path,
+    invoked from a worker thread via run_in_executor()) needs its own
+    dedicated, persistent background loop, kept entirely separate from
+    Rime's/Hume's bridge instances.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._start_lock = threading.Lock()
+
+    def _ensure_started(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is not None:
+            return loop
+        with self._start_lock:
+            if self._loop is not None:
+                return self._loop
+
+            ready = threading.Event()
+            state: dict[str, asyncio.AbstractEventLoop] = {}
+
+            def _run_forever() -> None:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                state["loop"] = loop
+                ready.set()
+                loop.run_forever()
+
+            thread = threading.Thread(
+                target=_run_forever,
+                name="xai-tts-sync-bridge",
+                daemon=True,
+            )
+            thread.start()
+            ready.wait()
+            self._loop = state["loop"]
+            return self._loop
+
+    def run(self, coro: "Coroutine[Any, Any, bytes]") -> bytes:
+        """Schedule `coro` on the dedicated bridge loop and block the
+        calling thread until it completes. Safe to call from any thread,
+        regardless of whether that thread has its own running event loop."""
+        loop = self._ensure_started()
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return future.result()
+
+
+_xai_sync_bridge = _XaiSyncEventLoopBridge()
 
 
 class BaseTTSProviderAdapter(ABC):
@@ -642,6 +697,118 @@ class HumeTTSAdapter(BaseTTSProviderAdapter):
         )
 
 
+class XaiTTSAdapter(BaseTTSProviderAdapter):
+    """
+    Adapter for xAI Grok TTS (streaming WebSocket, `wss://api.x.ai/v1/tts`).
+
+    Telephony output: mulaw 8 kHz — requested directly from xAI via
+    `codec=mulaw&sample_rate=8000` query params, so unlike Hume there is no
+    resampling step here (see xai_tts_service.py).
+
+    Default voice: "eve" (xAI's documented default), configurable via
+    voice_id per agent.
+
+    settings_json keys (all optional):
+        speed                        (float, default 1.0) — xAI's native speed param (0.7-1.5)
+        language                     (str, default "auto") — BCP-47 or "auto"
+        optimize_streaming_latency   (int, default 2) — 0=off, 1=moderate, 2=aggressive
+    """
+
+    def __init__(self) -> None:
+        from app.services.xai_tts_service import XAI_DEFAULT_VOICE
+
+        self._DEFAULT_VOICE = XAI_DEFAULT_VOICE
+        # Fail at adapter construction — not on first mid-call synthesis request.
+        key = (settings.XAI_API_KEY or "").strip()
+        if not key:
+            raise ValueError(
+                "XAI_API_KEY is not set. Add it to your environment/.env to use xAI TTS."
+            )
+        self._api_key = key
+
+    def list_voices(self) -> list[dict[str, Any]]:
+        # xAI's GET /v1/tts/voices exists but there is no vendor SDK / prior
+        # verified integration for it in this codebase — return a small
+        # static list (matches Rime's approach) so the admin voice-picker UI
+        # has something to show without depending on an unverified live call.
+        return [
+            {"voice_id": "eve", "name": "Eve"},
+        ]
+
+    def normalize_voice_payload(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "external_voice_id": payload.get("voice_id") or payload.get("id") or payload.get("name"),
+            "display_name": payload.get("name") or "xAI Voice",
+            "language_code": None,
+            "gender": None,
+            "accent": None,
+            "description": "xAI Grok voice",
+            "preview_audio_url": None,
+            "sample_rate_hz": 8000,
+            "metadata_json": payload,
+        }
+
+    def synthesize(
+        self,
+        text: str,
+        voice_external_id: str,
+        settings_json: dict[str, Any] | None = None,
+    ) -> bytes:
+        cfg = dict(settings_json or {})
+        speed = float(cfg.get("speed", 1.0))
+        language = cfg.get("language", "auto")
+        optimize_streaming_latency = int(cfg.get("optimize_streaming_latency", 2))
+        voice = voice_external_id or self._DEFAULT_VOICE
+        from app.services.xai_tts_service import xai_tts_service
+
+        coro = xai_tts_service.synthesize(
+            text=text,
+            voice=voice,
+            language=language,
+            speed=speed,
+            optimize_streaming_latency=optimize_streaming_latency,
+        )
+
+        # Drive the coroutine on a single persistent background event loop
+        # (see _XaiSyncEventLoopBridge above) instead of asyncio.run()'s
+        # per-call fresh-loop-then-teardown — mirrors the Rime/Hume
+        # sync-bridge rationale exactly, using its own dedicated bridge instance.
+        return _xai_sync_bridge.run(coro)
+
+    async def async_stream_synthesize(
+        self,
+        text: str,
+        voice_external_id: str,
+        settings_json: dict[str, Any] | None = None,
+    ) -> AsyncIterator[bytes]:
+        """True async streaming — yields raw mulaw bytes as they arrive."""
+        cfg = dict(settings_json or {})
+        speed = float(cfg.get("speed", 1.0))
+        language = cfg.get("language", "auto")
+        optimize_streaming_latency = int(cfg.get("optimize_streaming_latency", 2))
+        voice = voice_external_id or self._DEFAULT_VOICE
+        from app.services.xai_tts_service import xai_tts_service
+        async for chunk in xai_tts_service.stream_text_to_speech(
+            text=text,
+            voice=voice,
+            language=language,
+            speed=speed,
+            optimize_streaming_latency=optimize_streaming_latency,
+        ):
+            yield chunk
+
+    def stream_synthesize(
+        self,
+        text: str,
+        voice_external_id: str,
+        settings_json: dict[str, Any] | None = None,
+    ):
+        # Sync streaming is not used for xAI; callers should use async_stream_synthesize.
+        raise NotImplementedError(
+            "Use async_stream_synthesize for xAI TTS streaming"
+        )
+
+
 def get_tts_adapter(provider_slug: str) -> BaseTTSProviderAdapter:
     slug = (provider_slug or "").strip().lower()
     if slug == "elevenlabs":
@@ -652,6 +819,8 @@ def get_tts_adapter(provider_slug: str) -> BaseTTSProviderAdapter:
         return RimeTTSAdapter()
     if slug == "hume":
         return HumeTTSAdapter()
+    if slug == "xai":
+        return XaiTTSAdapter()
     raise ValueError(f"Unsupported TTS provider: {provider_slug}")
 
 

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -878,6 +878,10 @@ class LiveKitBrowserCallHandler:
                     from app.services.hume_tts_service import HUME_DEFAULT_VOICE
 
                     external_voice_id = HUME_DEFAULT_VOICE
+                elif not external_voice_id and tts_provider_slug == "xai":
+                    from app.services.xai_tts_service import XAI_DEFAULT_VOICE
+
+                    external_voice_id = XAI_DEFAULT_VOICE
                 if not external_voice_id:
                     logger.warning(
                         "[LiveKitBrowserCall] TTS voice not configured for streaming provider=%s",

--- a/app/voice/tts_provider_capabilities.py
+++ b/app/voice/tts_provider_capabilities.py
@@ -129,6 +129,20 @@ _CAPABILITIES: Dict[str, TTSProviderCapabilities] = {
         supports_pause_control=False,  # no native break/pause param used
         supports_streaming_session=False,  # one-shot WS request per chunk, not a persistent session
     ),
+    # XaiTTSAdapter.async_stream_synthesize (app/utils/tts_adapter.py)
+    "xai": TTSProviderCapabilities(
+        provider_slug="xai",
+        supports_streaming=True,  # sync stream_synthesize explicitly raises NotImplementedError
+        supports_ssml=False,  # xAI's WebSocket protocol has no SSML concept — plain text.delta only
+        supports_speaking_rate=True,  # settings_json["speed"] -> xAI's native "speed" query param (0.7-1.5)
+        supports_pitch=False,  # no pitch parameter documented for xAI's TTS WebSocket
+        supports_stability_control=False,  # no stability/similarity_boost-style numeric knob documented
+        supports_native_expressive_tags=False,  # bracket tags are stripped for non-ElevenLabs providers
+        supports_pause_control=False,  # no native break/pause param used
+        supports_streaming_session=False,  # one-shot WS request per chunk, not a persistent session
+        # (text.clear/audio.clear exist for a future persistent-session mode
+        # but are unused by this integration — see xai_tts_service.py)
+    ),
 }
 
 

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -454,6 +454,10 @@ class TtsStreamMixin:
                                     from app.services.hume_tts_service import HUME_DEFAULT_VOICE
 
                                     external_voice_id = HUME_DEFAULT_VOICE
+                                elif not external_voice_id and tts_provider_slug == "xai":
+                                    from app.services.xai_tts_service import XAI_DEFAULT_VOICE
+
+                                    external_voice_id = XAI_DEFAULT_VOICE
                                 if not external_voice_id:
                                     raise ValueError("TTS voice is not configured for streaming.")
                                 adapter = get_tts_adapter(tts_provider_slug)
@@ -468,6 +472,8 @@ class TtsStreamMixin:
                                     # (mulaw 8 kHz is the default in RimeTTSAdapter).
                                     pass
                                 else:
+                                    # xai/hume/google ignore this key — codec/sample_rate are fixed
+                                    # (mulaw/8kHz) in their own adapters, not read from provider_settings.
                                     provider_settings.setdefault("output_format", "ulaw_8000")
 
                                 # Prefer async streaming for providers that support it (Rime, ElevenLabs).
@@ -782,6 +788,10 @@ class TtsStreamMixin:
                     from app.services.hume_tts_service import HUME_DEFAULT_VOICE
 
                     external_voice_id = HUME_DEFAULT_VOICE
+                elif not external_voice_id and tts_provider_slug == "xai":
+                    from app.services.xai_tts_service import XAI_DEFAULT_VOICE
+
+                    external_voice_id = XAI_DEFAULT_VOICE
                 if not external_voice_id:
                     return None
                 adapter = get_tts_adapter(tts_provider_slug)
@@ -801,6 +811,8 @@ class TtsStreamMixin:
                     # Rime adapter handles format internally; no output_format key needed.
                     pass
                 else:
+                    # xai/hume/google ignore this key — codec/sample_rate are fixed
+                    # (mulaw/8kHz) in their own adapters, not read from provider_settings.
                     provider_settings.setdefault("output_format", "ulaw_8000")
 
                 # Fold in any humanization overlay (e.g. ElevenLabs stability hint)

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -19000,6 +19000,7 @@ components:
       - elevenlabs
       - elevenlabs_byo
       - hume
+      - xai
       title: TtsProviderEnum
     TtsSettingsJsonSchema:
       properties:

--- a/tests/voice/test_xai_tts_and_barge_in.py
+++ b/tests/voice/test_xai_tts_and_barge_in.py
@@ -1,0 +1,476 @@
+"""
+xAI Grok TTS integration unit tests — structural mirror of
+tests/voice/test_hume_tts_and_barge_in.py, adapted for xAI's WebSocket
+streaming protocol (one wss://api.x.ai/v1/tts connection per pipeline chunk,
+JSON messages: text.delta/text.done outbound, audio.delta/audio.done/error
+inbound, base64-encoded mulaw/8kHz audio — no PCM/resampling involved).
+
+No real network calls — `websockets.asyncio.client.connect` is always mocked.
+
+Tests cover:
+  1.  XaiTtsService.stream_text_to_speech — successful streaming, outbound
+      message shape (text.delta + text.done), chunk correctness.
+  2.  WebSocket connection — URL/query params (codec=mulaw, sample_rate=8000,
+      optimize_streaming_latency), Authorization header auth.
+  3.  Incremental streaming — multiple audio.delta chunks yielded as they
+      arrive, not buffered into one.
+  4.  audio.delta handling — base64 decode -> raw mulaw bytes.
+  5.  audio.done handling — clean stream termination.
+  6.  mulaw/8kHz output end-to-end — no resampling artifacts, no
+      PCMStreamDownsampler involvement.
+  7.  Cancellation/barge-in — task cancellation during streaming closes the
+      WS cleanly.
+  8.  Errors — `error`-type message raises XaiTtsServiceError; abnormal
+      connection drop before audio.done raises XaiTtsServiceError; connect
+      failure/timeout; idle-recv timeout.
+  9.  Empty/invalid responses — empty text short-circuits (no connect);
+      malformed JSON frame / stray binary frame don't crash the loop.
+  10. Provider registration — get_tts_adapter("xai") returns XaiTTSAdapter;
+      TtsProviderEnum.xai exists; capabilities entry present; catalog seed
+      includes "xai".
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+def _audio_delta(raw_bytes: bytes) -> str:
+    return json.dumps({"type": "audio.delta", "delta": base64.b64encode(raw_bytes).decode()})
+
+
+def _audio_done() -> str:
+    return json.dumps({"type": "audio.done", "trace_id": "trace-123"})
+
+
+def _error_msg(message: str) -> str:
+    return json.dumps({"type": "error", "message": message})
+
+
+class _FakeXaiWebSocket:
+    """Minimal stand-in for a `websockets` client connection object."""
+
+    def __init__(self, messages: list, recv_delay: float = 0.0):
+        self._messages = list(messages)
+        self.sent: list[str] = []
+        self.closed = False
+        self._recv_delay = recv_delay
+
+    async def send(self, payload: str) -> None:
+        self.sent.append(payload)
+
+    async def recv(self):
+        if self._recv_delay:
+            await asyncio.sleep(self._recv_delay)
+        if not self._messages:
+            raise RuntimeError("no more fake messages queued")
+        item = self._messages.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _patch_xai_connect(fake_ws: _FakeXaiWebSocket, captured: dict | None = None):
+    async def _fake_connect(url, *args, **kwargs):
+        if captured is not None:
+            captured["url"] = url
+            captured["kwargs"] = kwargs
+        return fake_ws
+
+    return patch("websockets.asyncio.client.connect", side_effect=_fake_connect)
+
+
+def _run_stream(svc, **kwargs) -> list[bytes]:
+    async def _run():
+        chunks = []
+        async for chunk in svc.stream_text_to_speech(**kwargs):
+            chunks.append(chunk)
+        return chunks
+
+    return asyncio.run(_run())
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1-4. Successful streaming / chunk correctness / audio.delta decode
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestXaiTtsServiceStreaming:
+    def test_stream_yields_expected_mulaw_bytes(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        chunk1 = b"\xff\xfe\xfd\xfc"
+        chunk2 = b"\x01\x02\x03\x04"
+        messages = [_audio_delta(chunk1), _audio_delta(chunk2), _audio_done()]
+        fake_ws = _FakeXaiWebSocket(messages)
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            chunks = _run_stream(svc, text="Hello there", voice="eve")
+
+        # No resampling: bytes come through byte-for-byte from audio.delta.
+        assert chunks == [chunk1, chunk2]
+        assert fake_ws.closed is True
+
+    def test_incremental_chunks_are_yielded_as_they_arrive_not_buffered(self):
+        """Multiple audio.delta messages must surface as multiple yields,
+        not be collected into a single chunk before yielding."""
+        from app.services.xai_tts_service import XaiTtsService
+
+        parts = [b"aaa", b"bbb", b"ccc"]
+        messages = [_audio_delta(p) for p in parts] + [_audio_done()]
+        fake_ws = _FakeXaiWebSocket(messages)
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            chunks = _run_stream(svc, text="Hi", voice="eve")
+
+        assert chunks == parts
+
+    def test_outbound_message_shape_is_text_delta_then_text_done(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket([_audio_delta(b"xyz"), _audio_done()])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            _run_stream(svc, text="  Hello there  ", voice="eve", speed=1.2)
+
+        assert len(fake_ws.sent) == 2
+        first = json.loads(fake_ws.sent[0])
+        second = json.loads(fake_ws.sent[1])
+        assert first == {"type": "text.delta", "delta": "Hello there"}  # stripped
+        assert second == {"type": "text.done"}
+
+    def test_audio_done_terminates_stream_cleanly(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket([_audio_delta(b"only-chunk"), _audio_done()])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            chunks = _run_stream(svc, text="Hi", voice="eve")
+
+        assert chunks == [b"only-chunk"]
+        assert fake_ws.closed is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. WebSocket connection — URL/query params + auth header
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestXaiTtsServiceConnection:
+    def test_connect_uses_mulaw_8000_and_aggressive_latency_by_default(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket([_audio_done()])
+        captured: dict = {}
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws, captured):
+            svc = XaiTtsService()
+            _run_stream(svc, text="Hi", voice="eve")
+
+        url = captured["url"]
+        assert "codec=mulaw" in url
+        assert "sample_rate=8000" in url
+        assert "optimize_streaming_latency=2" in url
+        assert "voice=eve" in url
+
+    def test_connect_sends_bearer_auth_header(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket([_audio_done()])
+        captured: dict = {}
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws, captured):
+            svc = XaiTtsService()
+            _run_stream(svc, text="Hi", voice="eve")
+
+        headers = captured["kwargs"].get("additional_headers")
+        assert headers == {"Authorization": "Bearer test-xai-key"}
+
+    def test_missing_api_key_raises_before_connecting(self):
+        from app.services.xai_tts_service import XaiTtsService, XaiTtsServiceError
+
+        with patch("app.core.config.settings.XAI_API_KEY", ""), patch(
+            "websockets.asyncio.client.connect"
+        ) as mock_connect:
+            svc = XaiTtsService()
+            with pytest.raises(XaiTtsServiceError):
+                _run_stream(svc, text="Hi", voice="eve")
+        mock_connect.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 8. Errors / timeouts / disconnects
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestXaiTtsServiceErrors:
+    def test_error_message_raises_xai_tts_service_error(self):
+        from app.services.xai_tts_service import XaiTtsService, XaiTtsServiceError
+
+        fake_ws = _FakeXaiWebSocket([_error_msg("bad voice id")])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            with pytest.raises(XaiTtsServiceError, match="bad voice id"):
+                _run_stream(svc, text="Hi", voice="eve")
+        assert fake_ws.closed is True
+
+    def test_abnormal_close_before_audio_done_raises(self):
+        from app.services.xai_tts_service import XaiTtsService, XaiTtsServiceError
+
+        fake_ws = _FakeXaiWebSocket([_audio_delta(b"partial"), ConnectionError("dropped")])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            with pytest.raises(XaiTtsServiceError):
+                _run_stream(svc, text="Hi", voice="eve")
+        assert fake_ws.closed is True
+
+    def test_connect_failure_raises_xai_tts_service_error(self):
+        from app.services.xai_tts_service import XaiTtsService, XaiTtsServiceError
+
+        async def _fail_connect(url, *args, **kwargs):
+            raise OSError("connection refused")
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), patch(
+            "websockets.asyncio.client.connect", side_effect=_fail_connect
+        ):
+            svc = XaiTtsService()
+            with pytest.raises(XaiTtsServiceError, match="failed to open"):
+                _run_stream(svc, text="Hi", voice="eve")
+
+    def test_idle_recv_timeout_raises(self):
+        from app.services.xai_tts_service import (
+            XaiTtsService,
+            XaiTtsServiceError,
+            _WS_RECV_TIMEOUT_S,
+        )
+
+        fake_ws = _FakeXaiWebSocket([_audio_delta(b"x")], recv_delay=_WS_RECV_TIMEOUT_S + 1)
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws), patch(
+            "app.services.xai_tts_service._WS_RECV_TIMEOUT_S", 0.05
+        ):
+            svc = XaiTtsService()
+            with pytest.raises(XaiTtsServiceError, match="idle timeout"):
+                _run_stream(svc, text="Hi", voice="eve")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 7. Cancellation / barge-in
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestXaiTtsServiceCancellation:
+    def test_cancelling_consumer_closes_ws_and_propagates(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket([_audio_delta(b"a"), _audio_delta(b"b"), _audio_done()], recv_delay=0.2)
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+
+            async def _consume():
+                async for _ in svc.stream_text_to_speech(text="Hi", voice="eve"):
+                    pass
+
+            async def _run():
+                task = asyncio.create_task(_consume())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+            asyncio.run(_run())
+
+        assert fake_ws.closed is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 9. Empty/invalid responses
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestXaiTtsServiceEdgeCases:
+    def test_empty_text_yields_nothing_and_does_not_connect(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), patch(
+            "websockets.asyncio.client.connect"
+        ) as mock_connect:
+            svc = XaiTtsService()
+            chunks = _run_stream(svc, text="   ", voice="eve")
+
+        assert chunks == []
+        mock_connect.assert_not_called()
+
+    def test_malformed_json_frame_does_not_crash_the_loop(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket(["not-json-{{{", _audio_delta(b"ok"), _audio_done()])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            chunks = _run_stream(svc, text="Hi", voice="eve")
+
+        assert chunks == [b"ok"]
+
+    def test_stray_binary_frame_is_skipped_not_crashed_on(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket([b"\x00\x01\x02", _audio_delta(b"ok"), _audio_done()])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            chunks = _run_stream(svc, text="Hi", voice="eve")
+
+        assert chunks == [b"ok"]
+
+    def test_unrecognized_message_type_is_ignored(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket(
+            [json.dumps({"type": "audio.clear"}), _audio_delta(b"ok"), _audio_done()]
+        )
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            chunks = _run_stream(svc, text="Hi", voice="eve")
+
+        assert chunks == [b"ok"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# synthesize() — batch/cache-path collection
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestXaiTtsServiceSynthesize:
+    def test_synthesize_collects_full_bytes(self):
+        from app.services.xai_tts_service import XaiTtsService
+
+        fake_ws = _FakeXaiWebSocket([_audio_delta(b"ab"), _audio_delta(b"cd"), _audio_done()])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            svc = XaiTtsService()
+            result = asyncio.run(svc.synthesize(text="Hi", voice="eve"))
+
+        assert result == b"abcd"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 10. Provider registration / configuration
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestXaiTTSAdapterRegistration:
+    def test_get_tts_adapter_returns_xai_adapter(self):
+        from app.utils.tts_adapter import XaiTTSAdapter, get_tts_adapter
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"):
+            adapter = get_tts_adapter("xai")
+        assert isinstance(adapter, XaiTTSAdapter)
+
+    def test_adapter_construction_fails_fast_without_api_key(self):
+        from app.utils.tts_adapter import get_tts_adapter
+
+        with patch("app.core.config.settings.XAI_API_KEY", ""):
+            with pytest.raises(ValueError):
+                get_tts_adapter("xai")
+
+    def test_adapter_default_voice_is_eve(self):
+        from app.services.xai_tts_service import XAI_DEFAULT_VOICE
+        from app.utils.tts_adapter import XaiTTSAdapter
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"):
+            adapter = XaiTTSAdapter()
+        assert adapter._DEFAULT_VOICE == XAI_DEFAULT_VOICE == "eve"
+
+    def test_adapter_stream_synthesize_raises_not_implemented(self):
+        from app.utils.tts_adapter import XaiTTSAdapter
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"):
+            adapter = XaiTTSAdapter()
+        with pytest.raises(NotImplementedError):
+            adapter.stream_synthesize(text="hi", voice_external_id="eve")
+
+    def test_adapter_list_voices_and_normalize(self):
+        from app.utils.tts_adapter import XaiTTSAdapter
+
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"):
+            adapter = XaiTTSAdapter()
+        voices = adapter.list_voices()
+        assert any(v.get("voice_id") == "eve" for v in voices)
+        normalized = adapter.normalize_voice_payload({"voice_id": "eve", "name": "Eve"})
+        assert normalized["external_voice_id"] == "eve"
+        assert normalized["sample_rate_hz"] == 8000
+
+    def test_adapter_async_stream_synthesize_passthrough(self):
+        from app.utils.tts_adapter import XaiTTSAdapter
+
+        fake_ws = _FakeXaiWebSocket([_audio_delta(b"abc"), _audio_done()])
+        with patch("app.core.config.settings.XAI_API_KEY", "test-xai-key"), _patch_xai_connect(fake_ws):
+            adapter = XaiTTSAdapter()
+
+            async def _run():
+                chunks = []
+                async for chunk in adapter.async_stream_synthesize(
+                    text="Hi", voice_external_id="eve", settings_json={"speed": 1.1}
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            chunks = asyncio.run(_run())
+        assert chunks == [b"abc"]
+
+    def test_tts_provider_enum_has_xai(self):
+        from app.schemas.agent import TtsProviderEnum
+
+        assert TtsProviderEnum.xai == "xai"
+
+    def test_capabilities_entry_present_for_xai(self):
+        from app.voice.tts_provider_capabilities import get_capabilities
+
+        caps = get_capabilities("xai")
+        assert caps.provider_slug == "xai"
+        assert caps.supports_streaming is True
+        assert caps.supports_speaking_rate is True
+        assert caps.supports_ssml is False
+        assert caps.supports_streaming_session is False
+
+    def test_catalog_seed_includes_xai(self):
+        from app.services.tts_catalog_service import TTSCatalogService
+
+        svc = TTSCatalogService()
+        # ensure_default_provider() is DB-backed; assert against the static
+        # seed spec list directly instead, mirroring how this module has no
+        # existing unit test hitting a real DB.
+        import inspect
+
+        source = inspect.getsource(svc.ensure_default_provider)
+        assert '"slug": "xai"' in source
+
+    def test_verify_xai_api_key_configured_raises_when_missing(self):
+        from app.services.tts_catalog_service import TTSCatalogService
+
+        with patch("app.core.config.settings.XAI_API_KEY", ""):
+            with pytest.raises(ValueError):
+                TTSCatalogService.verify_xai_api_key_configured()
+
+    def test_verify_xai_api_key_configured_passes_when_set(self):
+        from app.services.tts_catalog_service import TTSCatalogService
+
+        with patch("app.core.config.settings.XAI_API_KEY", "real-key"):
+            TTSCatalogService.verify_xai_api_key_configured()  # must not raise
+
+
+class TestAgentRuntimeXaiDefaults:
+    def test_ticket_triad_allows_xai_without_explicit_voice(self):
+        from app.core.agent_runtime import _ticket_tts_triad
+
+        agent = type(
+            "FakeAgent",
+            (),
+            {"tts_provider_slug": "xai", "tts_language": "en", "tts_voice_external_id": None},
+        )()
+        assert _ticket_tts_triad(agent) is True

--- a/tests/voice/test_xai_tts_and_barge_in.py
+++ b/tests/voice/test_xai_tts_and_barge_in.py
@@ -441,14 +441,16 @@ class TestXaiTTSAdapterRegistration:
     def test_catalog_seed_includes_xai(self):
         from app.services.tts_catalog_service import TTSCatalogService
 
-        svc = TTSCatalogService()
-        # ensure_default_provider() is DB-backed; assert against the static
-        # seed spec list directly instead, mirroring how this module has no
-        # existing unit test hitting a real DB.
-        import inspect
-
-        source = inspect.getsource(svc.ensure_default_provider)
-        assert '"slug": "xai"' in source
+        # ensure_default_provider() is DB-backed; assert against the
+        # SEED_PROVIDERS class constant directly (the actual seed data,
+        # not a text search over the method's source) instead of hitting a
+        # real DB, mirroring how this module has no existing unit test that
+        # does that.
+        slugs = [spec["slug"] for spec in TTSCatalogService.SEED_PROVIDERS]
+        assert "xai" in slugs
+        xai_spec = next(s for s in TTSCatalogService.SEED_PROVIDERS if s["slug"] == "xai")
+        assert xai_spec["is_active"] is True
+        assert xai_spec["supports_streaming"] is True
 
     def test_verify_xai_api_key_configured_raises_when_missing(self):
         from app.services.tts_catalog_service import TTSCatalogService


### PR DESCRIPTION
## Summary
- Integrates xAI's WebSocket TTS (`wss://api.x.ai/v1/tts`) as a 5th real-time streaming TTS provider, alongside ElevenLabs, Google, Rime, and Hume — reusing the existing multi-provider TTS pipeline architecture (`app/utils/tts_adapter.py`, `tts_provider_capabilities.py`, `tts_catalog_service.py`, `TtsProviderEnum`).
- Requests `codec=mulaw&sample_rate=8000` directly from xAI, so no local resampling is needed downstream (unlike Hume, which only streams PCM).
- One WebSocket per synthesis chunk, matching the Rime/Hume connection model; cancellation/barge-in uses the existing generic task-cancel → WS-close path.
- Registers the provider everywhere the other providers are wired in: adapter registry, capabilities, voice catalog seeding, `TtsProviderEnum`, OpenAPI spec, and default-voice wiring for both the Twilio and browser/LiveKit call transports.
- Reads `XAI_API_KEY` via `settings.XAI_API_KEY` directly (matching this repo's existing xAI STT integration), not via `secret_manager.py`'s GCP-backed path used by Rime/Hume — a deliberate, documented tradeoff (weaker secret-management story in staging/prod for this one provider) worth a conscious sign-off, not an oversight.

## Test plan
- [x] 29 new tests in `tests/voice/test_xai_tts_and_barge_in.py` covering streaming/chunking, connection URL + Bearer auth header, `audio.delta`/`audio.done`/`error` message handling, mulaw/8kHz format, cancellation/barge-in, timeouts/disconnects, empty/malformed/binary-frame edge cases, and provider registration.
- [x] Full TTS-related regression sweep (`tests/voice/ tests/services/ tests/core/ tests/utils/ -k "tts or xai"`): 268 passed, 0 regressions to ElevenLabs/Google/Rime/Hume.
- [x] `ruff check` clean on all changed files.
- [x] Real smoke test against live `wss://api.x.ai/v1/tts` with the configured `XAI_API_KEY`: connection succeeded, ~1870ms first-audio-chunk latency, 8 chunks / ~4.87s of mulaw/8kHz audio, clean `audio.done`.
- [x] Message protocol (field names, `error`/`audio.done` handling) verified line-by-line against xAI's official docs in a second review pass — no protocol-mismatch bugs (the class of bug that hit the earlier Hume integration).
- [x] `docs-vault-sync` (adds xAI to the vault's TTS provider notes) — not yet run, can follow post-merge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>