### PR TITLE
feat(integrations): add Slack OAuth integration for post-call summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,6 +111,20 @@ GHL_REDIRECT_URI=
 # MUST be a randomly generated 32-byte secret (represented as a 64-character hex string).
 GHL_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
 
+# --- Slack integration (post-call summary delivery) ----------------------------
+# OAuth app credentials from https://api.slack.com/apps. In staging/production
+# these are read from Secret Manager (see app/core/secret_manager.py); these env
+# vars are local-dev fallbacks only.
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+# Must exactly match a Redirect URL configured on the Slack app. Defaults to
+# {WEBHOOK_BASE_URL}/api/v1/integrations/slack/callback when unset.
+SLACK_REDIRECT_URI=
+# Symmetric encryption key for workspaceintegration.access_token (AES-256-GCM).
+# MUST be a randomly generated 32-byte secret (represented as a 64-character hex string).
+# Preserve compatibility with existing encrypted tokens by keeping the key unchanged.
+SLACK_TOKEN_ENCRYPTION_KEY=<generate with: python -c "import secrets; print(secrets.token_hex(32))">
+
 # --- Calendly calendar integration --------------------------------------------
 # OAuth app credentials from https://developer.calendly.com/.
 CALENDLY_CLIENT_ID=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,8 @@ Mock external HTTP APIs at the boundary with `unittest.mock.patch` or `respx`.
 | `OPENAI_API_KEY` | LLM | |
 | `DEEPGRAM_API_KEY` | STT | |
 | `ELEVENLABS_ENCRYPTION_KEY` | TTS | pgp_sym_encrypt for BYO keys |
+| `SLACK_CLIENT_ID` / `SLACK_CLIENT_SECRET` | Slack integration | OAuth v2 app credentials; local-dev fallback, Secret Manager in staging/production (`app/core/secret_manager.py::get_slack_oauth_credentials`) |
+| `SLACK_TOKEN_ENCRYPTION_KEY` | Slack integration | AES-256-GCM key for the stored `workspaceintegration` bot token |
 | `PINECONE_API_KEY` / `PINECONE_INDEX_HOST` | RAG | |
 | `API_DOCS_USERNAME` / `API_DOCS_PASSWORD` | Docs | HTTP Basic for `/api/docs` |
 | `ENVIRONMENT` | | `development` / `staging` / `production` |

--- a/alembic/versions/c4e70c96cb81_add_slack_summary_fields_to_call_flow.py
+++ b/alembic/versions/c4e70c96cb81_add_slack_summary_fields_to_call_flow.py
@@ -1,0 +1,31 @@
+"""add_slack_summary_fields_to_call_flow
+
+Revision ID: c4e70c96cb81
+Revises: 20260817_widen_llm_check_oair
+Create Date: 2026-08-20 10:50:45.827422
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4e70c96cb81'
+down_revision: Union[str, Sequence[str], None] = '20260817_widen_llm_check_oair'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('callflow', sa.Column('slack_summary_enabled', sa.Boolean(), server_default='false', nullable=False))
+    op.add_column('callflow', sa.Column('slack_channel_id', sa.String(length=50), nullable=True))
+    op.add_column('callflow', sa.Column('slack_channel_name', sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('callflow', 'slack_channel_name')
+    op.drop_column('callflow', 'slack_channel_id')
+    op.drop_column('callflow', 'slack_summary_enabled')

--- a/app/api/api_v1/api.py
+++ b/app/api/api_v1/api.py
@@ -51,6 +51,7 @@ from app.routers.recordings import router as recordings_router
 from app.routers.integrations import router as integrations_router
 from app.routers.hubspot_integration import router as hubspot_integration_router
 from app.routers.salesforce_integration import router as salesforce_integration_router
+from app.routers.slack_integration import router as slack_integration_router
 from app.routers.ghl_integration import router as ghl_integration_router
 from app.routers.call_history import router as call_history_router
 from app.routers.call_history import batch_router as batch_call_metrics_router
@@ -65,8 +66,12 @@ api_router.include_router(api_keys.router, prefix="/api-keys", tags=["API Keys"]
 api_router.include_router(tenant.router, prefix="/tenants", tags=["tenants"])
 # Invite/allowed-domains sub-routes must be registered BEFORE workspace.router so
 # that their literal paths take priority over /workspace/{workspace_id}.
-api_router.include_router(workspace_invites.router, prefix="/workspace", tags=["Workspace Invitations"])
-api_router.include_router(allowed_domains.router, prefix="/workspace", tags=["Workspace — Allowed Domains"])
+api_router.include_router(
+    workspace_invites.router, prefix="/workspace", tags=["Workspace Invitations"]
+)
+api_router.include_router(
+    allowed_domains.router, prefix="/workspace", tags=["Workspace — Allowed Domains"]
+)
 api_router.include_router(sso_router, prefix="/workspace/sso", tags=["SSO"])
 api_router.include_router(workspace.router, prefix="/workspace", tags=["Workspace"])
 api_router.include_router(role.router, prefix="/roles", tags=["roles"])
@@ -86,28 +91,48 @@ api_router.include_router(
     tags=["Live Voice - Talk to Assistant"],
     include_in_schema=False,
 )
-api_router.include_router(phone_numbers_router, prefix="/phone-numbers", tags=["Phone Numbers"])
+api_router.include_router(
+    phone_numbers_router, prefix="/phone-numbers", tags=["Phone Numbers"]
+)
 api_router.include_router(telephony_router, prefix="/telephony", tags=["Telephony"])
 api_router.include_router(
     transfer_routes_router,
     prefix="/transfer-routes",
     tags=["Transfer routes"],
 )
-api_router.include_router(call_sessions_router, prefix="/call-sessions", tags=["Call Sessions"])
+api_router.include_router(
+    call_sessions_router, prefix="/call-sessions", tags=["Call Sessions"]
+)
 api_router.include_router(call_logs_router, prefix="/call-logs", tags=["Call Logs"])
-api_router.include_router(general_websocket_router, prefix="/general", tags=["General WebSocket"])
-api_router.include_router(accept_invite.router, prefix="/accept-invite", tags=["accept-invite"])
+api_router.include_router(
+    general_websocket_router, prefix="/general", tags=["General WebSocket"]
+)
+api_router.include_router(
+    accept_invite.router, prefix="/accept-invite", tags=["accept-invite"]
+)
 api_router.include_router(billing.router, prefix="/billing", tags=["billing"])
 api_router.include_router(plan.router, prefix="/plans", tags=["plans"])
 api_router.include_router(dashboard_router, prefix="/dashboard", tags=["Dashboard"])
-api_router.include_router(provider.router, prefix="/providers", tags=["providers"], include_in_schema=True)
+api_router.include_router(
+    provider.router, prefix="/providers", tags=["providers"], include_in_schema=True
+)
 api_router.include_router(model.router, prefix="/models", tags=["models"])
-api_router.include_router(gemini.router, prefix="/gemini", tags=["gemini"], include_in_schema=False)
-api_router.include_router(openai.router, prefix="/openai", tags=["openai"], include_in_schema=False)
-api_router.include_router(tts_audio_router, prefix="/tts", tags=["Google TTS"], include_in_schema=False)
+api_router.include_router(
+    gemini.router, prefix="/gemini", tags=["gemini"], include_in_schema=False
+)
+api_router.include_router(
+    openai.router, prefix="/openai", tags=["openai"], include_in_schema=False
+)
+api_router.include_router(
+    tts_audio_router, prefix="/tts", tags=["Google TTS"], include_in_schema=False
+)
 api_router.include_router(tts_router, prefix="/tts", tags=["TTS"])
-api_router.include_router(internal_tts_router, prefix="/internal/tts", tags=["Internal TTS"])
-api_router.include_router(internal_stt_router, prefix="/internal/stt", tags=["Internal STT"])
+api_router.include_router(
+    internal_tts_router, prefix="/internal/tts", tags=["Internal TTS"]
+)
+api_router.include_router(
+    internal_stt_router, prefix="/internal/stt", tags=["Internal STT"]
+)
 api_router.include_router(
     bidirectional_stream_router,
     prefix="/stream",
@@ -120,9 +145,13 @@ api_router.include_router(
     tags=["LiveKit Bridge"],
     include_in_schema=False,
 )
-api_router.include_router(scheduled_calls_router, prefix="/schedule", tags=["Scheduled Calls"])
+api_router.include_router(
+    scheduled_calls_router, prefix="/schedule", tags=["Scheduled Calls"]
+)
 api_router.include_router(sdk_router, prefix="/sdk", tags=["Web SDK — Public"])
-api_router.include_router(crm_config_router, prefix="/crm-config", tags=["CRM Configuration"])
+api_router.include_router(
+    crm_config_router, prefix="/crm-config", tags=["CRM Configuration"]
+)
 api_router.include_router(
     clickup_oauth_router,
     prefix="/auth/clickup",
@@ -131,7 +160,9 @@ api_router.include_router(
 )
 api_router.include_router(knowledge_base_router, prefix="/kb", tags=["Knowledge Base"])
 api_router.include_router(calendar_router, prefix="/calendar", tags=["Calendar"])
-api_router.include_router(inbound_crm_router, prefix="/inbound-crm", tags=["Inbound CRM — Call logs"])
+api_router.include_router(
+    inbound_crm_router, prefix="/inbound-crm", tags=["Inbound CRM — Call logs"]
+)
 api_router.include_router(
     job_description_router,
     prefix="/recruiting/job-descriptions",
@@ -159,8 +190,12 @@ api_router.include_router(
     prefix="/recruiting/dashboard",
     tags=["Recruiting Dashboard"],
 )
-api_router.include_router(recordings_router, prefix="/recordings", tags=["Call Recordings"])
-api_router.include_router(integrations_router, prefix="/integrations", tags=["Integrations"])
+api_router.include_router(
+    recordings_router, prefix="/recordings", tags=["Call Recordings"]
+)
+api_router.include_router(
+    integrations_router, prefix="/integrations", tags=["Integrations"]
+)
 api_router.include_router(
     hubspot_integration_router,
     prefix="/integrations/hubspot",
@@ -176,7 +211,20 @@ api_router.include_router(
     prefix="/integrations/leadconnector",
     tags=["GoHighLevel Integration"],
 )
-api_router.include_router(call_history_router, prefix="/calls", tags=["Call History Analytics"])
-api_router.include_router(batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"])
-api_router.include_router(payments_router, prefix="/payments", tags=["In-Call Payments"])
-api_router.include_router(amd_webhook_router, prefix="/webhooks/twilio", tags=["AMD Webhook"])
+api_router.include_router(
+    slack_integration_router,
+    prefix="/integrations/slack",
+    tags=["Slack Integration"],
+)
+api_router.include_router(
+    call_history_router, prefix="/calls", tags=["Call History Analytics"]
+)
+api_router.include_router(
+    batch_call_metrics_router, prefix="/batch-calls", tags=["Batch Call Analytics"]
+)
+api_router.include_router(
+    payments_router, prefix="/payments", tags=["In-Call Payments"]
+)
+api_router.include_router(
+    amd_webhook_router, prefix="/webhooks/twilio", tags=["AMD Webhook"]
+)

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -18,6 +18,7 @@ Note: the caller memory settings path is deliberately NOT `/{flow_id}/settings` 
 that path is already registered by app.api.v2.routers.hipaa for the HIPAA
 compliance toggle, and reusing it here would silently shadow that endpoint.
 """
+
 from __future__ import annotations
 
 import uuid
@@ -112,7 +113,9 @@ def update_caller_memory_settings(
     db: Session = Depends(get_db),
 ) -> CallerMemorySettingsResponse:
     tenant_id = _tenant_id(principal)
-    result = call_flow_service.update_caller_memory_settings(db, flow_id, tenant_id, body)
+    result = call_flow_service.update_caller_memory_settings(
+        db, flow_id, tenant_id, body
+    )
 
     log_audit_event(
         db,
@@ -134,22 +137,27 @@ def update_caller_memory_settings(
     "/{flow_id}/post-call-actions-settings",
     response_model=PostCallActionsSettingsResponse,
     status_code=status.HTTP_200_OK,
-    summary="Configure post-call email summary actions on a call flow",
+    summary="Configure post-call email/Slack summary actions on a call flow",
     description=(
-        "Configures the two \"Post Call Actions\" toggles for this call flow:\n\n"
+        'Configures the "Post Call Actions" toggles for this call flow:\n\n'
         "- **Email Summary** (`email_summary_enabled` + `email_summary_recipients`): "
         "sends the call summary and extracted variables to an explicit list of "
         "recipient emails after each completed call.\n"
         "- **Summary to Business Owner** (`summary_to_business_owner_enabled`): sends "
         "the same email to the tenant's business owner (the workspace creator's "
         "account email) — there is no separate address field for this, the recipient "
-        "is resolved server-side.\n\n"
-        "Both toggles are independent and may be enabled together; recipients from "
-        "both sources are deduplicated before sending. The request body always fully "
-        "replaces all three fields (send the current values for any field you don't "
+        "is resolved server-side.\n"
+        "- **Slack Summary** (`slack_summary_enabled` + `slack_channel_id`/"
+        "`slack_channel_name`): posts the call summary and sentiment to a Slack channel "
+        "after each completed call. Requires the workspace to have connected Slack "
+        "first (see `/api/v1/integrations/slack`); falls back to the workspace's default "
+        "channel if `slack_channel_id` is not set.\n\n"
+        "All toggles are independent and may be enabled together; email recipients from "
+        "both email sources are deduplicated before sending. The request body always "
+        "fully replaces all fields (send the current values for any field you don't "
         "want to change). Sending is fire-and-forget after call completion — this "
-        "endpoint only updates the stored configuration; it does not send an email "
-        "itself. Requires admin rank."
+        "endpoint only updates the stored configuration; it does not send an email or "
+        "Slack message itself. Requires admin rank."
     ),
 )
 def update_post_call_actions_settings(
@@ -160,7 +168,9 @@ def update_post_call_actions_settings(
     db: Session = Depends(get_db),
 ) -> PostCallActionsSettingsResponse:
     tenant_id = _tenant_id(principal)
-    result = call_flow_service.update_post_call_actions_settings(db, flow_id, tenant_id, body)
+    result = call_flow_service.update_post_call_actions_settings(
+        db, flow_id, tenant_id, body
+    )
 
     log_audit_event(
         db,
@@ -173,6 +183,9 @@ def update_post_call_actions_settings(
             "email_summary_enabled": result.email_summary_enabled,
             "email_summary_recipients": result.email_summary_recipients,
             "summary_to_business_owner_enabled": result.summary_to_business_owner_enabled,
+            "slack_summary_enabled": result.slack_summary_enabled,
+            "slack_channel_id": result.slack_channel_id,
+            "slack_channel_name": result.slack_channel_name,
         },
         actor_user_id=principal.id,
     )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -162,7 +162,9 @@ class TtsSettings(BaseModel):
     api_key: str = Field(default="", validation_alias="TTS_API_KEY")
     rime_api_key: str = Field(default="", validation_alias="RIME_API_KEY")
     hume_api_key: str = Field(default="", validation_alias="HUME_API_KEY")
-    hume_sample_rate_hz: int = Field(default=48000, validation_alias="HUME_TTS_SAMPLE_RATE_HZ")
+    hume_sample_rate_hz: int = Field(
+        default=48000, validation_alias="HUME_TTS_SAMPLE_RATE_HZ"
+    )
     elevenlabs_api_key: str = Field(default="", validation_alias="ELEVENLABS_API_KEY")
     elevenlabs_encryption_key: str = Field(
         default="", validation_alias="ELEVENLABS_ENCRYPTION_KEY"
@@ -211,6 +213,13 @@ class CrmSettings(BaseModel):
     ghl_redirect_uri: str = Field(default="", validation_alias="GHL_REDIRECT_URI")
     ghl_token_encryption_key: str = Field(
         default="", validation_alias="GHL_TOKEN_ENCRYPTION_KEY"
+    )
+    # Slack
+    slack_client_id: str = Field(default="", validation_alias="SLACK_CLIENT_ID")
+    slack_client_secret: str = Field(default="", validation_alias="SLACK_CLIENT_SECRET")
+    slack_redirect_uri: str = Field(default="", validation_alias="SLACK_REDIRECT_URI")
+    slack_token_encryption_key: str = Field(
+        default="", validation_alias="SLACK_TOKEN_ENCRYPTION_KEY"
     )
     # Calendly
     calendly_client_id: str = Field(default="", validation_alias="CALENDLY_CLIENT_ID")
@@ -547,6 +556,19 @@ class Settings(BaseSettings):
     GHL_TOKEN_ENCRYPTION_KEY: str = ""
     GHL_API_BASE_URL: str = "https://services.leadconnectorhq.com"
     GHL_API_VERSION: str = "2021-07-28"
+
+    # Slack post-call-summary OAuth (app/services/slack_service.py).
+    # client_id/client_secret kept here as local-dev fallbacks only — in
+    # staging/production they are read from Secret Manager (see
+    # app/core/secret_manager.py::get_slack_oauth_credentials).
+    SLACK_CLIENT_ID: str = ""
+    SLACK_CLIENT_SECRET: str = ""
+    SLACK_REDIRECT_URI: str = (
+        ""  # defaults to {WEBHOOK_BASE_URL}/api/v1/integrations/slack/callback
+    )
+    # Symmetric encryption key for workspaceintegration.access_token
+    # (AES-256-GCM) — same scheme as HUBSPOT_TOKEN_ENCRYPTION_KEY above.
+    SLACK_TOKEN_ENCRYPTION_KEY: str = ""
 
     # Calendly calendar OAuth (app/services/calendly_service.py).
     CALENDLY_CLIENT_ID: str = ""
@@ -1152,6 +1174,10 @@ class Settings(BaseSettings):
             ghl_client_secret=self.GHL_CLIENT_SECRET,
             ghl_redirect_uri=self.GHL_REDIRECT_URI,
             ghl_token_encryption_key=self.GHL_TOKEN_ENCRYPTION_KEY,
+            slack_client_id=self.SLACK_CLIENT_ID,
+            slack_client_secret=self.SLACK_CLIENT_SECRET,
+            slack_redirect_uri=self.SLACK_REDIRECT_URI,
+            slack_token_encryption_key=self.SLACK_TOKEN_ENCRYPTION_KEY,
             calendly_client_id=self.CALENDLY_CLIENT_ID,
             calendly_client_secret=self.CALENDLY_CLIENT_SECRET,
             calendly_redirect_uri=self.CALENDLY_REDIRECT_URI,

--- a/app/core/db_encryption.py
+++ b/app/core/db_encryption.py
@@ -253,7 +253,9 @@ def _hubspot_aes_key() -> bytes:
     return hashlib.sha256(key.encode("utf-8")).digest()
 
 
-def encrypt_hubspot_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+def encrypt_hubspot_token(
+    plaintext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
     """Encrypt *plaintext* HubSpot OAuth token with AES-256-GCM.
 
     Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
@@ -286,7 +288,7 @@ def decrypt_hubspot_token(ciphertext: str, db: Session) -> str:
     if ciphertext.startswith(_HUBSPOT_AESGCM_PREFIX):
         key = _hubspot_aes_key()
         try:
-            raw = base64.b64decode(ciphertext[len(_HUBSPOT_AESGCM_PREFIX):])
+            raw = base64.b64decode(ciphertext[len(_HUBSPOT_AESGCM_PREFIX) :])
             nonce, body = raw[:12], raw[12:]
             return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
         except Exception as exc:
@@ -332,7 +334,9 @@ def _salesforce_aes_key() -> bytes:
     return hashlib.sha256(key.encode("utf-8")).digest()
 
 
-def encrypt_salesforce_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+def encrypt_salesforce_token(
+    plaintext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
     """Encrypt *plaintext* Salesforce OAuth token with AES-256-GCM.
 
     Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
@@ -344,10 +348,14 @@ def encrypt_salesforce_token(plaintext: str, db: Session) -> str:  # noqa: ARG00
     key = _salesforce_aes_key()
     nonce = os.urandom(12)  # 96-bit nonce, the standard size for AES-GCM
     ciphertext = AESGCM(key).encrypt(nonce, plaintext.encode("utf-8"), None)
-    return _SALESFORCE_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode("ascii")
+    return _SALESFORCE_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode(
+        "ascii"
+    )
 
 
-def decrypt_salesforce_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+def decrypt_salesforce_token(
+    ciphertext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
     """Decrypt a Salesforce OAuth token written by :func:`encrypt_salesforce_token`.
 
     Raises ``ValueError`` if ``SALESFORCE_TOKEN_ENCRYPTION_KEY`` is not configured,
@@ -360,7 +368,7 @@ def decrypt_salesforce_token(ciphertext: str, db: Session) -> str:  # noqa: ARG0
 
     key = _salesforce_aes_key()
     try:
-        raw = base64.b64decode(ciphertext[len(_SALESFORCE_AESGCM_PREFIX):])
+        raw = base64.b64decode(ciphertext[len(_SALESFORCE_AESGCM_PREFIX) :])
         nonce, body = raw[:12], raw[12:]
         return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
     except Exception as exc:
@@ -391,7 +399,9 @@ def _calendly_aes_key() -> bytes:
     return hashlib.sha256(key.encode("utf-8")).digest()
 
 
-def encrypt_calendly_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+def encrypt_calendly_token(
+    plaintext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
     """Encrypt *plaintext* Calendly OAuth token with AES-256-GCM.
 
     Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
@@ -403,10 +413,14 @@ def encrypt_calendly_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 
     key = _calendly_aes_key()
     nonce = os.urandom(12)  # 96-bit nonce, the standard size for AES-GCM
     ciphertext = AESGCM(key).encrypt(nonce, plaintext.encode("utf-8"), None)
-    return _CALENDLY_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode("ascii")
+    return _CALENDLY_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode(
+        "ascii"
+    )
 
 
-def decrypt_calendly_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+def decrypt_calendly_token(
+    ciphertext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
     """Decrypt a Calendly OAuth token written by :func:`encrypt_calendly_token`.
 
     Raises ``ValueError`` if ``CALENDLY_TOKEN_ENCRYPTION_KEY`` is not configured or
@@ -417,11 +431,13 @@ def decrypt_calendly_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001
         raise ValueError("ciphertext is empty")
 
     if not ciphertext.startswith(_CALENDLY_AESGCM_PREFIX):
-        raise ValueError("Unrecognized Calendly token ciphertext format (expected gcm1: prefix).")
+        raise ValueError(
+            "Unrecognized Calendly token ciphertext format (expected gcm1: prefix)."
+        )
 
     key = _calendly_aes_key()
     try:
-        raw = base64.b64decode(ciphertext[len(_CALENDLY_AESGCM_PREFIX):])
+        raw = base64.b64decode(ciphertext[len(_CALENDLY_AESGCM_PREFIX) :])
         nonce, body = raw[:12], raw[12:]
         return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
     except Exception as exc:
@@ -451,7 +467,9 @@ def _ghl_aes_key() -> bytes:
     return hashlib.sha256(key.encode("utf-8")).digest()
 
 
-def encrypt_ghl_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+def encrypt_ghl_token(
+    plaintext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
     """Encrypt *plaintext* GoHighLevel OAuth token with AES-256-GCM.
 
     Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
@@ -466,7 +484,9 @@ def encrypt_ghl_token(plaintext: str, db: Session) -> str:  # noqa: ARG001 - db 
     return _GHL_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode("ascii")
 
 
-def decrypt_ghl_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001 - db kept for call-site parity
+def decrypt_ghl_token(
+    ciphertext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
     """Decrypt a GoHighLevel OAuth token written by :func:`encrypt_ghl_token`.
 
     Raises ``ValueError`` if ``GHL_TOKEN_ENCRYPTION_KEY`` is not configured,
@@ -479,11 +499,73 @@ def decrypt_ghl_token(ciphertext: str, db: Session) -> str:  # noqa: ARG001 - db
 
     key = _ghl_aes_key()
     try:
-        raw = base64.b64decode(ciphertext[len(_GHL_AESGCM_PREFIX):])
+        raw = base64.b64decode(ciphertext[len(_GHL_AESGCM_PREFIX) :])
         nonce, body = raw[:12], raw[12:]
         return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
     except Exception as exc:
         raise ValueError(f"GoHighLevel token decryption failed: {exc}") from exc
+
+
+# Tags Slack OAuth token ciphertext. New integration — no legacy pgcrypto
+# rows exist, so unlike HubSpot's decrypt_hubspot_token there is no
+# fallback path.
+_SLACK_AESGCM_PREFIX = "gcm1:"
+
+
+def _slack_aes_key() -> bytes:
+    """Derive a 32-byte AES-256 key from SLACK_TOKEN_ENCRYPTION_KEY.
+
+    SECURITY NOTE:
+      For secure AES-256-GCM encryption, SLACK_TOKEN_ENCRYPTION_KEY must be
+      configured as a randomly generated 32-byte secret (typically represented
+      as a 64-character hex string, e.g. generated via `secrets.token_hex(32)`).
+    """
+    key = settings.SLACK_TOKEN_ENCRYPTION_KEY
+    if not key:
+        raise ValueError(
+            "SLACK_TOKEN_ENCRYPTION_KEY is not configured — "
+            "cannot encrypt/decrypt Slack OAuth token."
+        )
+    return hashlib.sha256(key.encode("utf-8")).digest()
+
+
+def encrypt_slack_token(
+    plaintext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
+    """Encrypt *plaintext* Slack OAuth token with AES-256-GCM.
+
+    Performed in Python via ``cryptography`` (not pgcrypto SQL — OpenPGP symmetric
+    encryption has no GCM mode). ``db`` is accepted only for parity with the other
+    encrypt_* helpers in this module; it is unused here.
+
+    Raises ``ValueError`` if ``SLACK_TOKEN_ENCRYPTION_KEY`` is not configured.
+    """
+    key = _slack_aes_key()
+    nonce = os.urandom(12)  # 96-bit nonce, the standard size for AES-GCM
+    ciphertext = AESGCM(key).encrypt(nonce, plaintext.encode("utf-8"), None)
+    return _SLACK_AESGCM_PREFIX + base64.b64encode(nonce + ciphertext).decode("ascii")
+
+
+def decrypt_slack_token(
+    ciphertext: str, db: Session
+) -> str:  # noqa: ARG001 - db kept for call-site parity
+    """Decrypt a Slack OAuth token written by :func:`encrypt_slack_token`.
+
+    Raises ``ValueError`` if ``SLACK_TOKEN_ENCRYPTION_KEY`` is not configured,
+    the ciphertext is missing/corrupt, or was encrypted with a different key.
+    """
+    if not ciphertext:
+        raise ValueError("ciphertext is empty")
+    if not ciphertext.startswith(_SLACK_AESGCM_PREFIX):
+        raise ValueError("Unrecognized Slack token ciphertext format")
+
+    key = _slack_aes_key()
+    try:
+        raw = base64.b64decode(ciphertext[len(_SLACK_AESGCM_PREFIX) :])
+        nonce, body = raw[:12], raw[12:]
+        return AESGCM(key).decrypt(nonce, body, None).decode("utf-8")
+    except Exception as exc:
+        raise ValueError(f"Slack token decryption failed: {exc}") from exc
 
 
 def decrypt_stored_elevenlabs_key(
@@ -518,6 +600,7 @@ def decrypt_stored_elevenlabs_key(
 
     if is_legacy_jwt_ciphertext(ciphertext):
         from app.core.security import decrypt_api_key
+
         return decrypt_api_key(ciphertext)
 
     if not is_pgcrypto_ciphertext(ciphertext):

--- a/app/core/db_encryption.py
+++ b/app/core/db_encryption.py
@@ -508,8 +508,11 @@ def decrypt_ghl_token(
 
 # Tags Slack OAuth token ciphertext. New integration — no legacy pgcrypto
 # rows exist, so unlike HubSpot's decrypt_hubspot_token there is no
-# fallback path.
-_SLACK_AESGCM_PREFIX = "gcm1:"
+# fallback path. Deliberately distinct from the other providers' "gcm1:"
+# prefix (HubSpot/Salesforce/Calendly/GHL) so a ciphertext accidentally routed
+# to the wrong provider's decrypt_* function fails with a clear
+# "unrecognized format" error instead of a misleading "wrong key" error.
+_SLACK_AESGCM_PREFIX = "slack_gcm1:"
 
 
 def _slack_aes_key() -> bytes:

--- a/app/core/secret_manager.py
+++ b/app/core/secret_manager.py
@@ -48,8 +48,12 @@ def _fetch_from_secret_manager(secret_id: str) -> str | None:
 @lru_cache(maxsize=1)
 def _load_production_credentials() -> Tuple[str, str]:
     """Fetch real Twilio credentials from Secret Manager (cached after first call)."""
-    sid = _fetch_from_secret_manager("TWILIO_ACCOUNT_SID") or settings.TWILIO_ACCOUNT_SID
-    token = _fetch_from_secret_manager("TWILIO_AUTH_TOKEN") or settings.TWILIO_AUTH_TOKEN
+    sid = (
+        _fetch_from_secret_manager("TWILIO_ACCOUNT_SID") or settings.TWILIO_ACCOUNT_SID
+    )
+    token = (
+        _fetch_from_secret_manager("TWILIO_AUTH_TOKEN") or settings.TWILIO_AUTH_TOKEN
+    )
     if not sid or not token:
         raise RuntimeError(
             "Twilio credentials unavailable. Set GCP_PROJECT_ID and Secret Manager secrets "
@@ -101,7 +105,9 @@ def _load_livekit_production_credentials() -> tuple[str, str, str]:
     """Fetch LiveKit credentials from Secret Manager (cached after first call)."""
     url = _fetch_from_secret_manager("LIVEKIT_URL") or settings.LIVEKIT_URL
     api_key = _fetch_from_secret_manager("LIVEKIT_API_KEY") or settings.LIVEKIT_API_KEY
-    api_secret = _fetch_from_secret_manager("LIVEKIT_API_SECRET") or settings.LIVEKIT_API_SECRET
+    api_secret = (
+        _fetch_from_secret_manager("LIVEKIT_API_SECRET") or settings.LIVEKIT_API_SECRET
+    )
     if not url or not api_key or not api_secret:
         raise RuntimeError(
             "LiveKit credentials unavailable. Set GCP_PROJECT_ID and Secret Manager secrets "
@@ -221,8 +227,13 @@ def get_hume_api_key() -> str:
 @lru_cache(maxsize=1)
 def _load_hubspot_production_credentials() -> Tuple[str, str]:
     """Fetch HubSpot OAuth app credentials from Secret Manager (cached after first call)."""
-    client_id = _fetch_from_secret_manager("HUBSPOT_CLIENT_ID") or settings.HUBSPOT_CLIENT_ID
-    client_secret = _fetch_from_secret_manager("HUBSPOT_CLIENT_SECRET") or settings.HUBSPOT_CLIENT_SECRET
+    client_id = (
+        _fetch_from_secret_manager("HUBSPOT_CLIENT_ID") or settings.HUBSPOT_CLIENT_ID
+    )
+    client_secret = (
+        _fetch_from_secret_manager("HUBSPOT_CLIENT_SECRET")
+        or settings.HUBSPOT_CLIENT_SECRET
+    )
     if not client_id or not client_secret:
         raise RuntimeError(
             "HubSpot OAuth credentials unavailable. Set GCP_PROJECT_ID and Secret Manager "
@@ -259,9 +270,13 @@ def get_hubspot_oauth_credentials() -> Tuple[str, str]:
 @lru_cache(maxsize=1)
 def _load_salesforce_production_credentials() -> Tuple[str, str]:
     """Fetch Salesforce Connected App credentials from Secret Manager (cached after first call)."""
-    client_id = _fetch_from_secret_manager("SALESFORCE_CLIENT_ID") or settings.SALESFORCE_CLIENT_ID
+    client_id = (
+        _fetch_from_secret_manager("SALESFORCE_CLIENT_ID")
+        or settings.SALESFORCE_CLIENT_ID
+    )
     client_secret = (
-        _fetch_from_secret_manager("SALESFORCE_CLIENT_SECRET") or settings.SALESFORCE_CLIENT_SECRET
+        _fetch_from_secret_manager("SALESFORCE_CLIENT_SECRET")
+        or settings.SALESFORCE_CLIENT_SECRET
     )
     if not client_id or not client_secret:
         raise RuntimeError(
@@ -297,10 +312,55 @@ def get_salesforce_oauth_credentials() -> Tuple[str, str]:
 
 
 @lru_cache(maxsize=1)
+def _load_slack_production_credentials() -> Tuple[str, str]:
+    """Fetch Slack OAuth app credentials from Secret Manager (cached after first call)."""
+    client_id = (
+        _fetch_from_secret_manager("SLACK_CLIENT_ID") or settings.SLACK_CLIENT_ID
+    )
+    client_secret = (
+        _fetch_from_secret_manager("SLACK_CLIENT_SECRET")
+        or settings.SLACK_CLIENT_SECRET
+    )
+    if not client_id or not client_secret:
+        raise RuntimeError(
+            "Slack OAuth credentials unavailable. Set GCP_PROJECT_ID and Secret Manager "
+            "secrets (SLACK_CLIENT_ID, SLACK_CLIENT_SECRET) or the equivalent env vars."
+        )
+    return client_id, client_secret
+
+
+def get_slack_oauth_credentials() -> Tuple[str, str]:
+    """
+    Return (client_id, client_secret) appropriate for the current environment.
+
+    - production/staging → GCP Secret Manager with env-var fallback
+    - development         → env-var / .env values
+
+    Raises RuntimeError in staging/production when credentials are absent,
+    ValueError in development.
+    """
+    env = settings.ENVIRONMENT.lower()
+
+    if env in ("production", "staging"):
+        return _load_slack_production_credentials()
+
+    client_id = settings.SLACK_CLIENT_ID
+    client_secret = settings.SLACK_CLIENT_SECRET
+    if not client_id or not client_secret:
+        raise ValueError(
+            "Slack OAuth credentials not configured. Set SLACK_CLIENT_ID and "
+            "SLACK_CLIENT_SECRET in your .env file for local development."
+        )
+    return client_id, client_secret
+
+
+@lru_cache(maxsize=1)
 def _load_ghl_production_credentials() -> Tuple[str, str]:
     """Fetch GoHighLevel OAuth app credentials from Secret Manager (cached after first call)."""
     client_id = _fetch_from_secret_manager("GHL_CLIENT_ID") or settings.GHL_CLIENT_ID
-    client_secret = _fetch_from_secret_manager("GHL_CLIENT_SECRET") or settings.GHL_CLIENT_SECRET
+    client_secret = (
+        _fetch_from_secret_manager("GHL_CLIENT_SECRET") or settings.GHL_CLIENT_SECRET
+    )
     if not client_id or not client_secret:
         raise RuntimeError(
             "GoHighLevel OAuth credentials unavailable. Set GCP_PROJECT_ID and Secret Manager "
@@ -362,10 +422,12 @@ def get_sso_encryption_key() -> bytes:
     if env in ("production", "staging"):
         key_str = _fetch_from_secret_manager("SSO_ENCRYPTION_KEY")
         if not key_str:
-            raise RuntimeError(f"SSO_ENCRYPTION_KEY not found in Secret Manager for env {env}")
+            raise RuntimeError(
+                f"SSO_ENCRYPTION_KEY not found in Secret Manager for env {env}"
+            )
     else:
         key_str = getattr(settings, "SSO_ENCRYPTION_KEY", "") or ""
         if not key_str:
             raise ValueError("SSO_ENCRYPTION_KEY not configured in .env")
-            
+
     return key_str.encode("utf-8")

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -52,6 +52,17 @@ class CallFlow(Base):
     email_summary_recipients = Column(JSONB, nullable=True, default=list)
     summary_to_business_owner_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
 
+    # Post Call Actions: post a call summary to a Slack channel after a call
+    # completes. Per-call-flow opt-in — a workspace connecting Slack (see
+    # WorkspaceIntegration, provider="slack") does not activate this for every
+    # call flow. If slack_channel_id is null, the send-time fallback is the
+    # workspace's default_channel_id in WorkspaceIntegration.extra_metadata.
+    slack_summary_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    slack_channel_id = Column(String(50), nullable=True)
+    # Denormalized display name of slack_channel_id, so the frontend doesn't
+    # need an extra Slack API round-trip to show the selected channel in the UI.
+    slack_channel_name = Column(String(255), nullable=True)
+
     # Post-Call Analysis: tenant-defined variables extracted from each completed
     # call via a dedicated LLM pass, independent of the fixed
     # summary/sentiment/recommendations fields computed by

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -1,4 +1,15 @@
-from sqlalchemy import Column, String, Text, DateTime, Integer, ForeignKey, Boolean, Index, CheckConstraint, Numeric
+from sqlalchemy import (
+    Column,
+    String,
+    Text,
+    DateTime,
+    Integer,
+    ForeignKey,
+    Boolean,
+    Index,
+    CheckConstraint,
+    Numeric,
+)
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -18,7 +29,9 @@ class CallFlow(Base):
     # Circular FK to promptversion — use_alter defers constraint creation
     current_prompt_id = Column(
         UUID(as_uuid=True),
-        ForeignKey("promptversion.id", use_alter=True, name="fk_callflow_current_prompt"),
+        ForeignKey(
+            "promptversion.id", use_alter=True, name="fk_callflow_current_prompt"
+        ),
         nullable=True,
     )
     flow_data = Column(JSONB, nullable=True)
@@ -28,7 +41,9 @@ class CallFlow(Base):
     knowledge_base_ids = Column(JSONB, nullable=True, default=list)
 
     # A/B prompt testing
-    ab_test_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    ab_test_enabled = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
     ab_prompt_a_id = Column(
         UUID(as_uuid=True),
         ForeignKey("promptversion.id", use_alter=True, name="fk_callflow_ab_prompt_a"),
@@ -40,24 +55,38 @@ class CallFlow(Base):
         nullable=True,
     )
     # Fraction of calls routed to variant A (0.10-0.90)
-    ab_split_ratio = Column(Numeric(3, 2), default=0.50, nullable=False, server_default="0.50")
+    ab_split_ratio = Column(
+        Numeric(3, 2), default=0.50, nullable=False, server_default="0.50"
+    )
 
     # Cross-session caller memory: inject summaries of a caller's past calls into the prompt
-    caller_memory_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
-    caller_memory_window = Column(Integer, default=3, nullable=False, server_default="3")
+    caller_memory_enabled = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+    caller_memory_window = Column(
+        Integer, default=3, nullable=False, server_default="3"
+    )
 
     # Post Call Actions: email a call summary and/or notify the tenant's business
     # owner (is_creator user) after a call completes
-    email_summary_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    email_summary_enabled = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
     email_summary_recipients = Column(JSONB, nullable=True, default=list)
-    summary_to_business_owner_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    summary_to_business_owner_enabled = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
 
     # Post Call Actions: post a call summary to a Slack channel after a call
     # completes. Per-call-flow opt-in — a workspace connecting Slack (see
     # WorkspaceIntegration, provider="slack") does not activate this for every
     # call flow. If slack_channel_id is null, the send-time fallback is the
     # workspace's default_channel_id in WorkspaceIntegration.extra_metadata.
-    slack_summary_enabled = Column(Boolean, default=False, nullable=False, server_default="false")
+    # Has no effect on inbound CRM-sync calls — mirrors email_summary_enabled's
+    # behavior for that call type (see call_session_service.py's post-call hooks).
+    slack_summary_enabled = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
     slack_channel_id = Column(String(50), nullable=True)
     # Denormalized display name of slack_channel_id, so the frontend doesn't
     # need an extra Slack API round-trip to show the selected channel in the UI.
@@ -68,17 +97,32 @@ class CallFlow(Base):
     # summary/sentiment/recommendations fields computed by
     # voice_analysis_service.analyze_call_transcript. Empty list = feature off;
     # the automatic call-summary generation is unaffected either way.
-    post_call_analysis_variables = Column(JSONB, nullable=False, default=list, server_default="'[]'::jsonb")
+    post_call_analysis_variables = Column(
+        JSONB, nullable=False, default=list, server_default="'[]'::jsonb"
+    )
     post_call_analysis_model = Column(String(100), nullable=True)
 
-    hipaa_compliance = Column(Boolean, default=False, nullable=False, server_default="false")
-    public_access = Column(Boolean, default=False, nullable=False, server_default="false")
+    hipaa_compliance = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+    public_access = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
     # "active" flows can be used to initiate outbound calls; "inactive" ones are rejected
     # at dispatch time (see voice_call_service.initiate_call) without being deleted.
-    status = Column(String(20), default="active", nullable=False, server_default="active")
+    status = Column(
+        String(20), default="active", nullable=False, server_default="active"
+    )
     is_deleted = Column(Boolean, default=False, nullable=False, server_default="false")
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=True,
+    )
 
     # Relationships
     tenant = relationship("Tenant")

--- a/app/routers/slack_integration.py
+++ b/app/routers/slack_integration.py
@@ -1,0 +1,171 @@
+"""
+Slack post-call-summary OAuth integration endpoints.
+
+GET    /connect   — redirect to Slack's OAuth v2 consent page (admin-authenticated)
+GET    /callback  — public; Slack redirects the browser here with no auth headers,
+                     so the connecting tenant is recovered from the signed `state` param
+DELETE ""         — revoke at Slack and delete the local connection
+GET    ""         — connection status (team name, default channel)
+GET    /channels  — list the tenant's available Slack channels (admin action, raises on error)
+PUT    /channel   — set (or clear) the workspace's default Slack channel for post-call summaries
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse, RedirectResponse
+from sqlalchemy.orm import Session
+
+from app.api.deps import get_db, require_tenant, require_admin
+from app.core.config import settings
+from app.core.logger import logger
+from app.schemas.base import SuccessResponse
+from app.schemas.slack_integration import (
+    SlackChannelOut,
+    SlackDisconnectResponse,
+    SlackIntegrationStatusOut,
+    SlackSetChannelRequest,
+)
+from app.services import slack_service
+from app.utils.response import create_success_response
+
+router = APIRouter()
+
+
+def _tenant_id(principal) -> uuid.UUID:
+    return principal.current_tenant_id
+
+
+@router.get("/connect", include_in_schema=False)
+async def slack_connect(
+    request: Request,
+    principal=Depends(require_admin),
+):
+    """Redirect to Slack's OAuth v2 consent page. Scopes: channels:read, groups:read, chat:write.
+
+    Frontend `fetch()` calls send `Accept: application/json` and can't follow
+    a cross-origin 302 to Slack with our auth headers attached, so they get
+    the URL back as JSON instead and navigate to it themselves. Normal browser
+    navigation (no `Accept: application/json`) keeps the existing 302.
+    """
+    tenant_id = _tenant_id(principal)
+    auth_url = slack_service.get_authorization_url(tenant_id)
+
+    if request.headers.get("accept") == "application/json":
+        return JSONResponse(content={"authorization_url": auth_url})
+
+    return RedirectResponse(url=auth_url, status_code=status.HTTP_302_FOUND)
+
+
+@router.get("/callback", include_in_schema=False)
+async def slack_callback(
+    code: str = Query(...),
+    state: str = Query(...),
+    db: Session = Depends(get_db),
+):
+    """
+    Slack OAuth callback. No auth dependency — this is a top-level browser
+    redirect from Slack, which cannot carry our JWT/API-key headers. The
+    connecting tenant is recovered from the signed `state` param instead.
+    """
+    try:
+        tenant_id = slack_service.verify_oauth_state(state)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+    try:
+        token_response = await slack_service.exchange_code_for_tokens(code)
+    except Exception as exc:
+        logger.warning(
+            "Slack OAuth code exchange failed for tenant=%s: %s", tenant_id, exc
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to exchange authorization code with Slack",
+        )
+
+    slack_service.upsert_integration(db, tenant_id, token_response)
+
+    base = (settings.FRONTEND_URL or "").rstrip("/")
+    redirect_to = (
+        f"{base}/settings/integrations?slack=connected"
+        if base
+        else "/settings/integrations"
+    )
+    return RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
+
+
+@router.delete("", response_model=SuccessResponse[SlackDisconnectResponse])
+async def slack_disconnect(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Revoke the bot token at Slack and delete the workspaceintegration row."""
+    tenant_id = _tenant_id(principal)
+    disconnected = await slack_service.disconnect(db, tenant_id)
+    if not disconnected:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Slack is not connected for this workspace",
+        )
+    return create_success_response(
+        SlackDisconnectResponse(disconnected=True),
+        "Slack disconnected successfully",
+    )
+
+
+@router.get("", response_model=SuccessResponse[SlackIntegrationStatusOut])
+async def slack_get_integration_status(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """Connection status and default channel for this workspace."""
+    tenant_id = _tenant_id(principal)
+    integration_status = slack_service.get_integration_status(db, tenant_id)
+    return create_success_response(SlackIntegrationStatusOut(**integration_status))
+
+
+@router.get("/channels", response_model=SuccessResponse[list[SlackChannelOut]])
+async def slack_list_channels(
+    principal=Depends(require_tenant),
+    db: Session = Depends(get_db),
+):
+    """List the tenant's available Slack channels (public + private the bot can see)."""
+    tenant_id = _tenant_id(principal)
+    try:
+        channels = await slack_service.list_channels(db, tenant_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    except Exception as exc:
+        logger.warning("Slack channel list failed for tenant=%s: %s", tenant_id, exc)
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to fetch Slack channels",
+        )
+    return create_success_response([SlackChannelOut(**c) for c in channels])
+
+
+@router.put("/channel", response_model=SuccessResponse[SlackIntegrationStatusOut])
+async def slack_set_channel(
+    payload: SlackSetChannelRequest,
+    principal=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """Set (or clear, by omitting both fields) the workspace's default Slack channel."""
+    tenant_id = _tenant_id(principal)
+    if not slack_service.tenant_has_slack_connected(db, tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Slack is not connected for this workspace",
+        )
+
+    slack_service.set_default_channel(
+        db, tenant_id, payload.channel_id, payload.channel_name
+    )
+    integration_status = slack_service.get_integration_status(db, tenant_id)
+    return create_success_response(
+        SlackIntegrationStatusOut(**integration_status),
+        "Default Slack channel updated successfully",
+    )

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -159,7 +159,8 @@ class PostCallActionsSettingsUpdate(BaseModel):
             "When true, a call summary is posted to a Slack channel after each completed "
             "call on this flow. Requires the workspace to have connected Slack (see "
             "`/api/v1/integrations/slack`). Falls back to the workspace's default channel "
-            "if `slack_channel_id` is not set."
+            "if `slack_channel_id` is not set. Has no effect on inbound CRM-sync calls "
+            "(mirrors `email_summary_enabled`'s behavior for that call type)."
         ),
     )
     slack_channel_id: str | None = Field(

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -5,7 +5,14 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List
 
-from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    EmailStr,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 from app.schemas.prompt_version import PromptVersionOut
 
@@ -51,7 +58,9 @@ class CallFlowCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=255)
     direction: DirectionEnum
     agent_id: uuid.UUID = Field(..., alias="agentId")
-    welcome_message_type: WelcomeMessageTypeEnum | None = Field(None, alias="welcomeMessageType")
+    welcome_message_type: WelcomeMessageTypeEnum | None = Field(
+        None, alias="welcomeMessageType"
+    )
     custom_welcome_message: str | None = Field(None, alias="customWelcomeMessage")
     prompt: str | None = None
     notes: str | None = None  # notes for the initial prompt version
@@ -70,7 +79,9 @@ class CallFlowUpdate(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=255)
     direction: DirectionEnum | None = None
     agent_id: uuid.UUID | None = Field(None, alias="agentId")
-    welcome_message_type: WelcomeMessageTypeEnum | None = Field(None, alias="welcomeMessageType")
+    welcome_message_type: WelcomeMessageTypeEnum | None = Field(
+        None, alias="welcomeMessageType"
+    )
     custom_welcome_message: str | None = Field(None, alias="customWelcomeMessage")
     prompt: str | None = None
     notes: str | None = None  # notes for the new prompt version
@@ -142,6 +153,37 @@ class PostCallActionsSettingsUpdate(BaseModel):
             "field is needed for this recipient."
         ),
     )
+    slack_summary_enabled: bool = Field(
+        default=False,
+        description=(
+            "When true, a call summary is posted to a Slack channel after each completed "
+            "call on this flow. Requires the workspace to have connected Slack (see "
+            "`/api/v1/integrations/slack`). Falls back to the workspace's default channel "
+            "if `slack_channel_id` is not set."
+        ),
+    )
+    slack_channel_id: str | None = Field(
+        default=None,
+        max_length=50,
+        description=(
+            "Slack channel ID to post the summary to for this flow, overriding the "
+            "workspace default. Must be set together with `slack_channel_name`, or both "
+            "left null to fall back to the workspace default channel."
+        ),
+    )
+    slack_channel_name: str | None = Field(
+        default=None,
+        max_length=255,
+        description="Denormalized display name of `slack_channel_id`, for the dashboard UI.",
+    )
+
+    @model_validator(mode="after")
+    def validate_slack_channel_pair(self) -> "PostCallActionsSettingsUpdate":
+        if bool(self.slack_channel_id) != bool(self.slack_channel_name):
+            raise ValueError(
+                "slack_channel_id and slack_channel_name must both be set or both be null"
+            )
+        return self
 
 
 class PostCallActionsSettingsResponse(BaseModel):
@@ -150,6 +192,9 @@ class PostCallActionsSettingsResponse(BaseModel):
     email_summary_enabled: bool
     email_summary_recipients: List[str]
     summary_to_business_owner_enabled: bool
+    slack_summary_enabled: bool
+    slack_channel_id: str | None = None
+    slack_channel_name: str | None = None
 
 
 class PostCallAnalysisVariableSpec(BaseModel):
@@ -227,14 +272,26 @@ class CallFlowOut(BaseModel):
     agent_id: uuid.UUID = Field(..., serialization_alias="agentId")
     # Full AgentOut shape on detail endpoints; slim AgentRef on list
     agent: Dict[str, Any] | None = None
-    welcome_message_type: str | None = Field(None, serialization_alias="welcomeMessageType")
-    custom_welcome_message: str | None = Field(None, serialization_alias="customWelcomeMessage")
-    current_prompt_id: uuid.UUID | None = Field(None, serialization_alias="currentPromptId")
-    prompt_versions: List[PromptVersionOut] = Field(default_factory=list, serialization_alias="promptVersions")
+    welcome_message_type: str | None = Field(
+        None, serialization_alias="welcomeMessageType"
+    )
+    custom_welcome_message: str | None = Field(
+        None, serialization_alias="customWelcomeMessage"
+    )
+    current_prompt_id: uuid.UUID | None = Field(
+        None, serialization_alias="currentPromptId"
+    )
+    prompt_versions: List[PromptVersionOut] = Field(
+        default_factory=list, serialization_alias="promptVersions"
+    )
     flow_data: Dict[str, Any] | None = Field(None, serialization_alias="flowData")
     settings: Dict[str, Any] | None = None
-    knowledge_base_ids: List[str] = Field(default_factory=list, serialization_alias="knowledgeBaseIds")
-    folder_ids: List[uuid.UUID] = Field(default_factory=list, serialization_alias="folderIds")
+    knowledge_base_ids: List[str] = Field(
+        default_factory=list, serialization_alias="knowledgeBaseIds"
+    )
+    folder_ids: List[uuid.UUID] = Field(
+        default_factory=list, serialization_alias="folderIds"
+    )
     public_access: bool = Field(False, serialization_alias="publicAccess")
     status: str = "active"
     created_at: datetime = Field(..., serialization_alias="createdAt")
@@ -251,13 +308,23 @@ class CallFlowListItem(BaseModel):
     direction: str
     agent_id: uuid.UUID = Field(..., serialization_alias="agentId")
     agent: AgentRef | None = None
-    welcome_message_type: str | None = Field(None, serialization_alias="welcomeMessageType")
-    custom_welcome_message: str | None = Field(None, serialization_alias="customWelcomeMessage")
-    current_prompt_id: uuid.UUID | None = Field(None, serialization_alias="currentPromptId")
+    welcome_message_type: str | None = Field(
+        None, serialization_alias="welcomeMessageType"
+    )
+    custom_welcome_message: str | None = Field(
+        None, serialization_alias="customWelcomeMessage"
+    )
+    current_prompt_id: uuid.UUID | None = Field(
+        None, serialization_alias="currentPromptId"
+    )
     flow_data: Dict[str, Any] | None = Field(None, serialization_alias="flowData")
     settings: Dict[str, Any] | None = None
-    knowledge_base_ids: List[str] = Field(default_factory=list, serialization_alias="knowledgeBaseIds")
-    folder_ids: List[uuid.UUID] = Field(default_factory=list, serialization_alias="folderIds")
+    knowledge_base_ids: List[str] = Field(
+        default_factory=list, serialization_alias="knowledgeBaseIds"
+    )
+    folder_ids: List[uuid.UUID] = Field(
+        default_factory=list, serialization_alias="folderIds"
+    )
     public_access: bool = Field(False, serialization_alias="publicAccess")
     status: str = "active"
     created_at: datetime = Field(..., serialization_alias="createdAt")
@@ -297,7 +364,9 @@ class FlowDataResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     flow_data: Dict[str, Any] | None = Field(None, serialization_alias="flowData")
-    flow_data_compiled: Dict[str, Any] | None = Field(None, serialization_alias="flowDataCompiled")
+    flow_data_compiled: Dict[str, Any] | None = Field(
+        None, serialization_alias="flowDataCompiled"
+    )
     validation_errors: List[FlowValidationError] = Field(
         default_factory=list, serialization_alias="validationErrors"
     )
@@ -322,7 +391,9 @@ class FlowDataListItem(BaseModel):
     flow_id: uuid.UUID = Field(..., serialization_alias="flowId")
     name: str
     flow_data: Dict[str, Any] | None = Field(None, serialization_alias="flowData")
-    flow_data_compiled: Dict[str, Any] | None = Field(None, serialization_alias="flowDataCompiled")
+    flow_data_compiled: Dict[str, Any] | None = Field(
+        None, serialization_alias="flowDataCompiled"
+    )
     updated_at: datetime | None = Field(None, serialization_alias="updatedAt")
 
 

--- a/app/schemas/slack_integration.py
+++ b/app/schemas/slack_integration.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, model_validator
+
+
+class SlackAuthorizeResponse(BaseModel):
+    authorization_url: str
+
+
+class SlackChannelOut(BaseModel):
+    id: str
+    name: str
+
+
+class SlackDisconnectResponse(BaseModel):
+    disconnected: bool
+    provider: str = "slack"
+
+
+class SlackIntegrationStatusOut(BaseModel):
+    connected: bool
+    connected_at: datetime | None = None
+    team_name: str | None = None
+    default_channel_id: str | None = None
+    default_channel_name: str | None = None
+
+
+class SlackSetChannelRequest(BaseModel):
+    channel_id: str | None = None
+    channel_name: str | None = None
+
+    @model_validator(mode="after")
+    def validate_channel_pair(self) -> "SlackSetChannelRequest":
+        if bool(self.channel_id) != bool(self.channel_name):
+            raise ValueError(
+                "channel_id and channel_name must both be set (to select a "
+                "default channel) or both be omitted/null (to clear it)"
+            )
+        return self

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -1,4 +1,5 @@
 """Call Flow service — ALL versioning and business logic lives here."""
+
 from __future__ import annotations
 
 import uuid
@@ -157,9 +158,7 @@ class CallFlowService:
 
         return version
 
-    def _prompt_changed(
-        self, db: Session, flow: CallFlow, new_prompt: str
-    ) -> bool:
+    def _prompt_changed(self, db: Session, flow: CallFlow, new_prompt: str) -> bool:
         """Return True if new_prompt text differs from the currently active version."""
         if flow.current_prompt_id is None:
             return True
@@ -189,7 +188,9 @@ class CallFlowService:
     def _flow_to_out(self, db: Session, flow: CallFlow) -> dict:
         pv_repo = PromptVersionRepository(db)
         versions = pv_repo.find_by_flow(flow.id, order_desc=True)
-        folder_ids = CallFlowRepository(db).find_folder_ids_map([flow.id]).get(flow.id, [])
+        folder_ids = (
+            CallFlowRepository(db).find_folder_ids_map([flow.id]).get(flow.id, [])
+        )
 
         # Full AgentOut on detail endpoints (POST 201, GET, PUT)
         agent_dict: dict | None = None
@@ -318,9 +319,7 @@ class CallFlowService:
             ).scalar_one_or_none()
         return self._flow_to_out(db, flow)
 
-    def get_flow(
-        self, db: Session, flow_id: uuid.UUID, tenant_id: uuid.UUID
-    ) -> dict:
+    def get_flow(self, db: Session, flow_id: uuid.UUID, tenant_id: uuid.UUID) -> dict:
         flow = self._get_flow_or_404(db, flow_id, tenant_id, load_relations=True)
         if flow.agent is None:
             flow.agent = db.execute(
@@ -395,7 +394,10 @@ class CallFlowService:
             if self._prompt_changed(db, flow, body.prompt):
                 # Protect the existing active version from pruning
                 version = self._insert_prompt_version(
-                    db, flow.id, body.prompt, body.notes,
+                    db,
+                    flow.id,
+                    body.prompt,
+                    body.notes,
                     current_prompt_id=flow.current_prompt_id,
                 )
                 scalar_updates["current_prompt_id"] = version.id
@@ -455,11 +457,13 @@ class CallFlowService:
 
         # 409 if any active call session is using this flow
         active = db.execute(
-            select(CallSession).where(
+            select(CallSession)
+            .where(
                 CallSession.call_flow_id == flow_id,
                 CallSession.tenant_id == tenant_id,
                 CallSession.status == "active",
-            ).limit(1)
+            )
+            .limit(1)
         ).scalar_one_or_none()
         if active is not None:
             raise HTTPException(
@@ -597,20 +601,20 @@ class CallFlowService:
     ) -> VariantMetrics:
         row = db.execute(
             select(
-                func.count().label('calls'),
-                func.sum(
-                    case((CallSession.status == 'completed', 1), else_=0)
-                ).label('completed'),
-                func.sum(
-                    case((CallSession.status == 'failed', 1), else_=0)
-                ).label('failed'),
-                func.avg(CallSession.duration).label('avg_duration'),
+                func.count().label("calls"),
+                func.sum(case((CallSession.status == "completed", 1), else_=0)).label(
+                    "completed"
+                ),
+                func.sum(case((CallSession.status == "failed", 1), else_=0)).label(
+                    "failed"
+                ),
+                func.avg(CallSession.duration).label("avg_duration"),
                 func.sum(
                     case((CallSession.transferred == True, 1), else_=0)  # noqa: E712
-                ).label('transferred'),
+                ).label("transferred"),
                 func.sum(
-                    case((CallSession.success_evaluation == 'success', 1), else_=0)
-                ).label('successes'),
+                    case((CallSession.success_evaluation == "success", 1), else_=0)
+                ).label("successes"),
             ).where(
                 CallSession.call_flow_id == flow_id,
                 CallSession.tenant_id == tenant_id,
@@ -636,7 +640,10 @@ class CallFlowService:
         Guardrail: fewer than 30 calls on either variant is always inconclusive,
         regardless of p-value — too few samples for the test to be meaningful.
         """
-        if calls_a < _AB_MIN_CALLS_FOR_SIGNIFICANCE or calls_b < _AB_MIN_CALLS_FOR_SIGNIFICANCE:
+        if (
+            calls_a < _AB_MIN_CALLS_FOR_SIGNIFICANCE
+            or calls_b < _AB_MIN_CALLS_FOR_SIGNIFICANCE
+        ):
             return False, "inconclusive"
 
         contingency = [
@@ -693,8 +700,13 @@ class CallFlowService:
             flow,
             {
                 "email_summary_enabled": body.email_summary_enabled,
-                "email_summary_recipients": [str(e) for e in body.email_summary_recipients],
+                "email_summary_recipients": [
+                    str(e) for e in body.email_summary_recipients
+                ],
                 "summary_to_business_owner_enabled": body.summary_to_business_owner_enabled,
+                "slack_summary_enabled": body.slack_summary_enabled,
+                "slack_channel_id": body.slack_channel_id,
+                "slack_channel_name": body.slack_channel_name,
             },
         )
         db.commit()
@@ -703,6 +715,9 @@ class CallFlowService:
             email_summary_enabled=flow.email_summary_enabled,
             email_summary_recipients=list(flow.email_summary_recipients or []),
             summary_to_business_owner_enabled=flow.summary_to_business_owner_enabled,
+            slack_summary_enabled=flow.slack_summary_enabled,
+            slack_channel_id=flow.slack_channel_id,
+            slack_channel_name=flow.slack_channel_name,
         )
 
     def update_post_call_analysis_settings(
@@ -770,7 +785,6 @@ class CallFlowService:
                 select(Agent).where(Agent.id == flow.agent_id)
             ).scalar_one_or_none()
         return self._flow_to_out(db, flow)
-
 
     # ── Visual Flow Editor ────────────────────────────────────────────────
 

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -77,17 +77,25 @@ def _fire_callback_enqueue(schedule_id: uuid.UUID, scheduled_at: datetime) -> No
 
 class CallSessionService:
     """Service class for handling call session operations"""
-    
-    def create_call_session(self, db: Session, user_id: uuid.UUID, agent_id: uuid.UUID,
-                           tenant_id: uuid.UUID, twilio_call_sid: str = None,
-                           from_number: str = None, to_number: str = None,
-                           call_type: str = "inbound", assistant_phone_number: str = None,
-                           customer_phone_number: str = None,
-                           session_id: uuid.UUID | None = None,
-                           status: str = "active") -> CallSession:
+
+    def create_call_session(
+        self,
+        db: Session,
+        user_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        twilio_call_sid: str = None,
+        from_number: str = None,
+        to_number: str = None,
+        call_type: str = "inbound",
+        assistant_phone_number: str = None,
+        customer_phone_number: str = None,
+        session_id: uuid.UUID | None = None,
+        status: str = "active",
+    ) -> CallSession:
         """
         Create a new call session and associated call log
-        
+
         Args:
             db: Database session
             user_id: User ID
@@ -99,11 +107,11 @@ class CallSessionService:
             call_type: Type of call (inbound, outbound, web)
             assistant_phone_number: Assistant's phone number
             customer_phone_number: Customer's phone number
-            
+
         Returns:
             CallSession object
         """
-        
+
         call_session = CallSession(
             id=session_id if session_id is not None else uuid.uuid4(),
             user_id=user_id,
@@ -118,30 +126,36 @@ class CallSessionService:
             assistant_phone_number=assistant_phone_number,
             customer_phone_number=customer_phone_number,
             call_transcript=[],
-            response_times=[]
+            response_times=[],
         )
-        
+
         db.add(call_session)
         db.commit()
         db.refresh(call_session)
-        
+
         # Create associated call log
         self._create_call_log_for_session(db, call_session)
-        
+
         # Broadcast call session created event
-        asyncio.create_task(self._broadcast_call_event(
-            str(call_session.id), 
-            "call_session_created", 
-            {
-                "call_session_id": str(call_session.id),
-                "status": call_session.status,
-                "call_type": call_session.call_type,
-                "start_time": call_session.start_time.isoformat() if call_session.start_time else None
-            }
-        ))
-        
+        asyncio.create_task(
+            self._broadcast_call_event(
+                str(call_session.id),
+                "call_session_created",
+                {
+                    "call_session_id": str(call_session.id),
+                    "status": call_session.status,
+                    "call_type": call_session.call_type,
+                    "start_time": (
+                        call_session.start_time.isoformat()
+                        if call_session.start_time
+                        else None
+                    ),
+                },
+            )
+        )
+
         return call_session
-    
+
     def _record_demo_link_usage(self, db: Session, call_session: CallSession) -> None:
         """
         Credit a finished call's duration against its originating demo link's
@@ -178,23 +192,32 @@ class CallSessionService:
             return
 
         from app.models.call_flow_demo_link import CallFlowDemoLink
-        from app.models.call_flow_demo_link_visitor_usage import CallFlowDemoLinkVisitorUsage
+        from app.models.call_flow_demo_link_visitor_usage import (
+            CallFlowDemoLinkVisitorUsage,
+        )
 
         try:
             demo_link_uuid = uuid.UUID(str(demo_link_id))
         except ValueError:
             logger.warning(
                 "Demo link usage accounting: malformed demo_link_id=%r session=%s",
-                demo_link_id, call_session.id,
+                demo_link_id,
+                call_session.id,
             )
             return
 
         minutes = Decimal(call_session.duration) / Decimal(60)
 
-        demo_link = db.query(CallFlowDemoLink).filter(CallFlowDemoLink.id == demo_link_uuid).first()
+        demo_link = (
+            db.query(CallFlowDemoLink)
+            .filter(CallFlowDemoLink.id == demo_link_uuid)
+            .first()
+        )
         if demo_link is None:
             return
-        demo_link.total_minutes_used = (demo_link.total_minutes_used or Decimal("0")) + minutes
+        demo_link.total_minutes_used = (
+            demo_link.total_minutes_used or Decimal("0")
+        ) + minutes
 
         visitor_usage = (
             db.query(CallFlowDemoLinkVisitorUsage)
@@ -205,19 +228,26 @@ class CallSessionService:
             .first()
         )
         if visitor_usage is not None:
-            visitor_usage.minutes_used = (visitor_usage.minutes_used or Decimal("0")) + minutes
+            visitor_usage.minutes_used = (
+                visitor_usage.minutes_used or Decimal("0")
+            ) + minutes
 
         db.commit()
         logger.info(
             "Demo link usage recorded demo_link_id=%s visitor_id=%s session=%s minutes=%s",
-            demo_link_id, visitor_id, call_session.id, minutes,
+            demo_link_id,
+            visitor_id,
+            call_session.id,
+            minutes,
         )
 
-    def _create_call_log_for_session(self, db: Session, call_session: CallSession) -> CallLog:
+    def _create_call_log_for_session(
+        self, db: Session, call_session: CallSession
+    ) -> CallLog:
         """Create a call log entry for a call session"""
         # Generate a shortened call ID for display (like in Vapi dashboard)
         call_id = str(call_session.id)[:8] + "..."
-        
+
         call_log_data = CallLogCreate(
             call_session_id=call_session.id,
             tenant_id=call_session.tenant_id,
@@ -226,23 +256,33 @@ class CallSessionService:
             call_type=call_session.call_type,
             assistant_phone_number=call_session.assistant_phone_number,
             customer_phone_number=call_session.customer_phone_number,
-            start_time=call_session.start_time
+            start_time=call_session.start_time,
         )
-        
+
         call_log = CallLog(**call_log_data.dict())
         db.add(call_log)
         db.commit()
         db.refresh(call_log)
-        
+
         return call_log
-    
-    def _update_call_log_for_session(self, db: Session, call_session: CallSession, 
-                                   ended_reason: str = None, success_evaluation: str = None,
-                                   cost: float = None, transferred: bool = None) -> CallLog | None:
+
+    def _update_call_log_for_session(
+        self,
+        db: Session,
+        call_session: CallSession,
+        ended_reason: str = None,
+        success_evaluation: str = None,
+        cost: float = None,
+        transferred: bool = None,
+    ) -> CallLog | None:
         """Update call log entry for a call session"""
         try:
-            call_log = db.query(CallLog).filter(CallLog.call_session_id == call_session.id).first()
-            
+            call_log = (
+                db.query(CallLog)
+                .filter(CallLog.call_session_id == call_session.id)
+                .first()
+            )
+
             if call_log:
                 if ended_reason:
                     call_log.ended_reason = ended_reason
@@ -256,50 +296,70 @@ class CallSessionService:
                     call_log.end_time = call_session.end_time
                 if call_session.duration:
                     call_log.duration = call_session.duration
-                
+
                 call_log.updated_at = datetime.utcnow()
                 db.commit()
                 db.refresh(call_log)
-            
+
             return call_log
 
         except Exception as e:
             db.rollback()
-            logger.error("DB error in _update_call_log_for_session (session=%s): %s", call_session.id, e, exc_info=True)
+            logger.error(
+                "DB error in _update_call_log_for_session (session=%s): %s",
+                call_session.id,
+                e,
+                exc_info=True,
+            )
             return None
-    
-    def get_call_session_by_id(self, db: Session, session_id: uuid.UUID) -> CallSession | None:
+
+    def get_call_session_by_id(
+        self, db: Session, session_id: uuid.UUID
+    ) -> CallSession | None:
         """
         Get call session by ID
-        
+
         Args:
             db: Database session
             session_id: Session ID (UUID)
-            
+
         Returns:
             CallSession object or None
         """
         return db.query(CallSession).filter(CallSession.id == session_id).first()
-    
-    def get_call_session_by_twilio_sid(self, db: Session, twilio_call_sid: str) -> CallSession | None:
+
+    def get_call_session_by_twilio_sid(
+        self, db: Session, twilio_call_sid: str
+    ) -> CallSession | None:
         """
         Get call session by Twilio call SID
-        
+
         Args:
             db: Database session
             twilio_call_sid: Twilio call SID
-            
+
         Returns:
             CallSession object or None
         """
-        return db.query(CallSession).filter(CallSession.twilio_call_sid == twilio_call_sid).first()
-    
-    def update_call_session_status(self, db: Session, session_id: uuid.UUID, status: str, 
-                                 ended_reason: str = None, success_evaluation: str = None,
-                                 cost: float = None, transferred: bool = None) -> CallSession | None:
+        return (
+            db.query(CallSession)
+            .filter(CallSession.twilio_call_sid == twilio_call_sid)
+            .first()
+        )
+
+    def update_call_session_status(
+        self,
+        db: Session,
+        session_id: uuid.UUID,
+        status: str,
+        ended_reason: str = None,
+        success_evaluation: str = None,
+        cost: float = None,
+        transferred: bool = None,
+    ) -> CallSession | None:
         """
         Update call session status and associated call log
-        
+
         Args:
             db: Database session
             session_id: Session ID (UUID)
@@ -307,7 +367,7 @@ class CallSessionService:
             ended_reason: Reason why call ended
             success_evaluation: Whether call was successful
             cost: Cost of the call
-            
+
         Returns:
             Updated CallSession object or None
         """
@@ -315,7 +375,7 @@ class CallSessionService:
             call_session = self.get_call_session_by_id(db, session_id)
             if call_session:
                 call_session.status = status
-                
+
                 if ended_reason:
                     call_session.ended_reason = ended_reason
                 if success_evaluation:
@@ -324,18 +384,25 @@ class CallSessionService:
                     call_session.cost = cost
                 if transferred is not None:
                     call_session.transferred = transferred
-                
+
                 if status in ["completed", "failed", "busy", "no_answer"]:
                     call_session.end_time = datetime.now(timezone.utc)
                     if call_session.start_time:
-                        duration = (call_session.end_time - call_session.start_time).total_seconds()
+                        duration = (
+                            call_session.end_time - call_session.start_time
+                        ).total_seconds()
                         call_session.duration = int(duration)
 
                 db.commit()
                 db.refresh(call_session)
 
                 self._update_call_log_for_session(
-                    db, call_session, ended_reason, success_evaluation, cost, transferred
+                    db,
+                    call_session,
+                    ended_reason,
+                    success_evaluation,
+                    cost,
+                    transferred,
                 )
 
                 # Demo link minute accounting: a call session created via
@@ -344,16 +411,20 @@ class CallSessionService:
                 # (see app/routers/sdk.py::demo_call_token). On terminal status
                 # with a computed duration, credit that duration against the
                 # link's total budget and the visitor's per-user budget.
-                is_demo_link_call = isinstance(call_session.call_metadata, dict) and isinstance(
-                    call_session.call_metadata.get("demo_link"), dict
-                )
-                if status in ("completed", "failed", "busy", "no_answer") and call_session.duration:
+                is_demo_link_call = isinstance(
+                    call_session.call_metadata, dict
+                ) and isinstance(call_session.call_metadata.get("demo_link"), dict)
+                if (
+                    status in ("completed", "failed", "busy", "no_answer")
+                    and call_session.duration
+                ):
                     try:
                         self._record_demo_link_usage(db, call_session)
                     except Exception as demo_exc:  # pragma: no cover
                         logger.warning(
                             "Demo link usage accounting failed (non-critical) session=%s: %s",
-                            session_id, demo_exc,
+                            session_id,
+                            demo_exc,
                         )
 
                 is_inbound_crm_sync_call = (
@@ -365,7 +436,9 @@ class CallSessionService:
                     try:
                         schedule_inbound_crm_sync(call_session.id)
                     except Exception as sync_exc:  # pragma: no cover
-                        logger.warning("Inbound CRM schedule failed (non-critical): %s", sync_exc)
+                        logger.warning(
+                            "Inbound CRM schedule failed (non-critical): %s", sync_exc
+                        )
 
                 # Automatic call summary generation: run the LLM
                 # summary/sentiment/recommendations analysis once, right when
@@ -436,6 +509,28 @@ class CallSessionService:
                             email_exc,
                         )
 
+                # Post-call Slack summary ("Slack Summary" toggle on the call flow's
+                # post-call-actions settings). Per-call-flow opt-in — connecting Slack
+                # for the workspace (see WorkspaceIntegration, provider="slack") does
+                # not activate this for every call flow. Fire-and-forget (fail open) —
+                # see app/services/slack_service.py::schedule_slack_summary.
+                if status == "completed" and not is_inbound_crm_sync_call:
+                    try:
+                        call_flow = call_session.call_flow
+                        if call_flow and call_flow.slack_summary_enabled:
+                            from app.services.slack_service import (
+                                schedule_slack_summary,
+                                tenant_has_slack_connected,
+                            )
+
+                            if tenant_has_slack_connected(db, call_session.tenant_id):
+                                schedule_slack_summary(call_session.id)
+                    except Exception as slack_exc:  # pragma: no cover
+                        logger.warning(
+                            "Slack summary schedule failed (non-critical): %s",
+                            slack_exc,
+                        )
+
                 # HubSpot post-call write-back: create a Call engagement with the
                 # transcript summary once the call has actually completed. Fire-and-forget
                 # (fail open) — see app/services/hubspot_service.py::schedule_hubspot_writeback.
@@ -453,7 +548,8 @@ class CallSessionService:
                             schedule_hubspot_writeback(call_session.id)
                     except Exception as hubspot_exc:  # pragma: no cover
                         logger.warning(
-                            "HubSpot write-back schedule failed (non-critical): %s", hubspot_exc
+                            "HubSpot write-back schedule failed (non-critical): %s",
+                            hubspot_exc,
                         )
 
                 # Salesforce post-call write-back: create a Task (Activity) with the
@@ -502,12 +598,19 @@ class CallSessionService:
                 # will re-submit it when the ARQ worker next starts.
                 if status in ("no_answer", "busy"):
                     try:
-                        from app.services.callback_scheduler_service import callback_scheduler_service
-                        cb_schedule = callback_scheduler_service.maybe_schedule_callback(
-                            db, call_session
+                        from app.services.callback_scheduler_service import (
+                            callback_scheduler_service,
+                        )
+
+                        cb_schedule = (
+                            callback_scheduler_service.maybe_schedule_callback(
+                                db, call_session
+                            )
                         )
                         if cb_schedule is not None:
-                            _fire_callback_enqueue(cb_schedule.id, cb_schedule.scheduled_at)
+                            _fire_callback_enqueue(
+                                cb_schedule.id, cb_schedule.scheduled_at
+                            )
                     except Exception as cb_exc:
                         logger.warning(
                             "Smart callback schedule failed (non-critical) session=%s: %s",
@@ -519,21 +622,33 @@ class CallSessionService:
 
         except Exception as e:
             db.rollback()
-            logger.error("DB error in update_call_session_status (session=%s status=%s): %s", session_id, status, e, exc_info=True)
+            logger.error(
+                "DB error in update_call_session_status (session=%s status=%s): %s",
+                session_id,
+                status,
+                e,
+                exc_info=True,
+            )
             return None
-    
-    def add_transcript_entry(self, db: Session, session_id: uuid.UUID, role: str, content: str, 
-                           response_time: float = None) -> CallSession | None:
+
+    def add_transcript_entry(
+        self,
+        db: Session,
+        session_id: uuid.UUID,
+        role: str,
+        content: str,
+        response_time: float = None,
+    ) -> CallSession | None:
         """
         Add a transcript entry to the call session
-        
+
         Args:
             db: Database session
             session_id: Session ID (UUID)
             role: Role (user or assistant)
             content: Message content
             response_time: Response time in seconds
-            
+
         Returns:
             Updated CallSession object or None
         """
@@ -542,103 +657,122 @@ class CallSessionService:
             # Initialize transcript if None
             if call_session.call_transcript is None:
                 call_session.call_transcript = []
-            
+
             # Add transcript entry
             transcript_entry = {
                 "timestamp": datetime.utcnow().isoformat(),
                 "role": role,
-                "content": content
+                "content": content,
             }
             call_session.call_transcript.append(transcript_entry)
-            
+
             # Add response time if provided
             if response_time is not None:
                 if call_session.response_times is None:
                     call_session.response_times = []
-                
+
                 response_time_entry = {
                     "timestamp": datetime.utcnow().isoformat(),
-                    "response_time": response_time
+                    "response_time": response_time,
                 }
                 call_session.response_times.append(response_time_entry)
-            
+
             db.commit()
             db.refresh(call_session)
-        
+
         return call_session
-    
-    def get_call_sessions_by_user(self, db: Session, user_id: uuid.UUID, 
-                                 limit: int = 50) -> List[CallSession]:
+
+    def get_call_sessions_by_user(
+        self, db: Session, user_id: uuid.UUID, limit: int = 50
+    ) -> List[CallSession]:
         """
         Get call sessions for a specific user
-        
+
         Args:
             db: Database session
             user_id: User ID
             limit: Maximum number of results
-            
+
         Returns:
             List of CallSession objects
         """
-        return db.query(CallSession).filter(
-            CallSession.user_id == user_id
-        ).order_by(CallSession.created_at.desc()).limit(limit).all()
-    
-    def get_call_sessions_by_agent(self, db: Session, agent_id: uuid.UUID, 
-                                  limit: int = 50) -> List[CallSession]:
+        return (
+            db.query(CallSession)
+            .filter(CallSession.user_id == user_id)
+            .order_by(CallSession.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def get_call_sessions_by_agent(
+        self, db: Session, agent_id: uuid.UUID, limit: int = 50
+    ) -> List[CallSession]:
         """
         Get call sessions for a specific agent
-        
+
         Args:
             db: Database session
             agent_id: Agent ID
             limit: Maximum number of results
-            
+
         Returns:
             List of CallSession objects
         """
-        return db.query(CallSession).filter(
-            CallSession.agent_id == agent_id
-        ).order_by(CallSession.created_at.desc()).limit(limit).all()
-    
-    def get_call_sessions_by_tenant(self, db: Session, tenant_id: uuid.UUID, 
-                                   limit: int = 100) -> List[CallSession]:
+        return (
+            db.query(CallSession)
+            .filter(CallSession.agent_id == agent_id)
+            .order_by(CallSession.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def get_call_sessions_by_tenant(
+        self, db: Session, tenant_id: uuid.UUID, limit: int = 100
+    ) -> List[CallSession]:
         """
         Get call sessions for a specific tenant
-        
+
         Args:
             db: Database session
             tenant_id: Tenant ID
             limit: Maximum number of results
-            
+
         Returns:
             List of CallSession objects
         """
-        return db.query(CallSession).filter(
-            CallSession.tenant_id == tenant_id
-        ).order_by(CallSession.created_at.desc()).limit(limit).all()
-    
-    def get_call_session_stats(self, db: Session, session_id: uuid.UUID) -> Dict[str, Any]:
+        return (
+            db.query(CallSession)
+            .filter(CallSession.tenant_id == tenant_id)
+            .order_by(CallSession.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+    def get_call_session_stats(
+        self, db: Session, session_id: uuid.UUID
+    ) -> Dict[str, Any]:
         """
         Get statistics for a call session
-        
+
         Args:
             db: Database session
             session_id: Session ID (UUID)
-            
+
         Returns:
             Dictionary with call session statistics
         """
         call_session = self.get_call_session_by_id(db, session_id)
         if not call_session:
             return {}
-        
+
         # Calculate average response time
         avg_response_time = None
         if call_session.response_times:
-            total_time = sum(entry.get("response_time", 0) for entry in call_session.response_times)
+            total_time = sum(
+                entry.get("response_time", 0) for entry in call_session.response_times
+            )
             avg_response_time = total_time / len(call_session.response_times)
-        
+
         # Count messages by role
         user_messages = 0
         assistant_messages = 0
@@ -648,51 +782,70 @@ class CallSessionService:
                     user_messages += 1
                 elif entry.get("role") == "assistant":
                     assistant_messages += 1
-        
+
         return {
             "session_id": str(call_session.id),
             "status": call_session.status,
             "duration": call_session.duration,
-            "start_time": call_session.start_time.isoformat() if call_session.start_time else None,
-            "end_time": call_session.end_time.isoformat() if call_session.end_time else None,
-            "total_messages": len(call_session.call_transcript) if call_session.call_transcript else 0,
+            "start_time": (
+                call_session.start_time.isoformat() if call_session.start_time else None
+            ),
+            "end_time": (
+                call_session.end_time.isoformat() if call_session.end_time else None
+            ),
+            "total_messages": (
+                len(call_session.call_transcript) if call_session.call_transcript else 0
+            ),
             "user_messages": user_messages,
             "assistant_messages": assistant_messages,
             "average_response_time": avg_response_time,
-            "total_response_time_entries": len(call_session.response_times) if call_session.response_times else 0
+            "total_response_time_entries": (
+                len(call_session.response_times) if call_session.response_times else 0
+            ),
         }
-    
-    async def _broadcast_call_event(self, call_session_id: str, event_type: str, event_data: dict):
+
+    async def _broadcast_call_event(
+        self, call_session_id: str, event_type: str, event_data: dict
+    ):
         """Broadcast a call event to WebSocket connections"""
         try:
             from app.routers.general_websocket import broadcast_call_event
+
             await broadcast_call_event(call_session_id, event_type, event_data)
         except Exception as e:
             logger.error(f"Error broadcasting call event: {e}")
-    
-    async def _broadcast_status_update(self, call_session_id: str, status: str, metadata: dict = None):
+
+    async def _broadcast_status_update(
+        self, call_session_id: str, status: str, metadata: dict = None
+    ):
         """Broadcast call status update to WebSocket connections"""
         try:
             from app.routers.general_websocket import broadcast_call_status_update
+
             await broadcast_call_status_update(call_session_id, status, metadata)
         except Exception as e:
             logger.error(f"Error broadcasting status update: {e}")
-    
-    async def _broadcast_transcript_update(self, call_session_id: str, transcript: list, new_messages: list = None):
+
+    async def _broadcast_transcript_update(
+        self, call_session_id: str, transcript: list, new_messages: list = None
+    ):
         """Broadcast transcript update to WebSocket connections"""
         try:
             from app.routers.general_websocket import broadcast_transcript_update
+
             await broadcast_transcript_update(call_session_id, transcript, new_messages)
         except Exception as e:
             logger.error(f"Error broadcasting transcript update: {e}")
-    
+
     async def _broadcast_metadata_update(self, call_session_id: str, metadata: dict):
         """Broadcast call metadata update to WebSocket connections"""
         try:
             from app.routers.general_websocket import broadcast_call_metadata_update
+
             await broadcast_call_metadata_update(call_session_id, metadata)
         except Exception as e:
             logger.error(f"Error broadcasting metadata update: {e}")
+
 
 # Global instance
 call_session_service = CallSessionService()

--- a/app/services/call_session_service.py
+++ b/app/services/call_session_service.py
@@ -6,6 +6,7 @@ Handles call session management including creation, updates, and retrieval
 from sqlalchemy.orm import Session
 from app.models.call_session import CallSession
 from app.models.call_log import CallLog
+from app.models.call_flow import CallFlow
 from app.schemas.call_log import CallLogCreate
 from typing import List, Dict, Any
 import uuid
@@ -516,7 +517,13 @@ class CallSessionService:
                 # see app/services/slack_service.py::schedule_slack_summary.
                 if status == "completed" and not is_inbound_crm_sync_call:
                     try:
-                        call_flow = call_session.call_flow
+                        call_flow = (
+                            db.query(CallFlow)
+                            .filter(CallFlow.id == call_session.call_flow_id)
+                            .first()
+                            if call_session.call_flow_id
+                            else None
+                        )
                         if call_flow and call_flow.slack_summary_enabled:
                             from app.services.slack_service import (
                                 schedule_slack_summary,

--- a/app/services/slack_service.py
+++ b/app/services/slack_service.py
@@ -1,0 +1,536 @@
+"""
+Slack integration — OAuth v2, channel listing, and post-call summary posting.
+
+External HTTP calls: Slack OAuth (slack.com/api/oauth.v2.access),
+conversations.list (fetch channels), chat.postMessage (post a summary), and
+auth.revoke (best-effort token revocation on disconnect).
+
+Rate limiting: Slack's Web API returns 429 with a `Retry-After` header when a
+tenant's app exceeds its per-method rate limit — `_request_with_backoff`
+retries on 429 with exponential backoff (honoring Retry-After when present),
+mirroring `hubspot_service.py`.
+
+`send_call_summary` (the call-time write path) fails open: a Slack outage or
+misconfiguration never blocks or affects call completion. `list_channels`
+(an admin-facing settings action, not call-time) raises on failure instead —
+mirroring how HubSpot's field-mapping property fetch (also an admin action)
+raises rather than fails open, since silently returning an empty channel list
+would look like "workspace has no channels" rather than "Slack is down".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from urllib.parse import urlencode
+
+import httpx
+from jose import JWTError, jwt
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.attributes import flag_modified
+
+from app.core.config import settings
+from app.core.db_encryption import decrypt_slack_token, encrypt_slack_token
+from app.core.logger import logger
+from app.core.secret_manager import get_slack_oauth_credentials
+from app.db.session import SessionLocal
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.models.workspace_integration import WorkspaceIntegration
+
+AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
+TOKEN_URL = "https://slack.com/api/oauth.v2.access"
+REVOKE_URL = "https://slack.com/api/auth.revoke"
+CONVERSATIONS_LIST_URL = "https://slack.com/api/conversations.list"
+POST_MESSAGE_URL = "https://slack.com/api/chat.postMessage"
+
+# Minimal bot-token scopes needed to list channels and post the summary message.
+# chat:write.public is required to post to a public channel the bot hasn't been
+# manually invited to — conversations.list surfaces every public channel in the
+# workspace regardless of bot membership, so without this scope most selected
+# channels would fail to receive messages with a silent (fail-open) not_in_channel
+# error. Private channels still require a manual /invite regardless of scope —
+# that's a Slack platform restriction with no API workaround.
+SCOPES = "channels:read,groups:read,chat:write,chat:write.public"
+
+PROVIDER = "slack"
+
+_MAX_RETRIES = 5
+_BASE_BACKOFF_SECONDS = 1.0
+
+_STATE_PURPOSE = "slack_oauth_state"
+_STATE_TTL_MINUTES = 10
+
+_MAX_ERROR_LEN = 500
+
+
+# ─── HTTP with backoff ────────────────────────────────────────────────────────
+
+
+async def _request_with_backoff(method: str, url: str, **kwargs) -> httpx.Response:
+    """Call Slack with exponential backoff on 429 (1s, 2s, 4s, 8s, 16s)."""
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        attempt = 0
+        while True:
+            response = await client.request(method, url, **kwargs)
+            if response.status_code != 429 or attempt >= _MAX_RETRIES:
+                return response
+
+            retry_after_header = response.headers.get("Retry-After")
+            wait_seconds = (
+                float(retry_after_header)
+                if retry_after_header
+                else _BASE_BACKOFF_SECONDS * (2**attempt)
+            )
+            logger.warning(
+                "Slack 429 on %s %s; retrying in %.1fs (attempt %d/%d)",
+                method,
+                url,
+                wait_seconds,
+                attempt + 1,
+                _MAX_RETRIES,
+            )
+            await asyncio.sleep(wait_seconds)
+            attempt += 1
+
+
+# ─── OAuth state (signed, carries tenant_id through the redirect round-trip) ──
+
+
+def build_oauth_state(tenant_id: uuid.UUID) -> str:
+    payload = {
+        "tenant_id": str(tenant_id),
+        "purpose": _STATE_PURPOSE,
+        "exp": datetime.now(timezone.utc) + timedelta(minutes=_STATE_TTL_MINUTES),
+    }
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def verify_oauth_state(state: str) -> uuid.UUID:
+    """Raises ValueError if state is missing, expired, tampered, or malformed."""
+    try:
+        payload = jwt.decode(
+            state, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+        )
+    except JWTError as exc:
+        raise ValueError("Invalid or expired OAuth state") from exc
+
+    if payload.get("purpose") != _STATE_PURPOSE:
+        raise ValueError("Invalid OAuth state purpose")
+
+    tenant_id_str = payload.get("tenant_id")
+    if not tenant_id_str:
+        raise ValueError("OAuth state missing tenant_id")
+
+    try:
+        return uuid.UUID(tenant_id_str)
+    except ValueError as exc:
+        raise ValueError("OAuth state has malformed tenant_id") from exc
+
+
+def get_redirect_uri() -> str:
+    return settings.SLACK_REDIRECT_URI or (
+        f"{settings.WEBHOOK_BASE_URL.rstrip('/')}/api/v1/integrations/slack/callback"
+    )
+
+
+def get_authorization_url(tenant_id: uuid.UUID) -> str:
+    client_id, _ = get_slack_oauth_credentials()
+    state = build_oauth_state(tenant_id)
+    params = {
+        "client_id": client_id,
+        "redirect_uri": get_redirect_uri(),
+        "scope": SCOPES,
+        "state": state,
+    }
+    return f"{AUTHORIZE_URL}?{urlencode(params)}"
+
+
+# ─── Token exchange ────────────────────────────────────────────────────────────
+
+
+async def exchange_code_for_tokens(code: str) -> dict:
+    """
+    POST to Slack's oauth.v2.access. Slack always returns HTTP 200 even on
+    failure, signalling errors via `ok: false` + `error` in the JSON body —
+    unlike HubSpot's token endpoint, which uses HTTP status codes.
+    """
+    client_id, client_secret = get_slack_oauth_credentials()
+    response = await _request_with_backoff(
+        "POST",
+        TOKEN_URL,
+        data={
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": get_redirect_uri(),
+            "code": code,
+        },
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not payload.get("ok"):
+        raise ValueError(f"Slack OAuth token exchange failed: {payload.get('error')}")
+    return payload
+
+
+# ─── WorkspaceIntegration CRUD ────────────────────────────────────────────────
+
+
+def get_integration(db: Session, tenant_id: uuid.UUID) -> WorkspaceIntegration | None:
+    return (
+        db.query(WorkspaceIntegration)
+        .filter(
+            WorkspaceIntegration.workspace_id == tenant_id,
+            WorkspaceIntegration.provider == PROVIDER,
+        )
+        .first()
+    )
+
+
+def tenant_has_slack_connected(db: Session, tenant_id: uuid.UUID) -> bool:
+    return get_integration(db, tenant_id) is not None
+
+
+def upsert_integration(
+    db: Session, tenant_id: uuid.UUID, token_response: dict
+) -> WorkspaceIntegration:
+    """
+    Encrypt+store the bot token, plus team_id/team_name in extra_metadata.
+
+    Slack bot tokens (`xoxb-...`) issued via oauth.v2.access do not expire and
+    there is no refresh_token in the response, unlike HubSpot's OAuth flow.
+    """
+    access_token = token_response["access_token"]
+    team = token_response.get("team") or {}
+
+    row = get_integration(db, tenant_id)
+    if row is None:
+        row = WorkspaceIntegration(workspace_id=tenant_id, provider=PROVIDER)
+
+    row.access_token = encrypt_slack_token(access_token, db)
+
+    updated_metadata = dict(row.extra_metadata or {})
+    updated_metadata["team_id"] = team.get("id")
+    updated_metadata["team_name"] = team.get("name")
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+async def get_valid_access_token(db: Session, tenant_id: uuid.UUID) -> str | None:
+    """
+    Return the decrypted bot token, or None if not connected.
+
+    Slack bot tokens don't expire, so there's no refresh cycle — this helper
+    exists purely to centralize the decrypt call so future rotation support
+    (e.g. token rotation via Slack's newer OAuth flows) only touches one place.
+    """
+    row = get_integration(db, tenant_id)
+    if row is None or not row.access_token:
+        return None
+    return decrypt_slack_token(row.access_token, db)
+
+
+def get_integration_status(db: Session, tenant_id: uuid.UUID) -> dict:
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return {
+            "connected": False,
+            "connected_at": None,
+            "team_name": None,
+            "default_channel_id": None,
+            "default_channel_name": None,
+        }
+
+    metadata = row.extra_metadata or {}
+    return {
+        "connected": True,
+        "connected_at": row.created_at,
+        "team_name": metadata.get("team_name"),
+        "default_channel_id": metadata.get("default_channel_id"),
+        "default_channel_name": metadata.get("default_channel_name"),
+    }
+
+
+def set_default_channel(
+    db: Session, tenant_id: uuid.UUID, channel_id: str | None, channel_name: str | None
+) -> WorkspaceIntegration:
+    """Persist (or clear, when both args are None) the workspace's default Slack channel."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        raise ValueError("Slack is not connected for this workspace")
+
+    updated_metadata = dict(row.extra_metadata or {})
+    if channel_id:
+        updated_metadata["default_channel_id"] = channel_id
+        updated_metadata["default_channel_name"] = channel_name
+    else:
+        updated_metadata.pop("default_channel_id", None)
+        updated_metadata.pop("default_channel_name", None)
+    row.extra_metadata = updated_metadata
+    flag_modified(row, "extra_metadata")
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+async def disconnect(db: Session, tenant_id: uuid.UUID) -> bool:
+    """Revoke the bot token at Slack (best-effort) and delete the local row."""
+    row = get_integration(db, tenant_id)
+    if row is None:
+        return False
+
+    try:
+        access_token = decrypt_slack_token(row.access_token, db)
+        await _request_with_backoff(
+            "POST",
+            REVOKE_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    except Exception:
+        logger.warning(
+            "Slack token revoke failed (continuing with local disconnect) tenant=%s",
+            tenant_id,
+            exc_info=True,
+        )
+
+    db.delete(row)
+    db.commit()
+    return True
+
+
+# ─── Channel listing (admin-facing settings action — raises on failure) ───────
+
+
+async def list_channels(db: Session, tenant_id: uuid.UUID) -> list[dict]:
+    """
+    Fetch the tenant's available Slack channels via conversations.list.
+
+    Admin-facing settings action, not a call-time path — raises ValueError on
+    any failure (Slack not connected, API error) instead of failing open, so
+    the dashboard can surface a clear error rather than silently showing an
+    empty channel list.
+    """
+    access_token = await get_valid_access_token(db, tenant_id)
+    if not access_token:
+        raise ValueError("Slack is not connected for this workspace")
+
+    channels: list[dict] = []
+    cursor: str | None = None
+    while True:
+        params = {
+            "types": "public_channel,private_channel",
+            "exclude_archived": "true",
+            "limit": "200",
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        response = await _request_with_backoff(
+            "GET",
+            CONVERSATIONS_LIST_URL,
+            headers={"Authorization": f"Bearer {access_token}"},
+            params=params,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not payload.get("ok"):
+            raise ValueError(f"Slack conversations.list failed: {payload.get('error')}")
+
+        for ch in payload.get("channels") or []:
+            channels.append({"id": ch.get("id"), "name": ch.get("name")})
+
+        cursor = (payload.get("response_metadata") or {}).get("next_cursor") or None
+        if not cursor:
+            break
+
+    return channels
+
+
+# ─── Post-call summary send (chat.postMessage) ─────────────────────────────────
+
+
+def _resolve_channel(
+    call_flow: CallFlow, integration: WorkspaceIntegration
+) -> str | None:
+    if call_flow.slack_channel_id:
+        return call_flow.slack_channel_id
+    metadata = integration.extra_metadata or {}
+    return metadata.get("default_channel_id")
+
+
+def _sentiment_and_summary(call_session: CallSession) -> tuple[str, str | None]:
+    """
+    Pull the summary/sentiment computed by voice_analysis_service.analyze_call_transcript
+    (cached on call_session.call_metadata["llm_call_analysis"]). Lazily computes it
+    (serialized against the automatic ARQ job via the same pg advisory lock) if it
+    isn't cached yet — mirrors post_call_email_service._build_email_content /
+    _send_post_call_email_summary_impl.
+    """
+    analysis_data: dict = {}
+    if call_session.call_metadata and "llm_call_analysis" in call_session.call_metadata:
+        analysis_data = (
+            call_session.call_metadata["llm_call_analysis"].get("analysis") or {}
+        )
+
+    summary = (
+        call_session.transcript_summary
+        or analysis_data.get("summary")
+        or "No summary available."
+    )
+    sentiment = analysis_data.get("sentiment")
+    return summary, sentiment
+
+
+async def _post_message(
+    access_token: str, channel: str, text: str, blocks: list[dict]
+) -> None:
+    response = await _request_with_backoff(
+        "POST",
+        POST_MESSAGE_URL,
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={"channel": channel, "text": text, "blocks": blocks},
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if not payload.get("ok"):
+        raise ValueError(f"Slack chat.postMessage failed: {payload.get('error')}")
+
+
+def _safe_error_msg(exc: Exception) -> str:
+    msg = str(exc)
+    return msg[:_MAX_ERROR_LEN]
+
+
+async def _send_call_summary_async(db: Session, call_session_id: uuid.UUID) -> None:
+    call_session = (
+        db.query(CallSession).filter(CallSession.id == call_session_id).first()
+    )
+    if not call_session:
+        return
+
+    if not call_session.call_flow_id:
+        return
+    call_flow = (
+        db.query(CallFlow).filter(CallFlow.id == call_session.call_flow_id).first()
+    )
+    if not call_flow or not call_flow.slack_summary_enabled:
+        return
+
+    integration = get_integration(db, call_session.tenant_id)
+    if integration is None:
+        return
+
+    channel = _resolve_channel(call_flow, integration)
+    if not channel:
+        logger.info(
+            "Slack summary skipped — no channel configured for session=%s",
+            call_session_id,
+        )
+        return
+
+    try:
+        access_token = decrypt_slack_token(integration.access_token, db)
+    except Exception:
+        logger.warning(
+            "Slack token decryption failed for tenant=%s (non-critical)",
+            call_session.tenant_id,
+            exc_info=True,
+        )
+        return
+
+    # Lazily compute the transcript summary/sentiment if the automatic
+    # generate_call_summary ARQ job hasn't finished yet — serializes on the
+    # same pg advisory lock so it never races/duplicates that (paid) LLM call.
+    if not (
+        call_session.call_metadata and "llm_call_analysis" in call_session.call_metadata
+    ):
+        try:
+            from app.services.voice_analysis_service import ensure_call_summary_locked
+
+            ensure_call_summary_locked(db, call_session, raise_on_no_transcript=False)
+        except Exception:
+            logger.warning(
+                "Slack summary: analysis generation failed (non-critical) session=%s",
+                call_session_id,
+                exc_info=True,
+            )
+
+    summary, sentiment = _sentiment_and_summary(call_session)
+
+    phone = call_session.customer_phone_number or "Unknown"
+    duration = call_session.duration
+    duration_text = f"{duration}s" if duration is not None else "Unknown"
+
+    text = f"Call summary — {phone}"
+    fields = [
+        {"type": "mrkdwn", "text": f"*Caller:*\n{phone}"},
+        {"type": "mrkdwn", "text": f"*Status:*\n{call_session.status}"},
+        {"type": "mrkdwn", "text": f"*Duration:*\n{duration_text}"},
+    ]
+    if sentiment:
+        fields.append({"type": "mrkdwn", "text": f"*Sentiment:*\n{sentiment}"})
+
+    blocks = [
+        {"type": "header", "text": {"type": "plain_text", "text": "Call Summary"}},
+        {"type": "section", "fields": fields},
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f"*Summary:*\n{summary}"},
+        },
+    ]
+
+    await _post_message(access_token, channel, text, blocks)
+    logger.info(
+        "Slack call summary posted for session=%s channel=%s", call_session_id, channel
+    )
+
+
+def send_call_summary(call_session_id: uuid.UUID) -> None:
+    """
+    Sync entrypoint — opens its own session, mirrors hubspot_service's
+    run_post_call_writeback. Entirely fail-open: never lets a failure here
+    affect call completion.
+    """
+    db: Session = SessionLocal()
+    try:
+        asyncio.run(_send_call_summary_async(db, call_session_id))
+    except Exception as exc:
+        logger.warning(
+            "Slack post-call summary send failed (non-critical) session=%s: %s",
+            call_session_id,
+            _safe_error_msg(exc),
+            exc_info=True,
+        )
+    finally:
+        db.close()
+
+
+async def _send_call_summary_in_thread(call_session_id: uuid.UUID) -> None:
+    await asyncio.to_thread(send_call_summary, call_session_id)
+
+
+def schedule_slack_summary(call_session_id: uuid.UUID) -> None:
+    """
+    Fire-and-forget post-call Slack summary send. Never blocks the caller.
+
+    Mirrors hubspot_service.schedule_hubspot_writeback's dispatch pattern:
+    asyncio.create_task + asyncio.to_thread when a loop is running (keeps the
+    sync DB work off the event loop), a daemon thread otherwise (e.g. called
+    from a sync context with no running loop).
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        threading.Thread(
+            target=send_call_summary, args=(call_session_id,), daemon=True
+        ).start()
+        return
+    asyncio.create_task(_send_call_summary_in_thread(call_session_id))

--- a/app/services/slack_service.py
+++ b/app/services/slack_service.py
@@ -60,6 +60,12 @@ PROVIDER = "slack"
 _MAX_RETRIES = 5
 _BASE_BACKOFF_SECONDS = 1.0
 
+# Caps the admin channel-picker fetch at 3 pages of 200 (600 channels) so a
+# workspace with thousands of channels can't turn GET /channels into a
+# multi-second blocking fan-out. The dashboard picker only needs a
+# reasonably-sized list to select from, not the full workspace inventory.
+_MAX_CHANNEL_LIST_PAGES = 3
+
 _STATE_PURPOSE = "slack_oauth_state"
 _STATE_TTL_MINUTES = 10
 
@@ -69,31 +75,52 @@ _MAX_ERROR_LEN = 500
 # ─── HTTP with backoff ────────────────────────────────────────────────────────
 
 
-async def _request_with_backoff(method: str, url: str, **kwargs) -> httpx.Response:
-    """Call Slack with exponential backoff on 429 (1s, 2s, 4s, 8s, 16s)."""
-    async with httpx.AsyncClient(timeout=20.0) as client:
-        attempt = 0
-        while True:
-            response = await client.request(method, url, **kwargs)
-            if response.status_code != 429 or attempt >= _MAX_RETRIES:
-                return response
+async def _request_with_backoff(
+    method: str,
+    url: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+    **kwargs,
+) -> httpx.Response:
+    """Call Slack with exponential backoff on 429 (1s, 2s, 4s, 8s, 16s).
 
-            retry_after_header = response.headers.get("Retry-After")
-            wait_seconds = (
-                float(retry_after_header)
-                if retry_after_header
-                else _BASE_BACKOFF_SECONDS * (2**attempt)
-            )
-            logger.warning(
-                "Slack 429 on %s %s; retrying in %.1fs (attempt %d/%d)",
-                method,
-                url,
-                wait_seconds,
-                attempt + 1,
-                _MAX_RETRIES,
-            )
-            await asyncio.sleep(wait_seconds)
-            attempt += 1
+    Pass an existing ``client`` to reuse a connection across multiple calls
+    (e.g. paginated ``conversations.list`` requests); otherwise a short-lived
+    client is opened and closed for this single call.
+    """
+    if client is not None:
+        return await _request_with_backoff_using_client(client, method, url, **kwargs)
+    async with httpx.AsyncClient(timeout=20.0) as owned_client:
+        return await _request_with_backoff_using_client(
+            owned_client, method, url, **kwargs
+        )
+
+
+async def _request_with_backoff_using_client(
+    client: httpx.AsyncClient, method: str, url: str, **kwargs
+) -> httpx.Response:
+    attempt = 0
+    while True:
+        response = await client.request(method, url, **kwargs)
+        if response.status_code != 429 or attempt >= _MAX_RETRIES:
+            return response
+
+        retry_after_header = response.headers.get("Retry-After")
+        wait_seconds = (
+            float(retry_after_header)
+            if retry_after_header
+            else _BASE_BACKOFF_SECONDS * (2**attempt)
+        )
+        logger.warning(
+            "Slack 429 on %s %s; retrying in %.1fs (attempt %d/%d)",
+            method,
+            url,
+            wait_seconds,
+            attempt + 1,
+            _MAX_RETRIES,
+        )
+        await asyncio.sleep(wait_seconds)
+        attempt += 1
 
 
 # ─── OAuth state (signed, carries tenant_id through the redirect round-trip) ──
@@ -324,32 +351,38 @@ async def list_channels(db: Session, tenant_id: uuid.UUID) -> list[dict]:
 
     channels: list[dict] = []
     cursor: str | None = None
-    while True:
-        params = {
-            "types": "public_channel,private_channel",
-            "exclude_archived": "true",
-            "limit": "200",
-        }
-        if cursor:
-            params["cursor"] = cursor
+    page = 0
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        while True:
+            params = {
+                "types": "public_channel,private_channel",
+                "exclude_archived": "true",
+                "limit": "200",
+            }
+            if cursor:
+                params["cursor"] = cursor
 
-        response = await _request_with_backoff(
-            "GET",
-            CONVERSATIONS_LIST_URL,
-            headers={"Authorization": f"Bearer {access_token}"},
-            params=params,
-        )
-        response.raise_for_status()
-        payload = response.json()
-        if not payload.get("ok"):
-            raise ValueError(f"Slack conversations.list failed: {payload.get('error')}")
+            response = await _request_with_backoff(
+                "GET",
+                CONVERSATIONS_LIST_URL,
+                client=client,
+                headers={"Authorization": f"Bearer {access_token}"},
+                params=params,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not payload.get("ok"):
+                raise ValueError(
+                    f"Slack conversations.list failed: {payload.get('error')}"
+                )
 
-        for ch in payload.get("channels") or []:
-            channels.append({"id": ch.get("id"), "name": ch.get("name")})
+            for ch in payload.get("channels") or []:
+                channels.append({"id": ch.get("id"), "name": ch.get("name")})
 
-        cursor = (payload.get("response_metadata") or {}).get("next_cursor") or None
-        if not cursor:
-            break
+            page += 1
+            cursor = (payload.get("response_metadata") or {}).get("next_cursor") or None
+            if not cursor or page >= _MAX_CHANNEL_LIST_PAGES:
+                break
 
     return channels
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -15060,7 +15060,9 @@ components:
           description: When true, a call summary is posted to a Slack channel after
             each completed call on this flow. Requires the workspace to have connected
             Slack (see `/api/v1/integrations/slack`). Falls back to the workspace's
-            default channel if `slack_channel_id` is not set.
+            default channel if `slack_channel_id` is not set. Has no effect on inbound
+            CRM-sync calls (mirrors `email_summary_enabled`'s behavior for that call
+            type).
           default: false
         slack_channel_id:
           type: string

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -7198,6 +7198,84 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
       security:
       - HTTPBearer: []
+  /api/v1/integrations/slack:
+    get:
+      tags:
+      - Slack Integration
+      summary: Slack Get Integration Status
+      description: Connection status and default channel for this workspace.
+      operationId: slack_get_integration_status_api_v1_integrations_slack_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SlackIntegrationStatusOut_'
+      security:
+      - HTTPBearer: []
+    delete:
+      tags:
+      - Slack Integration
+      summary: Slack Disconnect
+      description: Revoke the bot token at Slack and delete the workspaceintegration
+        row.
+      operationId: slack_disconnect_api_v1_integrations_slack_delete
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SlackDisconnectResponse_'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/slack/channels:
+    get:
+      tags:
+      - Slack Integration
+      summary: Slack List Channels
+      description: List the tenant's available Slack channels (public + private the
+        bot can see).
+      operationId: slack_list_channels_api_v1_integrations_slack_channels_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_list_SlackChannelOut__'
+      security:
+      - HTTPBearer: []
+  /api/v1/integrations/slack/channel:
+    put:
+      tags:
+      - Slack Integration
+      summary: Slack Set Channel
+      description: Set (or clear, by omitting both fields) the workspace's default
+        Slack channel.
+      operationId: slack_set_channel_api_v1_integrations_slack_channel_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SlackSetChannelRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_SlackIntegrationStatusOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /api/v1/calls/history:
     get:
       tags:
@@ -8569,8 +8647,8 @@ paths:
     put:
       tags:
       - A/B Prompt Testing
-      summary: Configure post-call email summary actions on a call flow
-      description: 'Configures the two "Post Call Actions" toggles for this call flow:
+      summary: Configure post-call email/Slack summary actions on a call flow
+      description: 'Configures the "Post Call Actions" toggles for this call flow:
 
 
         - **Email Summary** (`email_summary_enabled` + `email_summary_recipients`):
@@ -8582,13 +8660,19 @@ paths:
         email) — there is no separate address field for this, the recipient is resolved
         server-side.
 
+        - **Slack Summary** (`slack_summary_enabled` + `slack_channel_id`/`slack_channel_name`):
+        posts the call summary and sentiment to a Slack channel after each completed
+        call. Requires the workspace to have connected Slack first (see `/api/v1/integrations/slack`);
+        falls back to the workspace''s default channel if `slack_channel_id` is not
+        set.
 
-        Both toggles are independent and may be enabled together; recipients from
-        both sources are deduplicated before sending. The request body always fully
-        replaces all three fields (send the current values for any field you don''t
-        want to change). Sending is fire-and-forget after call completion — this endpoint
-        only updates the stored configuration; it does not send an email itself. Requires
-        admin rank.'
+
+        All toggles are independent and may be enabled together; email recipients
+        from both email sources are deduplicated before sending. The request body
+        always fully replaces all fields (send the current values for any field you
+        don''t want to change). Sending is fire-and-forget after call completion —
+        this endpoint only updates the stored configuration; it does not send an email
+        or Slack message itself. Requires admin rank.'
       operationId: update_post_call_actions_settings_api_v2_flows__flow_id__post_call_actions_settings_put
       security:
       - HTTPBearer: []
@@ -14929,11 +15013,21 @@ components:
         summary_to_business_owner_enabled:
           type: boolean
           title: Summary To Business Owner Enabled
+        slack_summary_enabled:
+          type: boolean
+          title: Slack Summary Enabled
+        slack_channel_id:
+          type: string
+          nullable: true
+        slack_channel_name:
+          type: string
+          nullable: true
       type: object
       required:
       - email_summary_enabled
       - email_summary_recipients
       - summary_to_business_owner_enabled
+      - slack_summary_enabled
       title: PostCallActionsSettingsResponse
     PostCallActionsSettingsUpdate:
       properties:
@@ -14960,6 +15054,22 @@ components:
           description: When true, the same post-call summary email is also sent to
             the tenant's business owner (the workspace creator's account email) —
             no separate email field is needed for this recipient.
+        slack_summary_enabled:
+          type: boolean
+          title: Slack Summary Enabled
+          description: When true, a call summary is posted to a Slack channel after
+            each completed call on this flow. Requires the workspace to have connected
+            Slack (see `/api/v1/integrations/slack`). Falls back to the workspace's
+            default channel if `slack_channel_id` is not set.
+          default: false
+        slack_channel_id:
+          type: string
+          maxLength: 50
+          nullable: true
+        slack_channel_name:
+          type: string
+          maxLength: 255
+          nullable: true
       additionalProperties: false
       type: object
       required:
@@ -16396,6 +16506,64 @@ components:
       - crm_type
       - message
       title: SingleCallResponse
+    SlackChannelOut:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+      type: object
+      required:
+      - id
+      - name
+      title: SlackChannelOut
+    SlackDisconnectResponse:
+      properties:
+        disconnected:
+          type: boolean
+          title: Disconnected
+        provider:
+          type: string
+          title: Provider
+          default: slack
+      type: object
+      required:
+      - disconnected
+      title: SlackDisconnectResponse
+    SlackIntegrationStatusOut:
+      properties:
+        connected:
+          type: boolean
+          title: Connected
+        connected_at:
+          type: string
+          format: date-time
+          nullable: true
+        team_name:
+          type: string
+          nullable: true
+        default_channel_id:
+          type: string
+          nullable: true
+        default_channel_name:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - connected
+      title: SlackIntegrationStatusOut
+    SlackSetChannelRequest:
+      properties:
+        channel_id:
+          type: string
+          nullable: true
+        channel_name:
+          type: string
+          nullable: true
+      type: object
+      title: SlackSetChannelRequest
     SsoConfigOut:
       properties:
         id:
@@ -18058,6 +18226,38 @@ components:
       required:
       - data
       title: SuccessResponse[SingleCallResponse]
+    SuccessResponse_SlackDisconnectResponse_:
+      properties:
+        data:
+          $ref: '#/components/schemas/SlackDisconnectResponse'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[SlackDisconnectResponse]
+    SuccessResponse_SlackIntegrationStatusOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/SlackIntegrationStatusOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[SlackIntegrationStatusOut]
     SuccessResponse_TTSProviderListOut_:
       properties:
         data:
@@ -18459,6 +18659,25 @@ components:
       required:
       - data
       title: SuccessResponse[list[ResumeListItem]]
+    SuccessResponse_list_SlackChannelOut__:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/SlackChannelOut'
+          type: array
+          title: Data
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[list[SlackChannelOut]]
     SuccessResponse_list_TenantMember__:
       properties:
         data:

--- a/tests/api/test_slack_integration.py
+++ b/tests/api/test_slack_integration.py
@@ -1,0 +1,537 @@
+"""
+Tests for Slack OAuth integration router endpoints.
+
+Router functions are called directly (mirroring tests/api/test_hubspot_integration.py),
+with `db` mocked and external Slack calls patched at the service boundary
+(`app.routers.slack_integration.slack_service.<fn>`).
+
+Coverage:
+  1.  GET /connect — redirect mode + JSON mode (Accept: application/json)
+  2.  GET /callback — exchanges code for tokens, upserts, redirects;
+      invalid/expired state -> 400; token exchange failure -> 502
+  3.  DELETE "" — disconnects; 404 when not connected
+  4.  GET "" — connection status shape
+  5.  GET /channels — success shape; raises -> 400 (ValueError) / 502 (other)
+  6.  PUT /channel — sets default channel; 400 when not connected
+  7.  Multi-tenant isolation — principal's tenant_id is always what's passed
+      to the service layer
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+_TENANT_ID = uuid.UUID("aa100000-0000-0000-0000-000000000001")
+_OTHER_TENANT_ID = uuid.UUID("aa200000-0000-0000-0000-000000000002")
+
+
+def _principal(tenant_id: uuid.UUID = _TENANT_ID):
+    p = MagicMock()
+    p.current_tenant_id = tenant_id
+    return p
+
+
+def _request(accept: str = ""):
+    req = MagicMock()
+    req.headers = {"accept": accept} if accept else {}
+    return req
+
+
+class TestConnect:
+    @pytest.mark.anyio
+    async def test_redirects_to_slack(self):
+        from app.routers.slack_integration import slack_connect
+
+        with patch(
+            "app.routers.slack_integration.slack_service.get_authorization_url",
+            return_value="https://slack.com/oauth/v2/authorize?client_id=abc&state=signed-state",
+        ) as mock_url:
+            response = await slack_connect(request=_request(), principal=_principal())
+
+        mock_url.assert_called_once_with(_TENANT_ID)
+        assert response.status_code == 302
+        assert response.headers["location"] == (
+            "https://slack.com/oauth/v2/authorize?client_id=abc&state=signed-state"
+        )
+
+    @pytest.mark.anyio
+    async def test_returns_json_when_accept_header_requests_it(self):
+        from app.routers.slack_integration import slack_connect
+
+        with patch(
+            "app.routers.slack_integration.slack_service.get_authorization_url",
+            return_value="https://slack.com/oauth/v2/authorize?client_id=abc&state=signed-state",
+        ):
+            response = await slack_connect(
+                request=_request("application/json"), principal=_principal()
+            )
+
+        assert response.status_code == 200
+        assert response.body == (
+            b'{"authorization_url":"https://slack.com/oauth/v2/authorize?'
+            b'client_id=abc&state=signed-state"}'
+        )
+
+    @pytest.mark.anyio
+    async def test_uses_tenant_from_principal_not_a_hardcoded_value(self):
+        """Multi-tenant isolation: /connect must build the state for the
+        *requesting* tenant, never a different one."""
+        from app.routers.slack_integration import slack_connect
+
+        with patch(
+            "app.routers.slack_integration.slack_service.get_authorization_url",
+            return_value="https://slack.com/oauth/v2/authorize",
+        ) as mock_url:
+            await slack_connect(
+                request=_request(), principal=_principal(_OTHER_TENANT_ID)
+            )
+
+        mock_url.assert_called_once_with(_OTHER_TENANT_ID)
+
+
+class TestCallback:
+    @pytest.mark.anyio
+    async def test_exchanges_code_and_stores_tokens(self):
+        from app.routers.slack_integration import slack_callback
+
+        db = MagicMock()
+        token_response = {
+            "access_token": "xoxb-abc",
+            "team": {"id": "T123", "name": "Acme Workspace"},
+        }
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.slack_integration.slack_service.exchange_code_for_tokens",
+                new=AsyncMock(return_value=token_response),
+            ) as mock_exchange,
+            patch(
+                "app.routers.slack_integration.slack_service.upsert_integration"
+            ) as mock_upsert,
+        ):
+            response = await slack_callback(
+                code="mock-auth-code", state="signed-state", db=db
+            )
+
+        mock_exchange.assert_awaited_once_with("mock-auth-code")
+        mock_upsert.assert_called_once_with(db, _TENANT_ID, token_response)
+        assert response.status_code == 302
+        assert "slack=connected" in response.headers["location"]
+
+    @pytest.mark.anyio
+    async def test_invalid_state_returns_400(self):
+        from app.routers.slack_integration import slack_callback
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.verify_oauth_state",
+                side_effect=ValueError("Invalid or expired OAuth state"),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await slack_callback(
+                code="mock-auth-code", state="bad-state", db=MagicMock()
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_expired_state_returns_400(self):
+        from app.routers.slack_integration import slack_callback
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.verify_oauth_state",
+                side_effect=ValueError("Invalid or expired OAuth state"),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await slack_callback(
+                code="mock-auth-code", state="expired-state", db=MagicMock()
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_token_exchange_failure_returns_502(self):
+        from app.routers.slack_integration import slack_callback
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.verify_oauth_state",
+                return_value=_TENANT_ID,
+            ),
+            patch(
+                "app.routers.slack_integration.slack_service.exchange_code_for_tokens",
+                new=AsyncMock(
+                    side_effect=Exception(
+                        "Slack OAuth token exchange failed: invalid_code"
+                    )
+                ),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await slack_callback(code="bad-code", state="signed-state", db=MagicMock())
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.anyio
+    async def test_upsert_uses_tenant_recovered_from_state_not_any_other_tenant(self):
+        """Multi-tenant isolation: the callback has no auth header — the only
+        source of truth for which tenant owns this connection is the signed
+        state param, and upsert must be scoped to exactly that tenant."""
+        from app.routers.slack_integration import slack_callback
+
+        db = MagicMock()
+        token_response = {"access_token": "xoxb-abc", "team": {}}
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.verify_oauth_state",
+                return_value=_OTHER_TENANT_ID,
+            ),
+            patch(
+                "app.routers.slack_integration.slack_service.exchange_code_for_tokens",
+                new=AsyncMock(return_value=token_response),
+            ),
+            patch(
+                "app.routers.slack_integration.slack_service.upsert_integration"
+            ) as mock_upsert,
+        ):
+            await slack_callback(code="mock-auth-code", state="signed-state", db=db)
+
+        mock_upsert.assert_called_once_with(db, _OTHER_TENANT_ID, token_response)
+
+
+class TestDisconnectEndpoint:
+    @pytest.mark.anyio
+    async def test_disconnects_successfully(self):
+        from app.routers.slack_integration import slack_disconnect
+
+        with patch(
+            "app.routers.slack_integration.slack_service.disconnect",
+            new=AsyncMock(return_value=True),
+        ) as mock_disconnect:
+            result = await slack_disconnect(principal=_principal(), db=MagicMock())
+
+        mock_disconnect.assert_awaited_once_with(
+            mock_disconnect.call_args[0][0], _TENANT_ID
+        )
+        assert result.data.disconnected is True
+        assert result.data.provider == "slack"
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_404(self):
+        from app.routers.slack_integration import slack_disconnect
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.disconnect",
+                new=AsyncMock(return_value=False),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await slack_disconnect(principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_uses_requesting_tenant_id(self):
+        from app.routers.slack_integration import slack_disconnect
+
+        db = MagicMock()
+        with patch(
+            "app.routers.slack_integration.slack_service.disconnect",
+            new=AsyncMock(return_value=True),
+        ) as mock_disconnect:
+            await slack_disconnect(principal=_principal(_OTHER_TENANT_ID), db=db)
+
+        mock_disconnect.assert_awaited_once_with(db, _OTHER_TENANT_ID)
+
+
+class TestStatusEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_status_shape(self):
+        from app.routers.slack_integration import slack_get_integration_status
+        from datetime import datetime, timezone
+
+        connected_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        status_data = {
+            "connected": True,
+            "connected_at": connected_at,
+            "team_name": "Acme Workspace",
+            "default_channel_id": "C1",
+            "default_channel_name": "general",
+        }
+
+        with patch(
+            "app.routers.slack_integration.slack_service.get_integration_status",
+            return_value=status_data,
+        ):
+            result = await slack_get_integration_status(
+                principal=_principal(), db=MagicMock()
+            )
+
+        assert result.data.connected is True
+        assert result.data.connected_at == connected_at
+        assert result.data.team_name == "Acme Workspace"
+        assert result.data.default_channel_id == "C1"
+        assert result.data.default_channel_name == "general"
+
+    @pytest.mark.anyio
+    async def test_not_connected_shape(self):
+        from app.routers.slack_integration import slack_get_integration_status
+
+        status_data = {
+            "connected": False,
+            "connected_at": None,
+            "team_name": None,
+            "default_channel_id": None,
+            "default_channel_name": None,
+        }
+
+        with patch(
+            "app.routers.slack_integration.slack_service.get_integration_status",
+            return_value=status_data,
+        ):
+            result = await slack_get_integration_status(
+                principal=_principal(), db=MagicMock()
+            )
+
+        assert result.data.connected is False
+        assert result.data.team_name is None
+
+
+class TestChannelsEndpoint:
+    @pytest.mark.anyio
+    async def test_returns_channel_list(self):
+        from app.routers.slack_integration import slack_list_channels
+
+        channels = [{"id": "C1", "name": "general"}, {"id": "C2", "name": "sales"}]
+
+        with patch(
+            "app.routers.slack_integration.slack_service.list_channels",
+            new=AsyncMock(return_value=channels),
+        ):
+            result = await slack_list_channels(principal=_principal(), db=MagicMock())
+
+        assert len(result.data) == 2
+        assert result.data[0].id == "C1"
+        assert result.data[0].name == "general"
+
+    @pytest.mark.anyio
+    async def test_not_connected_raises_400(self):
+        from app.routers.slack_integration import slack_list_channels
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.list_channels",
+                new=AsyncMock(
+                    side_effect=ValueError("Slack is not connected for this workspace")
+                ),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await slack_list_channels(principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_slack_api_failure_raises_502_not_fail_open(self):
+        """This is an admin action — must surface a clear error, not silently
+        return an empty channel list."""
+        from app.routers.slack_integration import slack_list_channels
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.list_channels",
+                new=AsyncMock(
+                    side_effect=Exception(
+                        "Slack conversations.list failed: invalid_auth"
+                    )
+                ),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await slack_list_channels(principal=_principal(), db=MagicMock())
+
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.anyio
+    async def test_uses_requesting_tenant_id(self):
+        from app.routers.slack_integration import slack_list_channels
+
+        db = MagicMock()
+        with patch(
+            "app.routers.slack_integration.slack_service.list_channels",
+            new=AsyncMock(return_value=[]),
+        ) as mock_list:
+            await slack_list_channels(principal=_principal(_OTHER_TENANT_ID), db=db)
+
+        mock_list.assert_awaited_once_with(db, _OTHER_TENANT_ID)
+
+
+class TestSetChannelEndpoint:
+    @pytest.mark.anyio
+    async def test_sets_default_channel(self):
+        from app.routers.slack_integration import slack_set_channel
+        from app.schemas.slack_integration import SlackSetChannelRequest
+
+        payload = SlackSetChannelRequest(channel_id="C1", channel_name="general")
+        updated_status = {
+            "connected": True,
+            "connected_at": None,
+            "team_name": "Acme Workspace",
+            "default_channel_id": "C1",
+            "default_channel_name": "general",
+        }
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.slack_integration.slack_service.set_default_channel"
+            ) as mock_set,
+            patch(
+                "app.routers.slack_integration.slack_service.get_integration_status",
+                return_value=updated_status,
+            ),
+        ):
+            result = await slack_set_channel(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
+
+        mock_set.assert_called_once_with(
+            mock_set.call_args[0][0], _TENANT_ID, "C1", "general"
+        )
+        assert result.data.default_channel_id == "C1"
+        assert result.data.default_channel_name == "general"
+
+    @pytest.mark.anyio
+    async def test_clears_default_channel(self):
+        from app.routers.slack_integration import slack_set_channel
+        from app.schemas.slack_integration import SlackSetChannelRequest
+
+        payload = SlackSetChannelRequest(channel_id=None, channel_name=None)
+        updated_status = {
+            "connected": True,
+            "connected_at": None,
+            "team_name": "Acme Workspace",
+            "default_channel_id": None,
+            "default_channel_name": None,
+        }
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.routers.slack_integration.slack_service.set_default_channel"
+            ) as mock_set,
+            patch(
+                "app.routers.slack_integration.slack_service.get_integration_status",
+                return_value=updated_status,
+            ),
+        ):
+            result = await slack_set_channel(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
+
+        mock_set.assert_called_once_with(
+            mock_set.call_args[0][0], _TENANT_ID, None, None
+        )
+        assert result.data.default_channel_id is None
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_400(self):
+        from app.routers.slack_integration import slack_set_channel
+        from app.schemas.slack_integration import SlackSetChannelRequest
+
+        payload = SlackSetChannelRequest(channel_id="C1", channel_name="general")
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.tenant_has_slack_connected",
+                return_value=False,
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await slack_set_channel(
+                payload=payload, principal=_principal(), db=MagicMock()
+            )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.anyio
+    async def test_uses_requesting_tenant_id(self):
+        from app.routers.slack_integration import slack_set_channel
+        from app.schemas.slack_integration import SlackSetChannelRequest
+
+        payload = SlackSetChannelRequest(channel_id="C1", channel_name="general")
+        db = MagicMock()
+
+        with (
+            patch(
+                "app.routers.slack_integration.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ) as mock_connected,
+            patch(
+                "app.routers.slack_integration.slack_service.set_default_channel"
+            ) as mock_set,
+            patch(
+                "app.routers.slack_integration.slack_service.get_integration_status",
+                return_value={
+                    "connected": True,
+                    "connected_at": None,
+                    "team_name": None,
+                    "default_channel_id": "C1",
+                    "default_channel_name": "general",
+                },
+            ),
+        ):
+            await slack_set_channel(
+                payload=payload, principal=_principal(_OTHER_TENANT_ID), db=db
+            )
+
+        mock_connected.assert_called_once_with(db, _OTHER_TENANT_ID)
+        mock_set.assert_called_once_with(db, _OTHER_TENANT_ID, "C1", "general")
+
+
+class TestSlackSetChannelRequestValidation:
+    def test_both_fields_set_is_valid(self):
+        from app.schemas.slack_integration import SlackSetChannelRequest
+
+        req = SlackSetChannelRequest(channel_id="C1", channel_name="general")
+        assert req.channel_id == "C1"
+
+    def test_both_fields_omitted_is_valid(self):
+        from app.schemas.slack_integration import SlackSetChannelRequest
+
+        req = SlackSetChannelRequest()
+        assert req.channel_id is None
+        assert req.channel_name is None
+
+    def test_only_channel_id_set_is_invalid(self):
+        from app.schemas.slack_integration import SlackSetChannelRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            SlackSetChannelRequest(channel_id="C1", channel_name=None)
+
+    def test_only_channel_name_set_is_invalid(self):
+        from app.schemas.slack_integration import SlackSetChannelRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            SlackSetChannelRequest(channel_id=None, channel_name="general")

--- a/tests/api/v2/test_post_call_actions_settings.py
+++ b/tests/api/v2/test_post_call_actions_settings.py
@@ -10,6 +10,7 @@ Coverage:
   - A successful update fires an audit event with the expected shape
   - The response echoes back the persisted three-field shape
 """
+
 from __future__ import annotations
 
 import uuid
@@ -33,7 +34,9 @@ def _build_app(db_override, principal, *, forbidden=False):
     if forbidden:
 
         def _raise_forbidden():
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
 
         mini.dependency_overrides[require_admin_or_api_key] = _raise_forbidden
     else:
@@ -272,6 +275,212 @@ class TestUpdatePostCallActionsSettings:
         assert flow.email_summary_enabled is False
         assert flow.summary_to_business_owner_enabled is False
 
+    def test_enables_slack_summary_with_channel_override(self, db, workspace, flow):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": True,
+                "slack_channel_id": "C123",
+                "slack_channel_name": "sales-calls",
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["slack_summary_enabled"] is True
+        assert body["slack_channel_id"] == "C123"
+        assert body["slack_channel_name"] == "sales-calls"
+
+        db.refresh(flow)
+        assert flow.slack_summary_enabled is True
+        assert flow.slack_channel_id == "C123"
+        assert flow.slack_channel_name == "sales-calls"
+
+    def test_slack_summary_defaults_to_disabled_with_no_channel_override(
+        self, db, workspace, flow
+    ):
+        """When slack_summary_enabled/channel fields are omitted entirely,
+        the flow should round-trip to the documented defaults (disabled, no
+        override — falls back to the workspace default channel at send time)."""
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["slack_summary_enabled"] is False
+        assert body["slack_channel_id"] is None
+        assert body["slack_channel_name"] is None
+
+    def test_slack_channel_id_without_name_rejected(self, db, workspace, flow):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": True,
+                "slack_channel_id": "C123",
+                "slack_channel_name": None,
+            },
+        )
+
+        assert resp.status_code == 400
+
+    def test_slack_channel_name_without_id_rejected(self, db, workspace, flow):
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": True,
+                "slack_channel_id": None,
+                "slack_channel_name": "sales-calls",
+            },
+        )
+
+        assert resp.status_code == 400
+
+    def test_disabling_slack_summary_clears_channel_override(self, db, workspace, flow):
+        """A previously-set channel override must be clearable independently
+        of the email settings on the same request."""
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": True,
+                "slack_channel_id": "C123",
+                "slack_channel_name": "sales-calls",
+            },
+        )
+
+        resp = client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": False,
+                "slack_channel_id": None,
+                "slack_channel_name": None,
+            },
+        )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["slack_summary_enabled"] is False
+        assert body["slack_channel_id"] is None
+        assert body["slack_channel_name"] is None
+
+    def test_two_flows_in_same_tenant_have_independent_slack_settings(
+        self, db, workspace, agent, flow
+    ):
+        """Agent/call-flow-specific config: a second call flow in the same
+        tenant must be able to enable Slack with a different channel without
+        affecting the first flow."""
+        from app.models.call_flow import CallFlow
+
+        other_flow = CallFlow(
+            tenant_id=workspace.id,
+            agent_id=agent.id,
+            name="Second Flow",
+            direction="inbound",
+        )
+        db.add(other_flow)
+        db.commit()
+        db.refresh(other_flow)
+
+        principal = _admin_principal(workspace.id)
+        client = _build_app(db, principal)
+
+        client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": True,
+                "slack_channel_id": "C-FLOW-1",
+                "slack_channel_name": "flow-one-channel",
+            },
+        )
+        client.put(
+            f"/flows/{other_flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": False,
+            },
+        )
+
+        db.refresh(flow)
+        db.refresh(other_flow)
+        assert flow.slack_summary_enabled is True
+        assert flow.slack_channel_id == "C-FLOW-1"
+        assert other_flow.slack_summary_enabled is False
+        assert other_flow.slack_channel_id is None
+
+    def test_flow_from_other_tenant_cannot_toggle_slack_settings(self, db, flow):
+        """Tenant isolation: a principal from another tenant must not be able
+        to change this flow's Slack settings."""
+        from app.models.tenant import Tenant
+
+        other_tenant = Tenant(
+            name=f"OtherSlackWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"other_slack_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(other_tenant)
+        db.commit()
+        db.refresh(other_tenant)
+
+        principal = _admin_principal(other_tenant.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/post-call-actions-settings",
+            json={
+                "email_summary_enabled": False,
+                "email_summary_recipients": [],
+                "summary_to_business_owner_enabled": False,
+                "slack_summary_enabled": True,
+                "slack_channel_id": "C123",
+                "slack_channel_name": "sales-calls",
+            },
+        )
+
+        assert resp.status_code == 404
+        db.refresh(flow)
+        assert flow.slack_summary_enabled is False
+        assert flow.slack_channel_id is None
+
     def test_update_fires_audit_event(self, db, workspace, flow):
         principal = _admin_principal(workspace.id)
         client = _build_app(db, principal)
@@ -296,5 +505,8 @@ class TestUpdatePostCallActionsSettings:
             "email_summary_enabled": True,
             "email_summary_recipients": ["owner@example.com"],
             "summary_to_business_owner_enabled": True,
+            "slack_summary_enabled": False,
+            "slack_channel_id": None,
+            "slack_channel_name": None,
         }
         assert kwargs["actor_user_id"] == principal.id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,10 @@ os.environ.setdefault(
     "HUBSPOT_TOKEN_ENCRYPTION_KEY",
     "test-hubspot-encryption-key-for-pytest-only",
 )
+os.environ.setdefault(
+    "SLACK_TOKEN_ENCRYPTION_KEY",
+    "test-slack-encryption-key-for-pytest-only",
+)
 
 # Mock google submodules recursively to avoid ImportError in unit tests.
 # Live Google STT integration tests set RUN_GOOGLE_STT_INTEGRATION=1 to skip mocks.
@@ -86,10 +90,10 @@ from app.models.user import User
 from app.models.role import Role
 from app.models.tenant import Tenant
 
-
 # ---------------------------------------------------------------------------
 # Custom markers
 # ---------------------------------------------------------------------------
+
 
 def pytest_configure(config):
     config.addinivalue_line(
@@ -155,13 +159,13 @@ def override_get_db():
 @pytest.fixture(autouse=True)
 def _configure_rate_limiting(request):
     from app.core.config import settings
+
     # Enable rate limiting only for files that specifically test rate limits
     if (
         hasattr(request, "module")
         and request.module
         and any(
-            x in request.module.__name__
-            for x in ("rate_limit", "sprint1_integration")
+            x in request.module.__name__ for x in ("rate_limit", "sprint1_integration")
         )
     ):
         prev = settings.RATE_LIMIT_ENABLED
@@ -174,8 +178,8 @@ def _configure_rate_limiting(request):
         yield
 
 
-
 from app.api.deps import get_db
+
 app.dependency_overrides[get_db] = override_get_db
 
 
@@ -242,52 +246,154 @@ def db():
         db.add_all([openai_p, gemini_p, groq_p])
         db.commit()
 
-        db.add_all([
-            Model(provider_id=openai_p.id, model_name="gpt-4o-mini", archive=False),
-            Model(provider_id=openai_p.id, model_name="gpt-4o", archive=False),
-            Model(provider_id=openai_p.id, model_name="gpt-4.1", archive=False),
-            Model(provider_id=openai_p.id, model_name="gpt-4.1-mini", archive=False),
-            Model(provider_id=openai_p.id, model_name="gpt-4-turbo", archive=False),
-            Model(provider_id=gemini_p.id, model_name="gemini-2.5-flash", archive=False),
-            Model(provider_id=gemini_p.id, model_name="gemini-2.0-flash-001", archive=False),
-            Model(provider_id=gemini_p.id, model_name="gemini-2.0-flash", archive=False),
-            Model(provider_id=gemini_p.id, model_name="gemini-1.5-pro", archive=False),
-            Model(provider_id=gemini_p.id, model_name="gemini-1.5-flash", archive=False),
-            Model(provider_id=gemini_p.id, model_name="claude-3-5-sonnet", archive=False),
-            Model(provider_id=gemini_p.id, model_name="claude-3-haiku", archive=False),
-            Model(provider_id=groq_p.id, model_name="llama-3.1-70b-versatile", archive=False),
-            Model(provider_id=groq_p.id, model_name="llama-3.1-8b-instant", archive=False),
-        ])
+        db.add_all(
+            [
+                Model(provider_id=openai_p.id, model_name="gpt-4o-mini", archive=False),
+                Model(provider_id=openai_p.id, model_name="gpt-4o", archive=False),
+                Model(provider_id=openai_p.id, model_name="gpt-4.1", archive=False),
+                Model(
+                    provider_id=openai_p.id, model_name="gpt-4.1-mini", archive=False
+                ),
+                Model(provider_id=openai_p.id, model_name="gpt-4-turbo", archive=False),
+                Model(
+                    provider_id=gemini_p.id,
+                    model_name="gemini-2.5-flash",
+                    archive=False,
+                ),
+                Model(
+                    provider_id=gemini_p.id,
+                    model_name="gemini-2.0-flash-001",
+                    archive=False,
+                ),
+                Model(
+                    provider_id=gemini_p.id,
+                    model_name="gemini-2.0-flash",
+                    archive=False,
+                ),
+                Model(
+                    provider_id=gemini_p.id, model_name="gemini-1.5-pro", archive=False
+                ),
+                Model(
+                    provider_id=gemini_p.id,
+                    model_name="gemini-1.5-flash",
+                    archive=False,
+                ),
+                Model(
+                    provider_id=gemini_p.id,
+                    model_name="claude-3-5-sonnet",
+                    archive=False,
+                ),
+                Model(
+                    provider_id=gemini_p.id, model_name="claude-3-haiku", archive=False
+                ),
+                Model(
+                    provider_id=groq_p.id,
+                    model_name="llama-3.1-70b-versatile",
+                    archive=False,
+                ),
+                Model(
+                    provider_id=groq_p.id,
+                    model_name="llama-3.1-8b-instant",
+                    archive=False,
+                ),
+            ]
+        )
         db.commit()
 
         # Seed STT Providers and Models
-        stt_deepgram = STTProvider(slug="deepgram", display_name="Deepgram", is_active=True)
-        stt_google = STTProvider(slug="google", display_name="Google Cloud STT", is_active=True)
+        stt_deepgram = STTProvider(
+            slug="deepgram", display_name="Deepgram", is_active=True
+        )
+        stt_google = STTProvider(
+            slug="google", display_name="Google Cloud STT", is_active=True
+        )
         db.add_all([stt_deepgram, stt_google])
         db.commit()
 
-        db.add_all([
-            STTModel(provider_id=stt_deepgram.id, external_model_id="nova-3", display_name="Nova-3", language_code="en", is_active=True),
-            STTModel(provider_id=stt_google.id, external_model_id="chirp-3", display_name="Chirp-3", language_code="en", is_active=True),
-        ])
+        db.add_all(
+            [
+                STTModel(
+                    provider_id=stt_deepgram.id,
+                    external_model_id="nova-3",
+                    display_name="Nova-3",
+                    language_code="en",
+                    is_active=True,
+                ),
+                STTModel(
+                    provider_id=stt_google.id,
+                    external_model_id="chirp-3",
+                    display_name="Chirp-3",
+                    language_code="en",
+                    is_active=True,
+                ),
+            ]
+        )
         db.commit()
 
         # Seed TTS Providers and Voices
-        tts_eleven = TTSProvider(slug="elevenlabs", display_name="ElevenLabs", is_active=True)
+        tts_eleven = TTSProvider(
+            slug="elevenlabs", display_name="ElevenLabs", is_active=True
+        )
         tts_rime = TTSProvider(slug="rime", display_name="Rime", is_active=True)
-        tts_cartesia = TTSProvider(slug="cartesia", display_name="Cartesia", is_active=True)
+        tts_cartesia = TTSProvider(
+            slug="cartesia", display_name="Cartesia", is_active=True
+        )
         db.add_all([tts_eleven, tts_rime, tts_cartesia])
         db.commit()
 
-        db.add_all([
-            TTSVoice(provider_id=tts_eleven.id, external_voice_id="21m00Tcm4TlvDq8ikWAM", display_name="Rachel", language_code="en", is_active=True),
-            TTSVoice(provider_id=tts_eleven.id, external_voice_id="voice-1", display_name="Voice 1", language_code="en", is_active=True),
-            TTSVoice(provider_id=tts_eleven.id, external_voice_id="EXAVITQu4vr4xnSDxMaL", display_name="Rachel 2", language_code="en", is_active=True),
-            TTSVoice(provider_id=tts_eleven.id, external_voice_id="vY", display_name="Voice Y", language_code="en", is_active=True),
-            TTSVoice(provider_id=tts_eleven.id, external_voice_id="vZ", display_name="Voice Z", language_code="en", is_active=True),
-            TTSVoice(provider_id=tts_rime.id, external_voice_id="rime-voice-1", display_name="Rime Voice 1", language_code="en", is_active=True),
-            TTSVoice(provider_id=tts_cartesia.id, external_voice_id="cartesia-voice-1", display_name="Cartesia Voice 1", language_code="en", is_active=True),
-        ])
+        db.add_all(
+            [
+                TTSVoice(
+                    provider_id=tts_eleven.id,
+                    external_voice_id="21m00Tcm4TlvDq8ikWAM",
+                    display_name="Rachel",
+                    language_code="en",
+                    is_active=True,
+                ),
+                TTSVoice(
+                    provider_id=tts_eleven.id,
+                    external_voice_id="voice-1",
+                    display_name="Voice 1",
+                    language_code="en",
+                    is_active=True,
+                ),
+                TTSVoice(
+                    provider_id=tts_eleven.id,
+                    external_voice_id="EXAVITQu4vr4xnSDxMaL",
+                    display_name="Rachel 2",
+                    language_code="en",
+                    is_active=True,
+                ),
+                TTSVoice(
+                    provider_id=tts_eleven.id,
+                    external_voice_id="vY",
+                    display_name="Voice Y",
+                    language_code="en",
+                    is_active=True,
+                ),
+                TTSVoice(
+                    provider_id=tts_eleven.id,
+                    external_voice_id="vZ",
+                    display_name="Voice Z",
+                    language_code="en",
+                    is_active=True,
+                ),
+                TTSVoice(
+                    provider_id=tts_rime.id,
+                    external_voice_id="rime-voice-1",
+                    display_name="Rime Voice 1",
+                    language_code="en",
+                    is_active=True,
+                ),
+                TTSVoice(
+                    provider_id=tts_cartesia.id,
+                    external_voice_id="cartesia-voice-1",
+                    display_name="Cartesia Voice 1",
+                    language_code="en",
+                    is_active=True,
+                ),
+            ]
+        )
         db.commit()
 
         yield db
@@ -328,6 +434,7 @@ def pg_engine():
         pytest.skip("TEST_DATABASE_URL not set")
 
     import uuid as _uuid
+
     schema = f"test_sprint1_{os.getpid()}_{_uuid.uuid4().hex[:6]}"
     _pg_test_schema = schema
 
@@ -434,6 +541,7 @@ def pg_client(pg_engine, pg_auth_middleware, pg_session_factory):
     The ``get_db`` override is applied only within this fixture's scope
     and does not affect the SQLite unit-test override.
     """
+
     def _pg_get_db():
         db = pg_session_factory()
         try:

--- a/tests/services/test_call_session_post_call_email_hook.py
+++ b/tests/services/test_call_session_post_call_email_hook.py
@@ -6,6 +6,7 @@ fixture setup and mocking conventions. Unlike that hook, this one requires
 at least one of the two call-flow toggles to be enabled before it fires —
 see app/services/post_call_email_service.py::schedule_post_call_email_summary.
 """
+
 from __future__ import annotations
 
 import uuid
@@ -94,6 +95,7 @@ def _make_flow(
     *,
     email_summary_enabled: bool = False,
     summary_to_business_owner_enabled: bool = False,
+    slack_summary_enabled: bool = False,
 ) -> CallFlow:
     f = CallFlow(
         tenant_id=tenant.id,
@@ -103,6 +105,7 @@ def _make_flow(
         email_summary_enabled=email_summary_enabled,
         email_summary_recipients=["x@example.com"] if email_summary_enabled else [],
         summary_to_business_owner_enabled=summary_to_business_owner_enabled,
+        slack_summary_enabled=slack_summary_enabled,
     )
     db.add(f)
     db.commit()
@@ -245,7 +248,9 @@ class TestPostCallEmailSummaryHook:
                 "app.services.post_call_email_service.schedule_post_call_email_summary"
             ) as mock_schedule,
         ):
-            updated = call_session_service.update_call_session_status(db, session.id, status)
+            updated = call_session_service.update_call_session_status(
+                db, session.id, status
+            )
 
         assert updated is not None
         assert updated.status == status
@@ -312,3 +317,289 @@ class TestPostCallEmailSummaryHook:
         assert updated is not None
         assert updated.status == "completed"
         assert updated.duration is not None
+
+
+@pytest.mark.usefixtures("db")
+class TestPostCallSlackSummaryHook:
+    """Coverage for the Slack post-call-summary hook wired into the same
+    update_call_session_status() completed-call block as the email hook
+    above. Gated on call_flow.slack_summary_enabled AND
+    tenant_has_slack_connected(db, tenant_id) — see
+    app/services/call_session_service.py's "Post-call Slack summary" block.
+    """
+
+    def test_completed_call_with_slack_enabled_and_connected_schedules_job(
+        self, db, tenant, agent, cs_user
+    ):
+        flow = _make_flow(db, tenant, agent, slack_summary_enabled=True)
+        session = _make_session(db, tenant, agent, cs_user, call_flow=flow)
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch("app.services.slack_service.schedule_slack_summary") as mock_schedule,
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        mock_schedule.assert_called_once_with(session.id)
+
+    def test_slack_enabled_but_workspace_not_connected_does_not_schedule(
+        self, db, tenant, agent, cs_user
+    ):
+        """slack_summary_enabled alone is not sufficient — the workspace must
+        also have an active Slack connection."""
+        flow = _make_flow(db, tenant, agent, slack_summary_enabled=True)
+        session = _make_session(db, tenant, agent, cs_user, call_flow=flow)
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                return_value=False,
+            ),
+            patch("app.services.slack_service.schedule_slack_summary") as mock_schedule,
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        mock_schedule.assert_not_called()
+
+    def test_slack_disabled_on_flow_does_not_schedule_even_if_connected(
+        self, db, tenant, agent, cs_user
+    ):
+        flow = _make_flow(db, tenant, agent, slack_summary_enabled=False)
+        session = _make_session(db, tenant, agent, cs_user, call_flow=flow)
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch("app.services.slack_service.schedule_slack_summary") as mock_schedule,
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        mock_schedule.assert_not_called()
+
+    def test_completed_call_with_no_call_flow_does_not_schedule_slack(
+        self, db, tenant, agent, cs_user
+    ):
+        session = _make_session(db, tenant, agent, cs_user, call_flow=None)
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch("app.services.slack_service.schedule_slack_summary") as mock_schedule,
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        mock_schedule.assert_not_called()
+
+    @pytest.mark.parametrize("status", ["failed", "no_answer", "ringing"])
+    def test_non_completed_status_does_not_schedule_slack(
+        self, db, tenant, agent, cs_user, status
+    ):
+        flow = _make_flow(db, tenant, agent, slack_summary_enabled=True)
+        session = _make_session(db, tenant, agent, cs_user, call_flow=flow)
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch("app.services.slack_service.schedule_slack_summary") as mock_schedule,
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, status
+            )
+
+        assert updated is not None
+        assert updated.status == status
+        mock_schedule.assert_not_called()
+
+    def test_inbound_crm_sync_call_does_not_schedule_slack(
+        self, db, tenant, agent, cs_user
+    ):
+        """Same skip condition as the sibling email/HubSpot hooks: an
+        inbound-CRM-sync call must not trigger the Slack summary either."""
+        flow = _make_flow(db, tenant, agent, slack_summary_enabled=True)
+        session = _make_session(db, tenant, agent, cs_user, call_flow=flow)
+        session.call_type = "inbound"
+        db.commit()
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.call_session_service.tenant_has_active_inbound_crm",
+                return_value=True,
+            ),
+            patch("app.services.call_session_service.schedule_inbound_crm_sync"),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch("app.services.slack_service.schedule_slack_summary") as mock_schedule,
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        mock_schedule.assert_not_called()
+
+    def test_slack_hook_failure_is_swallowed_and_status_update_still_succeeds(
+        self, db, tenant, agent, cs_user
+    ):
+        """Fail-open per app/services/call_session_service.py's Slack hook
+        try/except: an exception raised while checking/scheduling the Slack
+        summary must never propagate out of update_call_session_status."""
+        flow = _make_flow(db, tenant, agent, slack_summary_enabled=True)
+        session = _make_session(db, tenant, agent, cs_user, call_flow=flow)
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                side_effect=RuntimeError("DB connection dropped"),
+            ),
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        assert updated.duration is not None
+
+    def test_schedule_slack_summary_failure_is_swallowed(
+        self, db, tenant, agent, cs_user
+    ):
+        """Fail-open: an exception raised inside schedule_slack_summary itself
+        (not just the connectivity check) must also not break call completion."""
+        flow = _make_flow(db, tenant, agent, slack_summary_enabled=True)
+        session = _make_session(db, tenant, agent, cs_user, call_flow=flow)
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch(
+                "app.services.slack_service.schedule_slack_summary",
+                side_effect=RuntimeError("thread spawn failed"),
+            ),
+        ):
+            updated = call_session_service.update_call_session_status(
+                db, session.id, "completed"
+            )
+
+        assert updated is not None
+        assert updated.status == "completed"
+        assert updated.duration is not None
+
+    def test_two_flows_same_tenant_independent_slack_toggle(
+        self, db, tenant, agent, cs_user
+    ):
+        """Agent/call-flow-specific config: one call flow with Slack enabled
+        and another with it disabled in the same tenant must behave
+        independently."""
+        flow_enabled = _make_flow(db, tenant, agent, slack_summary_enabled=True)
+        flow_disabled = _make_flow(db, tenant, agent, slack_summary_enabled=False)
+        session_enabled = _make_session(
+            db, tenant, agent, cs_user, call_flow=flow_enabled
+        )
+        session_disabled = _make_session(
+            db, tenant, agent, cs_user, call_flow=flow_disabled
+        )
+
+        with (
+            _naive_utcnow_patch(),
+            patch(
+                "app.services.voice_analysis_service.schedule_call_summary_generation"
+            ),
+            patch(
+                "app.services.post_call_email_service.schedule_post_call_email_summary"
+            ),
+            patch(
+                "app.services.slack_service.tenant_has_slack_connected",
+                return_value=True,
+            ),
+            patch("app.services.slack_service.schedule_slack_summary") as mock_schedule,
+        ):
+            call_session_service.update_call_session_status(
+                db, session_enabled.id, "completed"
+            )
+            call_session_service.update_call_session_status(
+                db, session_disabled.id, "completed"
+            )
+
+        mock_schedule.assert_called_once_with(session_enabled.id)

--- a/tests/services/test_slack_service.py
+++ b/tests/services/test_slack_service.py
@@ -208,7 +208,7 @@ class TestUpsertIntegration:
 
         assert row.workspace_id == _TENANT_ID
         assert row.provider == "slack"
-        assert row.access_token.startswith("gcm1:")
+        assert row.access_token.startswith("slack_gcm1:")
         assert row.extra_metadata["team_id"] == "T123"
         assert row.extra_metadata["team_name"] == "Acme Workspace"
         db.add.assert_called_once_with(row)
@@ -235,7 +235,7 @@ class TestUpsertIntegration:
         assert row.extra_metadata["team_name"] == "New Team Name"
         # Reconnect must not clobber an already-configured default channel.
         assert row.extra_metadata["default_channel_id"] == "C1"
-        assert row.access_token.startswith("gcm1:")
+        assert row.access_token.startswith("slack_gcm1:")
 
 
 class TestGetValidAccessToken:
@@ -525,6 +525,43 @@ class TestListChannels:
         assert [c["id"] for c in channels] == ["C1", "C2"]
         assert mock_request.await_count == 2
         assert mock_request.await_args_list[1].kwargs["params"]["cursor"] == "cursor-2"
+
+    @pytest.mark.anyio
+    async def test_pagination_stops_at_page_cap(self):
+        """Regression test: a workspace with far more channels than the page
+        cap must not turn GET /channels into an unbounded blocking fan-out —
+        list_channels stops after _MAX_CHANNEL_LIST_PAGES pages even though
+        the server keeps returning a next_cursor."""
+        db = MagicMock()
+
+        def _page(n: int) -> MagicMock:
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {
+                "ok": True,
+                "channels": [{"id": f"C{n}", "name": f"chan-{n}"}],
+                "response_metadata": {"next_cursor": f"cursor-{n + 1}"},
+            }
+            return resp
+
+        # Server would keep paginating forever (always returns a next_cursor);
+        # only _MAX_CHANNEL_LIST_PAGES requests should ever be made.
+        pages = [_page(n) for n in range(1, slack_service._MAX_CHANNEL_LIST_PAGES + 2)]
+
+        with (
+            patch(
+                "app.services.slack_service.get_valid_access_token",
+                new=AsyncMock(return_value="xoxb-plain"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(side_effect=pages),
+            ) as mock_request,
+        ):
+            channels = await slack_service.list_channels(db, _TENANT_ID)
+
+        assert mock_request.await_count == slack_service._MAX_CHANNEL_LIST_PAGES
+        assert len(channels) == slack_service._MAX_CHANNEL_LIST_PAGES
 
     @pytest.mark.anyio
     async def test_raises_when_not_connected(self):
@@ -1211,7 +1248,7 @@ class TestSlackTokenEncryption:
 
         db = MagicMock()
         ciphertext = encrypt_slack_token("xoxb-secret-token", db)
-        assert ciphertext.startswith("gcm1:")
+        assert ciphertext.startswith("slack_gcm1:")
         assert decrypt_slack_token(ciphertext, db) == "xoxb-secret-token"
 
     def test_decrypt_unrecognized_format_raises(self):

--- a/tests/services/test_slack_service.py
+++ b/tests/services/test_slack_service.py
@@ -1,0 +1,1240 @@
+"""
+Tests for Slack post-call-summary OAuth integration service.
+
+External HTTP calls (OAuth token endpoint, conversations.list, chat.postMessage,
+auth.revoke) are mocked at the boundary (`_request_with_backoff`), mirroring
+tests/services/test_hubspot_service.py's convention.
+
+Coverage:
+  1.  OAuth state: sign/verify round trip, tamper rejection, wrong purpose
+      rejection, expired state rejection
+  2.  Authorization URL: client_id/scope/state present
+  3.  Token exchange: success shape; `ok: false` -> ValueError; HTTP failure -> raises
+  4.  upsert_integration: creates a new row; updates an existing row (encrypts token,
+      stores team metadata)
+  5.  get_valid_access_token: decrypts and returns; None when not connected
+  6.  list_channels: success shape (incl. pagination via cursor); raises (does not
+      fail open) when not connected / Slack API error / ok:false
+  7.  set_default_channel: persists; clears when both args None; raises when not
+      connected
+  8.  disconnect: revokes + deletes; returns False when not connected; revoke
+      failure still deletes local row (best-effort)
+  9.  tenant_has_slack_connected: True/False
+  10. send_call_summary: posts to call-flow-override channel over workspace
+      default; correct phone/summary/sentiment fields; fail-open on every
+      failure path (no call_flow, disabled, not connected, no channel,
+      decrypt failure, post failure); lazily computes analysis when not cached
+  11. 429 backoff (shared helper, mirrors HubSpot's suite)
+  12. Slack token encryption round trip (AES-256-GCM)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import slack_service
+
+_TENANT_ID = uuid.UUID("aa100000-0000-0000-0000-000000000001")
+_OTHER_TENANT_ID = uuid.UUID("aa200000-0000-0000-0000-000000000002")
+_SESSION_ID = uuid.UUID("bb100000-0000-0000-0000-000000000002")
+
+
+# ── OAuth state ────────────────────────────────────────────────────────────────
+
+
+class TestOAuthState:
+    def test_roundtrip(self):
+        state = slack_service.build_oauth_state(_TENANT_ID)
+        assert slack_service.verify_oauth_state(state) == _TENANT_ID
+
+    def test_tampered_state_rejected(self):
+        state = slack_service.build_oauth_state(_TENANT_ID)
+        with pytest.raises(ValueError):
+            slack_service.verify_oauth_state(state + "x")
+
+    def test_wrong_purpose_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        bad_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "something_else",
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            slack_service.verify_oauth_state(bad_state)
+
+    def test_expired_state_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        expired_state = jose_jwt.encode(
+            {
+                "tenant_id": str(_TENANT_ID),
+                "purpose": "slack_oauth_state",
+                "exp": datetime.now(timezone.utc) - timedelta(minutes=1),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            slack_service.verify_oauth_state(expired_state)
+
+    def test_missing_tenant_id_rejected(self):
+        from jose import jwt as jose_jwt
+        from app.core.config import settings
+
+        bad_state = jose_jwt.encode(
+            {
+                "purpose": "slack_oauth_state",
+                "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+            },
+            settings.SECRET_KEY,
+            algorithm=settings.ALGORITHM,
+        )
+        with pytest.raises(ValueError):
+            slack_service.verify_oauth_state(bad_state)
+
+
+class TestAuthorizationUrl:
+    def test_contains_client_id_scope_and_state(self):
+        with patch(
+            "app.services.slack_service.get_slack_oauth_credentials",
+            return_value=("client-123", "secret-456"),
+        ):
+            url = slack_service.get_authorization_url(_TENANT_ID)
+
+        assert url.startswith(slack_service.AUTHORIZE_URL)
+        assert "client_id=client-123" in url
+        assert "channels%3Aread" in url or "channels:read" in url
+        assert "chat%3Awrite" in url or "chat:write" in url
+        assert "state=" in url
+
+
+# ── Token exchange ──────────────────────────────────────────────────────────────
+
+
+class TestExchangeCodeForTokens:
+    @pytest.mark.anyio
+    async def test_success_returns_payload(self):
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "ok": True,
+            "access_token": "xoxb-abc",
+            "team": {"id": "T123", "name": "Acme Workspace"},
+        }
+
+        with (
+            patch(
+                "app.services.slack_service.get_slack_oauth_credentials",
+                return_value=("client-123", "secret-456"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ),
+        ):
+            payload = await slack_service.exchange_code_for_tokens("mock-code")
+
+        assert payload["access_token"] == "xoxb-abc"
+        assert payload["team"]["name"] == "Acme Workspace"
+
+    @pytest.mark.anyio
+    async def test_ok_false_raises_value_error(self):
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"ok": False, "error": "invalid_code"}
+
+        with (
+            patch(
+                "app.services.slack_service.get_slack_oauth_credentials",
+                return_value=("client-123", "secret-456"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ),
+            pytest.raises(ValueError, match="invalid_code"),
+        ):
+            await slack_service.exchange_code_for_tokens("bad-code")
+
+    @pytest.mark.anyio
+    async def test_http_failure_raises(self):
+        import httpx
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=MagicMock(status_code=500)
+            )
+        )
+
+        with (
+            patch(
+                "app.services.slack_service.get_slack_oauth_credentials",
+                return_value=("client-123", "secret-456"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await slack_service.exchange_code_for_tokens("mock-code")
+
+
+# ── WorkspaceIntegration CRUD ────────────────────────────────────────────────
+
+
+class TestUpsertIntegration:
+    def test_creates_new_row_when_none_exists(self):
+        db = MagicMock()
+        token_response = {
+            "access_token": "xoxb-abc",
+            "team": {"id": "T123", "name": "Acme Workspace"},
+        }
+
+        with patch("app.services.slack_service.get_integration", return_value=None):
+            row = slack_service.upsert_integration(db, _TENANT_ID, token_response)
+
+        assert row.workspace_id == _TENANT_ID
+        assert row.provider == "slack"
+        assert row.access_token.startswith("gcm1:")
+        assert row.extra_metadata["team_id"] == "T123"
+        assert row.extra_metadata["team_name"] == "Acme Workspace"
+        db.add.assert_called_once_with(row)
+        db.commit.assert_called_once()
+        db.refresh.assert_called_once_with(row)
+
+    def test_updates_existing_row_preserving_other_metadata(self):
+        db = MagicMock()
+        existing = MagicMock()
+        existing.extra_metadata = {
+            "default_channel_id": "C1",
+            "default_channel_name": "general",
+        }
+        token_response = {
+            "access_token": "xoxb-new",
+            "team": {"id": "T999", "name": "New Team Name"},
+        }
+
+        with patch("app.services.slack_service.get_integration", return_value=existing):
+            row = slack_service.upsert_integration(db, _TENANT_ID, token_response)
+
+        assert row is existing
+        assert row.extra_metadata["team_id"] == "T999"
+        assert row.extra_metadata["team_name"] == "New Team Name"
+        # Reconnect must not clobber an already-configured default channel.
+        assert row.extra_metadata["default_channel_id"] == "C1"
+        assert row.access_token.startswith("gcm1:")
+
+
+class TestGetValidAccessToken:
+    @pytest.mark.anyio
+    async def test_returns_decrypted_token(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.access_token = "gcm1:ciphertext"
+
+        with (
+            patch("app.services.slack_service.get_integration", return_value=row),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ) as mock_decrypt,
+        ):
+            token = await slack_service.get_valid_access_token(db, _TENANT_ID)
+
+        assert token == "xoxb-plain"
+        mock_decrypt.assert_called_once_with(row.access_token, db)
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.slack_service.get_integration", return_value=None):
+            token = await slack_service.get_valid_access_token(db, _TENANT_ID)
+        assert token is None
+
+    @pytest.mark.anyio
+    async def test_returns_none_when_row_has_no_token(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.access_token = None
+        with patch("app.services.slack_service.get_integration", return_value=row):
+            token = await slack_service.get_valid_access_token(db, _TENANT_ID)
+        assert token is None
+
+    @pytest.mark.anyio
+    async def test_decrypt_failure_propagates(self):
+        """Invalid/corrupted ciphertext (e.g. re-encrypted under a rotated key)
+        must surface as an error rather than silently return a bad token."""
+        db = MagicMock()
+        row = MagicMock()
+        row.access_token = "gcm1:corrupt"
+
+        with (
+            patch("app.services.slack_service.get_integration", return_value=row),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                side_effect=ValueError("Slack token decryption failed"),
+            ),
+            pytest.raises(ValueError),
+        ):
+            await slack_service.get_valid_access_token(db, _TENANT_ID)
+
+
+class TestTenantHasSlackConnected:
+    def test_true_when_connected(self):
+        db = MagicMock()
+        with patch(
+            "app.services.slack_service.get_integration", return_value=MagicMock()
+        ):
+            assert slack_service.tenant_has_slack_connected(db, _TENANT_ID) is True
+
+    def test_false_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.slack_service.get_integration", return_value=None):
+            assert slack_service.tenant_has_slack_connected(db, _TENANT_ID) is False
+
+
+class TestGetIntegrationStatus:
+    def test_not_connected_shape(self):
+        db = MagicMock()
+        with patch("app.services.slack_service.get_integration", return_value=None):
+            status = slack_service.get_integration_status(db, _TENANT_ID)
+
+        assert status == {
+            "connected": False,
+            "connected_at": None,
+            "team_name": None,
+            "default_channel_id": None,
+            "default_channel_name": None,
+        }
+
+    def test_connected_shape(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.created_at = datetime.now(timezone.utc)
+        row.extra_metadata = {
+            "team_name": "Acme Workspace",
+            "default_channel_id": "C1",
+            "default_channel_name": "general",
+        }
+
+        with patch("app.services.slack_service.get_integration", return_value=row):
+            status = slack_service.get_integration_status(db, _TENANT_ID)
+
+        assert status["connected"] is True
+        assert status["team_name"] == "Acme Workspace"
+        assert status["default_channel_id"] == "C1"
+        assert status["default_channel_name"] == "general"
+
+
+class TestSetDefaultChannel:
+    def test_sets_channel(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.extra_metadata = {}
+
+        with patch("app.services.slack_service.get_integration", return_value=row):
+            slack_service.set_default_channel(db, _TENANT_ID, "C1", "general")
+
+        assert row.extra_metadata["default_channel_id"] == "C1"
+        assert row.extra_metadata["default_channel_name"] == "general"
+        db.commit.assert_called_once()
+
+    def test_clears_channel_when_both_none(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.extra_metadata = {
+            "default_channel_id": "C1",
+            "default_channel_name": "general",
+        }
+
+        with patch("app.services.slack_service.get_integration", return_value=row):
+            slack_service.set_default_channel(db, _TENANT_ID, None, None)
+
+        assert "default_channel_id" not in row.extra_metadata
+        assert "default_channel_name" not in row.extra_metadata
+
+    def test_raises_when_not_connected(self):
+        db = MagicMock()
+        with (
+            patch("app.services.slack_service.get_integration", return_value=None),
+            pytest.raises(ValueError),
+        ):
+            slack_service.set_default_channel(db, _TENANT_ID, "C1", "general")
+
+
+# ── Disconnect ──────────────────────────────────────────────────────────────────
+
+
+class TestDisconnect:
+    @pytest.mark.anyio
+    async def test_revokes_and_deletes_row(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.access_token = "gcm1:ciphertext"
+
+        with (
+            patch("app.services.slack_service.get_integration", return_value=row),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(return_value=MagicMock(status_code=200)),
+            ) as mock_request,
+        ):
+            result = await slack_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        mock_request.assert_awaited_once()
+        assert mock_request.call_args[0][0] == "POST"
+        assert mock_request.call_args[0][1] == slack_service.REVOKE_URL
+        db.delete.assert_called_once_with(row)
+        db.commit.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_returns_false_when_not_connected(self):
+        db = MagicMock()
+        with patch("app.services.slack_service.get_integration", return_value=None):
+            result = await slack_service.disconnect(db, _TENANT_ID)
+        assert result is False
+        db.delete.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_revoke_failure_still_deletes_local_row(self):
+        """A Slack outage or already-revoked token during auth.revoke must not
+        block the local disconnect (best-effort revoke)."""
+        db = MagicMock()
+        row = MagicMock()
+        row.access_token = "gcm1:ciphertext"
+
+        with (
+            patch("app.services.slack_service.get_integration", return_value=row),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(side_effect=Exception("network error")),
+            ),
+        ):
+            result = await slack_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        db.delete.assert_called_once_with(row)
+        db.commit.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_decrypt_failure_during_revoke_still_deletes_local_row(self):
+        db = MagicMock()
+        row = MagicMock()
+        row.access_token = "gcm1:corrupt"
+
+        with (
+            patch("app.services.slack_service.get_integration", return_value=row),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                side_effect=ValueError("Slack token decryption failed"),
+            ),
+        ):
+            result = await slack_service.disconnect(db, _TENANT_ID)
+
+        assert result is True
+        db.delete.assert_called_once_with(row)
+
+
+# ── Channel listing (admin action — raises, does not fail open) ────────────────
+
+
+class TestListChannels:
+    @pytest.mark.anyio
+    async def test_returns_channel_shape(self):
+        db = MagicMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "ok": True,
+            "channels": [
+                {"id": "C1", "name": "general"},
+                {"id": "C2", "name": "sales"},
+            ],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        with (
+            patch(
+                "app.services.slack_service.get_valid_access_token",
+                new=AsyncMock(return_value="xoxb-plain"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ),
+        ):
+            channels = await slack_service.list_channels(db, _TENANT_ID)
+
+        assert channels == [
+            {"id": "C1", "name": "general"},
+            {"id": "C2", "name": "sales"},
+        ]
+
+    @pytest.mark.anyio
+    async def test_paginates_across_cursor(self):
+        db = MagicMock()
+        page1 = MagicMock()
+        page1.raise_for_status = MagicMock()
+        page1.json.return_value = {
+            "ok": True,
+            "channels": [{"id": "C1", "name": "general"}],
+            "response_metadata": {"next_cursor": "cursor-2"},
+        }
+        page2 = MagicMock()
+        page2.raise_for_status = MagicMock()
+        page2.json.return_value = {
+            "ok": True,
+            "channels": [{"id": "C2", "name": "sales"}],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        with (
+            patch(
+                "app.services.slack_service.get_valid_access_token",
+                new=AsyncMock(return_value="xoxb-plain"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(side_effect=[page1, page2]),
+            ) as mock_request,
+        ):
+            channels = await slack_service.list_channels(db, _TENANT_ID)
+
+        assert [c["id"] for c in channels] == ["C1", "C2"]
+        assert mock_request.await_count == 2
+        assert mock_request.await_args_list[1].kwargs["params"]["cursor"] == "cursor-2"
+
+    @pytest.mark.anyio
+    async def test_raises_when_not_connected(self):
+        db = MagicMock()
+        with (
+            patch(
+                "app.services.slack_service.get_valid_access_token",
+                new=AsyncMock(return_value=None),
+            ),
+            pytest.raises(ValueError, match="not connected"),
+        ):
+            await slack_service.list_channels(db, _TENANT_ID)
+
+    @pytest.mark.anyio
+    async def test_raises_on_ok_false(self):
+        db = MagicMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"ok": False, "error": "invalid_auth"}
+
+        with (
+            patch(
+                "app.services.slack_service.get_valid_access_token",
+                new=AsyncMock(return_value="xoxb-plain"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ),
+            pytest.raises(ValueError, match="invalid_auth"),
+        ):
+            await slack_service.list_channels(db, _TENANT_ID)
+
+    @pytest.mark.anyio
+    async def test_raises_on_http_error_does_not_fail_open(self):
+        """Admin-facing settings action: unlike send_call_summary, a Slack
+        outage here must raise, not silently return an empty list."""
+        import httpx
+
+        db = MagicMock()
+        response = MagicMock()
+        response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=MagicMock(status_code=500)
+            )
+        )
+
+        with (
+            patch(
+                "app.services.slack_service.get_valid_access_token",
+                new=AsyncMock(return_value="xoxb-plain"),
+            ),
+            patch(
+                "app.services.slack_service._request_with_backoff",
+                new=AsyncMock(return_value=response),
+            ),
+            pytest.raises(httpx.HTTPStatusError),
+        ):
+            await slack_service.list_channels(db, _TENANT_ID)
+
+
+# ── Post-call summary send ──────────────────────────────────────────────────────
+
+
+def _call_session(
+    *,
+    call_flow_id=uuid.uuid4(),
+    tenant_id=_TENANT_ID,
+    phone="+15550001111",
+    status="completed",
+    duration=125,
+    metadata=None,
+    transcript_summary=None,
+):
+    cs = MagicMock()
+    cs.id = _SESSION_ID
+    cs.tenant_id = tenant_id
+    cs.call_flow_id = call_flow_id
+    cs.customer_phone_number = phone
+    cs.status = status
+    cs.duration = duration
+    cs.call_metadata = metadata if metadata is not None else {}
+    cs.transcript_summary = transcript_summary
+    return cs
+
+
+def _call_flow(*, enabled=True, channel_id=None, channel_name=None):
+    flow = MagicMock()
+    flow.slack_summary_enabled = enabled
+    flow.slack_channel_id = channel_id
+    flow.slack_channel_name = channel_name
+    return flow
+
+
+def _integration(*, default_channel_id=None):
+    row = MagicMock()
+    row.access_token = "gcm1:ciphertext"
+    row.extra_metadata = (
+        {"default_channel_id": default_channel_id} if default_channel_id else {}
+    )
+    return row
+
+
+def _mock_query_chain(db, results_by_model):
+    """db.query(Model).filter(...).first() -> results_by_model[Model]"""
+
+    def _query(model):
+        q = MagicMock()
+        q.filter.return_value = q
+        q.first.return_value = results_by_model.get(model)
+        return q
+
+    db.query.side_effect = _query
+
+
+class TestSendCallSummary:
+    def _setup_db(self, db, *, call_session, call_flow):
+        from app.models.call_flow import CallFlow
+        from app.models.call_session import CallSession
+
+        _mock_query_chain(db, {CallSession: call_session, CallFlow: call_flow})
+
+    @pytest.mark.anyio
+    async def test_posts_correct_phone_summary_and_sentiment(self):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True)
+        call_session = _call_session(
+            call_flow_id=call_flow,
+            phone="+15550001111",
+            metadata={
+                "llm_call_analysis": {
+                    "analysis": {
+                        "summary": "Caller wants a demo.",
+                        "sentiment": "positive",
+                    }
+                }
+            },
+        )
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id="C1")
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        mock_post.assert_awaited_once()
+        access_token, channel, text, blocks = mock_post.call_args[0]
+        assert access_token == "xoxb-plain"
+        assert channel == "C1"
+        assert "+15550001111" in text
+        summary_block = next(
+            b for b in blocks if b.get("type") == "section" and "Summary" in str(b)
+        )
+        assert "Caller wants a demo." in str(summary_block)
+        sentiment_field = next(
+            f for f in blocks[1]["fields"] if "Sentiment" in f["text"]
+        )
+        assert "positive" in sentiment_field["text"]
+
+    @pytest.mark.anyio
+    async def test_call_flow_channel_override_wins_over_workspace_default(self):
+        db = MagicMock()
+        call_flow = _call_flow(
+            enabled=True, channel_id="C-OVERRIDE", channel_name="sales"
+        )
+        call_session = _call_session(call_flow_id=call_flow)
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id="C-DEFAULT")
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        channel = mock_post.call_args[0][1]
+        assert channel == "C-OVERRIDE"
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_workspace_default_channel(self):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True, channel_id=None, channel_name=None)
+        call_session = _call_session(call_flow_id=call_flow)
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id="C-DEFAULT")
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        channel = mock_post.call_args[0][1]
+        assert channel == "C-DEFAULT"
+
+    @pytest.mark.anyio
+    async def test_no_channel_configured_skips_without_raising(self):
+        """Neither a call-flow override nor a workspace default configured —
+        must log and skip cleanly, not crash or post to an empty channel."""
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True, channel_id=None, channel_name=None)
+        call_session = _call_session(call_flow_id=call_flow)
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id=None)
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_call_session_returns_quietly(self):
+        db = MagicMock()
+        from app.models.call_flow import CallFlow
+        from app.models.call_session import CallSession
+
+        _mock_query_chain(db, {CallSession: None, CallFlow: None})
+
+        with patch(
+            "app.services.slack_service._post_message", new=AsyncMock()
+        ) as mock_post:
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_no_call_flow_id_returns_quietly(self):
+        db = MagicMock()
+        call_session = _call_session(call_flow_id=None)
+        from app.models.call_flow import CallFlow
+        from app.models.call_session import CallSession
+
+        _mock_query_chain(db, {CallSession: call_session, CallFlow: None})
+
+        with patch(
+            "app.services.slack_service._post_message", new=AsyncMock()
+        ) as mock_post:
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_call_flow_disabled_returns_quietly(self):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=False)
+        call_session = _call_session(call_flow_id=call_flow)
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+
+        with patch(
+            "app.services.slack_service._post_message", new=AsyncMock()
+        ) as mock_post:
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_not_connected_returns_quietly(self):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True)
+        call_session = _call_session(call_flow_id=call_flow)
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+
+        with (
+            patch("app.services.slack_service.get_integration", return_value=None),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_decrypt_failure_fails_open(self):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True)
+        call_session = _call_session(call_flow_id=call_flow)
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id="C1")
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                side_effect=ValueError("Slack token decryption failed"),
+            ),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(
+                db, _SESSION_ID
+            )  # must not raise
+
+        mock_post.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_post_message_failure_fails_open_via_sync_entrypoint(self):
+        """send_call_summary (the sync entrypoint actually wired into the call-time
+        hook) must never raise even when everything downstream fails."""
+        db = MagicMock()
+
+        with (
+            patch("app.services.slack_service.SessionLocal", return_value=db),
+            patch(
+                "app.services.slack_service._send_call_summary_async",
+                new=AsyncMock(
+                    side_effect=Exception("Slack chat.postMessage failed: rate_limited")
+                ),
+            ),
+        ):
+            slack_service.send_call_summary(_SESSION_ID)  # must not raise
+
+        db.close.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_lazily_computes_analysis_when_not_cached(self):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True)
+        call_session = _call_session(call_flow_id=call_flow, metadata={})
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id="C1")
+
+        def _fake_ensure(db_arg, cs_arg, raise_on_no_transcript=False):
+            cs_arg.call_metadata = {
+                "llm_call_analysis": {
+                    "analysis": {"summary": "Lazy summary.", "sentiment": "neutral"}
+                }
+            }
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.voice_analysis_service.ensure_call_summary_locked",
+                side_effect=_fake_ensure,
+            ) as mock_ensure,
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        mock_ensure.assert_called_once()
+        text_blocks = mock_post.call_args[0][3]
+        summary_block = next(
+            b for b in text_blocks if b.get("type") == "section" and "Summary" in str(b)
+        )
+        assert "Lazy summary." in str(summary_block)
+
+    @pytest.mark.anyio
+    async def test_analysis_generation_failure_fails_open_and_uses_fallback_summary(
+        self,
+    ):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True)
+        call_session = _call_session(call_flow_id=call_flow, metadata={})
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id="C1")
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.voice_analysis_service.ensure_call_summary_locked",
+                side_effect=Exception("advisory lock contention"),
+            ),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(
+                db, _SESSION_ID
+            )  # must not raise
+
+        mock_post.assert_awaited_once()
+        text_blocks = mock_post.call_args[0][3]
+        summary_block = next(
+            b for b in text_blocks if b.get("type") == "section" and "Summary" in str(b)
+        )
+        assert "No summary available." in str(summary_block)
+
+    @pytest.mark.anyio
+    async def test_uses_transcript_summary_over_llm_analysis_when_present(self):
+        db = MagicMock()
+        call_flow = _call_flow(enabled=True)
+        call_session = _call_session(
+            call_flow_id=call_flow,
+            transcript_summary="Explicit transcript summary.",
+            metadata={
+                "llm_call_analysis": {"analysis": {"summary": "Analysis summary."}}
+            },
+        )
+        self._setup_db(db, call_session=call_session, call_flow=call_flow)
+        integration = _integration(default_channel_id="C1")
+
+        with (
+            patch(
+                "app.services.slack_service.get_integration", return_value=integration
+            ),
+            patch(
+                "app.services.slack_service.decrypt_slack_token",
+                return_value="xoxb-plain",
+            ),
+            patch(
+                "app.services.slack_service._post_message", new=AsyncMock()
+            ) as mock_post,
+        ):
+            await slack_service._send_call_summary_async(db, _SESSION_ID)
+
+        text_blocks = mock_post.call_args[0][3]
+        summary_block = next(
+            b for b in text_blocks if b.get("type") == "section" and "Summary" in str(b)
+        )
+        assert "Explicit transcript summary." in str(summary_block)
+        assert "Analysis summary." not in str(summary_block)
+
+
+class TestScheduleSlackSummary:
+    def test_dispatches_via_thread_when_no_running_loop(self):
+        with (
+            patch(
+                "app.services.slack_service.asyncio.get_running_loop",
+                side_effect=RuntimeError("no running loop"),
+            ),
+            patch("app.services.slack_service.threading.Thread") as mock_thread_cls,
+        ):
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            slack_service.schedule_slack_summary(_SESSION_ID)
+
+        mock_thread_cls.assert_called_once_with(
+            target=slack_service.send_call_summary, args=(_SESSION_ID,), daemon=True
+        )
+        mock_thread.start.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_dispatches_via_create_task_when_loop_running(self):
+        with patch(
+            "app.services.slack_service.asyncio.create_task"
+        ) as mock_create_task:
+            slack_service.schedule_slack_summary(_SESSION_ID)
+
+        mock_create_task.assert_called_once()
+
+
+# ── Multi-tenant isolation ───────────────────────────────────────────────────────
+
+
+class TestTenantIsolation:
+    def test_get_integration_filters_by_tenant_and_provider(self):
+        """The WorkspaceIntegration query must filter by both workspace_id AND
+        provider — never return tenant B's Slack row for tenant A."""
+        db = MagicMock()
+        query = MagicMock()
+        db.query.return_value = query
+        query.filter.return_value = query
+        query.first.return_value = MagicMock()
+
+        slack_service.get_integration(db, _TENANT_ID)
+
+        filter_args = query.filter.call_args[0]
+        # Two filter clauses passed: workspace_id == tenant_id, provider == "slack"
+        assert len(filter_args) == 2
+
+    def test_get_integration_never_returns_other_tenants_row(self, db):
+        """Real-DB proof: with two tenants each holding a Slack WorkspaceIntegration
+        row, tenant A's lookup must return only tenant A's row/token, never tenant B's,
+        even though both rows share provider="slack"."""
+        from app.models.tenant import Tenant
+        from app.models.workspace_integration import WorkspaceIntegration
+
+        tenant_a = Tenant(
+            name=f"SlackIsoA-{uuid.uuid4().hex[:8]}",
+            schema_name=f"slack_iso_a_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        tenant_b = Tenant(
+            name=f"SlackIsoB-{uuid.uuid4().hex[:8]}",
+            schema_name=f"slack_iso_b_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add_all([tenant_a, tenant_b])
+        db.commit()
+        db.refresh(tenant_a)
+        db.refresh(tenant_b)
+
+        row_a = WorkspaceIntegration(
+            workspace_id=tenant_a.id,
+            provider="slack",
+            access_token="gcm1:tenant-a-ciphertext",
+            extra_metadata={"team_id": "TEAMA", "default_channel_id": "C_A"},
+        )
+        row_b = WorkspaceIntegration(
+            workspace_id=tenant_b.id,
+            provider="slack",
+            access_token="gcm1:tenant-b-ciphertext",
+            extra_metadata={"team_id": "TEAMB", "default_channel_id": "C_B"},
+        )
+        db.add_all([row_a, row_b])
+        db.commit()
+
+        found_for_a = slack_service.get_integration(db, tenant_a.id)
+        found_for_b = slack_service.get_integration(db, tenant_b.id)
+
+        assert found_for_a is not None
+        assert found_for_a.id == row_a.id
+        assert found_for_a.access_token == "gcm1:tenant-a-ciphertext"
+        assert found_for_a.extra_metadata["default_channel_id"] == "C_A"
+
+        assert found_for_b is not None
+        assert found_for_b.id == row_b.id
+        assert found_for_b.access_token == "gcm1:tenant-b-ciphertext"
+
+        # Neither lookup ever leaks the other tenant's row.
+        assert found_for_a.id != found_for_b.id
+        assert found_for_a.workspace_id == tenant_a.id
+        assert found_for_b.workspace_id == tenant_b.id
+
+        db.delete(row_a)
+        db.delete(row_b)
+        db.delete(tenant_a)
+        db.delete(tenant_b)
+        db.commit()
+
+    def test_list_channels_uses_tenant_specific_token(self):
+        """Confirms list_channels resolves the access token via the tenant-scoped
+        get_valid_access_token rather than any global/shared credential."""
+        db = MagicMock()
+
+        async def _fake_get_valid_access_token(db_arg, tenant_id_arg):
+            assert tenant_id_arg == _TENANT_ID
+            return "tenant-a-token"
+
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {
+            "ok": True,
+            "channels": [],
+            "response_metadata": {},
+        }
+
+        async def _run():
+            with (
+                patch(
+                    "app.services.slack_service.get_valid_access_token",
+                    side_effect=_fake_get_valid_access_token,
+                ),
+                patch(
+                    "app.services.slack_service._request_with_backoff",
+                    new=AsyncMock(return_value=response),
+                ) as mock_request,
+            ):
+                await slack_service.list_channels(db, _TENANT_ID)
+            assert (
+                mock_request.call_args.kwargs["headers"]["Authorization"]
+                == "Bearer tenant-a-token"
+            )
+
+        import asyncio
+
+        asyncio.run(_run())
+
+
+# ── 429 backoff (shared helper) ──────────────────────────────────────────────────
+
+
+class TestBackoff:
+    @pytest.mark.anyio
+    async def test_retries_on_429_then_succeeds(self):
+        responses = [
+            MagicMock(status_code=429, headers={}),
+            MagicMock(status_code=200, headers={}),
+        ]
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            response = await slack_service._request_with_backoff(
+                "GET", "https://slack.com/api/x"
+            )
+
+        assert response.status_code == 200
+        mock_sleep.assert_awaited_once()
+        assert mock_sleep.call_args[0][0] == 1.0
+
+    @pytest.mark.anyio
+    async def test_honors_retry_after_header(self):
+        responses = [
+            MagicMock(status_code=429, headers={"Retry-After": "3"}),
+            MagicMock(status_code=200, headers={}),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        ):
+            await slack_service._request_with_backoff("GET", "https://slack.com/api/x")
+
+        assert mock_sleep.call_args[0][0] == 3.0
+
+    @pytest.mark.anyio
+    async def test_gives_up_after_max_retries(self):
+        always_429 = MagicMock(status_code=429, headers={})
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=always_429)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch("asyncio.sleep", new=AsyncMock()),
+        ):
+            response = await slack_service._request_with_backoff(
+                "GET", "https://slack.com/api/x"
+            )
+
+        assert response.status_code == 429
+        assert mock_client.request.await_count == slack_service._MAX_RETRIES + 1
+
+
+# ── Token encryption round trip ───────────────────────────────────────────────
+
+
+class TestSlackTokenEncryption:
+    def test_roundtrip(self):
+        from app.core.db_encryption import decrypt_slack_token, encrypt_slack_token
+
+        db = MagicMock()
+        ciphertext = encrypt_slack_token("xoxb-secret-token", db)
+        assert ciphertext.startswith("gcm1:")
+        assert decrypt_slack_token(ciphertext, db) == "xoxb-secret-token"
+
+    def test_decrypt_unrecognized_format_raises(self):
+        from app.core.db_encryption import decrypt_slack_token
+
+        db = MagicMock()
+        with pytest.raises(ValueError, match="Unrecognized Slack token"):
+            decrypt_slack_token("not-a-gcm-ciphertext", db)
+
+    def test_decrypt_empty_raises(self):
+        from app.core.db_encryption import decrypt_slack_token
+
+        db = MagicMock()
+        with pytest.raises(ValueError, match="ciphertext is empty"):
+            decrypt_slack_token("", db)
+
+    def test_decrypt_tampered_ciphertext_raises(self):
+        from app.core.db_encryption import decrypt_slack_token, encrypt_slack_token
+
+        db = MagicMock()
+        ciphertext = encrypt_slack_token("xoxb-secret-token", db)
+        tampered = (
+            ciphertext[:-4] + ("A" if ciphertext[-4] != "A" else "B") + ciphertext[-3:]
+        )
+        with pytest.raises(ValueError, match="decryption failed"):
+            decrypt_slack_token(tampered, db)


### PR DESCRIPTION
## Summary
- Adds a Slack OAuth integration for delivering post-call summaries to a Slack channel, following the existing HubSpot/Salesforce OAuth pattern (`WorkspaceIntegration` table, AES-256-GCM token encryption, signed-JWT OAuth state).
- New `app/routers/slack_integration.py` (mounted at `/api/v1/integrations/slack`): connect (dual redirect/JSON), callback, disconnect, status, channel listing, default-channel selection.
- New `CallFlow` columns (`slack_summary_enabled`, `slack_channel_id`, `slack_channel_name`) — Slack is **off by default** per call flow, matching the existing `email_summary_enabled` opt-in pattern. Exposed via the existing `PUT /api/v2/flows/{flow_id}/post-call-actions-settings` endpoint (no new endpoint added).
- New post-call hook in `CallSessionService.update_call_session_status()`: fires only when both the call flow has opted in and the tenant has Slack connected; entirely fail-open (wrapped in try/except that only logs) so a Slack outage or misconfiguration never affects call completion.
- OAuth scope includes `chat:write.public` (verified against Slack's own API docs) — without it, posting to public channels the bot wasn't manually invited to would silently fail.

## Test plan
- [x] `tests/services/test_slack_service.py` (56 tests) — OAuth state/CSRF, token encryption round-trip, channel listing (raises on failure — admin action), send-summary fail-open behavior, tenant isolation (real two-tenant DB test), disconnect/reconnect, async dispatch pattern.
- [x] `tests/api/test_slack_integration.py` (25 tests) — RBAC per endpoint, connect redirect vs JSON mode, callback state verification, error handling.
- [x] Updated `tests/api/v2/test_post_call_actions_settings.py` and `tests/services/test_call_session_post_call_email_hook.py` for the new Slack fields/hook.
- [x] Full existing suite (`pytest tests/ --ignore=tests/integration`) passes: 2984 passed, 1 pre-existing unrelated flaky timing test deselected (`test_audio_transcoder.py`, not touched by this branch).
- [x] `ruff check` / `black --check` clean on all touched files.
- [x] Migration `c4e70c96cb81` applied cleanly (pure additive `ADD COLUMN`, safe on a live table).
- [x] Reviewed by `code-reviewer` agent — no blocking findings; one test-quality gap (mocked tenant-isolation test) fixed with a real two-tenant DB test.
- [x] Manually cross-checked OAuth/API implementation against `docs.slack.dev` (oauth.v2.access, conversations.list, chat.postMessage) — found and fixed a missing `chat:write.public` scope.

## Setup required post-merge
A Slack app needs to be created with scopes `channels:read`, `groups:read`, `chat:write`, `chat:write.public`, and redirect URL `{WEBHOOK_BASE_URL}/api/v1/integrations/slack/callback`. Env vars: `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_TOKEN_ENCRYPTION_KEY` (optionally `SLACK_REDIRECT_URI`) — added to `.env.example` and `CLAUDE.md`.

https://claude.ai/code/session_01Y3RE1KRZwQZPwzHTypz34V