### PR TITLE
feat(billing): Studio/Agency subscription plans with plan-aware credit billing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,3 +346,5 @@ Mock external HTTP APIs at the boundary with `unittest.mock.patch` or `respx`.
 | `OTEL_TRACING_ENABLED` | Observability | Default `false`; enable to export spans via OTLP |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Observability | Default `http://localhost:4317` |
 | `OTEL_SERVICE_NAME` | Observability | Default `tgs-agent-be` |
+| `STRIPE_PRICE_ID_STUDIO` | Billing | Stripe Price ID for the Studio core-product plan ($99/mo, 100 included minutes) |
+| `STRIPE_PRICE_ID_AGENCY` | Billing | Stripe Price ID for the Agency core-product plan ($299/mo, 300 included minutes) |

--- a/alembic/versions/3ad4a023f421_add_studio_agency_plan_fields_and_.py
+++ b/alembic/versions/3ad4a023f421_add_studio_agency_plan_fields_and_.py
@@ -1,0 +1,72 @@
+"""add_studio_agency_plan_fields_and_tenant_scoped_subscriptions
+
+Revision ID: 3ad4a023f421
+Revises: c4e70c96cb81
+Create Date: 2026-08-22 11:05:32.525502
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '3ad4a023f421'
+down_revision: Union[str, Sequence[str], None] = 'c4e70c96cb81'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Studio/Agency core-product plan fields on `plan` — all nullable, so
+    # existing CRM-addon plan rows (monday/clickup/jira/trello) are unaffected.
+    op.add_column('plan', sa.Column('included_minutes', sa.Integer(), nullable=True))
+    op.add_column('plan', sa.Column('monthly_credits', sa.Numeric(precision=10, scale=2), nullable=True))
+    op.add_column('plan', sa.Column('max_subaccounts', sa.Integer(), nullable=True))
+    op.add_column('plan', sa.Column('free_phone_numbers', sa.Integer(), nullable=True))
+    op.add_column('plan', sa.Column('features', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+
+    # Tenant-scoped (core-product) subscriptions on `subscription`, coexisting
+    # with the existing user_id + crm_type keyed CRM-addon subscriptions.
+    op.add_column('subscription', sa.Column('tenant_id', sa.UUID(), nullable=True))
+    op.create_index(op.f('ix_subscription_tenant_id'), 'subscription', ['tenant_id'], unique=False)
+    op.create_foreign_key(
+        'subscription_tenant_id_fkey', 'subscription', 'tenant', ['tenant_id'], ['id']
+    )
+    # Partial unique index: at most one active core (non-CRM) subscription per
+    # tenant. Legacy/future CRM-addon rows keep tenant_id NULL and are excluded
+    # by the predicate — a plain UniqueConstraint on tenant_id wouldn't work
+    # here since Postgres doesn't dedupe NULLs across the mixed rows.
+    op.create_index(
+        'uq_tenant_core_subscription',
+        'subscription',
+        ['tenant_id'],
+        unique=True,
+        postgresql_where=sa.text('crm_type IS NULL AND tenant_id IS NOT NULL'),
+    )
+
+    # Per-usage-row credit deduction (0 while inside a plan's free-minute
+    # allowance, >0 during overage billing). Backfilled to 0 for existing rows
+    # via server_default so this is a non-locking additive change.
+    op.add_column(
+        'usagerecord',
+        sa.Column('credits_charged', sa.Numeric(precision=10, scale=4), server_default='0', nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('usagerecord', 'credits_charged')
+
+    op.drop_index('uq_tenant_core_subscription', table_name='subscription', postgresql_where=sa.text('crm_type IS NULL AND tenant_id IS NOT NULL'))
+    op.drop_constraint('subscription_tenant_id_fkey', 'subscription', type_='foreignkey')
+    op.drop_index(op.f('ix_subscription_tenant_id'), table_name='subscription')
+    op.drop_column('subscription', 'tenant_id')
+
+    op.drop_column('plan', 'features')
+    op.drop_column('plan', 'free_phone_numbers')
+    op.drop_column('plan', 'max_subaccounts')
+    op.drop_column('plan', 'monthly_credits')
+    op.drop_column('plan', 'included_minutes')

--- a/app/api/api_v1/endpoints/billing.py
+++ b/app/api/api_v1/endpoints/billing.py
@@ -71,6 +71,48 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
                 return {**result, "message": "Webhook processed successfully"}
             return {"status": "failed", "reason": "sync_failed"}
         
+        if event_type == 'invoice.payment_succeeded':
+            logger.info("STRIPE WEBHOOK: invoice.payment_succeeded")
+            # StripeObject supports [] not dict.get(); .get looks up key "get" and raises.
+            invoice = event["data"]["object"]
+
+            try:
+                stripe_subscription_id = invoice["subscription"]
+            except (KeyError, TypeError):
+                stripe_subscription_id = None
+            if not stripe_subscription_id:
+                return {"status": "ignored", "reason": "no_subscription_id"}
+
+            try:
+                invoice_id = invoice["id"]
+            except (KeyError, TypeError):
+                invoice_id = None
+
+            period_start, period_end = None, None
+            try:
+                line = invoice["lines"]["data"][0]
+                period = line["period"]
+                from datetime import datetime, timezone
+                if period["start"]:
+                    period_start = datetime.fromtimestamp(period["start"], tz=timezone.utc)
+                if period["end"]:
+                    period_end = datetime.fromtimestamp(period["end"], tz=timezone.utc)
+            except (KeyError, TypeError, IndexError) as exc:
+                logger.warning(f"Failed to extract invoice line period: {exc}")
+
+            if not period_start or not period_end:
+                logger.warning(
+                    "invoice.payment_succeeded missing period bounds for subscription %s",
+                    stripe_subscription_id,
+                )
+                return {"status": "ignored", "reason": "missing_period"}
+
+            from app.services.billing_service import BillingService
+            BillingService.handle_subscription_renewed(
+                db, stripe_subscription_id, period_start, period_end, invoice_id=invoice_id
+            )
+            return {"status": "success", "event_type": event_type}
+
         if event_type in IGNORED_EVENT_TYPES:
             logger.info(f"Ignored event type: {event_type}")
             return {"status": "ignored", "event_type": event_type}

--- a/app/api/api_v1/endpoints/tenant.py
+++ b/app/api/api_v1/endpoints/tenant.py
@@ -236,7 +236,7 @@ def start_credit_checkout_session(
 ):
     """
     Start Stripe checkout session for one-time credit purchase (pay as you go).
-    $1 = 10 credits. User can buy any amount of credits.
+    $1 = 1 credit. User can buy any amount of credits.
     """
     if not current_user.current_tenant_id:
         raise HTTPException(

--- a/app/api/api_v1/endpoints/tenant.py
+++ b/app/api/api_v1/endpoints/tenant.py
@@ -2,7 +2,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from app.schemas.tenant import TenantCreate
+from app.schemas.tenant import TenantCreate, TenantPlanOut
 from app.schemas.auth import SwitchTenantRequest, TokenResponse, RoleInfo
 from app.schemas.base import SuccessResponse
 from app.models.tenant import Tenant
@@ -558,3 +558,121 @@ def get_payment_history(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error: {str(e)}"
         )
+
+
+@router.post("/plans/start-checkout", response_model=SuccessResponse[dict])
+def start_core_plan_checkout(
+    stripe_price_id: str,
+    current_user: User = Depends(get_current_user_jwt),
+    owner_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Start a Stripe subscription-mode checkout session for a tenant-level core-product
+    plan (Studio / Agency). Mirrors `crm_config.py`'s `start_plan_checkout` but is
+    tenant-scoped (metadata carries `tenant_id`, `crm_type` is always empty).
+    """
+    from app.models.plan import Plan
+
+    if not current_user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No tenant selected"
+        )
+    tenant = db.query(Tenant).filter(Tenant.id == current_user.current_tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    plan = db.query(Plan).filter(Plan.stripe_price_id == stripe_price_id, Plan.crm_type.is_(None)).first()
+    if not plan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Core plan not found for the given stripe_price_id"
+        )
+
+    import stripe
+    stripe.api_key = settings.STRIPE_SECRET_KEY
+
+    if not tenant.stripe_customer_id:
+        stripe_customer_id = StripeService.create_customer(
+            tenant=tenant,
+            email=current_user.email,
+            user=current_user
+        )
+        tenant.stripe_customer_id = stripe_customer_id
+        db.commit()
+    else:
+        stripe_customer_id = tenant.stripe_customer_id
+
+    tenant_id_str = str(current_user.current_tenant_id)
+    success_url = f"{settings.FRONTEND_URL}/payment/success?tenant_id={tenant_id_str}&session_id={{CHECKOUT_SESSION_ID}}"
+    cancel_url = f"{settings.FRONTEND_URL}/payment/cancel?tenant_id={tenant_id_str}"
+
+    if not plan.stripe_price_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Plan has no Stripe price ID configured for recurring billing"
+        )
+
+    try:
+        checkout_session = stripe.checkout.Session.create(
+            customer=stripe_customer_id,
+            success_url=success_url,
+            cancel_url=cancel_url,
+            mode="subscription",
+            line_items=[{
+                "price": plan.stripe_price_id,
+                "quantity": 1
+            }],
+            metadata={
+                "tenant_id": tenant_id_str,
+                "user_id": str(current_user.id),
+                "purchase_type": "plan_purchase",
+                "plan_id": str(plan.id),
+                "crm_type": ""
+            }
+        )
+        return create_success_response(
+            {"session_id": checkout_session.id, "url": checkout_session.url},
+            "Checkout session created successfully"
+        )
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/plan", response_model=TenantPlanOut)
+def get_tenant_plan(
+    current_user: User = Depends(get_current_user_jwt),
+    db: Session = Depends(get_db),
+):
+    """Current core-product plan + entitlements for the caller's active tenant."""
+    from app.models.plan import Plan
+    from app.services.billing_service import BillingService
+
+    if not current_user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No tenant selected"
+        )
+    tenant = db.query(Tenant).filter(Tenant.id == current_user.current_tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    subscription = BillingService.get_workspace_subscription(db, tenant.id)
+    plan = db.query(Plan).filter(Plan.id == subscription.plan_id).first() if subscription else None
+
+    _, used_this_cycle, remaining = BillingService.get_included_minutes_status(db, tenant.id)
+
+    return TenantPlanOut(
+        plan_name=plan.name if plan else None,
+        display_name=plan.display_name if plan else None,
+        included_minutes=plan.included_minutes if plan else None,
+        minutes_used_this_cycle=used_this_cycle,
+        minutes_remaining=remaining,
+        monthly_credits=plan.monthly_credits if plan else None,
+        free_phone_numbers=plan.free_phone_numbers if plan else None,
+        max_subaccounts=plan.max_subaccounts if plan else None,
+        features=plan.features if plan and plan.features else [],
+        credits_balance=tenant.credits or 0,
+    )

--- a/app/api/api_v1/endpoints/tenant.py
+++ b/app/api/api_v1/endpoints/tenant.py
@@ -236,8 +236,13 @@ def start_credit_checkout_session(
 ):
     """
     Start Stripe checkout session for one-time credit purchase (pay as you go).
-    $1 = 1 credit. User can buy any amount of credits.
+    $1 = 1 credit. Minimum purchase is $5.
     """
+    if amount < 5:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Minimum credit purchase is $5"
+        )
     if not current_user.current_tenant_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -15,6 +15,7 @@ from app.schemas.workspace import (
     BrandingConfigOut,
     PricingConfigUpsert,
     PricingConfigOut,
+    SurchargeInfoOut,
     WorkspaceUsageOut,
     MemberRoleUpdate,
     MemberRoleOut,
@@ -24,6 +25,7 @@ from app.schemas.workspace import (
     SubAccountCreateOut,
     SubAccountListOut,
 )
+from app.services.credit_service import credit_service
 
 import uuid
 
@@ -41,6 +43,24 @@ from app.services.data_export_service import create_export_job, get_export_job
 router = APIRouter(prefix="/workspace", tags=["workspace-gdpr"])
 
 v2_router = APIRouter()
+
+
+def _surcharge_catalog_out() -> list[SurchargeInfoOut]:
+    """Advertise the full surcharge catalog (see
+    app.services.credit_service.SURCHARGE_CATALOG) via the pricing/usage
+    APIs so a tenant can discover what can stack on top of the base
+    per-minute rate — these endpoints are workspace-scoped, not agent-scoped,
+    so this lists everything the platform *can* charge rather than what's
+    active for a specific agent/call right now."""
+    return [
+        SurchargeInfoOut(
+            key=s.key,
+            label=s.label,
+            rate_per_minute=s.rate_per_minute,
+            applies_when=s.applies_when,
+        )
+        for s in credit_service.get_surcharge_catalog()
+    ]
 
 @v2_router.get("/branding", response_model=BrandingConfigOut)
 def get_branding_config(
@@ -100,7 +120,8 @@ def get_pricing_config(
     return PricingConfigOut(
         per_minute_rate=per_minute_rate,
         markup_percent=markup_percent,
-        effective_client_rate=effective_client_rate
+        effective_client_rate=effective_client_rate,
+        available_surcharges=_surcharge_catalog_out(),
     )
 
 @v2_router.put("/pricing", response_model=PricingConfigOut)
@@ -133,7 +154,8 @@ def upsert_pricing_config(
     return PricingConfigOut(
         per_minute_rate=config.per_minute_rate,
         markup_percent=config.markup_percent,
-        effective_client_rate=effective_client_rate
+        effective_client_rate=effective_client_rate,
+        available_surcharges=_surcharge_catalog_out(),
     )
 
 @v2_router.get("/usage", response_model=WorkspaceUsageOut)
@@ -142,19 +164,16 @@ def get_workspace_usage(
     db: Session = Depends(get_db),
 ):
     """Get the usage statistics for the current billing cycle."""
-    from sqlalchemy import func
     from decimal import Decimal
-    
-    usage_sum = db.query(func.sum(UsageRecord.billable_minutes)).filter(
-        UsageRecord.workspace_id == user.current_tenant_id,
-        UsageRecord.recorded_at >= func.date_trunc('month', func.now())
-    ).scalar() or Decimal("0")
-    
-    minutes_used_this_cycle = Decimal(str(usage_sum))
-    minutes_included = None
-    
+
+    from app.services.billing_service import BillingService
+
+    minutes_included, minutes_used_this_cycle, remaining = BillingService.get_included_minutes_status(
+        db, user.current_tenant_id
+    )
+
     overage_minutes = max(Decimal("0"), minutes_used_this_cycle - minutes_included)
-    
+
     config = db.query(PricingConfig).filter(PricingConfig.workspace_id == user.current_tenant_id).first()
     if config:
         effective_rate = Decimal(str(config.per_minute_rate)) * (Decimal("1") + Decimal(str(config.markup_percent)) / Decimal("100"))
@@ -167,7 +186,8 @@ def get_workspace_usage(
         minutes_used_this_cycle=minutes_used_this_cycle,
         minutes_included=minutes_included,
         overage_minutes=overage_minutes,
-        overage_cost=overage_cost
+        overage_cost=overage_cost,
+        available_surcharges=_surcharge_catalog_out(),
     )
 
 
@@ -460,6 +480,26 @@ def create_sub_account(
 ):
     if workspace.workspace_type != "agency":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Only agency workspaces can create sub-accounts.")
+
+    from app.services.billing_service import BillingService
+    from app.models.plan import Plan
+
+    subscription = BillingService.get_workspace_subscription(db, workspace.id)
+    if subscription is not None:
+        plan = db.query(Plan).filter(Plan.id == subscription.plan_id).first()
+        if plan is not None and plan.max_subaccounts is not None:
+            existing_count = db.query(Tenant).filter(
+                Tenant.parent_workspace_id == workspace.id,
+                Tenant.deleted_at.is_(None),
+            ).count()
+            if existing_count >= plan.max_subaccounts:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        f"Sub-account limit reached for your plan "
+                        f"({plan.max_subaccounts} max). Upgrade your plan to add more."
+                    ),
+                )
 
     # Create Tenant
     new_tenant = Tenant(

--- a/app/core/agent_runtime.py
+++ b/app/core/agent_runtime.py
@@ -91,6 +91,15 @@ class ResolvedTtsRuntime:
     language: str
     settings_json: dict[str, Any]
     used_ticket_tts: bool
+    # True only when the agent's raw ticket TTS slug is "11labs_byo" AND a
+    # usable BYO ElevenLabs key is actually stored — i.e. the platform incurs
+    # zero ElevenLabs cost for this call. `adapter_slug` alone can't express
+    # this: both platform ElevenLabs ("11labs") and BYO ElevenLabs
+    # ("11labs_byo") collapse to the same adapter_slug "elevenlabs". Callers
+    # that need to gate the ElevenLabs surcharge (see
+    # app.services.credit_service.get_active_surcharges) must consult this
+    # flag, not adapter_slug.
+    is_byo_elevenlabs: bool = False
 
 
 def _decrypt_stored_api_key(
@@ -289,6 +298,7 @@ def resolve_tts_runtime(
         voice_id = agent.tts_voice_external_id
         if agent.tts_language:
             language = agent.tts_language
+        is_byo_elevenlabs = slug == "11labs_byo" and bool(agent.encrypted_elevenlabs_api_key)
         if slug == "11labs_byo" and agent.encrypted_elevenlabs_api_key:
             try:
                 from app.core.db_encryption import decrypt_stored_elevenlabs_key
@@ -325,6 +335,7 @@ def resolve_tts_runtime(
             language=language,
             settings_json=settings,
             used_ticket_tts=True,
+            is_byo_elevenlabs=is_byo_elevenlabs,
         )
 
     legacy_provider = getattr(agent, "tts_provider", None)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -262,6 +262,12 @@ class CrmSettings(BaseModel):
         default="", validation_alias="STRIPE_PRICE_ID_FREE"
     )
     stripe_price_id_pro: str = Field(default="", validation_alias="STRIPE_PRICE_ID_PRO")
+    stripe_price_id_studio: str = Field(
+        default="", validation_alias="STRIPE_PRICE_ID_STUDIO"
+    )
+    stripe_price_id_agency: str = Field(
+        default="", validation_alias="STRIPE_PRICE_ID_AGENCY"
+    )
     payment_page_base_url: str = Field(
         default="https://pay.yourdomain.com", validation_alias="PAYMENT_PAGE_BASE_URL"
     )
@@ -843,6 +849,8 @@ class Settings(BaseSettings):
     )
     STRIPE_PRICE_ID_FREE: str = ""
     STRIPE_PRICE_ID_PRO: str = ""
+    STRIPE_PRICE_ID_STUDIO: str = ""
+    STRIPE_PRICE_ID_AGENCY: str = ""
 
     # In-call payment page URL — returned to the agent as the caller-facing payment link.
     # Format: "{PAYMENT_PAGE_BASE_URL}/pay/{payment_intent_id}?client_secret={client_secret}"
@@ -1194,6 +1202,8 @@ class Settings(BaseSettings):
             stripe_incall_webhook_secret=self.STRIPE_INCALL_WEBHOOK_SECRET,
             stripe_price_id_free=self.STRIPE_PRICE_ID_FREE,
             stripe_price_id_pro=self.STRIPE_PRICE_ID_PRO,
+            stripe_price_id_studio=self.STRIPE_PRICE_ID_STUDIO,
+            stripe_price_id_agency=self.STRIPE_PRICE_ID_AGENCY,
             payment_page_base_url=self.PAYMENT_PAGE_BASE_URL,
             free_plan_agent_limit=self.FREE_PLAN_AGENT_LIMIT,
             free_plan_monthly_calls=self.FREE_PLAN_MONTHLY_CALLS,

--- a/app/models/plan.py
+++ b/app/models/plan.py
@@ -1,5 +1,5 @@
-from sqlalchemy import Column, String, Integer, Boolean, DateTime
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import Column, String, Integer, Boolean, DateTime, Numeric
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 import uuid
@@ -22,7 +22,14 @@ class Plan(Base):
     # Status
     is_active = Column(Boolean, default=True)
     is_popular = Column(Boolean, default=False)  # Show as "Popular"
-    
+
+    # Studio/Agency (core product) tier fields — nullable, unused by CRM-addon plans
+    included_minutes = Column(Integer, nullable=True)  # total inbound+outbound minutes per billing cycle
+    monthly_credits = Column(Numeric(10, 2), nullable=True)  # credit grant per renewal; 1 credit = $1
+    max_subaccounts = Column(Integer, nullable=True)  # cap on whitelabel sub-accounts; NULL = unlimited
+    free_phone_numbers = Column(Integer, nullable=True)  # cap on phone numbers included free
+    features = Column(JSONB, nullable=True)  # list of display strings, e.g. ["WhiteLabel workspaces", ...]
+
     # Timestamps
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, ForeignKey, Boolean, UniqueConstraint
+from sqlalchemy import Column, String, DateTime, ForeignKey, Boolean, UniqueConstraint, Index, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -9,6 +9,7 @@ class Subscription(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
     user_id = Column(UUID(as_uuid=True), ForeignKey('user.id'), nullable=False, index=True)
     plan_id = Column(UUID(as_uuid=True), ForeignKey('plan.id'), nullable=False)
+    tenant_id = Column(UUID(as_uuid=True), ForeignKey('tenant.id'), nullable=True, index=True)
     stripe_subscription_id = Column(String, unique=True, nullable=True, index=True)
     stripe_customer_id = Column(String, nullable=True, index=True)
     stripe_session_id = Column(String, nullable=True, index=True)
@@ -24,6 +25,16 @@ class Subscription(Base):
     # Relationships
     user = relationship("User", back_populates="subscriptions")
     plan = relationship("Plan", back_populates="subscriptions")
+    tenant = relationship("Tenant", back_populates="core_subscriptions")
     __table_args__ = (
         UniqueConstraint('user_id', 'crm_type', name='uq_user_crm_subscription'),
+        # One active core (tenant-scoped, non-CRM) subscription per tenant. Legacy/future
+        # CRM-addon rows keep tenant_id NULL and are excluded via the partial predicate,
+        # since plain UniqueConstraint doesn't dedupe NULLs the way we need here.
+        Index(
+            "uq_tenant_core_subscription",
+            "tenant_id",
+            unique=True,
+            postgresql_where=text("crm_type IS NULL AND tenant_id IS NOT NULL"),
+        ),
     )

--- a/app/models/tenant.py
+++ b/app/models/tenant.py
@@ -47,6 +47,7 @@ class Tenant(Base):
     branding_config = relationship("BrandingConfig", uselist=False, back_populates="tenant", cascade="all, delete-orphan")
     pricing_config = relationship("PricingConfig", uselist=False, back_populates="tenant", cascade="all, delete-orphan")
     usage_record = relationship("UsageRecord", back_populates="tenant", cascade="all, delete-orphan")
+    core_subscriptions = relationship("Subscription", back_populates="tenant")
     sso_config = relationship("SsoConfig", uselist=False, back_populates="workspace", cascade="all, delete-orphan")
 
     __table_args__ = (

--- a/app/models/usage_record.py
+++ b/app/models/usage_record.py
@@ -11,6 +11,7 @@ class UsageRecord(Base):
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("tenant.id", ondelete="CASCADE"), nullable=False)
     call_id = Column(UUID(as_uuid=True), ForeignKey("callsession.id", ondelete="SET NULL"), nullable=True)
     billable_minutes = Column(Numeric(10, 2), nullable=False)
+    credits_charged = Column(Numeric(10, 4), nullable=False, server_default="0")  # credits deducted; 0 within plan's free allowance
     recorded_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     deleted_at = Column(DateTime(timezone=True), nullable=True)
 

--- a/app/routers/sdk.py
+++ b/app/routers/sdk.py
@@ -34,6 +34,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.api.deps import get_db
+from app.core.agent_runtime import resolve_tts_runtime
 from app.core.config import settings
 from app.core.error_responses import build_api_error_payload
 from app.core.logger import logger
@@ -294,6 +295,37 @@ async def demo_call_token(
             403,
             "You have used up your allotted call time for this demo link.",
             "demo_link_visitor_limit_exceeded",
+        )
+
+    from app.services.credit_service import credit_service
+
+    demo_model_name = agent.model.model_name if agent.model else None
+    try:
+        demo_tts_runtime = resolve_tts_runtime(agent, db=db)
+    except Exception as exc:
+        logger.warning(
+            "Demo call token denied (TTS runtime resolution failed) demo_link_id=%s "
+            "agent_id=%s ip=%s error=%s",
+            demo_link.id, flow.agent_id, ip, exc,
+        )
+        return _demo_error(
+            request, 500, "This demo is temporarily unavailable. Please try again later.", "demo_tts_runtime_error"
+        )
+    demo_tts_provider_slug = demo_tts_runtime.adapter_slug
+    has_sufficient, _current_credits, _required_credits, decline_reason = credit_service.has_sufficient_credits(
+        db=db,
+        tenant_id=demo_link.tenant_id,
+        model_name=demo_model_name,
+        tts_provider_slug=demo_tts_provider_slug,
+        is_byo_elevenlabs=demo_tts_runtime.is_byo_elevenlabs,
+    )
+    if not has_sufficient:
+        logger.info(
+            "Demo call token denied (insufficient tenant credits) demo_link_id=%s ip=%s reason=%s",
+            demo_link.id, ip, decline_reason,
+        )
+        return _demo_error(
+            request, 403, "This demo is temporarily unavailable. Please try again later.", "demo_unavailable"
         )
 
     from app.services.livekit_service import livekit_service

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -7,6 +7,7 @@ import uuid
 import requests
 import asyncio
 
+from app.core.agent_runtime import resolve_tts_runtime
 from app.core.logger import logger
 from app.api.deps import get_db, require_tenant, get_optional_tenant_user
 from app.schemas.twilio import CallInitiateRequest, CallInitiateResponse
@@ -231,19 +232,23 @@ async def handle_incoming_call(
             )
 
         model_name = inbound_agent.model.model_name
-        has_sufficient, current_credits, required_credits = credit_service.has_sufficient_credits(
+        inbound_tts_runtime = resolve_tts_runtime(inbound_agent, db=db)
+        tts_provider_slug = inbound_tts_runtime.adapter_slug
+        has_sufficient, current_credits, required_credits, decline_reason = credit_service.has_sufficient_credits(
             db=db,
             tenant_id=phone_number.tenant_id,
             model_name=model_name,
-            estimated_minutes=1,
+            tts_provider_slug=tts_provider_slug,
+            is_byo_elevenlabs=inbound_tts_runtime.is_byo_elevenlabs,
         )
         if not has_sufficient:
             logger.warning(
-                "Inbound credit check failed for tenant %s: current=%s required=%s model=%s",
+                "Inbound credit check failed for tenant %s: current=%s required=%s model=%s reason=%s",
                 phone_number.tenant_id,
                 current_credits,
                 required_credits,
                 model_name,
+                decline_reason,
             )
             return _fallback_twiml(
                 "Sorry, this service is currently unavailable. Please try again later."

--- a/app/schemas/tenant.py
+++ b/app/schemas/tenant.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict, Field
 from datetime import datetime
+from decimal import Decimal
 import uuid
 
 class TenantBase(BaseModel):
@@ -23,3 +24,20 @@ class TenantOut(TenantBase):
 class TenantCreateResponse(BaseModel):
     tenant_id: uuid.UUID
     tenant: TenantOut
+
+
+class TenantPlanOut(BaseModel):
+    """Response shape for GET /api/v1/tenants/plan — current plan + entitlements."""
+
+    plan_name: str | None = None
+    display_name: str | None = None
+    included_minutes: int | None = None
+    minutes_used_this_cycle: Decimal
+    minutes_remaining: Decimal
+    monthly_credits: Decimal | None = None
+    free_phone_numbers: int | None = None
+    max_subaccounts: int | None = None
+    features: list[str] = Field(default_factory=list)
+    credits_balance: Decimal
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/workspace.py
+++ b/app/schemas/workspace.py
@@ -94,11 +94,42 @@ class PricingConfigUpsert(BaseModel):
     markup_percent: Decimal = Field(..., ge=0, le=500)
 
 
+class SurchargeInfoOut(BaseModel):
+    """A single named per-minute surcharge that can stack on top of the base
+    per-minute rate (see app.services.credit_service.SURCHARGE_CATALOG).
+
+    This is the full catalog of surcharges the platform knows how to apply —
+    not necessarily all active for every agent/call — since these endpoints
+    are workspace-scoped rather than agent-scoped. `applies_when` documents
+    the condition that activates it for a given call.
+    """
+    key: str
+    label: str
+    rate_per_minute: Decimal
+    applies_when: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+_SURCHARGE_FIELD_DESCRIPTION = (
+    "Full catalog of per-minute surcharges the platform knows how to apply "
+    "(e.g. OpenAI Realtime, ElevenLabs voice) — this is NOT the list of "
+    "surcharges currently being charged on any specific call or agent. "
+    "Whether a given surcharge is actually active depends on that agent's "
+    "model/TTS configuration at call time; these endpoints are "
+    "workspace-scoped, not agent- or call-scoped, so this field only "
+    "advertises what CAN stack on top of the base per-minute rate."
+)
+
+
 class PricingConfigOut(BaseModel):
     """Response shape for pricing config"""
     per_minute_rate: Decimal
     markup_percent: Decimal
     effective_client_rate: Decimal
+    available_surcharges: list[SurchargeInfoOut] = Field(
+        default_factory=list, description=_SURCHARGE_FIELD_DESCRIPTION
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -109,6 +140,9 @@ class WorkspaceUsageOut(BaseModel):
     minutes_included: Decimal | None = None
     overage_minutes: Decimal
     overage_cost: Decimal
+    available_surcharges: list[SurchargeInfoOut] = Field(
+        default_factory=list, description=_SURCHARGE_FIELD_DESCRIPTION
+    )
 
 class SubAccountCreate(BaseModel):
     name: str = Field(..., min_length=3, max_length=50)

--- a/app/scripts/init_plans.py
+++ b/app/scripts/init_plans.py
@@ -1,86 +1,115 @@
 #!/usr/bin/env python3
 """
-Simple script to create Vapi-style plans.
-Just run: python app/scripts/init_plans.py
+Seed/upsert the core-product (non-CRM) Studio and Agency Plan rows.
+
+Run: python app/scripts/init_plans.py
+
+These are tenant-level subscription plans (see `app/models/plan.py`'s
+Studio/Agency fields: included_minutes, monthly_credits, max_subaccounts,
+free_phone_numbers, features). `crm_type` is left NULL for both — they are
+NOT one of the three CRM-addon plan stacks.
+
+Set STRIPE_PRICE_ID_STUDIO / STRIPE_PRICE_ID_AGENCY in the environment before
+running so the seeded rows have a working `stripe_price_id` for checkout.
 """
 
-import sys
 import os
+import sys
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 from sqlalchemy.orm import Session
+
 from app.db.session import SessionLocal
+import app.db.base  # noqa: F401 - registers all models so relationship() strings resolve
 from app.models.plan import Plan
 
-def create_simple_plans():
-    """Create 3 simple plans like Vapi"""
+CORE_PLAN_FEATURES = [
+    "WhiteLabel workspaces",
+    "Advanced analytics",
+    "Priority support",
+]
+
+
+def _upsert_plan(db: Session, *, name: str, display_name: str, description: str,
+                  price_monthly_cents: int, included_minutes: int, monthly_credits: str,
+                  max_subaccounts: int | None, free_phone_numbers: int, features: list[str],
+                  stripe_price_id_env: str, is_popular: bool = False) -> Plan:
+    plan = db.query(Plan).filter(Plan.name == name).first()
+    if plan is None:
+        plan = Plan(name=name)
+        db.add(plan)
+
+    plan.display_name = display_name
+    plan.description = description
+    plan.price_monthly = price_monthly_cents
+    plan.crm_type = None
+    plan.is_active = True
+    plan.is_popular = is_popular
+    plan.included_minutes = included_minutes
+    plan.monthly_credits = monthly_credits
+    plan.max_subaccounts = max_subaccounts
+    plan.free_phone_numbers = free_phone_numbers
+    plan.features = features
+    plan.stripe_price_id = os.environ.get(stripe_price_id_env) or plan.stripe_price_id
+
+    return plan
+
+
+def seed_core_plans() -> None:
+    """Create/update the Studio and Agency core-product Plan rows."""
     db: Session = SessionLocal()
-    
+
     try:
-        # Check if plans already exist
-        if db.query(Plan).count() > 0:
-            print("✅ Plans already exist!")
-            return
-        
-        # 1. Free Plan
-        free = Plan(
-            name="free",
-            display_name="Free",
-            description="Perfect for testing. Pay $0.05 per minute.",
-            price_monthly=0,  # Free
-            price_per_minute=0.05,  # $0.05 per minute
-            agent_limit=2,
-            monthly_calls_limit=0,  # No limit, pay per minute
-            included_minutes=0
+        studio = _upsert_plan(
+            db,
+            name="studio",
+            display_name="Studio",
+            description="100 included call minutes/mo, whitelabel workspaces, up to 3 sub-accounts.",
+            price_monthly_cents=9900,
+            included_minutes=100,
+            monthly_credits="12.00",
+            max_subaccounts=3,
+            free_phone_numbers=3,
+            features=CORE_PLAN_FEATURES,
+            stripe_price_id_env="STRIPE_PRICE_ID_STUDIO",
         )
-        
-        # 2. Starter Plan (Popular)
-        starter = Plan(
-            name="starter", 
-            display_name="Starter",
-            description="Great for small businesses. $10/month + $0.05/minute.",
-            price_monthly=1,  # $10.00 in cents
-            price_per_minute=0.05,
-            agent_limit=1,  # As per your edit
-            monthly_calls_limit=0,  # No limit, pay per minute
-            included_minutes=500,  # 500 free minutes
-            is_popular=True
+
+        agency = _upsert_plan(
+            db,
+            name="agency",
+            display_name="Agency",
+            description="300 included call minutes/mo, unlimited whitelabel sub-accounts.",
+            price_monthly_cents=29900,
+            included_minutes=300,
+            monthly_credits="36.00",
+            max_subaccounts=None,
+            free_phone_numbers=10,
+            features=CORE_PLAN_FEATURES + ["Unlimited sub-accounts"],
+            stripe_price_id_env="STRIPE_PRICE_ID_AGENCY",
+            is_popular=True,
         )
-        
-        # 3. Pro Plan
-        pro = Plan(
-            name="pro",
-            display_name="Pro", 
-            description="For growing businesses. $99/month + $0.05/minute.",
-            price_monthly=2,  # $99.00 in cents
-            price_per_minute=0.05,
-            agent_limit=50,
-            monthly_calls_limit=0,  # No limit, pay per minute
-            included_minutes=2000  # 2000 free minutes
-        )
-        
-        # Save to database
-        db.add(free)
-        db.add(starter) 
-        db.add(pro)
+
         db.commit()
-        
-        print("✅ Created 3 simple plans:")
-        print("   📱 Free: $0/month, $0.05/minute, 2 agents")
-        print("   🚀 Starter: $10/month, 500 free minutes, 1 agent (Popular)")
-        print("   💼 Pro: $99/month, 2000 free minutes, 50 agents")
-        
+
+        print("Seeded core plans:")
+        print(f"   Studio: $99/month, {studio.included_minutes} included minutes, "
+              f"${studio.monthly_credits} credit grant, {studio.max_subaccounts} max sub-accounts")
+        print(f"   Agency: $299/month, {agency.included_minutes} included minutes, "
+              f"${agency.monthly_credits} credit grant, unlimited sub-accounts")
+
     except Exception as e:
-        print(f"❌ Error: {str(e)}")
+        print(f"Error seeding core plans: {e}")
         db.rollback()
+        raise
     finally:
         db.close()
 
+
 if __name__ == "__main__":
-    print("🚀 Creating simple Vapi-style plans...")
-    create_simple_plans()
-    print("\n✅ Done! Your plans are ready.")
-    print("\n💡 Next steps:")
-    print("   1. Set up Stripe products in your dashboard")
-    print("   2. Add STRIPE_PRICE_ID_PRO to your .env file")
-    print("   3. Test the billing endpoints")
+    print("Seeding Studio/Agency core-product plans...")
+    seed_core_plans()
+    print("\nDone.")
+    print("\nNext steps:")
+    print("   1. Set STRIPE_PRICE_ID_STUDIO / STRIPE_PRICE_ID_AGENCY in your .env if not already set")
+    print("   2. Re-run this script if you update pricing/features so the DB rows stay in sync")

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -7,22 +7,39 @@ from app.models.plan import Plan
 from app.models.usage_record import UsageRecord
 from app.services.stripe_service import StripeService
 from typing import Dict, Any
+from decimal import Decimal
 from datetime import datetime, timedelta, timezone
 import uuid
 
 class BillingService:
-    
+
     # Default subscription period in days (e.g. 1 month)
     DEFAULT_PERIOD_DAYS = 30
 
     @staticmethod
-    def get_or_create_subscription(db: Session, user_id: uuid.UUID, crm_type: str | None = None) -> Subscription:
-        """Get existing subscription for user (and optional crm_type) or create a free one for default usage."""
-        subscription = db.query(Subscription).filter(
-            Subscription.user_id == user_id,
-            (Subscription.crm_type == crm_type) if crm_type is not None else (Subscription.crm_type.is_(None))
-        ).first()
-        
+    def get_or_create_subscription(
+        db: Session,
+        user_id: uuid.UUID,
+        crm_type: str | None = None,
+        tenant_id: uuid.UUID | None = None,
+    ) -> Subscription:
+        """Get existing subscription (for user+crm_type, or tenant's core subscription) or create a free one.
+
+        When `tenant_id` is provided, look up/create the tenant-scoped core-product
+        subscription (`tenant_id` match, `crm_type IS NULL`) instead of the legacy
+        `user_id` + `crm_type` row. When `tenant_id` is None, behavior is unchanged.
+        """
+        if tenant_id is not None:
+            subscription = db.query(Subscription).filter(
+                Subscription.tenant_id == tenant_id,
+                Subscription.crm_type.is_(None),
+            ).first()
+        else:
+            subscription = db.query(Subscription).filter(
+                Subscription.user_id == user_id,
+                (Subscription.crm_type == crm_type) if crm_type is not None else (Subscription.crm_type.is_(None))
+            ).first()
+
         if not subscription:
             free_plan = db.query(Plan).filter(Plan.name == "free").first()
             if not free_plan:
@@ -36,17 +53,26 @@ class BillingService:
                 db.add(free_plan)
                 db.commit()
                 db.refresh(free_plan)
-            
-            subscription = Subscription(
-                user_id=user_id,
-                plan_id=free_plan.id,
-                status="active",
-                crm_type=crm_type
-            )
+
+            if tenant_id is not None:
+                subscription = Subscription(
+                    user_id=user_id,
+                    tenant_id=tenant_id,
+                    plan_id=free_plan.id,
+                    status="active",
+                    crm_type=None,
+                )
+            else:
+                subscription = Subscription(
+                    user_id=user_id,
+                    plan_id=free_plan.id,
+                    status="active",
+                    crm_type=crm_type
+                )
             db.add(subscription)
             db.commit()
             db.refresh(subscription)
-        
+
         return subscription
 
     @staticmethod
@@ -112,13 +138,15 @@ class BillingService:
                 logger.info(f"Session {session_id} already processed.")
                 return {"status": "already_processed"}
 
-            # Plan purchase: update subscription only, NO credits
+            # Plan purchase: update subscription (core plans additionally grant monthly credits)
             if purchase_type == 'plan_purchase' and user_id and plan_id:
+                plan_row = db.query(Plan).filter(Plan.id == plan_id).first()
                 # If crm_type missing/empty in metadata, get from plan so we create correct subscription row
-                if not crm_type and plan_id:
-                    plan_row = db.query(Plan).filter(Plan.id == plan_id).first()
-                    if plan_row and plan_row.crm_type:
-                        crm_type = plan_row.crm_type
+                if not crm_type and plan_row and plan_row.crm_type:
+                    crm_type = plan_row.crm_type
+
+                is_core_plan = plan_row is not None and plan_row.crm_type is None
+
                 stripe_sub_id = session["subscription"]  # set when mode=subscription
                 period_start, period_end = None, None
                 if stripe_sub_id:
@@ -130,6 +158,40 @@ class BillingService:
                             period_end = datetime.fromtimestamp(sub.current_period_end, tz=timezone.utc)
                     except Exception as exc:
                         logger.warning(f"Failed to retrieve Stripe subscription period for {stripe_sub_id}: {exc}")
+
+                if is_core_plan:
+                    BillingService.update_subscription(
+                        db=db,
+                        user_id=user_id,
+                        plan_id=plan_id,
+                        status="active",
+                        stripe_subscription_id=stripe_sub_id,
+                        stripe_customer_id=session["customer"],
+                        stripe_session_id=session_id,
+                        current_period_start=period_start,
+                        current_period_end=period_end,
+                        tenant_id=tenant_id,
+                    )
+                    credits_granted = Decimal("0")
+                    if plan_row.monthly_credits:
+                        tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+                        if tenant:
+                            credits_granted = Decimal(str(plan_row.monthly_credits))
+                            tenant.credits = (tenant.credits or Decimal("0")) + credits_granted
+                            tenant.status = 'active'
+                            db.commit()
+                    logger.info(
+                        f"Core plan subscription updated for tenant {tenant_id} (plan={plan_row.name}) "
+                        f"via sync - granted {credits_granted} credits"
+                    )
+                    return {
+                        "status": "success",
+                        "credits_added": float(credits_granted),
+                        "crm_type": None,
+                        "purchase_type": purchase_type,
+                        "message": "Core plan subscription updated and monthly credits granted."
+                    }
+
                 BillingService.update_subscription(
                     db=db,
                     user_id=user_id,
@@ -201,20 +263,36 @@ class BillingService:
         stripe_session_id: str | None = None,
         crm_type: str | None = None,
         current_period_start: datetime | None = None,
-        current_period_end: datetime | None = None
+        current_period_end: datetime | None = None,
+        tenant_id: uuid.UUID | None = None,
     ) -> Subscription:
-        """Update or create user subscription for this CRM. Sets current_period_start/end from args or default 30 days."""
-        subscription = db.query(Subscription).filter(
-            Subscription.user_id == user_id,
-            (Subscription.crm_type == crm_type) if crm_type is not None else Subscription.crm_type.is_(None)
-        ).first()
+        """Update or create a subscription. Sets current_period_start/end from args or default 30 days.
+
+        When `tenant_id` is provided, the subscription is looked up/created by
+        `tenant_id` + `crm_type IS NULL` (the tenant-scoped core-product subscription)
+        instead of by `user_id` + `crm_type`. When `tenant_id` is None, behavior is
+        unchanged from before.
+        """
+        if tenant_id is not None:
+            subscription = db.query(Subscription).filter(
+                Subscription.tenant_id == tenant_id,
+                Subscription.crm_type.is_(None),
+            ).first()
+        else:
+            subscription = db.query(Subscription).filter(
+                Subscription.user_id == user_id,
+                (Subscription.crm_type == crm_type) if crm_type is not None else Subscription.crm_type.is_(None)
+            ).first()
 
         now = datetime.now(timezone.utc)
         period_start = current_period_start if current_period_start is not None else now
         period_end = current_period_end if current_period_end is not None else (now + timedelta(days=BillingService.DEFAULT_PERIOD_DAYS))
 
         if not subscription:
-            subscription = Subscription(user_id=user_id, crm_type=crm_type)
+            if tenant_id is not None:
+                subscription = Subscription(user_id=user_id, tenant_id=tenant_id, crm_type=None)
+            else:
+                subscription = Subscription(user_id=user_id, crm_type=crm_type)
             db.add(subscription)
 
         subscription.plan_id = plan_id
@@ -227,7 +305,7 @@ class BillingService:
             subscription.stripe_customer_id = stripe_customer_id
         if stripe_session_id:
             subscription.stripe_session_id = stripe_session_id
-        if crm_type is not None:
+        if tenant_id is None and crm_type is not None:
             subscription.crm_type = crm_type
         subscription.updated_at = now
 
@@ -236,18 +314,172 @@ class BillingService:
         return subscription
 
     @staticmethod
+    def get_workspace_subscription(db: Session, tenant_id: uuid.UUID) -> Subscription | None:
+        """Return the tenant's active core-product (non-CRM) subscription, if any."""
+        return db.query(Subscription).filter(
+            Subscription.tenant_id == tenant_id,
+            Subscription.crm_type.is_(None),
+            Subscription.status == "active",
+        ).first()
+
+    @staticmethod
+    def get_included_minutes_status(
+        db: Session, tenant_id: uuid.UUID
+    ) -> tuple[Decimal, Decimal, Decimal]:
+        """Return (included_minutes, used_this_cycle, remaining) for the tenant's current billing cycle.
+
+        If the tenant has an active core subscription, the cycle window is
+        `current_period_start` -> now and `included_minutes` comes from the plan.
+        Otherwise (pure pay-as-you-go), included_minutes is 0 and the cycle window
+        is calendar-month-to-date (matching the existing `get_workspace_usage` convention).
+        """
+        from sqlalchemy import func
+
+        subscription = BillingService.get_workspace_subscription(db, tenant_id)
+
+        if subscription is not None:
+            plan = db.query(Plan).filter(Plan.id == subscription.plan_id).first()
+            included_minutes = Decimal(str(plan.included_minutes)) if plan and plan.included_minutes is not None else Decimal("0")
+            cycle_start = subscription.current_period_start or datetime.now(timezone.utc).replace(
+                day=1, hour=0, minute=0, second=0, microsecond=0
+            )
+        else:
+            included_minutes = Decimal("0")
+            cycle_start = datetime.now(timezone.utc).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+        usage_sum = db.query(func.sum(UsageRecord.billable_minutes)).filter(
+            UsageRecord.workspace_id == tenant_id,
+            UsageRecord.recorded_at >= cycle_start,
+        ).scalar() or Decimal("0")
+        used_this_cycle = Decimal(str(usage_sum))
+
+        remaining = max(Decimal("0"), included_minutes - used_this_cycle)
+        return (included_minutes, used_this_cycle, remaining)
+
+    @staticmethod
+    def record_call_minutes(
+        db: Session,
+        tenant_id: uuid.UUID,
+        call_id: uuid.UUID | None,
+        minutes: Decimal,
+        credits_charged: Decimal = Decimal("0"),
+    ) -> UsageRecord:
+        """Record a billing usage row for a call: minutes consumed + credits actually charged."""
+        record = UsageRecord(
+            workspace_id=tenant_id,
+            call_id=call_id,
+            billable_minutes=minutes,
+            credits_charged=credits_charged,
+        )
+        db.add(record)
+        db.commit()
+        db.refresh(record)
+        return record
+
+    @staticmethod
     def record_call_usage(
         db: Session,
         tenant_id: uuid.UUID,
         user_id: uuid.UUID | None = None,
     ) -> None:
-        """Record a billing event for a connected outbound call."""
-        record = UsageRecord(
-            workspace_id=tenant_id,
+        """Record a billing event for a connected outbound call.
+
+        Legacy stub kept for existing callers (e.g. batch_call_worker_service.py)
+        that don't yet compute real minutes/credits — behaviorally identical to
+        before (inserts a 0-minute record). New code should call
+        `record_call_minutes` directly with real values.
+        """
+        BillingService.record_call_minutes(
+            db=db,
+            tenant_id=tenant_id,
             call_id=None,
-            billable_minutes=0,
+            minutes=Decimal("0"),
+            credits_charged=Decimal("0"),
         )
-        db.add(record)
+
+    @staticmethod
+    def _same_instant(a: datetime | None, b: datetime | None) -> bool:
+        """Compare two datetimes for practical equality, tolerant of SQLite's
+        tzinfo-dropping round-trip and Stripe's integer-second timestamps."""
+        if a is None or b is None:
+            return False
+
+        def _norm(dt: datetime) -> datetime:
+            if dt.tzinfo is not None:
+                return dt.astimezone(timezone.utc).replace(tzinfo=None)
+            return dt
+
+        return abs((_norm(a) - _norm(b)).total_seconds()) < 1
+
+    @staticmethod
+    def handle_subscription_renewed(
+        db: Session,
+        stripe_subscription_id: str,
+        period_start: datetime,
+        period_end: datetime,
+        invoice_id: str | None = None,
+    ) -> None:
+        """Handle a Stripe `invoice.payment_succeeded` renewal: roll the period forward and
+        re-grant the plan's monthly credit allotment to the tenant (core plans only).
+
+        Idempotency (two guards, since a tenant's very first invoice for a new core-plan
+        subscription fires BOTH `checkout.session.completed` — which already grants
+        `monthly_credits` once via `sync_payment_status` — AND `invoice.payment_succeeded`
+        for that same period):
+
+        1. Claim on the Stripe invoice id (mirrors `_claim_checkout_session`) so a
+           redelivered `invoice.payment_succeeded` webhook event (Stripe is at-least-once)
+           is a hard no-op.
+        2. If the incoming `period_start` matches what's already recorded on the
+           subscription, this is the same period already credited by the checkout-
+           completion path (or a prior call to this method) — skip granting credits again.
+        """
+        from app.core.logger import logger
+
+        subscription = db.query(Subscription).filter(
+            Subscription.stripe_subscription_id == stripe_subscription_id
+        ).first()
+        if not subscription:
+            logger.warning(
+                "handle_subscription_renewed: no subscription found for stripe_subscription_id=%s",
+                stripe_subscription_id,
+            )
+            return
+
+        if invoice_id and not BillingService._claim_checkout_session(db, f"invoice:{invoice_id}"):
+            logger.info(
+                "Invoice %s already processed for subscription %s - skipping duplicate renewal.",
+                invoice_id, stripe_subscription_id,
+            )
+            return
+
+        already_recorded_period = BillingService._same_instant(
+            subscription.current_period_start, period_start
+        )
+
+        subscription.current_period_start = period_start
+        subscription.current_period_end = period_end
+        subscription.updated_at = datetime.now(timezone.utc)
+
+        if already_recorded_period:
+            logger.info(
+                "Renewal for subscription %s: period %s already recorded (likely granted "
+                "via checkout completion) - skipping duplicate credit grant.",
+                stripe_subscription_id, period_start,
+            )
+            db.commit()
+            return
+
+        plan = db.query(Plan).filter(Plan.id == subscription.plan_id).first()
+        if plan and plan.monthly_credits and subscription.tenant_id:
+            tenant = db.query(Tenant).filter(Tenant.id == subscription.tenant_id).first()
+            if tenant:
+                tenant.credits = (tenant.credits or Decimal("0")) + Decimal(str(plan.monthly_credits))
+                logger.info(
+                    "Renewed subscription %s: granted %s credits to tenant %s",
+                    stripe_subscription_id, plan.monthly_credits, subscription.tenant_id,
+                )
+
         db.commit()
 
     @staticmethod

--- a/app/services/billing_service.py
+++ b/app/services/billing_service.py
@@ -213,24 +213,24 @@ class BillingService:
                     "message": "Plan subscription updated. No credits added for plan purchase."
                 }
 
-            # Credit purchase: add credits to tenant
-            credits_to_add = 0
+            # Credit purchase: add credits to tenant. 1 credit = $1.
+            credits_to_add = Decimal("0")
             amount_total_cents = session["amount_total"] or 0
-            amount_dollars = float(amount_total_cents) / 100.0
+            amount_dollars = Decimal(amount_total_cents) / Decimal("100")
             if purchase_type == 'credit_purchase':
-                credits_to_add = int(amount_dollars * 10)
+                credits_to_add = amount_dollars
 
             if credits_to_add > 0:
                 tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
                 if tenant:
-                    tenant.credits = (tenant.credits or 0) + credits_to_add
+                    tenant.credits = (tenant.credits or Decimal("0")) + credits_to_add
                     tenant.status = 'active'
                     logger.info(f"Added {credits_to_add} credits to tenant {tenant_id} (credit_purchase)")
 
             db.commit()
             return {
                 "status": "success",
-                "credits_added": credits_to_add,
+                "credits_added": float(credits_to_add),
                 "purchase_type": purchase_type
             }
         except Exception as e:

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -8,6 +8,10 @@ from app.models.tenant import Tenant
 from app.models.agent import Agent
 from app.models.call_session import CallSession
 from app.models.call_log import CallLog
+from app.models.pricing_configs import PricingConfig
+from app.core.llm_models import is_openai_realtime_model
+from dataclasses import dataclass
+from decimal import Decimal
 from typing import Dict, Any
 import uuid
 import asyncio
@@ -16,96 +20,215 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Flat per-minute rate fallback when a workspace has no PricingConfig row yet.
+# Matches PricingConfig.per_minute_rate's own column default.
+DEFAULT_PER_MINUTE_RATE = Decimal("0.12")
+
+# Flat per-minute surcharge for calls using an OpenAI Realtime speech-to-speech
+# model (see app.core.llm_models.OPENAI_REALTIME_MODELS). Charged from
+# tenant.credits on top of the normal base-rate/included-minutes handling —
+# applies to the FULL call duration (both the free-allowance and
+# billable/overage portions), never waived by the included-minutes pool.
+OPENAI_REALTIME_SURCHARGE_PER_MINUTE = Decimal("0.50")
+
+# Flat per-minute surcharge for calls whose agent's resolved TTS provider
+# (see app.core.agent_runtime.resolve_tts_runtime) is ElevenLabs. Same
+# mechanic as the realtime surcharge above: charged from tenant.credits,
+# never waived by the included-minutes pool.
+ELEVENLABS_TTS_SURCHARGE_PER_MINUTE = Decimal("0.05")
+
+
+@dataclass(frozen=True)
+class ActiveSurcharge:
+    """A single named per-minute surcharge that applies to a call.
+
+    `key` is a stable machine-readable identifier (used in logs/descriptions);
+    `label` is the human-readable name surfaced in deduction descriptions and
+    the pricing/usage APIs; `rate_per_minute` is charged against tenant.credits
+    for the FULL call duration, independent of the included-minutes pool.
+    """
+
+    key: str
+    label: str
+    rate_per_minute: Decimal
+    applies_when: str
+
+
+# Full catalog of surcharges this service knows how to apply, independent of
+# any specific call — used to advertise "what can stack on top of the base
+# rate" via the pricing/usage APIs (app/api/v2/routers/workspace.py) even
+# when no agent/model context is available to say whether it's *currently*
+# active for a given call.
+SURCHARGE_CATALOG: tuple[ActiveSurcharge, ...] = (
+    ActiveSurcharge(
+        key="openai_realtime",
+        label="OpenAI Realtime speech-to-speech surcharge",
+        rate_per_minute=OPENAI_REALTIME_SURCHARGE_PER_MINUTE,
+        applies_when="Agent's model is an OpenAI Realtime speech-to-speech model (gpt-realtime / gpt-realtime-2).",
+    ),
+    ActiveSurcharge(
+        key="elevenlabs_tts",
+        label="ElevenLabs voice surcharge",
+        rate_per_minute=ELEVENLABS_TTS_SURCHARGE_PER_MINUTE,
+        applies_when="Agent's resolved TTS provider is ElevenLabs.",
+    ),
+)
+
 
 class CreditService:
     """
     Service for managing tenant credits and call billing
     Vapi-style: Real-time per-second billing with accurate duration tracking
+
+    Per-model credit costs have been retired in favor of a flat $/min rate
+    (see `get_effective_rate_per_minute`); the plan-aware included-minutes
+    allowance is applied before any credits are deducted.
     """
-    
-    # ============================================================================
-    # MODEL CREDIT COSTS (Per Minute) - Structured for easy addition
-    # ============================================================================
-    # Add new models here with their per-minute credit cost
-    MODEL_CREDIT_COSTS_PER_MINUTE: Dict[str, int] = {
-        # Gemini Models
-        "gemini-2.0-flash": 8,
-        "gemini-2.0-flash-exp": 8,
-        "gemini-1.5-flash": 8,
-        "gemini-1.5-pro": 12,
-        
-        # OpenAI Models
-        "gpt-4o-mini": 12,
-        "gpt-4o": 15,
-        "gpt-4": 20,
-        "gpt-3.5-turbo": 8,
-        
-        # Groq Models
-        "llama-3.3-70b-versatile": 10,
-        "llama-3.1-70b-versatile": 10,
-        "llama-3.1-8b-instant": 8,
-        
-        # Default fallback
-        "default": 10
-    }
-    
+
     # Monitoring interval (check every N seconds for real-time accuracy)
     MONITORING_INTERVAL = 10  # Check every 10 seconds (Vapi-style real-time)
-    
+
     def __init__(self):
         self._active_monitors = {}  # {call_session_id: task}
         self._call_start_times = {}  # {call_session_id: start_time}
         self._last_deduction_time = {}  # {call_session_id: last_deduction_timestamp}
         self._accumulated_seconds = {}  # {call_session_id: accumulated_seconds}
-    
-    def get_credit_cost_per_minute(self, model_name: str) -> int:
+
+    def get_surcharge_catalog(self) -> tuple[ActiveSurcharge, ...]:
+        """All surcharges this service knows how to apply, regardless of whether
+        they're currently active for any particular call — used by the pricing/usage
+        APIs to advertise what can stack on top of the base per-minute rate."""
+        return SURCHARGE_CATALOG
+
+    def get_active_surcharges(
+        self,
+        model_name: str | None = None,
+        tts_provider_slug: str | None = None,
+        is_byo_elevenlabs: bool = False,
+        realtime_fallen_back: bool = False,
+    ) -> list[ActiveSurcharge]:
         """
-        Get credit cost per minute for a specific model
-        
-        Args:
-            model_name: Name of the model (e.g., "gemini-2.0-flash", "gpt-4o-mini")
-            
-        Returns:
-            Credits per minute
+        Resolve which named surcharges apply to a call given its model/TTS
+        configuration. Returns a list so multiple independent surcharges can
+        stack additively — extend this by appending another check, never by
+        hardcoding a single combined rate.
+
+        OpenAI Realtime speech-to-speech calls (see
+        `app.voice.voice_orchestrator.VoiceOrchestrator._is_openai_realtime` /
+        `_feed_openai_realtime_audio`) never invoke the separate TTS
+        synthesis pipeline (`TtsPipeline` / `tts_stream_mixin`) — audio is
+        generated natively by the realtime session. `agent.tts_provider_slug`
+        may still hold a configured value (e.g. "elevenlabs") even though
+        it's functionally unused for these calls, so the ElevenLabs surcharge
+        is deliberately NOT evaluated when the model is an OpenAI Realtime
+        model (and it hasn't fallen back — see `realtime_fallen_back` below),
+        to avoid billing for TTS synthesis that never happened. If a future
+        architecture makes both paths coexist on the same call, this early
+        return should become an additive check instead.
+
+        `is_byo_elevenlabs` (see `app.core.agent_runtime.ResolvedTtsRuntime`)
+        must be True only when the tenant supplied their own ElevenLabs API
+        key — the platform incurs zero ElevenLabs cost in that case, so the
+        surcharge must NOT apply even though `tts_provider_slug` still
+        resolves to "elevenlabs" for both platform and BYO ElevenLabs (the
+        adapter_slug collapses the two).
+
+        `realtime_fallen_back` must be True once
+        `VoiceOrchestrator._fallback_to_legacy_pipeline_openai()` has kicked
+        in for this call (persisted on `CallSession.call_metadata
+        ["openai_realtime_fallback"]` — see that method's docstring for why
+        call_metadata is the cross-process signal). Once fallen back, the
+        call is no longer using OpenAI's realtime speech-to-speech API for
+        the remainder of its duration, so the realtime surcharge must stop
+        applying and the ElevenLabs surcharge (if applicable) must start
+        being evaluated for real instead of being skipped by the early
+        return below.
         """
-        # Normalize model name (lowercase, strip whitespace)
-        model_name = model_name.lower().strip()
-        
-        # Check for exact match first
-        if model_name in self.MODEL_CREDIT_COSTS_PER_MINUTE:
-            return self.MODEL_CREDIT_COSTS_PER_MINUTE[model_name]
-        
-        # Check for partial match (e.g., "gemini-2.0-flash" in "gemini-2.0-flash-thinking-exp")
-        for key, cost in self.MODEL_CREDIT_COSTS_PER_MINUTE.items():
-            if key != "default" and key in model_name:
-                logger.info(f"Matched model '{model_name}' to '{key}' with cost {cost} credits/min")
-                return cost
-        
-        # Return default cost if no match found
-        logger.warning(f"Model '{model_name}' not found in pricing, using default cost")
-        return self.MODEL_CREDIT_COSTS_PER_MINUTE["default"]
-    
-    def calculate_credits_for_duration(self, duration_seconds: float, credits_per_minute: int) -> float:
+        surcharges: list[ActiveSurcharge] = []
+
+        is_realtime = (
+            is_openai_realtime_model(model_name) if model_name else False
+        ) and not realtime_fallen_back
+        if is_realtime:
+            surcharges.append(
+                next(s for s in SURCHARGE_CATALOG if s.key == "openai_realtime")
+            )
+            return surcharges
+
+        if (
+            tts_provider_slug
+            and tts_provider_slug.strip().lower() == "elevenlabs"
+            and not is_byo_elevenlabs
+        ):
+            surcharges.append(
+                next(s for s in SURCHARGE_CATALOG if s.key == "elevenlabs_tts")
+            )
+
+        return surcharges
+
+    @staticmethod
+    def total_surcharge_rate_per_minute(surcharges: list[ActiveSurcharge]) -> Decimal:
+        """Sum of the active surcharges' per-minute rates."""
+        total = Decimal("0")
+        for s in surcharges:
+            total += s.rate_per_minute
+        return total
+
+    def _describe_surcharges(
+        self, accumulated_seconds: float, surcharges: list[ActiveSurcharge]
+    ) -> tuple[float, str]:
+        """
+        Compute the total surcharge credits owed for `accumulated_seconds` of
+        call time (surcharges apply to the FULL duration, never waived by the
+        included-minutes pool) plus a human-readable breakdown string
+        attributing the amount to each active surcharge, for deduction
+        descriptions/logs.
+        """
+        if not surcharges:
+            return 0.0, ""
+
+        minutes = Decimal(str(accumulated_seconds)) / Decimal("60")
+        parts: list[str] = []
+        total = Decimal("0")
+        for s in surcharges:
+            amount = minutes * s.rate_per_minute
+            total += amount
+            parts.append(
+                f"{s.label} on {accumulated_seconds:.1f}s ({float(amount):.4f} credits)"
+            )
+        return float(total), " + ".join(parts)
+
+    def get_effective_rate_per_minute(self, db: Session, tenant_id: uuid.UUID) -> Decimal:
+        """
+        Get the effective flat $/min (== credits/min, since 1 credit = $1) rate for a tenant.
+        Falls back to DEFAULT_PER_MINUTE_RATE (0.12) if no PricingConfig row exists yet.
+        """
+        config = db.query(PricingConfig).filter(PricingConfig.workspace_id == tenant_id).first()
+        if config and config.per_minute_rate is not None:
+            return Decimal(str(config.per_minute_rate))
+        return DEFAULT_PER_MINUTE_RATE
+
+    def calculate_credits_for_duration(self, duration_seconds: float, credits_per_minute: float) -> float:
         """
         Calculate credits for a specific duration (Vapi-style: per-second accurate calculation)
-        
+
         Args:
             duration_seconds: Duration in seconds (can be fractional)
-            credits_per_minute: Credits per minute for the model
-            
+            credits_per_minute: Credits (== dollars) per minute
+
         Returns:
             Credits to deduct (as float for accurate billing)
         """
         if duration_seconds <= 0:
             return 0.0
-        
+
         # Vapi-style: Calculate per-second cost (accurate, no rounding)
         credits_per_second = credits_per_minute / 60.0
         total_credits = duration_seconds * credits_per_second
-        
+
         # Return float for accurate billing (no rounding until final deduction)
         return round(total_credits, 4)  # Round to 4 decimal places for precision
-    
+
     def get_tenant_credits(self, db: Session, tenant_id: uuid.UUID) -> float:
         """
         Get current credit balance for a tenant
@@ -123,30 +246,83 @@ class CreditService:
         return float(tenant.credits or 0)
     
     def has_sufficient_credits(
-        self, 
-        db: Session, 
-        tenant_id: uuid.UUID, 
-        model_name: str,
-        estimated_minutes: int = 1
-    ) -> tuple[bool, float, float]:
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        model_name: str | None = None,
+        tts_provider_slug: str | None = None,
+        is_byo_elevenlabs: bool = False,
+    ) -> tuple[bool, float, float, str]:
         """
-        Check if tenant has sufficient credits for a call
-        
+        Check if tenant is allowed to start a call: plan-aware pre-call gate.
+
+        If the tenant still has remaining included plan minutes this cycle, the call
+        is allowed regardless of credit balance (it's covered by the plan allowance).
+        Otherwise, fall back to the existing "credits > 0" check.
+
+        Any call whose agent configuration triggers one or more surcharges (see
+        `get_active_surcharges` — currently: OpenAI Realtime speech-to-speech models,
+        or an ElevenLabs-resolved TTS provider) has those surcharges deducted from
+        credits starting from the very first monitoring tick, regardless of remaining
+        included minutes — so a tenant with a zero credit balance must not be allowed
+        to start one of these calls even if they still have plenty of included minutes
+        left, since the first tick's surcharge deduction would immediately force-end
+        the call.
+
         Args:
-            db: Database session
-            tenant_id: Tenant UUID
-            model_name: Name of the model being used
-            estimated_minutes: Estimated call duration in minutes (for calculation)
-            
+            model_name: Agent's model name, if known at call-start time. Only
+                affects the gate when it is an OpenAI Realtime model.
+            tts_provider_slug: Agent's resolved TTS adapter slug (see
+                `app.core.agent_runtime.resolve_tts_runtime`), if known at
+                call-start time. Only affects the gate when it is "elevenlabs".
+            is_byo_elevenlabs: True when the agent uses a tenant-supplied BYO
+                ElevenLabs key (see `ResolvedTtsRuntime.is_byo_elevenlabs`) —
+                exempts the call from the ElevenLabs surcharge gate below.
+
         Returns:
-            Tuple of (has_sufficient, current_credits, required_credits)
+            Tuple of (has_sufficient, current_credits, required_credits, reason).
+            `required_credits` is kept in the return shape for backward-compat callers
+            but is no longer a meaningful "cost estimate" now that per-model pricing
+            is retired; it's always 0.0. `reason` is a short machine/human-readable
+            string identifying which rule produced the result (for diagnosable
+            rejection logging/messaging at call sites) — "ok" when allowed.
         """
+        from app.services.billing_service import BillingService
+
         current_credits = self.get_tenant_credits(db, tenant_id)
-        credits_per_minute = self.get_credit_cost_per_minute(model_name)
-        required_credits = float(credits_per_minute * estimated_minutes)
-        
-        # Require credits > 0 (call will end when reaching 0 during monitoring)
-        return (current_credits > 0, current_credits, required_credits)
+        _, _, remaining_minutes = BillingService.get_included_minutes_status(db, tenant_id)
+
+        surcharges = self.get_active_surcharges(
+            model_name=model_name,
+            tts_provider_slug=tts_provider_slug,
+            is_byo_elevenlabs=is_byo_elevenlabs,
+        )
+
+        if remaining_minutes > 0:
+            if surcharges:
+                # Base rate is still waived by the included-minutes allowance, but
+                # active surcharges are not — require a positive credit balance too.
+                if current_credits > 0:
+                    return (True, current_credits, 0.0, "ok")
+                names = " + ".join(s.label for s in surcharges)
+                return (
+                    False,
+                    current_credits,
+                    0.0,
+                    f"blocked: {names} requires a positive credit balance "
+                    "(included minutes remain, but surcharges are never waived by the allowance)",
+                )
+            return (True, current_credits, 0.0, "ok")
+
+        # No included minutes left (or pure pay-as-you-go) — require positive credit balance.
+        if current_credits > 0:
+            return (True, current_credits, 0.0, "ok")
+        return (
+            False,
+            current_credits,
+            0.0,
+            "blocked: no included minutes remaining and no credit balance",
+        )
     
     def deduct_credits(
         self, 
@@ -241,56 +417,149 @@ class CreditService:
             logger.warning(f"Credit monitor already active for call {call_session_id}")
             return
         
-        # Get agent and model information (using provided session for initial query)
+        # Agent/model lookup kept for logging context, and to resolve which
+        # surcharges (if any) apply for the full duration of this call.
         agent = db.query(Agent).filter(Agent.id == agent_id).first()
-        if not agent or not agent.model:
-            logger.error(f"Agent {agent_id} or model not found")
+        if not agent:
+            logger.error(f"Agent {agent_id} not found")
             return
-        
-        model_name = agent.model.model_name
-        credits_per_minute = self.get_credit_cost_per_minute(model_name)
-        
+
+        model_name = agent.model.model_name if agent.model else "unknown"
+        credits_per_minute = float(self.get_effective_rate_per_minute(db, tenant_id))
+
+        # Determined once per call (agents don't change mid-call) so the 10s tick
+        # loop never needs to re-resolve the agent's TTS runtime just to check this.
+        tts_provider_slug: str | None = None
+        is_byo_elevenlabs = False
+        try:
+            from app.core.agent_runtime import resolve_tts_runtime
+
+            tts_runtime = resolve_tts_runtime(agent, db=db)
+            tts_provider_slug = tts_runtime.adapter_slug
+            is_byo_elevenlabs = tts_runtime.is_byo_elevenlabs
+        except Exception as exc:
+            logger.warning(
+                f"Failed to resolve TTS runtime for agent {agent_id} while starting "
+                f"credit monitor (ElevenLabs surcharge check skipped): {exc}"
+            )
+        surcharges = self.get_active_surcharges(
+            model_name=model_name,
+            tts_provider_slug=tts_provider_slug,
+            is_byo_elevenlabs=is_byo_elevenlabs,
+        )
+
         # Initialize tracking for this call
         call_start_time = datetime.now(timezone.utc)
         call_id_str = str(call_session_id)
         self._call_start_times[call_id_str] = call_start_time
         self._last_deduction_time[call_id_str] = call_start_time
         self._accumulated_seconds[call_id_str] = 0.0
-        
+
         logger.info(
             f"Starting credit monitor for call {call_session_id}. "
-            f"Model: {model_name}, Cost: {credits_per_minute} credits/min "
+            f"Model: {model_name}, Rate: {credits_per_minute} credits/min, "
+            f"Surcharges: {[s.key for s in surcharges] or 'none'} "
             f"(Vapi-style per-second billing with float precision)"
         )
-        logger.info(f"💰 CREDIT MONITORING STARTED: Call {call_session_id} | Model: {model_name} | Cost: {credits_per_minute} credits/min | Float credits enabled")
-        
-        # Create monitoring task (will create its own DB session for thread-safety)
+        logger.info(f"💰 CREDIT MONITORING STARTED: Call {call_session_id} | Model: {model_name} | Rate: {credits_per_minute} credits/min | Float credits enabled")
+
+        # Create monitoring task (will create its own DB session for thread-safety).
+        # NOTE: tts_provider_slug/is_byo_elevenlabs (not a fixed `surcharges` list)
+        # are passed through so the tick loop can re-derive which surcharges are
+        # CURRENTLY active every 10s by reading CallSession.call_metadata
+        # ["openai_realtime_fallback"] fresh each time — a call configured for an
+        # OpenAI Realtime model can fall back mid-call to the legacy TTS pipeline
+        # (see VoiceOrchestrator._fallback_to_legacy_pipeline_openai), at which
+        # point the realtime surcharge must stop and the ElevenLabs surcharge (if
+        # applicable) must start applying for the remainder of the call.
         task = asyncio.create_task(
             self._monitor_and_deduct_credits(
-                call_session_id, tenant_id, model_name, credits_per_minute
+                call_session_id,
+                tenant_id,
+                model_name,
+                credits_per_minute,
+                tts_provider_slug=tts_provider_slug,
+                is_byo_elevenlabs=is_byo_elevenlabs,
             )
         )
         self._active_monitors[call_id_str] = task
-    
+
+    def _resolve_current_surcharges(
+        self,
+        call_session: CallSession,
+        model_name: str | None,
+        tts_provider_slug: str | None,
+        is_byo_elevenlabs: bool,
+    ) -> list[ActiveSurcharge]:
+        """
+        Re-derive which surcharges are active for `call_session` RIGHT NOW —
+        called on every monitoring tick (and at finalization) rather than
+        once at call-start, so a mid-call OpenAI Realtime fallback (see
+        `VoiceOrchestrator._fallback_to_legacy_pipeline_openai`) is picked up
+        for the remainder of the call. `call_session` is re-queried by the
+        caller on every tick already, so this reads whatever the orchestrator
+        most recently persisted with no extra DB round-trip.
+        """
+        realtime_fallen_back = False
+        try:
+            meta = call_session.call_metadata or {}
+            if isinstance(meta, dict):
+                fallback_meta = meta.get("openai_realtime_fallback")
+                if isinstance(fallback_meta, dict):
+                    realtime_fallen_back = bool(fallback_meta.get("fell_back"))
+                else:
+                    realtime_fallen_back = bool(fallback_meta)
+        except Exception as exc:
+            logger.warning(
+                f"Failed to read openai_realtime_fallback from call_metadata for "
+                f"call {call_session.id}: {exc}"
+            )
+
+        return self.get_active_surcharges(
+            model_name=model_name,
+            tts_provider_slug=tts_provider_slug,
+            is_byo_elevenlabs=is_byo_elevenlabs,
+            realtime_fallen_back=realtime_fallen_back,
+        )
+
     async def _monitor_and_deduct_credits(
         self,
         call_session_id: uuid.UUID,
         tenant_id: uuid.UUID,
         model_name: str,
-        credits_per_minute: int
+        credits_per_minute: float,
+        tts_provider_slug: str | None = None,
+        is_byo_elevenlabs: bool = False,
     ):
         """
         Background task to monitor and deduct credits during call
-        Vapi-style: Real-time per-second billing with accurate duration tracking
-        
+        Vapi-style: Real-time per-second billing with accurate duration tracking, plan-aware:
+        minutes within the tenant's remaining included-minutes allowance are recorded as
+        usage but not charged; only minutes beyond the allowance are deducted from credits.
+
         Args:
             call_session_id: Call session UUID
             tenant_id: Tenant UUID
-            model_name: Model name
-            credits_per_minute: Credits per minute for the model
+            model_name: Model name — the DB-configured model, used both for
+                logging and (via `_resolve_current_surcharges`) as the
+                starting point for surcharge resolution each tick.
+            credits_per_minute: Flat effective $/min (== credits/min) rate for this tenant
+            tts_provider_slug: Agent's resolved TTS adapter slug (see
+                `app.core.agent_runtime.resolve_tts_runtime`), fixed for the
+                call (agents don't change mid-call).
+            is_byo_elevenlabs: True when the agent uses a tenant-supplied BYO
+                ElevenLabs key — exempts the ElevenLabs surcharge.
+
+        Surcharges are NOT resolved once and cached — `_resolve_current_surcharges`
+        is called fresh on every tick (and at finalization) so a mid-call OpenAI
+        Realtime fallback (`VoiceOrchestrator._fallback_to_legacy_pipeline_openai`,
+        persisted on `CallSession.call_metadata["openai_realtime_fallback"]`) is
+        picked up for the remainder of the call: the realtime surcharge stops
+        applying and the ElevenLabs surcharge (if applicable) starts applying
+        from that point onward.
         """
         call_id_str = str(call_session_id)
-        
+
         # Create dedicated DB session for this async task (Vapi-style: proper session handling)
         from app.db.session import SessionLocal
         db = SessionLocal()
@@ -308,15 +577,23 @@ class CreditService:
                 if not call_session:
                     logger.info(f"Call session {call_session_id} not found, stopping monitor")
                     break
-                
+
+                # Re-derive active surcharges every tick (not cached from call-start)
+                # so a mid-call OpenAI Realtime fallback is reflected immediately.
+                surcharges = self._resolve_current_surcharges(
+                    call_session, model_name, tts_provider_slug, is_byo_elevenlabs
+                )
+
                 # Only deduct for active call statuses
                 if call_session.status not in ["active", "in-progress", "connected", "answered"]:
                     # Call ended - do final deduction for remaining time
                     await self._finalize_call_credits(
-                        db, call_session_id, tenant_id, model_name, credits_per_minute, call_session
+                        db, call_session_id, tenant_id, model_name, credits_per_minute, call_session,
+                        tts_provider_slug=tts_provider_slug,
+                        is_byo_elevenlabs=is_byo_elevenlabs,
                     )
                     break
-                
+
                 # Calculate duration since last deduction
                 current_time = datetime.now(timezone.utc)
                 last_deduction = self._last_deduction_time.get(call_id_str)
@@ -327,103 +604,129 @@ class CreditService:
                 
                 # Calculate seconds since last deduction
                 elapsed_seconds = (current_time - last_deduction).total_seconds()
-                
+
                 if elapsed_seconds > 0:
-                    # Check current credits before attempting deduction
-                    current_tenant_credits = self.get_tenant_credits(db, tenant_id)
-                    if current_tenant_credits <= 0:
-                        # Credits already finished - end call immediately
-                        logger.warning(
-                            f"⛔ Credits already finished for call {call_session_id}. "
-                            f"Current credits: {current_tenant_credits}. Ending call immediately."
-                        )
-                        call_session.status = "completed"
-                        call_session.end_time = datetime.now(timezone.utc)
-                        call_session.ended_reason = "Insufficient credits"
-                        if call_session.start_time:
-                            duration = (call_session.end_time - call_session.start_time).total_seconds()
-                            call_session.duration = int(duration)
-                        db.commit()
-                        try:
-                            await self._end_twilio_call(call_session.twilio_call_sid)
-                        except Exception as e:
-                            logger.error(f"Error ending Twilio call: {e}")
-                        break
-                    
+                    from app.services.billing_service import BillingService
+
                     # Accumulate seconds
                     accumulated = self._accumulated_seconds.get(call_id_str, 0.0)
                     accumulated += elapsed_seconds
                     self._accumulated_seconds[call_id_str] = accumulated
-                    
-                    # Calculate credits for accumulated time (Vapi-style: per-second, as float)
-                    credits_to_deduct_float = self.calculate_credits_for_duration(accumulated, credits_per_minute)
-                    
-                    # Only deduct if we have at least 0.01 credits (prevents micro-deductions)
-                    # This ensures accurate billing without over-deduction
-                    if credits_to_deduct_float >= 0.01:
-                        # ✅ Deduct accumulated credits (updates DB immediately)
-                        success, remaining_credits = self.deduct_credits(
+
+                    # Split accumulated time into the portion still covered by the tenant's
+                    # remaining included-plan minutes ("free") and the portion beyond it
+                    # ("billable") — a call must never be force-ended while fully within
+                    # its free allowance, even at a zero credit balance.
+                    _, _, remaining_minutes = BillingService.get_included_minutes_status(db, tenant_id)
+                    remaining_seconds = float(remaining_minutes) * 60.0
+                    free_seconds = min(accumulated, remaining_seconds)
+                    billable_seconds = max(0.0, accumulated - free_seconds)
+
+                    # Calculate credits owed for only the billable (overage) portion
+                    credits_to_deduct_float = self.calculate_credits_for_duration(billable_seconds, credits_per_minute)
+
+                    # Active surcharges (OpenAI Realtime, ElevenLabs TTS, or both,
+                    # summed additively) apply to the FULL accumulated seconds
+                    # (both the free-allowance and billable portions) — never
+                    # waived by the included-minutes pool, unlike the base rate above.
+                    surcharge_float, surcharge_desc = self._describe_surcharges(accumulated, surcharges)
+
+                    total_deduction_float = credits_to_deduct_float + surcharge_float
+
+                    deduction_success = True
+                    remaining_credits = self.get_tenant_credits(db, tenant_id)
+
+                    if total_deduction_float >= 0.01:
+                        description = (
+                            f"Call duration: {accumulated:.1f}s "
+                            f"(billable {billable_seconds:.1f}s) - Model: {model_name}"
+                        )
+                        if surcharge_float > 0:
+                            description += f" + {surcharge_desc}"
+                        # ✅ Deduct accumulated overage + active surcharge credits in one
+                        # combined deduction (updates DB immediately)
+                        deduction_success, remaining_credits = self.deduct_credits(
                             db=db,
                             tenant_id=tenant_id,
-                            amount=credits_to_deduct_float,
+                            amount=total_deduction_float,
                             call_session_id=call_session_id,
-                            description=f"Call duration: {accumulated:.1f}s - Model: {model_name}"
+                            description=description,
                         )
-                        
-                        if not success or remaining_credits <= 0:
-                            # ✅ CREDITS FINISHED - END CALL IMMEDIATELY
-                            logger.warning(
-                                f"⛔ Credits finished for call {call_session_id}. "
-                                f"Remaining credits: {remaining_credits}. Ending call immediately."
+
+                    # Record the FULL accumulated minutes as usage regardless of whether
+                    # anything was charged, so the included-minutes pool actually depletes.
+                    try:
+                        BillingService.record_call_minutes(
+                            db=db,
+                            tenant_id=tenant_id,
+                            call_id=call_session_id,
+                            minutes=Decimal(str(accumulated)) / Decimal("60"),
+                            credits_charged=(
+                                Decimal(str(total_deduction_float))
+                                if total_deduction_float >= 0.01
+                                else Decimal("0")
+                            ),
+                        )
+                    except Exception as exc:
+                        logger.error(f"Failed to record call minutes for {call_session_id}: {exc}")
+
+                    self._accumulated_seconds[call_id_str] = 0.0
+                    self._last_deduction_time[call_id_str] = current_time
+
+                    # Only force-end the call if there was a real charge (billable overage
+                    # and/or realtime surcharge) AND the deduction failed or exhausted the
+                    # tenant's balance.
+                    if total_deduction_float >= 0.01 and (not deduction_success or remaining_credits <= 0):
+                        # ✅ CREDITS FINISHED - END CALL IMMEDIATELY
+                        logger.warning(
+                            f"⛔ Credits finished for call {call_session_id}. "
+                            f"Remaining credits: {remaining_credits}. Ending call immediately."
+                        )
+
+                        # Update call session status immediately
+                        call_session.status = "completed"
+                        call_session.end_time = datetime.now(timezone.utc)
+                        call_session.ended_reason = "Insufficient credits"
+
+                        if call_session.start_time:
+                            duration = (call_session.end_time - call_session.start_time).total_seconds()
+                            call_session.duration = int(duration)
+
+                        # ✅ IMMEDIATE DATABASE UPDATE
+                        db.commit()
+
+                        # Try to end the Twilio call immediately
+                        try:
+                            await self._end_twilio_call(call_session.twilio_call_sid)
+                            logger.info("✅ Twilio call ended immediately due to insufficient credits")
+                        except Exception as e:
+                            logger.error(f"Error ending Twilio call: {e}")
+
+                        # Broadcast call ended event
+                        try:
+                            from app.routers.general_websocket import broadcast_call_status_update
+                            await broadcast_call_status_update(
+                                call_session_id=str(call_session_id),
+                                status="completed",
+                                metadata={
+                                    "reason": "insufficient_credits",
+                                    "message": "Call ended due to insufficient credits",
+                                    "remaining_credits": remaining_credits,
+                                    "timestamp": datetime.now(timezone.utc).isoformat()
+                                }
                             )
-                            
-                            # Update call session status immediately
-                            call_session.status = "completed"
-                            call_session.end_time = datetime.now(timezone.utc)
-                            call_session.ended_reason = "Insufficient credits"
-                            
-                            if call_session.start_time:
-                                duration = (call_session.end_time - call_session.start_time).total_seconds()
-                                call_session.duration = int(duration)
-                            
-                            # ✅ IMMEDIATE DATABASE UPDATE
-                            db.commit()
-                            
-                            # Try to end the Twilio call immediately
-                            try:
-                                await self._end_twilio_call(call_session.twilio_call_sid)
-                                logger.info("✅ Twilio call ended immediately due to insufficient credits")
-                            except Exception as e:
-                                logger.error(f"Error ending Twilio call: {e}")
-                            
-                            # Broadcast call ended event
-                            try:
-                                from app.routers.general_websocket import broadcast_call_status_update
-                                await broadcast_call_status_update(
-                                    call_session_id=str(call_session_id),
-                                    status="completed",
-                                    metadata={
-                                        "reason": "insufficient_credits",
-                                        "message": "Call ended due to insufficient credits",
-                                        "remaining_credits": remaining_credits,
-                                        "timestamp": datetime.now(timezone.utc).isoformat()
-                                    }
-                                )
-                            except Exception as e:
-                                logger.error(f"Error broadcasting call end event: {e}")
-                            
-                            # Stop monitoring immediately
-                            break
-                        
-                        # Reset accumulated time after successful deduction
-                        self._accumulated_seconds[call_id_str] = 0.0
-                        self._last_deduction_time[call_id_str] = current_time
-                        
-                        logger.info(
-                            f"Call {call_session_id}: Deducted {credits_to_deduct_float:.4f} credits "
-                            f"for {accumulated:.1f}s duration. Remaining: {remaining_credits:.4f}"
-                        )
-                        logger.info(f"💰 CREDIT DEDUCTED: {credits_to_deduct_float:.4f} credits for {accumulated:.1f}s | Remaining: {remaining_credits:.4f} | Call: {call_session_id}")
+                        except Exception as e:
+                            logger.error(f"Error broadcasting call end event: {e}")
+
+                        # Stop monitoring immediately
+                        break
+
+                    logger.info(
+                        f"Call {call_session_id}: {accumulated:.1f}s elapsed "
+                        f"({billable_seconds:.1f}s billable, {total_deduction_float:.4f} credits deducted "
+                        f"[base {credits_to_deduct_float:.4f} + surcharge {surcharge_float:.4f}]). "
+                        f"Remaining: {remaining_credits:.4f}"
+                    )
         
         except asyncio.CancelledError:
             logger.info(f"Credit monitor cancelled for call {call_session_id}")
@@ -440,7 +743,9 @@ class CreditService:
                 ).first()
                 if call_session:
                     await self._finalize_call_credits(
-                        db, call_session_id, tenant_id, model_name, credits_per_minute, call_session
+                        db, call_session_id, tenant_id, model_name, credits_per_minute, call_session,
+                        tts_provider_slug=tts_provider_slug,
+                        is_byo_elevenlabs=is_byo_elevenlabs,
                     )
             except Exception as e:
                 logger.error(f"Error in final credit deduction: {e}")
@@ -466,33 +771,78 @@ class CreditService:
         call_session_id: uuid.UUID,
         tenant_id: uuid.UUID,
         model_name: str,
-        credits_per_minute: int,
-        call_session: CallSession
+        credits_per_minute: float,
+        call_session: CallSession,
+        tts_provider_slug: str | None = None,
+        is_byo_elevenlabs: bool = False,
     ):
         """
-        Finalize credits for call end - deduct any remaining accumulated time (Vapi-style)
+        Finalize credits for call end - deduct any remaining accumulated time (Vapi-style),
+        plan-aware: only the portion beyond the tenant's remaining included minutes is charged
+        at the base rate. Active surcharges (when applicable) apply to the full accumulated
+        seconds regardless of the included-minutes split — mirrors
+        `_monitor_and_deduct_credits`.
+
+        Surcharges are re-resolved from `call_session.call_metadata` here (via
+        `_resolve_current_surcharges`) rather than reused from an earlier tick,
+        so a fallback that happened since the last tick is still reflected in
+        the final deduction.
         """
+        from app.services.billing_service import BillingService
+
+        surcharges = self._resolve_current_surcharges(
+            call_session, model_name, tts_provider_slug, is_byo_elevenlabs
+        )
         call_id_str = str(call_session_id)
         accumulated = self._accumulated_seconds.get(call_id_str, 0.0)
-        
+
         if accumulated > 0:
-            # Calculate final credits for remaining time
-            final_credits = self.calculate_credits_for_duration(accumulated, credits_per_minute)
-            
-            if final_credits >= 0.01:  # Only deduct if at least 0.01 credits
+            _, _, remaining_minutes = BillingService.get_included_minutes_status(db, tenant_id)
+            remaining_seconds = float(remaining_minutes) * 60.0
+            free_seconds = min(accumulated, remaining_seconds)
+            billable_seconds = max(0.0, accumulated - free_seconds)
+
+            # Calculate final credits for the billable (overage) portion only
+            final_credits = self.calculate_credits_for_duration(billable_seconds, credits_per_minute)
+
+            # Active surcharges apply to the FULL accumulated seconds.
+            surcharge_final, surcharge_desc = self._describe_surcharges(accumulated, surcharges)
+
+            total_final = final_credits + surcharge_final
+            credits_charged = Decimal("0")
+
+            if total_final >= 0.01:  # Only deduct if at least 0.01 credits
+                description = f"Final call duration: {accumulated:.1f}s (billable {billable_seconds:.1f}s) - Model: {model_name}"
+                if surcharge_final > 0:
+                    description += f" + {surcharge_desc}"
                 success, remaining_credits = self.deduct_credits(
                     db=db,
                     tenant_id=tenant_id,
-                    amount=final_credits,
+                    amount=total_final,
                     call_session_id=call_session_id,
-                    description=f"Final call duration: {accumulated:.1f}s - Model: {model_name}"
+                    description=description,
                 )
-                
+                credits_charged = Decimal(str(total_final))
+
                 logger.info(
-                    f"Call {call_session_id}: Final deduction of {final_credits:.4f} credits "
+                    f"Call {call_session_id}: Final deduction of {total_final:.4f} credits "
+                    f"(base {final_credits:.4f} + surcharge {surcharge_final:.4f}) "
                     f"for {accumulated:.1f}s. Remaining: {remaining_credits:.4f}"
                 )
-                logger.info(f"💰 FINAL CREDIT DEDUCTION: {final_credits:.4f} credits for {accumulated:.1f}s | Remaining: {remaining_credits:.4f} | Call: {call_session_id}")
+                logger.info(f"💰 FINAL CREDIT DEDUCTION: {total_final:.4f} credits for {accumulated:.1f}s | Remaining: {remaining_credits:.4f} | Call: {call_session_id}")
+
+            try:
+                BillingService.record_call_minutes(
+                    db=db,
+                    tenant_id=tenant_id,
+                    call_id=call_session_id,
+                    minutes=Decimal(str(accumulated)) / Decimal("60"),
+                    credits_charged=credits_charged,
+                )
+            except Exception as exc:
+                logger.error(f"Failed to record final call minutes for {call_session_id}: {exc}")
+
+            self._accumulated_seconds[call_id_str] = 0.0
     
     async def _end_twilio_call(self, twilio_call_sid: str):
         """

--- a/app/services/phone_number_service.py
+++ b/app/services/phone_number_service.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from decimal import Decimal
 from typing import List
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -59,6 +60,70 @@ class PhoneNumberService:
         ).scalar_one_or_none()
         if existing is None:
             db.add(NumberConfiguration(phone_number_id=pn.id))
+
+    # $2 flat charge (== 2 credits, 1 credit = $1) per phone number purchased/imported
+    # beyond the tenant's plan-included `free_phone_numbers` allowance.
+    PHONE_NUMBER_OVERAGE_COST = Decimal("2")
+
+    @staticmethod
+    def _phone_number_overage_check(db: Session, tenant_id: uuid.UUID) -> bool:
+        """
+        Plan-aware phone-number allowance check — NOT a hard cap. Returns True if the
+        next number purchase/import would be billed as overage (tenant already at/over
+        `plan.free_phone_numbers`), after confirming the tenant can cover
+        `PHONE_NUMBER_OVERAGE_COST`; raises HTTP 402 (mirrors the insufficient-credits
+        pattern used for the pre-call gate) if it can't — callers must not proceed to
+        Twilio in that case. Returns False (no charge) when there's no active core plan,
+        `free_phone_numbers` is NULL (unlimited), or the tenant is still within its free
+        allowance.
+        """
+        from fastapi import HTTPException
+
+        from app.models.plan import Plan
+        from app.models.tenant import Tenant
+        from app.services.billing_service import BillingService
+
+        subscription = BillingService.get_workspace_subscription(db, tenant_id)
+        if subscription is None:
+            return False
+        plan = db.query(Plan).filter(Plan.id == subscription.plan_id).first()
+        if plan is None or plan.free_phone_numbers is None:
+            return False
+
+        existing_count = db.execute(
+            select(func.count()).select_from(PhoneNumber).where(
+                PhoneNumber.tenant_id == tenant_id,
+                PhoneNumber.status == "active",
+            )
+        ).scalar_one()
+
+        if existing_count < plan.free_phone_numbers:
+            return False
+
+        tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+        current_credits = tenant.credits if tenant and tenant.credits is not None else Decimal("0")
+        if tenant is None or current_credits < PhoneNumberService.PHONE_NUMBER_OVERAGE_COST:
+            raise HTTPException(
+                status_code=402,
+                detail=(
+                    f"Insufficient balance to purchase an additional phone number. "
+                    f"Your plan includes {plan.free_phone_numbers} free numbers; "
+                    f"additional numbers cost ${PhoneNumberService.PHONE_NUMBER_OVERAGE_COST} "
+                    f"each, deducted from your credit balance."
+                ),
+            )
+        return True
+
+    @staticmethod
+    def _charge_phone_number_overage(db: Session, tenant_id: uuid.UUID) -> None:
+        """Deduct the flat overage cost from the tenant's credit balance. Caller must
+        have already confirmed sufficient balance via `_phone_number_overage_check`."""
+        from app.models.tenant import Tenant
+
+        tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+        if tenant is None:
+            return
+        tenant.credits = (tenant.credits or Decimal("0")) - PhoneNumberService.PHONE_NUMBER_OVERAGE_COST
 
     # ------------------------------------------------------------------
     # Legacy CRUD (backward compat — existing router uses these)
@@ -179,6 +244,10 @@ class PhoneNumberService:
         twilio_auth_token: str,
     ) -> PhoneNumber:
         """Import a BYO Twilio number with custom per-number credentials."""
+        # Plan-aware overage check before touching Twilio: raises 402 if this import
+        # would be billed as overage and the tenant can't cover it.
+        needs_overage_charge = self._phone_number_overage_check(db, tenant_id)
+
         existing = db.execute(
             select(PhoneNumber).where(PhoneNumber.phone_number == phone_number)
         ).scalar_one_or_none()
@@ -235,6 +304,8 @@ class PhoneNumberService:
         )
         db.add(pn)
         try:
+            if needs_overage_charge:
+                self._charge_phone_number_overage(db, tenant_id)
             db.commit()
         except IntegrityError:
             db.rollback()
@@ -263,6 +334,10 @@ class PhoneNumberService:
 
         from app.core.config import settings
         from app.services.twilio_service import twilio_service
+
+        # Plan-aware overage check before touching Twilio: raises 402 if this purchase
+        # would be billed as overage and the tenant can't cover it.
+        needs_overage_charge = self._phone_number_overage_check(db, tenant_id)
 
         # Global uniqueness check before touching Twilio
         existing = db.execute(
@@ -300,6 +375,8 @@ class PhoneNumberService:
         try:
             db.flush()
             self._attach_default_configuration(db, pn)
+            if needs_overage_charge:
+                self._charge_phone_number_overage(db, tenant_id)
             db.commit()
         except IntegrityError:
             db.rollback()

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 from twilio.base.exceptions import TwilioRestException
 
+from app.core.agent_runtime import resolve_tts_runtime
 from app.core.config import settings
 from app.core.error_responses import build_call_initiate_error_payload
 from app.middleware.request_id_middleware import new_request_id
@@ -232,33 +233,40 @@ async def initiate_call(
             )
 
         model_name = agent.model.model_name
-        has_sufficient, current_credits, required_credits = (
+        outbound_tts_runtime = resolve_tts_runtime(agent, db=db)
+        tts_provider_slug = outbound_tts_runtime.adapter_slug
+        has_sufficient, current_credits, required_credits, decline_reason = (
             credit_service.has_sufficient_credits(
                 db=db,
                 tenant_id=tenant_id_filter,
                 model_name=model_name,
-                estimated_minutes=1,
+                tts_provider_slug=tts_provider_slug,
+                is_byo_elevenlabs=outbound_tts_runtime.is_byo_elevenlabs,
             )
         )
 
         if not has_sufficient:
             logger.warning(
-                "❌ Insufficient credits: %s < %s", current_credits, required_credits
+                "❌ Insufficient credits: %s < %s (reason=%s)",
+                current_credits,
+                required_credits,
+                decline_reason,
             )
-            raise HTTPException(
-                status_code=status.HTTP_402_PAYMENT_REQUIRED,
-                detail=(
+            return _err(
+                status.HTTP_402_PAYMENT_REQUIRED,
+                "insufficient_credits",
+                (
                     f"Insufficient credits to initiate call. Current balance: "
-                    f"{current_credits} credits, Required: {required_credits} credits. "
-                    f"Model: {model_name}"
+                    f"{current_credits} credits. Model: {model_name}. "
+                    f"Reason: {decline_reason}"
                 ),
             )
 
         logger.info(
-            "✅ Credit check passed: %s credits available, %s required for model %s",
+            "✅ Credit check passed: %s credits available for model %s (tts=%s)",
             current_credits,
-            required_credits,
             model_name,
+            tts_provider_slug,
         )
 
         # ── 7. Per-workspace concurrent outbound limit (GAP 6) ────────────

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -89,6 +89,21 @@ _STT_INPUT_ENCODING = "LINEAR16"
 _GREETING_DELAY_SEC = 0.6
 _TURN_TIMEOUT_SEC = 25.0
 
+# Hard safety cap on total call duration. This is a new mechanism (no
+# equivalent exists on the Twilio path or anywhere else in the codebase as of
+# this writing) added specifically because this loop now bills the tenant's
+# plan-included-minutes/credits via credit_service for every second the call
+# is held open (see the credit-monitoring block in run_livekit_browser_call).
+# Per the module docstring / Voice Pipeline vault notes, there is no reliable
+# end-of-call signal for a browser-only LiveKit call if the visitor's network
+# dies or the tab closes ungracefully — only participant_disconnected/
+# disconnected room events, which never fire in that failure mode. Without
+# this cap a dead connection could bill indefinitely. This is orthogonal to
+# (and does not replace) CallFlowDemoLink.per_user_limit_minutes /
+# total_budget_minutes, which are tenant-configured usage budgets enforced
+# elsewhere — this is a fixed, code-level upper bound on any single call.
+_MAX_CALL_DURATION_SEC = 1800.0
+
 # asyncio.Task objects are only weakly referenced by the event loop (see the
 # asyncio docs' explicit warning) — a fire-and-forget asyncio.create_task()
 # with no other reference is eligible for GC at any point. For a short burst
@@ -1334,6 +1349,10 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
     # trigger CRM write-back scheduling for a call nothing ever happened on.
     agent_joined = False
     recording_egress_id: str | None = None
+    # Set only when the hard max-duration cap fires, so the finally block can
+    # record a distinct, identifiable ended_reason instead of the generic
+    # "completed" it uses for a normal caller/room disconnect.
+    forced_end_reason: str | None = None
 
     try:
         call_session, agent, call_flow = await _load_browser_call_context(db, call_session_id)
@@ -1518,12 +1537,42 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
             call_session.start_time = datetime.now(timezone.utc)
         db.commit()
 
+        # 🎯 START CREDIT MONITORING - demo/browser calls bill the demo link's
+        # owning tenant through the same plan-aware credit system as real calls.
+        try:
+            from app.services.credit_service import credit_service
+
+            if str(call_session.id) not in credit_service._active_monitors:
+                asyncio.create_task(credit_service.start_credit_monitoring(
+                    db=db,
+                    call_session_id=call_session.id,
+                    tenant_id=call_session.tenant_id,
+                    agent_id=call_session.agent_id
+                ))
+        except Exception as e:
+            logger.debug("[LiveKitBrowserCall] Could not start credit monitoring: %s", e)
+
         await asyncio.sleep(_GREETING_DELAY_SEC)
         if not handler._stop_event.is_set():
             await handler.generate_and_stream_response("", 1.0, is_greeting=True)
 
-        # ── Hold the call until the caller/room disconnects ─────────────────
-        await handler._stop_event.wait()
+        # ── Hold the call until the caller/room disconnects, or until the ──
+        # hard max-duration safety cap trips (see _MAX_CALL_DURATION_SEC).
+        try:
+            await asyncio.wait_for(handler._stop_event.wait(), timeout=_MAX_CALL_DURATION_SEC)
+        except asyncio.TimeoutError:
+            forced_end_reason = "max_duration_exceeded"
+            logger.warning(
+                "[LiveKitBrowserCall] hard max-call-duration cap (%.0fs) reached — "
+                "force-ending call room=%s call_session=%s",
+                _MAX_CALL_DURATION_SEC, room_name, call_session_id,
+            )
+            # Mirrors the participant/room-disconnect handlers above: signal
+            # the stop event and fall through to the shared finally cleanup
+            # below (recording teardown, audio subscriber stop, publisher
+            # disconnect — which actually drops the agent's LiveKit
+            # connection/room — credit-monitor stop, and status finalize).
+            handler._stop_event.set()
 
     except Exception as exc:
         logger.error(
@@ -1562,12 +1611,32 @@ async def run_livekit_browser_call(call_session_id: uuid.UUID) -> None:
             except Exception as exc:
                 logger.debug("[LiveKitBrowserCall] publisher disconnect failed: %s", exc)
 
+        if agent_joined:
+            try:
+                from app.services.credit_service import credit_service
+
+                credit_service.stop_credit_monitoring(call_session_id)
+                logger.info(
+                    "[LiveKitBrowserCall] Stopped credit monitoring for call session %s",
+                    call_session_id,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[LiveKitBrowserCall] failed to stop credit monitoring call_session=%s: %s",
+                    call_session_id, exc,
+                )
+
         if call_session is not None:
             try:
                 from app.services.call_session_service import call_session_service
 
                 if agent_joined:
-                    call_session_service.update_call_session_status(db, call_session_id, "completed")
+                    if forced_end_reason:
+                        call_session_service.update_call_session_status(
+                            db, call_session_id, "completed", ended_reason=forced_end_reason
+                        )
+                    else:
+                        call_session_service.update_call_session_status(db, call_session_id, "completed")
                 else:
                     call_session_service.update_call_session_status(
                         db, call_session_id, "failed", ended_reason="agent_join_failed"

--- a/app/voice/voice_orchestrator.py
+++ b/app/voice/voice_orchestrator.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Set
 
 from app.core.config import settings
@@ -1297,6 +1298,36 @@ class VoiceOrchestrator:
                 reason,
             )
             agent.llm_model = _OPENAI_REALTIME_FALLBACK_TEXT_MODEL
+
+            # Persist the fallback on CallSession.call_metadata so
+            # credit_service's out-of-process billing tick (which re-queries
+            # CallSession every 10s, never holds a reference to this
+            # orchestrator instance) can stop billing the OpenAI Realtime
+            # surcharge and start evaluating the ElevenLabs TTS surcharge for
+            # the remainder of the call — see
+            # CreditService.get_active_surcharges(realtime_fallen_back=...).
+            # Mirrors the existing call_metadata write pattern in
+            # CallControlMixin._transfer_call (human_transfer).
+            try:
+                call_session = getattr(h, "call_session", None)
+                db = getattr(h, "db", None)
+                if call_session is not None and db is not None:
+                    meta = dict(call_session.call_metadata or {})
+                    meta["openai_realtime_fallback"] = {
+                        "fell_back": True,
+                        "reason": reason,
+                        "at": datetime.now(timezone.utc).isoformat(),
+                    }
+                    call_session.call_metadata = meta
+                    db.commit()
+                    db.refresh(call_session)
+            except Exception as exc:
+                logger.error(
+                    "[OpenAIRealtime] failed to persist realtime-fallback flag on "
+                    "call_metadata for call_session_id=%s (credit billing may keep "
+                    "charging the realtime surcharge for this call): %s",
+                    getattr(h, "call_session_id", None), exc, exc_info=True,
+                )
         else:
             logger.error(
                 "[OpenAIRealtime] pre-session failure with no agent loaded for call_session_id=%s "

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -592,6 +592,58 @@ paths:
               schema: {}
       security:
       - HTTPBearer: []
+  /api/v1/tenants/plans/start-checkout:
+    post:
+      tags:
+      - tenants
+      summary: Start Core Plan Checkout
+      description: 'Start a Stripe subscription-mode checkout session for a tenant-level
+        core-product
+
+        plan (Studio / Agency). Mirrors `crm_config.py`''s `start_plan_checkout` but
+        is
+
+        tenant-scoped (metadata carries `tenant_id`, `crm_type` is always empty).'
+      operationId: start_core_plan_checkout_api_v1_tenants_plans_start_checkout_post
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: stripe_price_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Stripe Price Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_dict_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/tenants/plan:
+    get:
+      tags:
+      - tenants
+      summary: Get Tenant Plan
+      description: Current core-product plan + entitlements for the caller's active
+        tenant.
+      operationId: get_tenant_plan_api_v1_tenants_plan_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TenantPlanOut'
+      security:
+      - HTTPBearer: []
   /api/v1/workspace/invite:
     post:
       tags:
@@ -15150,6 +15202,18 @@ components:
           type: string
           pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
           title: Effective Client Rate
+        available_surcharges:
+          items:
+            $ref: '#/components/schemas/SurchargeInfoOut'
+          type: array
+          title: Available Surcharges
+          description: Full catalog of per-minute surcharges the platform knows how
+            to apply (e.g. OpenAI Realtime, ElevenLabs voice) — this is NOT the list
+            of surcharges currently being charged on any specific call or agent. Whether
+            a given surcharge is actually active depends on that agent's model/TTS
+            configuration at call time; these endpoints are workspace-scoped, not
+            agent- or call-scoped, so this field only advertises what CAN stack on
+            top of the base per-minute rate.
       type: object
       required:
       - per_minute_rate
@@ -18699,6 +18763,41 @@ components:
       required:
       - data
       title: SuccessResponse[list[TenantMember]]
+    SurchargeInfoOut:
+      properties:
+        key:
+          type: string
+          title: Key
+        label:
+          type: string
+          title: Label
+        rate_per_minute:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Rate Per Minute
+        applies_when:
+          type: string
+          title: Applies When
+      type: object
+      required:
+      - key
+      - label
+      - rate_per_minute
+      - applies_when
+      title: SurchargeInfoOut
+      description: 'A single named per-minute surcharge that can stack on top of the
+        base
+
+        per-minute rate (see app.services.credit_service.SURCHARGE_CATALOG).
+
+
+        This is the full catalog of surcharges the platform knows how to apply —
+
+        not necessarily all active for every agent/call — since these endpoints
+
+        are workspace-scoped rather than agent-scoped. `applies_when` documents
+
+        the condition that activates it for a given call.'
     SwitchTenantRequest:
       properties:
         tenant_id:
@@ -19046,6 +19145,51 @@ components:
       - join_date
       - created_at
       title: TenantMember
+    TenantPlanOut:
+      properties:
+        plan_name:
+          type: string
+          nullable: true
+        display_name:
+          type: string
+          nullable: true
+        included_minutes:
+          type: integer
+          nullable: true
+        minutes_used_this_cycle:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Minutes Used This Cycle
+        minutes_remaining:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Minutes Remaining
+        monthly_credits:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          nullable: true
+        free_phone_numbers:
+          type: integer
+          nullable: true
+        max_subaccounts:
+          type: integer
+          nullable: true
+        features:
+          items:
+            type: string
+          type: array
+          title: Features
+        credits_balance:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Credits Balance
+      type: object
+      required:
+      - minutes_used_this_cycle
+      - minutes_remaining
+      - credits_balance
+      title: TenantPlanOut
+      description: Response shape for GET /api/v1/tenants/plan — current plan + entitlements.
     TokenResponse:
       properties:
         access_token:
@@ -19721,6 +19865,18 @@ components:
           type: string
           pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
           title: Overage Cost
+        available_surcharges:
+          items:
+            $ref: '#/components/schemas/SurchargeInfoOut'
+          type: array
+          title: Available Surcharges
+          description: Full catalog of per-minute surcharges the platform knows how
+            to apply (e.g. OpenAI Realtime, ElevenLabs voice) — this is NOT the list
+            of surcharges currently being charged on any specific call or agent. Whether
+            a given surcharge is actually active depends on that agent's model/TTS
+            configuration at call time; these endpoints are workspace-scoped, not
+            agent- or call-scoped, so this field only advertises what CAN stack on
+            top of the base per-minute rate.
       type: object
       required:
       - minutes_used_this_cycle

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -490,7 +490,7 @@ paths:
       description: 'Start Stripe checkout session for one-time credit purchase (pay
         as you go).
 
-        $1 = 10 credits. User can buy any amount of credits.'
+        $1 = 1 credit. Minimum purchase is $5.'
       operationId: start_credit_checkout_session_api_v1_tenants_start_credit_checkout_session_post
       security:
       - HTTPBearer: []

--- a/tests/api/test_outbound_call_dispatch.py
+++ b/tests/api/test_outbound_call_dispatch.py
@@ -50,6 +50,16 @@ def _agent(*, status: str = "ready"):
     ag.name = "Test Agent"
     ag.status = status
     ag.model = MagicMock(model_name="gpt-4o")
+    # Explicit (non-MagicMock) TTS fields so resolve_tts_runtime(agent, db=...)
+    # — invoked for the surcharge gate in voice_call_service.initiate_call —
+    # resolves safely to the "google" default instead of tripping over
+    # arbitrary MagicMock attribute access (dict(MagicMock()), .lower(), etc.).
+    ag.tts_settings_json = {}
+    ag.tts_provider_slug = None
+    ag.tts_language = None
+    ag.tts_voice_external_id = None
+    ag.tts_provider = None
+    ag.language = "en"
     return ag
 
 
@@ -117,6 +127,7 @@ async def _run(
     twilio_make_call=None,
     call_session_obj=None,
     phone_obj=None,
+    credit_check_result=(True, 100, 10, "ok"),
 ):
     from app.services.voice_call_service import initiate_call
 
@@ -150,7 +161,7 @@ async def _run(
         ),
         patch(
             "app.services.voice_call_service.credit_service",
-            MagicMock(has_sufficient_credits=MagicMock(return_value=(True, 100, 10))),
+            MagicMock(has_sufficient_credits=MagicMock(return_value=credit_check_result)),
         ),
         patch(
             "app.services.voice_call_service.call_session_service",
@@ -313,6 +324,54 @@ class TestAgentNotReady:
 
 
 # ---------------------------------------------------------------------------
+# Test: insufficient credits — surcharge-specific decline messaging
+# ---------------------------------------------------------------------------
+
+
+class TestInsufficientCreditsDeclineMessaging:
+    @pytest.mark.asyncio
+    async def test_generic_insufficient_credits_returns_402(self):
+        req = _request()
+        result, _, twilio_call, _ = await _run(
+            req,
+            credit_check_result=(
+                False, 0.0, 0.0,
+                "blocked: no included minutes remaining and no credit balance",
+            ),
+        )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_402_PAYMENT_REQUIRED
+        twilio_call.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_surcharge_specific_decline_reason_is_in_response_detail(self):
+        """A surcharge-driven decline (included minutes remain, but a
+        positive credit balance is required for the active surcharge) must be
+        diagnosable from the error response — not indistinguishable from the
+        generic "no minutes, no credits" rejection."""
+        import json
+
+        req = _request()
+        reason = (
+            "blocked: ElevenLabs voice surcharge requires a positive credit "
+            "balance (included minutes remain, but surcharges are never "
+            "waived by the allowance)"
+        )
+        result, _, _, _ = await _run(
+            req,
+            credit_check_result=(False, 0.0, 0.0, reason),
+        )
+
+        assert isinstance(result, JSONResponse)
+        assert result.status_code == http_status.HTTP_402_PAYMENT_REQUIRED
+        body = json.loads(result.body)
+        assert body["error"]["code"] == "insufficient_credits"
+        assert "ElevenLabs" in body["error"]["message"]
+        assert reason in body["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
 # Test: concurrent outbound limit
 # ---------------------------------------------------------------------------
 
@@ -435,7 +494,7 @@ class TestLivekitRoomCreationFailure:
             ),
             patch(
                 "app.services.voice_call_service.credit_service",
-                MagicMock(has_sufficient_credits=MagicMock(return_value=(True, 100, 10))),
+                MagicMock(has_sufficient_credits=MagicMock(return_value=(True, 100, 10, "ok"))),
             ),
             patch("app.services.voice_call_service.call_session_service", mock_css),
             patch(

--- a/tests/api/test_sdk_demo_link.py
+++ b/tests/api/test_sdk_demo_link.py
@@ -31,6 +31,10 @@ def tenant(db) -> Tenant:
         name=f"DemoSdkWS-{uuid.uuid4().hex[:8]}",
         schema_name=f"demo_sdk_ws_{uuid.uuid4().hex[:8]}",
         status="active",
+        # demo calls now go through the same plan-aware credit gate as real
+        # calls (credit_service.has_sufficient_credits) — give the tenant a
+        # positive balance so existing happy-path tests aren't blocked by it.
+        credits=Decimal("100"),
     )
     db.add(t)
     db.commit()
@@ -316,6 +320,189 @@ class TestDemoCallToken:
         )
         assert resp.status_code == 200, resp.text
         assert "livekit_token" in resp.json()
+
+
+@pytest.mark.usefixtures("db")
+class TestDemoCallTokenCreditGate:
+    """demo_call_token bills the demo link's owning tenant through the same
+    plan-aware credit_service.has_sufficient_credits gate used for real
+    inbound/outbound calls — see app/routers/sdk.py."""
+
+    def test_insufficient_credits_returns_403(
+        self, client: TestClient, db, tenant, flow, demo_link, mock_livekit
+    ):
+        tenant.credits = Decimal("0")
+        db.add(tenant)
+        db.commit()
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-no-credits"),
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "demo_unavailable"
+        # No call session should have been created for the rejected call.
+        assert (
+            db.query(CallSession)
+            .filter(CallSession.tenant_id == tenant.id)
+            .count()
+            == 0
+        )
+
+    def test_sufficient_credits_allows_call(
+        self, client: TestClient, db, tenant, flow, demo_link, mock_livekit
+    ):
+        tenant.credits = Decimal("5")
+        db.add(tenant)
+        db.commit()
+
+        resp = client.post(
+            f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+            json=_body("visitor-has-credits"),
+        )
+        assert resp.status_code == 200, resp.text
+
+    def test_elevenlabs_surcharge_decline_reason_is_specific_in_logs(
+        self, client: TestClient, db, tenant, agent, flow, demo_link, mock_livekit, caplog
+    ):
+        """The `agent` fixture is configured with tts_provider_slug="elevenlabs"
+        (see the fixture above). With an active plan (included minutes remain)
+        but a zero credit balance, the rejection must be attributable in logs
+        to the ElevenLabs surcharge specifically — not the generic "insufficient
+        credits" message — per the has_sufficient_credits `reason` contract."""
+        from datetime import timedelta
+
+        from app.models.plan import Plan
+        from app.models.subscription import Subscription
+
+        plan = Plan(
+            name=f"studio_{uuid.uuid4().hex[:8]}",
+            display_name="Studio",
+            price_monthly=9900,
+            crm_type=None,
+            included_minutes=100,
+            monthly_credits=Decimal("50.00"),
+            is_active=True,
+        )
+        db.add(plan)
+        db.commit()
+        db.refresh(plan)
+
+        now = datetime.now(timezone.utc)
+        sub = Subscription(
+            user_id=agent.created_by,
+            tenant_id=tenant.id,
+            plan_id=plan.id,
+            crm_type=None,
+            status="active",
+            current_period_start=now - timedelta(days=1),
+            current_period_end=now + timedelta(days=29),
+        )
+        db.add(sub)
+        tenant.credits = Decimal("0")
+        db.add(tenant)
+        db.commit()
+
+        import logging
+
+        with caplog.at_level(logging.INFO, logger="app.routers.sdk"):
+            resp = client.post(
+                f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+                json=_body("visitor-elevenlabs-blocked"),
+            )
+
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "demo_unavailable"
+        assert any(
+            "ElevenLabs" in record.getMessage() for record in caplog.records
+        ), [r.getMessage() for r in caplog.records]
+
+    def test_byo_elevenlabs_not_surcharged_even_at_zero_credits(
+        self, client: TestClient, db, tenant, agent, flow, demo_link, mock_livekit
+    ):
+        """Fix #1: a demo call for an agent using BYO ElevenLabs must NOT be
+        gated by the ElevenLabs surcharge rule — the platform incurs zero
+        ElevenLabs cost, so a plan with remaining included minutes is enough
+        to allow the call even at a zero credit balance."""
+        from datetime import timedelta
+
+        from app.models.plan import Plan
+        from app.models.subscription import Subscription
+
+        agent.tts_provider_slug = "11labs_byo"
+        agent.encrypted_elevenlabs_api_key = "byo-ciphertext"
+        db.add(agent)
+
+        plan = Plan(
+            name=f"studio_{uuid.uuid4().hex[:8]}",
+            display_name="Studio",
+            price_monthly=9900,
+            crm_type=None,
+            included_minutes=100,
+            monthly_credits=Decimal("50.00"),
+            is_active=True,
+        )
+        db.add(plan)
+        db.commit()
+        db.refresh(plan)
+
+        now = datetime.now(timezone.utc)
+        sub = Subscription(
+            user_id=agent.created_by,
+            tenant_id=tenant.id,
+            plan_id=plan.id,
+            crm_type=None,
+            status="active",
+            current_period_start=now - timedelta(days=1),
+            current_period_end=now + timedelta(days=29),
+        )
+        db.add(sub)
+        tenant.credits = Decimal("0")
+        db.add(tenant)
+        db.commit()
+
+        with patch(
+            "app.core.db_encryption.decrypt_stored_elevenlabs_key",
+            return_value="xi-byo-key",
+        ):
+            resp = client.post(
+                f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+                json=_body("visitor-byo-elevenlabs"),
+            )
+
+        assert resp.status_code == 200, resp.text
+
+    def test_byo_elevenlabs_decrypt_failure_returns_demo_error_not_500(
+        self, client: TestClient, db, tenant, agent, flow, demo_link, mock_livekit
+    ):
+        """Fix #2: resolve_tts_runtime() raises RuntimeError when a stored BYO
+        ElevenLabs key fails to decrypt. demo_call_token must degrade
+        gracefully like every other precondition check here, not 500."""
+        agent.tts_provider_slug = "11labs_byo"
+        agent.encrypted_elevenlabs_api_key = "corrupted-ciphertext"
+        db.add(agent)
+        tenant.credits = Decimal("100")
+        db.add(tenant)
+        db.commit()
+
+        with patch(
+            "app.core.db_encryption.decrypt_stored_elevenlabs_key",
+            side_effect=RuntimeError("corrupted ciphertext"),
+        ):
+            resp = client.post(
+                f"/api/v1/sdk/demo/{demo_link.token}/call-token",
+                json=_body("visitor-byo-corrupted"),
+            )
+
+        assert resp.status_code == 500, resp.text
+        assert resp.json()["error"]["code"] == "demo_tts_runtime_error"
+        # No call session should have been created for the failed call.
+        assert (
+            db.query(CallSession)
+            .filter(CallSession.tenant_id == tenant.id)
+            .count()
+            == 0
+        )
 
 
 @pytest.mark.usefixtures("db")

--- a/tests/api/test_tenant_credit_checkout.py
+++ b/tests/api/test_tenant_credit_checkout.py
@@ -1,0 +1,75 @@
+"""Minimum-purchase validation for POST /tenants/start-credit-checkout-session."""
+import uuid
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.api_v1.endpoints.tenant import start_credit_checkout_session
+from app.models.tenant import Tenant
+from app.models.user import User
+
+
+@pytest.fixture
+def tenant(db):
+    suffix = uuid.uuid4().hex[:8]
+    t = Tenant(
+        id=uuid.uuid4(),
+        name=f"Credit Checkout Tenant {suffix}",
+        schema_name=f"credit_checkout_{suffix}",
+        status="active",
+        credits=Decimal("0"),
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def user(db, tenant):
+    suffix = uuid.uuid4().hex[:8]
+    u = User(
+        id=uuid.uuid4(),
+        email=f"checkout_{suffix}@example.com",
+        first_name="Test",
+        last_name="User",
+        hashed_password="x",
+        current_tenant_id=tenant.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def test_amount_below_minimum_rejected(db, tenant, user):
+    with pytest.raises(HTTPException) as exc_info:
+        start_credit_checkout_session(
+            amount=4.99,
+            current_user=user,
+            admin_user=user,
+            db=db,
+        )
+    assert exc_info.value.status_code == 400
+    assert "Minimum credit purchase is $5" in exc_info.value.detail
+
+
+def test_amount_at_minimum_boundary_passes_validation(db, tenant, user):
+    # Stub Stripe so we only exercise the $5 minimum check, not real network calls.
+    class _FakeSession:
+        id = "cs_test_min"
+        url = "https://checkout.stripe.test/cs_test_min"
+
+    with patch("stripe.checkout.Session.create", return_value=_FakeSession()), patch(
+        "app.services.stripe_service.StripeService.create_customer",
+        return_value="cus_test_min",
+    ):
+        result = start_credit_checkout_session(
+            amount=5.0,
+            current_user=user,
+            admin_user=user,
+            db=db,
+        )
+    assert result is not None

--- a/tests/api/v2/test_sub_accounts.py
+++ b/tests/api/v2/test_sub_accounts.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -7,6 +8,8 @@ from fastapi.testclient import TestClient
 
 from app.api.deps import get_db, require_admin, get_current_workspace
 from app.core.exception_handlers import register_exception_handlers
+from app.models.plan import Plan
+from app.models.subscription import Subscription
 from app.models.tenant import Tenant
 from app.models.user import User
 
@@ -160,6 +163,80 @@ def test_rbac_enforcement(db, agency_workspace):
     res = client.post("/workspace/sub-accounts", json={"name": "Sub", "contact_email": "x@x.com"})
     assert res.status_code == 403
     assert "Workspace context does not match" in res.json()["error"]["message"]
+
+def _activate_plan(db, tenant, *, max_subaccounts):
+    suffix = uuid.uuid4().hex[:8]
+    plan = Plan(
+        name=f"plan_{suffix}",
+        display_name="Plan",
+        price_monthly=9900,
+        crm_type=None,
+        max_subaccounts=max_subaccounts,
+        is_active=True,
+    )
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+
+    now = datetime.now(timezone.utc)
+    admin_user = User(
+        email=f"owner_{suffix}@test.com",
+        current_tenant_id=tenant.id,
+        first_name="Owner",
+        last_name="Test",
+        hashed_password="X",
+    )
+    db.add(admin_user)
+    db.commit()
+    db.refresh(admin_user)
+
+    sub = Subscription(
+        user_id=admin_user.id,
+        tenant_id=tenant.id,
+        plan_id=plan.id,
+        crm_type=None,
+        status="active",
+        current_period_start=now - timedelta(days=1),
+        current_period_end=now + timedelta(days=29),
+    )
+    db.add(sub)
+    db.commit()
+    return plan
+
+
+def test_create_sub_account_studio_tier_rejects_over_cap(db, agency_workspace):
+    _activate_plan(db, agency_workspace, max_subaccounts=3)
+    client = _client(db, agency_workspace)
+    suffix = uuid.uuid4().hex[:8]
+
+    for i in range(3):
+        res = client.post(
+            "/workspace/sub-accounts",
+            json={"name": f"Sub {suffix}-{i}", "contact_email": f"sub{suffix}{i}@example.com"},
+        )
+        assert res.status_code == 201
+
+    # 4th sub-account exceeds the Studio-tier cap of 3.
+    res = client.post(
+        "/workspace/sub-accounts",
+        json={"name": f"Sub {suffix}-4", "contact_email": f"sub{suffix}4@example.com"},
+    )
+    assert res.status_code == 422
+    assert "Sub-account limit reached" in res.json()["error"]["message"]
+
+
+def test_create_sub_account_agency_tier_no_cap(db, agency_workspace):
+    _activate_plan(db, agency_workspace, max_subaccounts=None)
+    client = _client(db, agency_workspace)
+    suffix = uuid.uuid4().hex[:8]
+
+    for i in range(4):
+        res = client.post(
+            "/workspace/sub-accounts",
+            json={"name": f"Sub {suffix}-{i}", "contact_email": f"sub{suffix}{i}@example.com"},
+        )
+        assert res.status_code == 201
+
 
 def test_create_member_role_post_alias(db, agency_workspace):
     user = User(email=f"test{uuid.uuid4().hex[:8]}@x.com", current_tenant_id=agency_workspace.id, first_name="A", last_name="B", hashed_password="X")

--- a/tests/api/v2/test_workspace_config.py
+++ b/tests/api/v2/test_workspace_config.py
@@ -83,7 +83,10 @@ def test_upsert_pricing_valid(client):
     
     resp = client.put("/api/v2/workspace/pricing", json=payload)
     assert resp.status_code == 200
-    assert float(resp.json()["effective_client_rate"]) == 0.12
+    body = resp.json()
+    assert float(body["effective_client_rate"]) == 0.12
+    # GAP fix: surcharges must be inspectable via the pricing API response.
+    assert {s["key"] for s in body["available_surcharges"]} == {"openai_realtime", "elevenlabs_tts"}
 
 def test_rbac_enforcement():
     # FastAPI automatically handles Depends(require_admin), returning 403 or 401 if not provided.

--- a/tests/api/v2/test_workspace_usage.py
+++ b/tests/api/v2/test_workspace_usage.py
@@ -1,0 +1,133 @@
+"""GET /api/v2/workspace/usage — plan-aware usage endpoint.
+
+Prior to the Studio/Agency plan work this endpoint crashed for any tenant
+without the old (removed) per-model credit-cost table. Coverage:
+  - Returns correctly with an active plan + some recorded usage
+    (minutes_included / overage_minutes reflect the plan's included_minutes).
+  - Does not raise for a tenant with no active plan (pay-as-you-go).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_db, require_billing
+from app.core.exception_handlers import register_exception_handlers
+from app.models.plan import Plan
+from app.models.subscription import Subscription
+from app.models.tenant import Tenant
+from app.models.usage_record import UsageRecord
+from app.models.user import User
+
+
+@pytest.fixture
+def tenant(db):
+    suffix = uuid.uuid4().hex[:8]
+    t = Tenant(
+        id=uuid.uuid4(),
+        name=f"UsageEP Tenant {suffix}",
+        schema_name=f"usageep_{suffix}",
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def billing_user(db, tenant):
+    suffix = uuid.uuid4().hex[:8]
+    u = User(
+        email=f"billing_{suffix}@test.com",
+        current_tenant_id=tenant.id,
+        first_name="Bill",
+        last_name="User",
+        hashed_password="X",
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _client(db, user):
+    from app.api.v2.routers.workspace import v2_router
+
+    app = FastAPI()
+    register_exception_handlers(app)
+    app.include_router(v2_router, prefix="/workspace")
+
+    app.dependency_overrides[require_billing] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_usage_endpoint_with_active_plan_and_recorded_usage(db, tenant, billing_user):
+    suffix = uuid.uuid4().hex[:8]
+    plan = Plan(
+        name=f"studio_{suffix}",
+        display_name="Studio",
+        price_monthly=9900,
+        crm_type=None,
+        included_minutes=100,
+        is_active=True,
+    )
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+
+    now = datetime.now(timezone.utc)
+    sub = Subscription(
+        user_id=billing_user.id,
+        tenant_id=tenant.id,
+        plan_id=plan.id,
+        crm_type=None,
+        status="active",
+        current_period_start=now - timedelta(days=1),
+        current_period_end=now + timedelta(days=29),
+    )
+    db.add(sub)
+    db.add(
+        UsageRecord(
+            workspace_id=tenant.id,
+            billable_minutes=Decimal("130"),
+            credits_charged=Decimal("3.60"),
+            recorded_at=now,
+        )
+    )
+    db.commit()
+
+    client = _client(db, billing_user)
+    res = client.get("/workspace/usage")
+
+    assert res.status_code == 200
+    data = res.json()
+    assert Decimal(str(data["minutes_included"])) == Decimal("100")
+    assert Decimal(str(data["minutes_used_this_cycle"])) == Decimal("130")
+    assert Decimal(str(data["overage_minutes"])) == Decimal("30")
+
+    # GAP fix: the realtime/ElevenLabs surcharges must be visible via the API,
+    # not just documented in a source comment.
+    surcharge_keys = {s["key"] for s in data["available_surcharges"]}
+    assert surcharge_keys == {"openai_realtime", "elevenlabs_tts"}
+    realtime = next(s for s in data["available_surcharges"] if s["key"] == "openai_realtime")
+    assert Decimal(str(realtime["rate_per_minute"])) == Decimal("0.50")
+    elevenlabs = next(s for s in data["available_surcharges"] if s["key"] == "elevenlabs_tts")
+    assert Decimal(str(elevenlabs["rate_per_minute"])) == Decimal("0.05")
+
+
+def test_usage_endpoint_no_active_plan_does_not_raise(db, tenant, billing_user):
+    client = _client(db, billing_user)
+    res = client.get("/workspace/usage")
+
+    assert res.status_code == 200
+    data = res.json()
+    assert Decimal(str(data["minutes_included"])) == Decimal("0")
+    assert Decimal(str(data["overage_minutes"])) == Decimal("0")
+    assert {s["key"] for s in data["available_surcharges"]} == {"openai_realtime", "elevenlabs_tts"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -455,7 +455,11 @@ def pg_engine():
 
     yield schema_engine
 
-    Base.metadata.drop_all(bind=schema_engine)
+    # DROP SCHEMA ... CASCADE below removes every table/FK in one shot
+    # regardless of dependency order — drop_all() is redundant here and was
+    # failing on FK-dependent table pairs (e.g. resumeinterview /
+    # resumeinterviewevent) since it doesn't resolve cross-table drop order
+    # the same way CASCADE does.
     schema_engine.dispose()
 
     with engine.connect() as conn:

--- a/tests/core/test_agent_runtime.py
+++ b/tests/core/test_agent_runtime.py
@@ -121,6 +121,9 @@ def test_resolve_tts_runtime_ticket_elevenlabs():
     assert runtime.adapter_slug == "elevenlabs"
     assert runtime.voice_external_id == "voice-abc"
     assert runtime.used_ticket_tts is True
+    # Platform ElevenLabs (raw slug "11labs", not "11labs_byo") must NOT be
+    # flagged as BYO — the ElevenLabs surcharge applies to this call.
+    assert runtime.is_byo_elevenlabs is False
 
 
 def _byo_agent(ciphertext: str = "enc") -> MagicMock:
@@ -149,6 +152,23 @@ def test_resolve_tts_runtime_byo_injects_api_key_pgcrypto():
 
     assert runtime.settings_json.get("elevenlabs_api_key") == "xi-pgcrypto-key"
     mock_dec.assert_called_once_with("jA0ECQMCpgcrypto_base64==", db=mock_db)
+    # BYO ElevenLabs with a usable stored key: adapter_slug still collapses
+    # to "elevenlabs", but is_byo_elevenlabs must be True so the platform
+    # surcharge (app.services.credit_service) is exempted.
+    assert runtime.adapter_slug == "elevenlabs"
+    assert runtime.is_byo_elevenlabs is True
+
+
+def test_resolve_tts_runtime_byo_slug_without_stored_key_not_flagged_byo():
+    """BYO slug ("11labs_byo") with NO stored encrypted key is not a usable
+    BYO configuration — must not be exempted from the surcharge."""
+    agent = _byo_agent(ciphertext=None)
+    agent.encrypted_elevenlabs_api_key = None
+
+    runtime = resolve_tts_runtime(agent, db=MagicMock())
+
+    assert runtime.adapter_slug == "elevenlabs"
+    assert runtime.is_byo_elevenlabs is False
 
 
 def test_resolve_tts_runtime_byo_injects_api_key_jwt_legacy():

--- a/tests/integration/test_billing_plans_postgres.py
+++ b/tests/integration/test_billing_plans_postgres.py
@@ -1,0 +1,167 @@
+"""Studio/Agency plan-aware subscription integrity, against real PostgreSQL.
+
+`Subscription.uq_tenant_core_subscription` is a *partial* unique index
+(`postgresql_where="crm_type IS NULL AND tenant_id IS NOT NULL"`). SQLite has
+no `sqlite_where` fallback declared for this particular index (unlike, say,
+`Tenant.uq_tenant_name_active`), so under the SQLite unit-test fixture it
+silently compiles down to a plain unique index on `tenant_id` — stricter than
+production, since it would also reject a legitimate CRM-addon row sharing a
+tenant_id. Real Postgres semantics can only be verified against a real engine.
+
+Requires TEST_DATABASE_URL. Skipped otherwise.
+
+Coverage:
+  1. test_second_core_subscription_for_same_tenant_rejected
+  2. test_crm_addon_subscription_coexists_with_core_subscription_same_tenant
+  3. test_core_subscription_allowed_for_different_tenants
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.plan import Plan
+from app.models.subscription import Subscription
+from app.models.tenant import Tenant
+from app.models.user import User
+from tests.conftest import _INTEGRATION_SKIP
+
+pytestmark = [_INTEGRATION_SKIP, pytest.mark.integration]
+
+
+@pytest.fixture()
+def tenant(pg_session):
+    t = Tenant(
+        name=f"PG Plan Tenant {uuid.uuid4().hex[:8]}",
+        schema_name=f"pg_plan_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    pg_session.add(t)
+    pg_session.commit()
+    pg_session.refresh(t)
+    return t
+
+
+@pytest.fixture()
+def user(pg_session, tenant):
+    u = User(
+        email=f"pg_plan_{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="x",
+        first_name="PG",
+        last_name="Tester",
+        current_tenant_id=tenant.id,
+    )
+    pg_session.add(u)
+    pg_session.commit()
+    pg_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def core_plan(pg_session):
+    p = Plan(
+        name=f"studio_{uuid.uuid4().hex[:8]}",
+        display_name="Studio",
+        price_monthly=9900,
+        crm_type=None,
+        included_minutes=100,
+        monthly_credits=Decimal("50.00"),
+        is_active=True,
+    )
+    pg_session.add(p)
+    pg_session.commit()
+    pg_session.refresh(p)
+    return p
+
+
+@pytest.fixture()
+def crm_plan(pg_session):
+    p = Plan(
+        name=f"monday_{uuid.uuid4().hex[:8]}",
+        display_name="Monday CRM Addon",
+        price_monthly=1900,
+        crm_type="monday",
+        is_active=True,
+    )
+    pg_session.add(p)
+    pg_session.commit()
+    pg_session.refresh(p)
+    return p
+
+
+def test_second_core_subscription_for_same_tenant_rejected(pg_session, tenant, user, core_plan):
+    first = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=core_plan.id,
+        crm_type=None,
+        status="active",
+    )
+    pg_session.add(first)
+    pg_session.commit()
+
+    second = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=core_plan.id,
+        crm_type=None,
+        status="active",
+    )
+    pg_session.add(second)
+    with pytest.raises(IntegrityError):
+        pg_session.commit()
+    pg_session.rollback()
+
+
+def test_crm_addon_subscription_coexists_with_core_subscription_same_tenant(
+    pg_session, tenant, user, core_plan, crm_plan
+):
+    """A tenant's core (crm_type IS NULL) subscription and a legacy
+    user+crm_type CRM-addon row (tenant_id left NULL) must be able to coexist
+    without tripping the partial unique index."""
+    core_sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=core_plan.id,
+        crm_type=None,
+        status="active",
+    )
+    pg_session.add(core_sub)
+    pg_session.commit()
+
+    crm_sub = Subscription(
+        user_id=user.id,
+        tenant_id=None,
+        plan_id=crm_plan.id,
+        crm_type="monday",
+        status="active",
+    )
+    pg_session.add(crm_sub)
+    pg_session.commit()  # must not raise
+
+    assert core_sub.id != crm_sub.id
+
+
+def test_core_subscription_allowed_for_different_tenants(pg_session, tenant, user, core_plan):
+    other_tenant = Tenant(
+        name=f"PG Plan Tenant B {uuid.uuid4().hex[:8]}",
+        schema_name=f"pg_plan_b_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    pg_session.add(other_tenant)
+    pg_session.commit()
+    pg_session.refresh(other_tenant)
+
+    sub_a = Subscription(
+        user_id=user.id, tenant_id=tenant.id, plan_id=core_plan.id, crm_type=None, status="active"
+    )
+    sub_b = Subscription(
+        user_id=user.id, tenant_id=other_tenant.id, plan_id=core_plan.id, crm_type=None, status="active"
+    )
+    pg_session.add_all([sub_a, sub_b])
+    pg_session.commit()  # must not raise
+
+    assert sub_a.id != sub_b.id

--- a/tests/services/test_billing_idempotency.py
+++ b/tests/services/test_billing_idempotency.py
@@ -56,11 +56,11 @@ def test_sync_payment_credits_once(mock_retrieve, db, tenant):
     second = BillingService.sync_payment_status(db, "cs_test_123", "evt_2")
 
     assert first["status"] == "success"
-    assert first["credits_added"] == 100
+    assert first["credits_added"] == 10
     assert second["status"] == "already_processed"
 
     db.refresh(tenant)
-    assert tenant.credits == Decimal("200")
+    assert tenant.credits == Decimal("110")
 
     rows = db.query(StripeCheckoutFulfillment).filter(
         StripeCheckoutFulfillment.checkout_session_id == "cs_test_123"

--- a/tests/services/test_billing_plans.py
+++ b/tests/services/test_billing_plans.py
@@ -1,0 +1,484 @@
+"""Studio/Agency plan-aware billing_service coverage.
+
+Coverage:
+  - get_included_minutes_status: no subscription -> included=0; active Studio
+    subscription with 0 usage -> remaining == included_minutes; usage recorded
+    within the current cycle reduces remaining; usage recorded before the
+    cycle start does not count.
+  - get_or_create_subscription / update_subscription with tenant_id: creates a
+    tenant-scoped core-plan row distinct from user_id+crm_type rows, and
+    coexists with legacy CRM-addon rows for the same user.
+  - sync_payment_status plan_purchase branch: core plan grants monthly_credits;
+    CRM plan grants zero credits (unchanged).
+  - handle_subscription_renewed: rolls the period forward and re-grants
+    monthly_credits.
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.models.plan import Plan
+from app.models.subscription import Subscription
+from app.models.tenant import Tenant
+from app.models.usage_record import UsageRecord
+from app.models.user import User
+from app.services.billing_service import BillingService
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tenant(db):
+    suffix = uuid.uuid4().hex[:8]
+    t = Tenant(
+        id=uuid.uuid4(),
+        name=f"Plan Test Tenant {suffix}",
+        schema_name=f"plan_test_{suffix}",
+        status="active",
+        credits=Decimal("0"),
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def user(db, tenant):
+    suffix = uuid.uuid4().hex[:8]
+    u = User(
+        email=f"plan_test_{suffix}@example.com",
+        hashed_password="x",
+        first_name="Plan",
+        last_name="Tester",
+        current_tenant_id=tenant.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def studio_plan(db):
+    suffix = uuid.uuid4().hex[:8]
+    p = Plan(
+        name=f"studio_{suffix}",
+        display_name="Studio",
+        price_monthly=9900,
+        crm_type=None,
+        included_minutes=100,
+        monthly_credits=Decimal("50.00"),
+        max_subaccounts=3,
+        free_phone_numbers=1,
+        is_active=True,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+@pytest.fixture
+def crm_plan(db):
+    suffix = uuid.uuid4().hex[:8]
+    p = Plan(
+        name=f"monday_crm_{suffix}",
+        display_name="Monday CRM Addon",
+        price_monthly=1900,
+        crm_type="monday",
+        is_active=True,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# get_included_minutes_status
+# ---------------------------------------------------------------------------
+
+
+def test_no_active_subscription_included_is_zero(db, tenant):
+    included, used, remaining = BillingService.get_included_minutes_status(db, tenant.id)
+    assert included == Decimal("0")
+    assert remaining == Decimal("0")
+
+
+def test_active_studio_subscription_no_usage_remaining_equals_included(db, tenant, user, studio_plan):
+    now = datetime.now(timezone.utc)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=studio_plan.id,
+        crm_type=None,
+        status="active",
+        current_period_start=now - timedelta(days=1),
+        current_period_end=now + timedelta(days=29),
+    )
+    db.add(sub)
+    db.commit()
+
+    included, used, remaining = BillingService.get_included_minutes_status(db, tenant.id)
+    assert included == Decimal("100")
+    assert used == Decimal("0")
+    assert remaining == Decimal("100")
+
+
+def test_usage_within_cycle_reduces_remaining(db, tenant, user, studio_plan):
+    now = datetime.now(timezone.utc)
+    cycle_start = now - timedelta(days=1)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=studio_plan.id,
+        crm_type=None,
+        status="active",
+        current_period_start=cycle_start,
+        current_period_end=now + timedelta(days=29),
+    )
+    db.add(sub)
+    db.commit()
+
+    db.add(
+        UsageRecord(
+            workspace_id=tenant.id,
+            billable_minutes=Decimal("30"),
+            credits_charged=Decimal("0"),
+            recorded_at=now,
+        )
+    )
+    db.commit()
+
+    included, used, remaining = BillingService.get_included_minutes_status(db, tenant.id)
+    assert included == Decimal("100")
+    assert used == Decimal("30")
+    assert remaining == Decimal("70")
+
+
+def test_usage_outside_cycle_window_does_not_count(db, tenant, user, studio_plan):
+    now = datetime.now(timezone.utc)
+    cycle_start = now - timedelta(days=1)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=studio_plan.id,
+        crm_type=None,
+        status="active",
+        current_period_start=cycle_start,
+        current_period_end=now + timedelta(days=29),
+    )
+    db.add(sub)
+    db.commit()
+
+    # Usage recorded before the current cycle started must not count.
+    db.add(
+        UsageRecord(
+            workspace_id=tenant.id,
+            billable_minutes=Decimal("999"),
+            credits_charged=Decimal("0"),
+            recorded_at=cycle_start - timedelta(days=5),
+        )
+    )
+    db.commit()
+
+    included, used, remaining = BillingService.get_included_minutes_status(db, tenant.id)
+    assert used == Decimal("0")
+    assert remaining == Decimal("100")
+
+
+# ---------------------------------------------------------------------------
+# get_or_create_subscription / update_subscription — tenant_id path vs. legacy
+# ---------------------------------------------------------------------------
+
+
+def test_get_or_create_subscription_tenant_scoped_row(db, tenant, user):
+    sub = BillingService.get_or_create_subscription(db, user_id=user.id, tenant_id=tenant.id)
+    assert sub.tenant_id == tenant.id
+    assert sub.crm_type is None
+
+    # Idempotent: fetching again returns the same row.
+    sub2 = BillingService.get_or_create_subscription(db, user_id=user.id, tenant_id=tenant.id)
+    assert sub2.id == sub.id
+
+
+def test_tenant_scoped_and_crm_subscriptions_coexist_for_same_user(db, tenant, user, crm_plan):
+    tenant_sub = BillingService.get_or_create_subscription(db, user_id=user.id, tenant_id=tenant.id)
+
+    crm_sub = BillingService.update_subscription(
+        db=db,
+        user_id=user.id,
+        plan_id=crm_plan.id,
+        crm_type="monday",
+    )
+
+    assert tenant_sub.id != crm_sub.id
+    assert tenant_sub.tenant_id == tenant.id
+    assert crm_sub.tenant_id is None
+    assert crm_sub.crm_type == "monday"
+
+
+def test_update_subscription_legacy_crm_path_unchanged(db, tenant, user, crm_plan):
+    """Re-run of the core test_billing_idempotency-style scenario: update_subscription
+    without tenant_id behaves exactly as before (user_id + crm_type lookup/create)."""
+    first = BillingService.update_subscription(
+        db=db,
+        user_id=user.id,
+        plan_id=crm_plan.id,
+        crm_type="monday",
+        stripe_subscription_id="sub_abc",
+    )
+    assert first.user_id == user.id
+    assert first.crm_type == "monday"
+    assert first.tenant_id is None
+
+    second = BillingService.update_subscription(
+        db=db,
+        user_id=user.id,
+        plan_id=crm_plan.id,
+        crm_type="monday",
+        stripe_subscription_id="sub_abc_updated",
+    )
+    # Same row updated in place, not a duplicate.
+    assert second.id == first.id
+    assert second.stripe_subscription_id == "sub_abc_updated"
+
+
+def test_update_subscription_tenant_scoped_updates_existing_row(db, tenant, user, studio_plan):
+    now = datetime.now(timezone.utc)
+    first = BillingService.update_subscription(
+        db=db,
+        user_id=user.id,
+        plan_id=studio_plan.id,
+        tenant_id=tenant.id,
+        current_period_start=now,
+        current_period_end=now + timedelta(days=30),
+    )
+    assert first.tenant_id == tenant.id
+
+    second = BillingService.update_subscription(
+        db=db,
+        user_id=user.id,
+        plan_id=studio_plan.id,
+        tenant_id=tenant.id,
+        status="past_due",
+    )
+    assert second.id == first.id
+    assert second.status == "past_due"
+
+
+# ---------------------------------------------------------------------------
+# sync_payment_status — plan_purchase branch
+# ---------------------------------------------------------------------------
+
+
+class _FakeStripeSession:
+    payment_status = "paid"
+
+    def __init__(self, *, tenant_id, user_id, plan_id, session_id="cs_plan_test", crm_type=None):
+        self._data = {
+            "id": session_id,
+            "payment_status": "paid",
+            "amount_total": 9900,
+            "customer": "cus_test123",
+            "subscription": None,
+            "metadata": {
+                "tenant_id": str(tenant_id),
+                "user_id": str(user_id),
+                "plan_id": str(plan_id),
+                "purchase_type": "plan_purchase",
+                **({"crm_type": crm_type} if crm_type else {}),
+            },
+        }
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+
+@patch("stripe.checkout.Session.retrieve")
+def test_sync_payment_status_core_plan_grants_monthly_credits(mock_retrieve, db, tenant, user, studio_plan):
+    mock_retrieve.return_value = _FakeStripeSession(
+        tenant_id=tenant.id, user_id=user.id, plan_id=studio_plan.id, session_id="cs_core_1"
+    )
+
+    result = BillingService.sync_payment_status(db, "cs_core_1", "evt_core_1")
+
+    assert result["status"] == "success"
+    assert Decimal(str(result["credits_added"])) == Decimal("50.00")
+    assert result["crm_type"] is None
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("50.00")
+
+    sub = BillingService.get_workspace_subscription(db, tenant.id)
+    assert sub is not None
+    assert sub.plan_id == studio_plan.id
+
+
+@patch("stripe.checkout.Session.retrieve")
+def test_sync_payment_status_crm_plan_grants_zero_credits(mock_retrieve, db, tenant, user, crm_plan):
+    mock_retrieve.return_value = _FakeStripeSession(
+        tenant_id=tenant.id, user_id=user.id, plan_id=crm_plan.id, session_id="cs_crm_1", crm_type="monday"
+    )
+
+    result = BillingService.sync_payment_status(db, "cs_crm_1", "evt_crm_1")
+
+    assert result["status"] == "success"
+    assert result["credits_added"] == 0
+    assert result["crm_type"] == "monday"
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# handle_subscription_renewed
+# ---------------------------------------------------------------------------
+
+
+def test_handle_subscription_renewed_rolls_period_and_regrants_credits(db, tenant, user, studio_plan):
+    now = datetime.now(timezone.utc)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=studio_plan.id,
+        crm_type=None,
+        status="active",
+        stripe_subscription_id="sub_renew_1",
+        current_period_start=now - timedelta(days=30),
+        current_period_end=now,
+    )
+    db.add(sub)
+    tenant.credits = Decimal("5.00")
+    db.commit()
+
+    new_start = now
+    new_end = now + timedelta(days=30)
+    BillingService.handle_subscription_renewed(db, "sub_renew_1", new_start, new_end)
+
+    db.refresh(sub)
+    db.refresh(tenant)
+
+    # SQLite drops tzinfo on round-trip; compare naive wall-clock values.
+    assert sub.current_period_start.replace(tzinfo=None) == new_start.replace(tzinfo=None)
+    assert sub.current_period_end.replace(tzinfo=None) == new_end.replace(tzinfo=None)
+    assert tenant.credits == Decimal("5.00") + Decimal("50.00")
+
+
+def test_handle_subscription_renewed_unknown_subscription_is_noop(db):
+    # Should not raise for an unrecognized stripe_subscription_id.
+    BillingService.handle_subscription_renewed(
+        db, "sub_does_not_exist", datetime.now(timezone.utc), datetime.now(timezone.utc)
+    )
+
+
+def test_handle_subscription_renewed_same_invoice_twice_grants_credits_once(db, tenant, user, studio_plan):
+    """Regression: Stripe redelivers the same `invoice.payment_succeeded` event (at-least-once
+    delivery) — the second call with the same invoice_id must be a no-op."""
+    now = datetime.now(timezone.utc)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=studio_plan.id,
+        crm_type=None,
+        status="active",
+        stripe_subscription_id="sub_renew_dup",
+        current_period_start=now - timedelta(days=30),
+        current_period_end=now,
+    )
+    db.add(sub)
+    tenant.credits = Decimal("5.00")
+    db.commit()
+
+    new_start = now
+    new_end = now + timedelta(days=30)
+
+    BillingService.handle_subscription_renewed(
+        db, "sub_renew_dup", new_start, new_end, invoice_id="in_dup_1"
+    )
+    BillingService.handle_subscription_renewed(
+        db, "sub_renew_dup", new_start, new_end, invoice_id="in_dup_1"
+    )
+
+    db.refresh(tenant)
+    # Only one grant despite two calls with the same invoice id.
+    assert tenant.credits == Decimal("5.00") + Decimal("50.00")
+
+
+def test_handle_subscription_renewed_same_period_via_checkout_and_invoice_grants_once(
+    db, tenant, user, studio_plan
+):
+    """Regression: the tenant's FIRST invoice fires both `checkout.session.completed`
+    (which grants monthly_credits via sync_payment_status) and `invoice.payment_succeeded`
+    for that same period — the renewal path must not grant credits a second time for a
+    period the subscription already has recorded."""
+    now = datetime.now(timezone.utc)
+    period_start = now
+    period_end = now + timedelta(days=30)
+
+    # Simulate what sync_payment_status's plan_purchase branch already did: it created
+    # the subscription with this exact period recorded, and granted credits once.
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=studio_plan.id,
+        crm_type=None,
+        status="active",
+        stripe_subscription_id="sub_first_invoice",
+        current_period_start=period_start,
+        current_period_end=period_end,
+    )
+    db.add(sub)
+    tenant.credits = Decimal("50.00")  # already granted once via checkout.session.completed
+    db.commit()
+
+    # The subscription's first invoice.payment_succeeded event arrives for the same period.
+    BillingService.handle_subscription_renewed(
+        db, "sub_first_invoice", period_start, period_end, invoice_id="in_first_1"
+    )
+
+    db.refresh(tenant)
+    # Must NOT be double-granted.
+    assert tenant.credits == Decimal("50.00")
+
+
+def test_handle_subscription_renewed_new_period_still_grants_credits(db, tenant, user, studio_plan):
+    """Sanity check: a genuine subsequent renewal (new period, new invoice) still grants
+    credits — the idempotency guards must not block legitimate renewals."""
+    now = datetime.now(timezone.utc)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=studio_plan.id,
+        crm_type=None,
+        status="active",
+        stripe_subscription_id="sub_ongoing",
+        current_period_start=now - timedelta(days=60),
+        current_period_end=now - timedelta(days=30),
+    )
+    db.add(sub)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    # First renewal (period 1 -> period 2)
+    BillingService.handle_subscription_renewed(
+        db, "sub_ongoing", now - timedelta(days=30), now, invoice_id="in_period_2"
+    )
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("50.00")
+
+    # Second, genuinely later renewal (period 2 -> period 3) with a different invoice id.
+    BillingService.handle_subscription_renewed(
+        db, "sub_ongoing", now, now + timedelta(days=30), invoice_id="in_period_3"
+    )
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("100.00")

--- a/tests/services/test_credit_service.py
+++ b/tests/services/test_credit_service.py
@@ -1,0 +1,832 @@
+"""Plan-aware credit billing coverage for app.services.credit_service.
+
+Coverage:
+  - get_effective_rate_per_minute: PricingConfig row vs. flat default fallback.
+  - has_sufficient_credits: plan-aware pre-call gate (remaining included
+    minutes covers the call even at zero credits; pay-as-you-go still
+    requires positive credits).
+  - _finalize_call_credits (the shared free/billable split logic used by
+    both the periodic tick and the final flush): a tick fully within the
+    plan's remaining included minutes deducts 0 credits; a tick that
+    exceeds it is charged only for the overage portion; a tenant with no
+    active plan is charged from the first second.
+  - _monitor_and_deduct_credits: a tick fully covered by the plan never
+    force-ends the call even at tenant.credits == 0; credits exhausted
+    mid-overage still force-ends the call (existing behavior preserved).
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.models.plan import Plan
+from app.models.pricing_configs import PricingConfig
+from app.models.subscription import Subscription
+from app.models.tenant import Tenant
+from app.models.user import User
+from app.models.agent import Agent
+from app.models.call_session import CallSession
+from app.models.usage_record import UsageRecord
+from app.services.credit_service import (
+    CreditService,
+    DEFAULT_PER_MINUTE_RATE,
+    OPENAI_REALTIME_SURCHARGE_PER_MINUTE,
+    ELEVENLABS_TTS_SURCHARGE_PER_MINUTE,
+)
+
+
+class _CloseSafeSessionWrapper:
+    """Wraps a shared test session so credit_service's internal
+    `SessionLocal()` calls reuse it instead of opening a real DB connection,
+    and so its `.close()` doesn't tear down the fixture session."""
+
+    def __init__(self, session):
+        self._session = session
+
+    def __getattr__(self, name):
+        return getattr(self._session, name)
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def override_session_local(db):
+    with patch("app.db.session.SessionLocal", lambda: _CloseSafeSessionWrapper(db)):
+        yield
+
+
+@pytest.fixture
+def service():
+    """Fresh CreditService instance per test — avoids cross-test state leakage
+    in the singleton's per-call tracking dicts."""
+    return CreditService()
+
+
+@pytest.fixture
+def tenant(db):
+    suffix = uuid.uuid4().hex[:8]
+    t = Tenant(
+        id=uuid.uuid4(),
+        name=f"Credit Test Tenant {suffix}",
+        schema_name=f"credit_test_{suffix}",
+        status="active",
+        credits=Decimal("0"),
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def user(db, tenant):
+    suffix = uuid.uuid4().hex[:8]
+    u = User(
+        email=f"credit_test_{suffix}@example.com",
+        hashed_password="x",
+        first_name="Credit",
+        last_name="Tester",
+        current_tenant_id=tenant.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def call_session(db, tenant, user):
+    agent = Agent(tenant_id=tenant.id, name="Test Agent")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+
+    cs = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=tenant.id,
+        start_time=datetime.now(timezone.utc),
+        status="active",
+        call_type="inbound",
+        twilio_call_sid="CA_test_123",
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+    return cs
+
+
+def _activate_plan(db, tenant, user, *, included_minutes):
+    plan = Plan(
+        name=f"studio_{uuid.uuid4().hex[:8]}",
+        display_name="Studio",
+        price_monthly=9900,
+        crm_type=None,
+        included_minutes=included_minutes,
+        monthly_credits=Decimal("50.00"),
+        is_active=True,
+    )
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+
+    now = datetime.now(timezone.utc)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=plan.id,
+        crm_type=None,
+        status="active",
+        current_period_start=now - timedelta(days=1),
+        current_period_end=now + timedelta(days=29),
+    )
+    db.add(sub)
+    db.commit()
+    return plan, sub
+
+
+# ---------------------------------------------------------------------------
+# get_effective_rate_per_minute
+# ---------------------------------------------------------------------------
+
+
+def test_effective_rate_defaults_when_no_pricing_config(db, tenant, service):
+    rate = service.get_effective_rate_per_minute(db, tenant.id)
+    assert rate == DEFAULT_PER_MINUTE_RATE
+
+
+def test_effective_rate_uses_configured_pricing(db, tenant, service):
+    db.add(PricingConfig(workspace_id=tenant.id, per_minute_rate=Decimal("0.25")))
+    db.commit()
+    rate = service.get_effective_rate_per_minute(db, tenant.id)
+    assert rate == Decimal("0.25")
+
+
+# ---------------------------------------------------------------------------
+# has_sufficient_credits
+# ---------------------------------------------------------------------------
+
+
+def test_has_sufficient_credits_allowed_by_plan_even_at_zero_credits(db, tenant, user, service):
+    _activate_plan(db, tenant, user, included_minutes=100)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    ok, current_credits, _, reason = service.has_sufficient_credits(db, tenant.id)
+    assert ok is True
+    assert current_credits == 0.0
+    assert reason == "ok"
+
+
+def test_has_sufficient_credits_pay_as_you_go_requires_credits(db, tenant, service):
+    tenant.credits = Decimal("0")
+    db.commit()
+    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id)
+    assert ok is False
+    assert "no included minutes" in reason and "no credit" in reason
+
+    tenant.credits = Decimal("5")
+    db.commit()
+    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id)
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_has_sufficient_credits_realtime_model_blocked_at_zero_credits_despite_plan(
+    db, tenant, user, service
+):
+    """A gpt-realtime call must be blocked at 0 credits even with plenty of
+    included minutes remaining, since the surcharge draws from credits from
+    the very first tick regardless of the included-minutes allowance."""
+    _activate_plan(db, tenant, user, included_minutes=100)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id, model_name="gpt-realtime")
+    assert ok is False
+    assert "OpenAI Realtime" in reason
+
+    tenant.credits = Decimal("1")
+    db.commit()
+    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id, model_name="gpt-realtime-2")
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_has_sufficient_credits_non_realtime_model_unaffected_at_zero_credits(
+    db, tenant, user, service
+):
+    """Non-realtime models keep today's behavior: included minutes alone are
+    enough to allow the call, even at 0 credits."""
+    _activate_plan(db, tenant, user, included_minutes=100)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id, model_name="gpt-4o-mini")
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_has_sufficient_credits_elevenlabs_tts_blocked_at_zero_credits_despite_plan(
+    db, tenant, user, service
+):
+    """An agent resolved to the ElevenLabs TTS provider must be blocked at 0
+    credits even with plenty of included minutes remaining — same mechanic as
+    the realtime surcharge."""
+    _activate_plan(db, tenant, user, included_minutes=100)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    ok, _, _, reason = service.has_sufficient_credits(
+        db, tenant.id, model_name="gpt-4o-mini", tts_provider_slug="elevenlabs"
+    )
+    assert ok is False
+    assert "ElevenLabs" in reason
+
+    tenant.credits = Decimal("1")
+    db.commit()
+    ok, _, _, reason = service.has_sufficient_credits(
+        db, tenant.id, model_name="gpt-4o-mini", tts_provider_slug="elevenlabs"
+    )
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_has_sufficient_credits_byo_elevenlabs_unaffected_at_zero_credits(
+    db, tenant, user, service
+):
+    """BYO ElevenLabs must behave like a non-surcharged TTS provider at the
+    pre-call gate: included minutes alone are enough, even at 0 credits."""
+    _activate_plan(db, tenant, user, included_minutes=100)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    ok, _, _, reason = service.has_sufficient_credits(
+        db,
+        tenant.id,
+        model_name="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        is_byo_elevenlabs=True,
+    )
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_has_sufficient_credits_non_elevenlabs_tts_unaffected_at_zero_credits(
+    db, tenant, user, service
+):
+    """A non-ElevenLabs TTS provider (e.g. google) keeps today's behavior:
+    included minutes alone are enough to allow the call, even at 0 credits."""
+    _activate_plan(db, tenant, user, included_minutes=100)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    ok, _, _, reason = service.has_sufficient_credits(
+        db, tenant.id, model_name="gpt-4o-mini", tts_provider_slug="google"
+    )
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_get_active_surcharges_realtime_model_excludes_elevenlabs_check(service):
+    """Architectural guarantee: OpenAI Realtime speech-to-speech calls bypass
+    the separate TTS synthesis pipeline entirely, so even if the agent's
+    configured tts_provider_slug happens to be "elevenlabs" (an unused, stale
+    field for a realtime call), only the realtime surcharge is returned — the
+    two surcharges never stack on the same call in this codebase today."""
+    surcharges = service.get_active_surcharges(
+        model_name="gpt-realtime", tts_provider_slug="elevenlabs"
+    )
+    keys = [s.key for s in surcharges]
+    assert keys == ["openai_realtime"]
+
+
+def test_get_active_surcharges_non_realtime_elevenlabs_returns_single_surcharge(service):
+    surcharges = service.get_active_surcharges(
+        model_name="gpt-4o-mini", tts_provider_slug="elevenlabs"
+    )
+    keys = [s.key for s in surcharges]
+    assert keys == ["elevenlabs_tts"]
+
+
+def test_get_active_surcharges_none_when_neither_applies(service):
+    assert service.get_active_surcharges(model_name="gpt-4o-mini", tts_provider_slug="google") == []
+
+
+def test_get_active_surcharges_byo_elevenlabs_exempted(service):
+    """Fix #1: BYO ElevenLabs must NOT incur the ElevenLabs surcharge — the
+    platform pays nothing when the tenant supplies their own key."""
+    surcharges = service.get_active_surcharges(
+        model_name="gpt-4o-mini", tts_provider_slug="elevenlabs", is_byo_elevenlabs=True
+    )
+    assert surcharges == []
+
+
+def test_get_active_surcharges_platform_elevenlabs_still_charged(service):
+    """Sanity counterpart: platform ElevenLabs (is_byo_elevenlabs=False, the
+    default) is still charged."""
+    surcharges = service.get_active_surcharges(
+        model_name="gpt-4o-mini", tts_provider_slug="elevenlabs", is_byo_elevenlabs=False
+    )
+    keys = [s.key for s in surcharges]
+    assert keys == ["elevenlabs_tts"]
+
+
+def test_get_active_surcharges_realtime_fallen_back_switches_to_elevenlabs(service):
+    """Fix #4: once a realtime-configured call has fallen back to the legacy
+    pipeline, the realtime surcharge must stop applying and the ElevenLabs
+    surcharge (if applicable) must be evaluated for real instead of being
+    skipped by the realtime early-return."""
+    surcharges = service.get_active_surcharges(
+        model_name="gpt-realtime",
+        tts_provider_slug="elevenlabs",
+        realtime_fallen_back=True,
+    )
+    keys = [s.key for s in surcharges]
+    assert keys == ["elevenlabs_tts"]
+
+
+def test_get_active_surcharges_realtime_fallen_back_byo_elevenlabs_exempted(service):
+    """Fix #1 + #4 combined: post-fallback BYO ElevenLabs is exempt from
+    both the (now-inactive) realtime surcharge and the ElevenLabs surcharge."""
+    surcharges = service.get_active_surcharges(
+        model_name="gpt-realtime",
+        tts_provider_slug="elevenlabs",
+        is_byo_elevenlabs=True,
+        realtime_fallen_back=True,
+    )
+    assert surcharges == []
+
+
+def test_get_active_surcharges_realtime_not_fallen_back_unaffected(service):
+    """`realtime_fallen_back` defaults to False and must not change existing
+    (non-fallback) realtime behavior."""
+    surcharges = service.get_active_surcharges(
+        model_name="gpt-realtime", tts_provider_slug="elevenlabs"
+    )
+    keys = [s.key for s in surcharges]
+    assert keys == ["openai_realtime"]
+
+
+# ---------------------------------------------------------------------------
+# _finalize_call_credits — free/billable split
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_within_free_allowance_deducts_zero(db, tenant, user, call_session, service):
+    _activate_plan(db, tenant, user, included_minutes=10)  # 600s remaining, 0 used
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    service._accumulated_seconds[call_id_str] = 120.0  # 2 minutes, well within 600s allowance
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session
+    )
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("0")
+
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+    assert record is not None
+    assert record.credits_charged == Decimal("0")
+    assert round(float(record.billable_minutes), 2) == 2.0
+
+
+@pytest.mark.asyncio
+async def test_finalize_overage_charges_only_billable_portion(db, tenant, user, call_session, service):
+    plan, sub = _activate_plan(db, tenant, user, included_minutes=1)  # 60s remaining, 0 used so far
+    tenant.credits = Decimal("10")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    # 90s accumulated: 60s free, 30s billable (0.5 min) at 12 credits/min => 6 credits
+    service._accumulated_seconds[call_id_str] = 90.0
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session
+    )
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("10") - Decimal("6")
+
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+    assert record is not None
+    assert round(float(record.credits_charged), 2) == 6.0
+    assert round(float(record.billable_minutes), 2) == 1.5
+
+
+@pytest.mark.asyncio
+async def test_finalize_pay_as_you_go_charges_from_first_second(db, tenant, call_session, service):
+    # No active subscription at all.
+    tenant.credits = Decimal("5")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    service._accumulated_seconds[call_id_str] = 30.0  # 0.5 min, fully billable
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session
+    )
+
+    db.refresh(tenant)
+    # deduct_credits never allows a negative balance (clamped to 0), even though
+    # the nominal charge (6) exceeds the starting balance (5).
+    assert tenant.credits == Decimal("0")
+
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+    assert round(float(record.credits_charged), 2) == 6.0
+
+
+# ---------------------------------------------------------------------------
+# _finalize_call_credits — OpenAI Realtime surcharge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_realtime_within_allowance_charges_surcharge_only(
+    db, tenant, user, call_session, service
+):
+    """Within the plan's included minutes: base rate stays waived, but the
+    flat $0.50/min surcharge is still charged on the full accumulated time."""
+    _activate_plan(db, tenant, user, included_minutes=10)  # 600s remaining, 0 used
+    tenant.credits = Decimal("10")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    service._accumulated_seconds[call_id_str] = 120.0  # 2 minutes, fully within allowance
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-realtime", 12.0, call_session,
+    )
+
+    db.refresh(tenant)
+    expected_surcharge = Decimal("2") * OPENAI_REALTIME_SURCHARGE_PER_MINUTE  # 2 min * 0.50
+    assert tenant.credits == Decimal("10") - expected_surcharge
+
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+    assert record is not None
+    assert round(float(record.credits_charged), 2) == float(expected_surcharge)
+
+
+@pytest.mark.asyncio
+async def test_finalize_realtime_overage_charges_base_plus_surcharge(
+    db, tenant, user, call_session, service
+):
+    """Once included minutes are exhausted: total charge is base rate +
+    surcharge on the full duration ($0.62/min at the default 0.12 base)."""
+    _activate_plan(db, tenant, user, included_minutes=1)  # 60s remaining, 0 used so far
+    tenant.credits = Decimal("100")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    # 120s accumulated: 60s free (base waived), 60s billable at 12 credits/min => 12 credits base
+    # Surcharge applies to the FULL 120s => 2 min * 0.50 = 1.0 credit
+    service._accumulated_seconds[call_id_str] = 120.0
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-realtime-2", 12.0, call_session,
+    )
+
+    db.refresh(tenant)
+    expected_base = Decimal("12")  # 1 billable minute * 12 credits/min
+    expected_surcharge = Decimal("2") * OPENAI_REALTIME_SURCHARGE_PER_MINUTE  # 2 min * 0.50
+    expected_total = expected_base + expected_surcharge
+    assert tenant.credits == Decimal("100") - expected_total
+
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+    assert round(float(record.credits_charged), 2) == float(expected_total)
+
+
+@pytest.mark.asyncio
+async def test_finalize_non_realtime_model_unaffected_by_surcharge_logic(
+    db, tenant, user, call_session, service
+):
+    """Sanity check: a non-realtime, non-ElevenLabs model/TTS combo (the
+    defaults) behaves identically to the pre-existing tests — no surcharges
+    apply."""
+    _activate_plan(db, tenant, user, included_minutes=10)
+    tenant.credits = Decimal("10")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    service._accumulated_seconds[call_id_str] = 120.0
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session,
+    )
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("10")
+
+
+# ---------------------------------------------------------------------------
+# _finalize_call_credits — ElevenLabs TTS surcharge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_elevenlabs_within_allowance_charges_surcharge_only(
+    db, tenant, user, call_session, service
+):
+    """Within the plan's included minutes: base rate stays waived, but the
+    flat $0.05/min ElevenLabs surcharge is still charged on the full
+    accumulated time."""
+    _activate_plan(db, tenant, user, included_minutes=10)  # 600s remaining, 0 used
+    tenant.credits = Decimal("10")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    service._accumulated_seconds[call_id_str] = 120.0  # 2 minutes, fully within allowance
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session,
+        tts_provider_slug="elevenlabs",
+    )
+
+    db.refresh(tenant)
+    expected_surcharge = Decimal("2") * ELEVENLABS_TTS_SURCHARGE_PER_MINUTE  # 2 min * 0.05
+    assert tenant.credits == Decimal("10") - expected_surcharge
+
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+    assert record is not None
+    assert round(float(record.credits_charged), 4) == float(expected_surcharge)
+
+
+@pytest.mark.asyncio
+async def test_finalize_elevenlabs_overage_charges_base_plus_surcharge(
+    db, tenant, user, call_session, service
+):
+    """Once included minutes are exhausted: total charge is base rate +
+    ElevenLabs surcharge on the full duration ($0.17/min at the default 0.12
+    base)."""
+    _activate_plan(db, tenant, user, included_minutes=1)  # 60s remaining, 0 used so far
+    tenant.credits = Decimal("100")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    # 120s accumulated: 60s free (base waived), 60s billable at 12 credits/min => 12 credits base
+    # Surcharge applies to the FULL 120s => 2 min * 0.05 = 0.10 credit
+    service._accumulated_seconds[call_id_str] = 120.0
+
+    await service._finalize_call_credits(
+        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session,
+        tts_provider_slug="elevenlabs",
+    )
+
+    db.refresh(tenant)
+    expected_base = Decimal("12")  # 1 billable minute * 12 credits/min
+    expected_surcharge = Decimal("2") * ELEVENLABS_TTS_SURCHARGE_PER_MINUTE  # 2 min * 0.05
+    expected_total = expected_base + expected_surcharge
+    assert tenant.credits == Decimal("100") - expected_total
+
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+    assert round(float(record.credits_charged), 4) == float(expected_total)
+
+
+def test_describe_surcharges_stacks_additively_if_both_active(service):
+    """Structural stacking check: if a call's active-surcharges list somehow
+    contained both rules (not reachable via get_active_surcharges today per
+    the architectural guarantee tested in
+    test_get_active_surcharges_realtime_model_excludes_elevenlabs_check —
+    OpenAI Realtime bypasses the separate TTS pipeline entirely — but the
+    deduction math itself (_describe_surcharges, the shared computation used
+    by both _monitor_and_deduct_credits and _finalize_call_credits) must sum
+    every entry in the list additively so future stacking works without code
+    changes here)."""
+    surcharges = list(service.get_surcharge_catalog())  # both rules, forced
+    total, _desc = service._describe_surcharges(60.0, surcharges)  # 1 minute
+
+    expected_surcharge = OPENAI_REALTIME_SURCHARGE_PER_MINUTE + ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    assert round(total, 4) == float(expected_surcharge)
+
+
+# ---------------------------------------------------------------------------
+# _monitor_and_deduct_credits — force-end behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_monitor_loop_does_not_force_end_within_free_allowance(db, tenant, user, call_session, service):
+    """A tick fully within remaining included minutes must not force-end the
+    call, even at tenant.credits == 0."""
+    _activate_plan(db, tenant, user, included_minutes=100)  # far more than one tick's worth
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    past = datetime.now(timezone.utc) - timedelta(seconds=30)
+    service._call_start_times[call_id_str] = past
+    service._last_deduction_time[call_id_str] = past
+    service._accumulated_seconds[call_id_str] = 0.0
+
+    calls = {"n": 0}
+
+    async def _fake_sleep(_interval):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            # End the loop deterministically after one processed tick by
+            # flipping the call to a terminal status for the next iteration's
+            # status check (mirrors a real call hangup).
+            fresh = db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            fresh.status = "completed"
+            fresh.ended_reason = "Customer hung up"
+            db.commit()
+
+    with patch("asyncio.sleep", side_effect=_fake_sleep), \
+         patch.object(service, "_end_twilio_call", new=AsyncMock()) as mock_end_twilio, \
+         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()) as mock_broadcast:
+        await service._monitor_and_deduct_credits(call_session.id, tenant.id, "gpt-4o-mini", 12.0)
+
+    db.refresh(tenant)
+    db.refresh(call_session)
+
+    assert tenant.credits == Decimal("0")
+    assert call_session.ended_reason == "Customer hung up"  # not force-ended for credits
+    mock_end_twilio.assert_not_called()
+    mock_broadcast.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_monitor_loop_force_ends_call_when_credits_exhausted_mid_overage(db, tenant, call_session, service):
+    """Pay-as-you-go tenant with insufficient credits to cover overage must
+    still be force-ended (existing behavior, unchanged by the plan split)."""
+    tenant.credits = Decimal("0.05")  # not enough to cover the tick
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    # Naive (see _NaiveUtcDatetime note below) so it's directly comparable to
+    # the patched module's `datetime.now()` inside the monitor loop.
+    past = datetime.utcnow() - timedelta(seconds=60)
+    service._call_start_times[call_id_str] = past
+    service._last_deduction_time[call_id_str] = past
+    service._accumulated_seconds[call_id_str] = 0.0
+
+    # SQLite (used by the "db" test fixture) drops tzinfo on datetime columns
+    # on round-trip, so call_session.start_time comes back naive once
+    # re-queried inside the monitor loop's own session. Real Postgres
+    # (DateTime(timezone=True)) preserves tzinfo end-to-end and never hits
+    # this mismatch — this shim only neutralizes the SQLite-only artifact so
+    # the force-end duration computation (`end_time - start_time`) doesn't
+    # raise on a naive/aware subtraction in this test environment.
+    class _NaiveUtcDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime.utcnow()
+
+    with patch("asyncio.sleep", new=AsyncMock()), \
+         patch.object(service, "_end_twilio_call", new=AsyncMock()) as mock_end_twilio, \
+         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()) as mock_broadcast, \
+         patch("app.services.credit_service.datetime", _NaiveUtcDatetime):
+        await service._monitor_and_deduct_credits(call_session.id, tenant.id, "gpt-4o-mini", 12.0)
+
+    db.refresh(tenant)
+    db.refresh(call_session)
+
+    assert tenant.credits == Decimal("0")
+    assert call_session.status == "completed"
+    assert call_session.ended_reason == "Insufficient credits"
+    mock_end_twilio.assert_awaited_once()
+    mock_broadcast.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_monitor_loop_force_ends_realtime_call_when_surcharge_exhausts_credits_within_free_allowance(
+    db, tenant, user, call_session, service
+):
+    """A realtime-model call must still be force-ended when credits run out,
+    even while nominally "within the free minutes" for the base rate —
+    the surcharge alone can exhaust the balance."""
+    _activate_plan(db, tenant, user, included_minutes=100)  # far more than one tick's worth
+    tenant.credits = Decimal("0.05")  # not enough to cover even one tick's surcharge
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    past = datetime.utcnow() - timedelta(seconds=30)
+    service._call_start_times[call_id_str] = past
+    service._last_deduction_time[call_id_str] = past
+    service._accumulated_seconds[call_id_str] = 0.0
+
+    class _NaiveUtcDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime.utcnow()
+
+    with patch("asyncio.sleep", new=AsyncMock()), \
+         patch.object(service, "_end_twilio_call", new=AsyncMock()) as mock_end_twilio, \
+         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()) as mock_broadcast, \
+         patch("app.services.credit_service.datetime", _NaiveUtcDatetime):
+        await service._monitor_and_deduct_credits(
+            call_session.id, tenant.id, "gpt-realtime", 12.0
+        )
+
+    db.refresh(tenant)
+    db.refresh(call_session)
+
+    assert tenant.credits == Decimal("0")
+    assert call_session.status == "completed"
+    assert call_session.ended_reason == "Insufficient credits"
+    mock_end_twilio.assert_awaited_once()
+    mock_broadcast.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Fix #4 — mid-call OpenAI Realtime fallback re-evaluates surcharges per tick
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_current_surcharges_reads_fallback_flag_from_call_metadata(
+    call_session, service
+):
+    """`_resolve_current_surcharges` must treat a call as fallen-back once
+    CallSession.call_metadata["openai_realtime_fallback"]["fell_back"] is
+    True — the shape VoiceOrchestrator._fallback_to_legacy_pipeline_openai
+    persists."""
+    # Before fallback: realtime model → realtime surcharge only.
+    surcharges = service._resolve_current_surcharges(
+        call_session, "gpt-realtime", "elevenlabs", False
+    )
+    assert [s.key for s in surcharges] == ["openai_realtime"]
+
+    # Orchestrator persists the fallback flag on call_metadata.
+    call_session.call_metadata = {
+        "openai_realtime_fallback": {"fell_back": True, "reason": "timeout"}
+    }
+
+    surcharges = service._resolve_current_surcharges(
+        call_session, "gpt-realtime", "elevenlabs", False
+    )
+    assert [s.key for s in surcharges] == ["elevenlabs_tts"]
+
+
+@pytest.mark.asyncio
+async def test_monitor_loop_switches_surcharge_after_mid_call_realtime_fallback(
+    db, tenant, user, call_session, service
+):
+    """End-to-end fix #4 scenario: a call configured for an OpenAI Realtime
+    model bills the realtime surcharge on its first tick; once the
+    orchestrator's fallback flag lands on call_metadata (simulated here the
+    same way VoiceOrchestrator._fallback_to_legacy_pipeline_openai persists
+    it), the very next tick must stop charging the realtime surcharge and
+    start charging the ElevenLabs surcharge instead."""
+    _activate_plan(db, tenant, user, included_minutes=100)  # base rate fully waived
+    tenant.credits = Decimal("10")
+    db.commit()
+
+    call_id_str = str(call_session.id)
+    past = datetime.now(timezone.utc) - timedelta(seconds=60)
+    service._call_start_times[call_id_str] = past
+    service._last_deduction_time[call_id_str] = past
+    service._accumulated_seconds[call_id_str] = 0.0
+
+    calls = {"n": 0}
+
+    async def _fake_sleep(_interval):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            # Orchestrator falls back mid-call — persist the flag exactly as
+            # VoiceOrchestrator._fallback_to_legacy_pipeline_openai does.
+            fresh = db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            meta = dict(fresh.call_metadata or {})
+            meta["openai_realtime_fallback"] = {"fell_back": True, "reason": "test"}
+            fresh.call_metadata = meta
+            db.commit()
+            # Force a second deterministic ~60s tick.
+            service._last_deduction_time[call_id_str] = datetime.now(timezone.utc) - timedelta(seconds=60)
+        elif calls["n"] >= 3:
+            fresh = db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            fresh.status = "completed"
+            fresh.ended_reason = "Customer hung up"
+            db.commit()
+
+    with patch("asyncio.sleep", side_effect=_fake_sleep), \
+         patch.object(service, "_end_twilio_call", new=AsyncMock()), \
+         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()):
+        await service._monitor_and_deduct_credits(
+            call_session.id,
+            tenant.id,
+            "gpt-realtime",
+            12.0,
+            tts_provider_slug="elevenlabs",
+            is_byo_elevenlabs=False,
+        )
+
+    db.refresh(tenant)
+    db.refresh(call_session)
+
+    # Tick 1 (not yet fallen back): ~1 min * $0.50/min realtime surcharge.
+    # Tick 2 (fallen back): ~1 min * $0.05/min ElevenLabs surcharge instead of
+    # a second realtime surcharge (which would total ~$1.00 if the bug were
+    # still present).
+    expected_total = OPENAI_REALTIME_SURCHARGE_PER_MINUTE + ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    charged = float(Decimal("10") - tenant.credits)
+    assert charged == pytest.approx(float(expected_total), abs=0.01)
+    assert call_session.call_metadata.get("openai_realtime_fallback", {}).get("fell_back") is True
+    assert call_session.ended_reason == "Customer hung up"

--- a/tests/services/test_phone_number_service.py
+++ b/tests/services/test_phone_number_service.py
@@ -1,0 +1,259 @@
+"""Studio/Agency `free_phone_numbers` allowance — paid overage, not a hard cap.
+
+Coverage:
+  - purchase_phone_number / import_twilio_phone_number, once a tenant is at/over
+    its plan's free_phone_numbers allowance, charge a flat $2 (2 credits) overage
+    fee and still succeed if the tenant has enough credit balance.
+  - If the tenant's credit balance can't cover the $2 overage, the purchase/import
+    is rejected (HTTP 402) *before* any Twilio call is made, and no credits move.
+  - No charge/cap at all when the plan field is NULL or there's no active plan —
+    purchases remain free in that case.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.phone_number import PhoneNumber
+from app.models.plan import Plan
+from app.models.subscription import Subscription
+from app.models.tenant import Tenant
+from app.models.user import User
+from app.services.phone_number_service import phone_number_service
+
+
+@pytest.fixture
+def tenant(db):
+    suffix = uuid.uuid4().hex[:8]
+    t = Tenant(
+        id=uuid.uuid4(),
+        name=f"PhoneCap Tenant {suffix}",
+        schema_name=f"phonecap_{suffix}",
+        status="active",
+        credits=Decimal("0"),
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+def _activate_plan(db, tenant, *, free_phone_numbers):
+    suffix = uuid.uuid4().hex[:8]
+    plan = Plan(
+        name=f"plan_{suffix}",
+        display_name="Plan",
+        price_monthly=9900,
+        crm_type=None,
+        free_phone_numbers=free_phone_numbers,
+        is_active=True,
+    )
+    db.add(plan)
+    db.commit()
+    db.refresh(plan)
+
+    user = User(
+        email=f"owner_{suffix}@test.com",
+        hashed_password="X",
+        first_name="Owner",
+        last_name="Test",
+        current_tenant_id=tenant.id,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    now = datetime.now(timezone.utc)
+    sub = Subscription(
+        user_id=user.id,
+        tenant_id=tenant.id,
+        plan_id=plan.id,
+        crm_type=None,
+        status="active",
+        current_period_start=now - timedelta(days=1),
+        current_period_end=now + timedelta(days=29),
+    )
+    db.add(sub)
+    db.commit()
+    return plan
+
+
+def _existing_number(db, tenant, n=1):
+    for i in range(n):
+        pn = PhoneNumber(
+            phone_number=f"+1555{uuid.uuid4().hex[:7]}",
+            tenant_id=tenant.id,
+            status="active",
+            provider="twilio",
+        )
+        db.add(pn)
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# purchase_phone_number
+# ---------------------------------------------------------------------------
+
+
+def test_purchase_phone_number_overage_charged_when_credits_sufficient(db, tenant):
+    _activate_plan(db, tenant, free_phone_numbers=1)
+    _existing_number(db, tenant, n=1)  # already at the free allowance of 1
+    tenant.credits = Decimal("5.00")
+    db.commit()
+
+    with patch(
+        "app.services.twilio_service.twilio_service.purchase_phone_number",
+        return_value={"phone_number": "+15551234567", "sid": "PN123"},
+    ) as mock_purchase:
+        pn = phone_number_service.purchase_phone_number(
+            db, phone_number="+15551234567", tenant_id=tenant.id
+        )
+
+    mock_purchase.assert_called_once()
+    assert pn.phone_number == "+15551234567"
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("3.00")
+
+
+def test_purchase_phone_number_overage_rejected_when_credits_insufficient_twilio_never_called(db, tenant):
+    _activate_plan(db, tenant, free_phone_numbers=1)
+    _existing_number(db, tenant, n=1)  # already at the free allowance of 1
+    tenant.credits = Decimal("1.00")  # not enough to cover the $2 overage
+    db.commit()
+
+    with patch("app.services.twilio_service.twilio_service.purchase_phone_number") as mock_purchase:
+        with pytest.raises(HTTPException) as exc_info:
+            phone_number_service.purchase_phone_number(
+                db, phone_number="+15551234567", tenant_id=tenant.id
+            )
+
+    assert exc_info.value.status_code == 402
+    assert "Insufficient balance" in exc_info.value.detail
+    mock_purchase.assert_not_called()
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("1.00")  # untouched
+
+
+def test_purchase_phone_number_within_free_allowance_no_charge(db, tenant):
+    _activate_plan(db, tenant, free_phone_numbers=3)
+    _existing_number(db, tenant, n=1)  # still within the free allowance of 3
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    with patch(
+        "app.services.twilio_service.twilio_service.purchase_phone_number",
+        return_value={"phone_number": "+15551234568", "sid": "PN124"},
+    ) as mock_purchase:
+        pn = phone_number_service.purchase_phone_number(
+            db, phone_number="+15551234568", tenant_id=tenant.id
+        )
+
+    mock_purchase.assert_called_once()
+    assert pn.phone_number == "+15551234568"
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("0")  # no overage charge
+
+
+def test_purchase_phone_number_no_cap_when_plan_field_null(db, tenant):
+    _activate_plan(db, tenant, free_phone_numbers=None)
+    _existing_number(db, tenant, n=5)
+    tenant.credits = Decimal("0")
+    db.commit()
+
+    with patch(
+        "app.services.twilio_service.twilio_service.purchase_phone_number",
+        return_value={"phone_number": "+15551234569", "sid": "PN125"},
+    ) as mock_purchase:
+        pn = phone_number_service.purchase_phone_number(
+            db, phone_number="+15551234569", tenant_id=tenant.id
+        )
+
+    mock_purchase.assert_called_once()
+    assert pn.phone_number == "+15551234569"
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("0")  # unlimited plan — never charged
+
+
+def test_purchase_phone_number_no_cap_when_no_active_plan(db, tenant):
+    # No subscription at all for this tenant.
+    _existing_number(db, tenant, n=5)
+
+    with patch(
+        "app.services.twilio_service.twilio_service.purchase_phone_number",
+        return_value={"phone_number": "+15559876543", "sid": "PN456"},
+    ) as mock_purchase:
+        pn = phone_number_service.purchase_phone_number(
+            db, phone_number="+15559876543", tenant_id=tenant.id
+        )
+
+    mock_purchase.assert_called_once()
+    assert pn.phone_number == "+15559876543"
+
+
+# ---------------------------------------------------------------------------
+# import_twilio_phone_number
+# ---------------------------------------------------------------------------
+
+
+def test_import_twilio_phone_number_overage_charged_when_credits_sufficient(db, tenant):
+    _activate_plan(db, tenant, free_phone_numbers=2)
+    _existing_number(db, tenant, n=2)  # already at the free allowance of 2
+    tenant.credits = Decimal("10.00")
+    db.commit()
+
+    with patch("app.services.twilio_service.twilio_service.get_client_with_credentials") as mock_get_client:
+        mock_client = mock_get_client.return_value
+        mock_number = type(
+            "OwnedNumber", (), {"sid": "PNIMPORT1", "capabilities": {"voice": True}}
+        )()
+        mock_client.incoming_phone_numbers.list.return_value = [mock_number]
+
+        with patch(
+            "app.services.twilio_service.twilio_service.update_number_configuration_with_credentials"
+        ):
+            pn = phone_number_service.import_twilio_phone_number(
+                db,
+                phone_number="+15551112222",
+                label=None,
+                tenant_id=tenant.id,
+                twilio_account_sid="ACxxx",
+                twilio_auth_token="authxxx",
+            )
+
+    assert pn.phone_number == "+15551112222"
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("8.00")
+
+
+def test_import_twilio_phone_number_overage_rejected_when_credits_insufficient_twilio_never_called(db, tenant):
+    _activate_plan(db, tenant, free_phone_numbers=2)
+    _existing_number(db, tenant, n=2)  # already at the free allowance of 2
+    tenant.credits = Decimal("0.50")  # not enough to cover the $2 overage
+    db.commit()
+
+    with patch("app.services.twilio_service.twilio_service.get_client_with_credentials") as mock_client:
+        with pytest.raises(HTTPException) as exc_info:
+            phone_number_service.import_twilio_phone_number(
+                db,
+                phone_number="+15551112222",
+                label=None,
+                tenant_id=tenant.id,
+                twilio_account_sid="ACxxx",
+                twilio_auth_token="authxxx",
+            )
+
+    assert exc_info.value.status_code == 402
+    assert "Insufficient balance" in exc_info.value.detail
+    mock_client.assert_not_called()
+
+    db.refresh(tenant)
+    assert tenant.credits == Decimal("0.50")  # untouched

--- a/tests/services/test_voice_call_livekit.py
+++ b/tests/services/test_voice_call_livekit.py
@@ -47,6 +47,16 @@ def _agent():
     ag.name = "Test Agent"
     ag.status = "ready"  # telephony bind sets this; required for outbound calls
     ag.model = MagicMock(model_name="gpt-4o")
+    # Explicit (non-MagicMock) TTS fields so resolve_tts_runtime(agent, db=...)
+    # — invoked for the surcharge gate in voice_call_service.initiate_call —
+    # resolves safely to the "google" default instead of tripping over
+    # arbitrary MagicMock attribute access (dict(MagicMock()), .lower(), etc.).
+    ag.tts_settings_json = {}
+    ag.tts_provider_slug = None
+    ag.tts_language = None
+    ag.tts_voice_external_id = None
+    ag.tts_provider = None
+    ag.language = "en"
     return ag
 
 
@@ -153,7 +163,7 @@ async def _run(
         patch(
             "app.services.voice_call_service.credit_service",
             MagicMock(
-                has_sufficient_credits=MagicMock(return_value=(True, 100, 10))
+                has_sufficient_credits=MagicMock(return_value=(True, 100, 10, "ok"))
             ),
         ),
         patch(
@@ -324,7 +334,7 @@ async def _run_raw(request, *, flow_status: str = "active") -> object:
         patch(
             "app.services.voice_call_service.credit_service",
             MagicMock(
-                has_sufficient_credits=MagicMock(return_value=(True, 100, 10))
+                has_sufficient_credits=MagicMock(return_value=(True, 100, 10, "ok"))
             ),
         ),
         patch(

--- a/tests/voice/test_livekit_browser_call_handler.py
+++ b/tests/voice/test_livekit_browser_call_handler.py
@@ -829,6 +829,106 @@ class TestRunLiveKitBrowserCall:
         mock_stop_rec.assert_awaited_once_with(call_session_id, None)
 
     @pytest.mark.asyncio
+    async def test_max_call_duration_cap_force_ends_and_finalizes_with_reason(self):
+        """
+        If the caller/room never signals _stop_event (e.g. a dead network
+        with no disconnect event ever firing), the hard max-duration safety
+        cap must still force the call through the normal finally cleanup —
+        including actually disconnecting the publisher's LiveKit room
+        connection — and finalize the call_session as "completed" with a
+        distinct, identifiable ended_reason instead of hanging forever.
+        """
+        call_session_id = uuid.uuid4()
+        call_session = MagicMock()
+        call_session.id = call_session_id
+        call_session.call_flow_id = None
+        call_session.call_metadata = {}
+        agent = MagicMock()
+        agent.id = uuid.uuid4()
+        agent.stt_provider_slug = None
+        agent.stt_model_id = None
+
+        mock_db = MagicMock()
+
+        publisher_instance = MagicMock()
+        publisher_instance.connect = AsyncMock(return_value=True)
+        publisher_instance.disconnect = AsyncMock()
+        publisher_instance._room = MagicMock()
+
+        mock_subscriber_instance = MagicMock()
+        mock_subscriber_instance.run = AsyncMock()
+        mock_subscriber_instance.stop = AsyncMock()
+
+        mock_vo_instance = MagicMock()
+        mock_vo_instance.shutdown = AsyncMock()
+        mock_vo_instance.stt_event_bus = MagicMock()
+        mock_vo_instance._on_interim = AsyncMock()
+        mock_vo_instance._on_final = AsyncMock()
+        mock_vo_instance._is_gemini_live = False
+        mock_vo_instance._is_openai_realtime = False
+
+        async def _greet_but_never_stop(self, *_args, **_kwargs):
+            # Unlike the happy-path test, this never sets _stop_event —
+            # simulates the caller's tab/network dying without any
+            # participant_disconnected/disconnected room event ever firing.
+            return None
+
+        with patch("app.voice.livekit_browser_call_handler.settings") as mock_settings, \
+             patch("app.voice.livekit_browser_call_handler._MAX_CALL_DURATION_SEC", 0.01), \
+             patch("app.db.session.SessionLocal", return_value=mock_db), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._load_browser_call_context",
+                 new=AsyncMock(return_value=(call_session, agent, None)),
+             ), \
+             patch("app.voice.voice_orchestrator.VoiceOrchestrator", return_value=mock_vo_instance), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._LiveKitAgentAudioPublisher",
+                 return_value=publisher_instance,
+             ), \
+             patch("app.core.agent_runtime.resolve_stt_runtime") as mock_resolve_stt, \
+             patch("app.voice.stt_pipeline.SttPipeline.from_runtime_config", return_value=MagicMock()), \
+             patch(
+                 "app.voice.livekit_audio_subscriber.LiveKitAudioSubscriber",
+                 return_value=mock_subscriber_instance,
+             ), \
+             patch("app.services.call_session_service.call_session_service") as mock_svc, \
+             patch(
+                 "app.voice.livekit_browser_call_handler._start_browser_call_recording",
+                 new=AsyncMock(return_value=None),
+             ), \
+             patch(
+                 "app.voice.livekit_browser_call_handler._stop_browser_call_recording",
+                 new=AsyncMock(),
+             ), \
+             patch.object(
+                 LiveKitBrowserCallHandler,
+                 "generate_and_stream_response",
+                 new=_greet_but_never_stop,
+             ):
+            mock_settings.LIVEKIT_ENABLED = True
+            mock_resolve_stt.return_value = ResolvedSttRuntime(
+                provider_slug="deepgram",
+                model_id="nova-3",
+                language_code="en",
+                sample_rate_hz=8000,
+                encoding="MULAW",
+                silence_threshold_ms=1500,
+                api_config={},
+            )
+
+            await asyncio.wait_for(run_livekit_browser_call(call_session_id), timeout=5.0)
+
+        # The cap must actually force-end the call, not just stop waiting:
+        # the publisher's LiveKit room connection is disconnected via the
+        # same finally-block path used for a normal disconnect.
+        publisher_instance.disconnect.assert_awaited_once()
+        mock_vo_instance.shutdown.assert_awaited_once()
+        mock_svc.update_call_session_status.assert_called_once_with(
+            mock_db, call_session_id, "completed", ended_reason="max_duration_exceeded"
+        )
+        mock_db.close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_agent_join_failure_is_caught_not_raised(self):
         """An exception anywhere in the join/conversation loop must never
         propagate out as an unhandled background-task exception."""

--- a/tests/voice/test_openai_realtime_twilio_fork.py
+++ b/tests/voice/test_openai_realtime_twilio_fork.py
@@ -403,6 +403,50 @@ class TestPreSessionFallback:
         assert orch._openai_realtime_setup_failed is True
         h._full_shutdown.assert_called_once()
 
+    def test_fallback_persists_flag_on_call_metadata_for_credit_billing(self):
+        """Fix #4: the fallback must persist a flag on
+        CallSession.call_metadata so credit_service's out-of-process billing
+        tick (which re-queries CallSession every 10s and has no reference to
+        this orchestrator instance) can stop billing the realtime surcharge
+        and start evaluating the ElevenLabs surcharge for the rest of the
+        call."""
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        call_session = MagicMock()
+        call_session.call_metadata = {"existing_key": "kept"}
+        h.call_session = call_session
+        h.db = MagicMock()
+
+        asyncio.run(orch._fallback_to_legacy_pipeline_openai(h, reason="pre-session boom"))
+
+        assert orch._is_openai_realtime is False
+        assert call_session.call_metadata["existing_key"] == "kept"
+        fallback_meta = call_session.call_metadata["openai_realtime_fallback"]
+        assert fallback_meta["fell_back"] is True
+        assert fallback_meta["reason"] == "pre-session boom"
+        assert "at" in fallback_meta
+        h.db.commit.assert_called_once()
+
+    def test_fallback_write_failure_does_not_raise(self):
+        """A DB error while persisting the fallback flag must not blow up the
+        call — it's a best-effort billing-accuracy signal, not a correctness
+        requirement for the call itself."""
+        h = _fake_handler(llm_model=NATIVE_AUDIO_MODEL)
+        orch = VoiceOrchestrator(h)
+
+        call_session = MagicMock()
+        call_session.call_metadata = {}
+        h.call_session = call_session
+        h.db = MagicMock()
+        h.db.commit.side_effect = RuntimeError("db down")
+
+        # Must not raise.
+        asyncio.run(orch._fallback_to_legacy_pipeline_openai(h, reason="boom"))
+
+        assert orch._is_openai_realtime is False
+        h._full_shutdown.assert_not_awaited()
+
 
 class TestMidCallError:
     def test_mid_call_error_ends_call_gracefully(self):


### PR DESCRIPTION
## Summary
- Two tenant-level subscription plans: Studio ($99/mo, 100 included min, $12 credit grant, 3 free phone numbers, 3 max sub-accounts) and Agency ($299/mo, 300 included min, $36 credit grant, 10 free phone numbers, unlimited sub-accounts), built on top of the existing CRM-addon Plan/Subscription tables via a new tenant-scoped subscription path.
- Replaces the old per-LLM-model credit-cost table with a flat $0.12/min rate: included minutes are free, then overage (or pay-as-you-go with no plan) draws from `tenant.credits` (1 credit = $1).
- Stacking per-model/provider surcharges on top of the base rate, charged regardless of included-minutes status: $0.50/min for OpenAI Realtime models, $0.05/min for platform ElevenLabs voices (BYO ElevenLabs keys exempt). Surcharges are re-evaluated every billing tick so a mid-call fallback from Realtime to the legacy pipeline bills correctly. Surfaced via `GET /workspace/pricing` and `/usage` as `available_surcharges`.
- Phone numbers beyond the plan's free allowance cost $2 each from credits (no hard cap); sub-accounts are capped per plan.
- New endpoints: `POST /tenants/plans/start-checkout`, `GET /tenants/plan`. Fixes a pre-existing crash in `GET /workspace/usage`.
- Wires the same plan-aware billing into the public "Share Demo Link" browser-call path (previously charged nothing), with a 30-minute hard call-duration safety cap since that transport has no reliable disconnect signal.

## Test plan
- [x] `pytest tests/` — 3055+ passed, 0 failed
- [x] `alembic upgrade head` applied and verified against a real Postgres (Neon) instance
- [x] `tests/integration/test_billing_plans_postgres.py` run against real Postgres — confirms the `uq_tenant_core_subscription` partial unique index behaves correctly
- [x] Studio/Agency plans seeded via `app/scripts/init_plans.py` and confirmed in DB
- [x] `ruff check .` clean on all touched files
- [x] Four rounds of code review (schema/services, demo-call wiring, GPT Realtime surcharge, ElevenLabs surcharge + BYO exemption + fallback billing) — no outstanding blocking findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPN1hgjPzsVUTcvCDnR1vW