### PR TITLE
feat(billing): billing dashboard - plan/credits, Stripe portal, usage reporting, wallet auto-recharge & sharing

### DIFF
--- a/alembic/versions/3f67072326de_add_wallet_auto_recharge_trigger_trail.py
+++ b/alembic/versions/3f67072326de_add_wallet_auto_recharge_trigger_trail.py
@@ -1,0 +1,41 @@
+"""add_wallet_auto_recharge_trigger_trail
+
+Revision ID: 3f67072326de
+Revises: 7ec8c07644d0
+Create Date: 2026-08-23 11:20:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "3f67072326de"
+down_revision: Union[str, Sequence[str], None] = "7ec8c07644d0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "walletautorechargeconfig",
+        sa.Column("last_payment_intent_id", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "walletautorechargeconfig",
+        sa.Column("last_trigger_status", sa.String(), nullable=True),
+    )
+    op.add_column(
+        "walletautorechargeconfig",
+        sa.Column("last_trigger_error", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("walletautorechargeconfig", "last_trigger_error")
+    op.drop_column("walletautorechargeconfig", "last_trigger_status")
+    op.drop_column("walletautorechargeconfig", "last_payment_intent_id")

--- a/alembic/versions/7ec8c07644d0_add_wallet_auto_recharge_and_wallet_sharing.py
+++ b/alembic/versions/7ec8c07644d0_add_wallet_auto_recharge_and_wallet_sharing.py
@@ -1,0 +1,46 @@
+"""add_wallet_auto_recharge_and_wallet_sharing
+
+Revision ID: 7ec8c07644d0
+Revises: 3ad4a023f421
+Create Date: 2026-08-23 10:52:14.369656
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '7ec8c07644d0'
+down_revision: Union[str, Sequence[str], None] = '3ad4a023f421'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'walletautorechargeconfig',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('workspace_id', sa.UUID(), nullable=False),
+        sa.Column('enabled', sa.Boolean(), server_default='false', nullable=False),
+        sa.Column('min_balance', sa.Numeric(precision=10, scale=4), server_default='10.00', nullable=False),
+        sa.Column('recharge_amount', sa.Numeric(precision=10, scale=4), server_default='20.00', nullable=False),
+        sa.Column('stripe_payment_method_id', sa.String(), nullable=True),
+        sa.Column('last_triggered_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['workspace_id'], ['tenant.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('workspace_id'),
+    )
+    op.add_column('tenant', sa.Column('uses_master_wallet', sa.Boolean(), server_default='false', nullable=False))
+    op.add_column('tenant', sa.Column('auto_link_new_workspaces', sa.Boolean(), server_default='false', nullable=False))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('tenant', 'auto_link_new_workspaces')
+    op.drop_column('tenant', 'uses_master_wallet')
+    op.drop_table('walletautorechargeconfig')

--- a/app/api/api_v1/endpoints/tenant.py
+++ b/app/api/api_v1/endpoints/tenant.py
@@ -79,7 +79,7 @@ def create_tenant(tenant_in: TenantCreate, current_user: User = Depends(get_curr
         name=tenant_in.name,
         schema_name=schema_name,
         status="pending_payment",
-        credits=50
+        credits=0
     )
     
     db.add(db_tenant)

--- a/app/api/api_v1/endpoints/tenant.py
+++ b/app/api/api_v1/endpoints/tenant.py
@@ -9,6 +9,8 @@ from app.schemas.tenant import (
     CancelPlanOut,
     InvoiceListOut,
     InvoiceOut,
+    AutoRechargeSettingsOut,
+    AutoRechargeSettingsUpsert,
 )
 from app.schemas.auth import SwitchTenantRequest, TokenResponse, RoleInfo
 from app.schemas.base import SuccessResponse
@@ -896,3 +898,121 @@ def get_tenant_invoices(
         ))
 
     return create_success_response(InvoiceListOut(invoices=invoices), "Invoices fetched successfully")
+
+
+@router.get("/billing/auto-recharge", response_model=SuccessResponse[AutoRechargeSettingsOut])
+def get_auto_recharge_settings(
+    current_user: User = Depends(get_current_user_jwt),
+    billing_user: User = Depends(require_billing),
+    db: Session = Depends(get_db),
+):
+    """
+    Current wallet auto-recharge configuration for the caller's active tenant
+    (min-balance threshold, recharge amount, saved payment method, cooldown
+    state). Returns sensible defaults (enabled=false) when no config row
+    exists yet, rather than 404ing — most tenants won't have configured this.
+    """
+    from decimal import Decimal
+
+    from app.models.wallet_auto_recharge_config import WalletAutoRechargeConfig
+
+    if not current_user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No tenant selected"
+        )
+    tenant_id = current_user.current_tenant_id
+
+    config = db.query(WalletAutoRechargeConfig).filter(
+        WalletAutoRechargeConfig.workspace_id == tenant_id,
+        WalletAutoRechargeConfig.deleted_at.is_(None),
+    ).first()
+
+    if not config:
+        return create_success_response(
+            AutoRechargeSettingsOut(
+                enabled=False,
+                min_balance=Decimal("10.00"),
+                recharge_amount=Decimal("20.00"),
+                stripe_payment_method_id=None,
+                last_triggered_at=None,
+            ),
+            "Auto-recharge settings fetched successfully"
+        )
+
+    return create_success_response(
+        AutoRechargeSettingsOut.model_validate(config),
+        "Auto-recharge settings fetched successfully"
+    )
+
+
+@router.put("/billing/auto-recharge", response_model=SuccessResponse[AutoRechargeSettingsOut])
+def upsert_auto_recharge_settings(
+    payload: AutoRechargeSettingsUpsert,
+    current_user: User = Depends(get_current_user_jwt),
+    admin_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Create or update wallet auto-recharge settings for the caller's active
+    tenant. When `stripe_payment_method_id` is provided, it must belong to
+    this tenant's own Stripe customer — verified against Stripe's own
+    payment-method listing so a tenant can't point auto-recharge at an
+    arbitrary/other-customer's saved card. `min_balance`/`recharge_amount`
+    bounds are enforced at the schema level (`AutoRechargeSettingsUpsert`).
+    """
+    from app.models.wallet_auto_recharge_config import WalletAutoRechargeConfig
+
+    if not current_user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No tenant selected"
+        )
+    tenant_id = current_user.current_tenant_id
+
+    tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    if payload.stripe_payment_method_id:
+        if not tenant.stripe_customer_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Tenant has no Stripe customer on file yet; add a payment method first"
+            )
+        try:
+            payment_methods = StripeService.get_customer_payment_methods(tenant.stripe_customer_id)
+        except Exception as e:
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+
+        valid_ids = {
+            pm.get("id") if isinstance(pm, dict) else getattr(pm, "id", None)
+            for pm in payment_methods
+        }
+        if payload.stripe_payment_method_id not in valid_ids:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="stripe_payment_method_id does not belong to this tenant's Stripe customer"
+            )
+
+    config = db.query(WalletAutoRechargeConfig).filter(
+        WalletAutoRechargeConfig.workspace_id == tenant_id,
+        WalletAutoRechargeConfig.deleted_at.is_(None),
+    ).first()
+
+    if not config:
+        config = WalletAutoRechargeConfig(workspace_id=tenant_id)
+        db.add(config)
+
+    config.enabled = payload.enabled
+    config.min_balance = payload.min_balance
+    config.recharge_amount = payload.recharge_amount
+    config.stripe_payment_method_id = payload.stripe_payment_method_id
+
+    db.commit()
+    db.refresh(config)
+
+    return create_success_response(
+        AutoRechargeSettingsOut.model_validate(config),
+        "Auto-recharge settings updated successfully"
+    )

--- a/app/api/api_v1/endpoints/tenant.py
+++ b/app/api/api_v1/endpoints/tenant.py
@@ -1,14 +1,21 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
-from app.schemas.tenant import TenantCreate, TenantPlanOut
+from app.schemas.tenant import (
+    TenantCreate,
+    TenantPlanOut,
+    BillingPortalSessionOut,
+    CancelPlanOut,
+    InvoiceListOut,
+    InvoiceOut,
+)
 from app.schemas.auth import SwitchTenantRequest, TokenResponse, RoleInfo
 from app.schemas.base import SuccessResponse
 from app.models.tenant import Tenant
 from app.models.user import User
 from app.models.role import Role
-from app.api.deps import get_db, get_current_user_jwt, require_admin
+from app.api.deps import get_db, get_current_user_jwt, require_admin, require_billing
 from app.core.security import create_user_token, create_refresh_token_value, refresh_token_expires_at
 from app.utils.response import create_success_response
 import re
@@ -20,6 +27,7 @@ from sqlalchemy import update
 from app.core.logger import logger
 from app.services.stripe_service import StripeService
 from app.services.role_service import get_default_product_id
+from app.services.audit_service import log_audit_event
 
 router = APIRouter()
 
@@ -652,7 +660,10 @@ def get_tenant_plan(
     db: Session = Depends(get_db),
 ):
     """Current core-product plan + entitlements for the caller's active tenant."""
+    from decimal import Decimal
+
     from app.models.plan import Plan
+    from app.models.pricing_configs import PricingConfig
     from app.services.billing_service import BillingService
 
     if not current_user.current_tenant_id:
@@ -669,6 +680,9 @@ def get_tenant_plan(
 
     _, used_this_cycle, remaining = BillingService.get_included_minutes_status(db, tenant.id)
 
+    pricing_config = db.query(PricingConfig).filter(PricingConfig.workspace_id == tenant.id).first()
+    per_minute_rate = pricing_config.per_minute_rate if pricing_config else Decimal("0.12")
+
     return TenantPlanOut(
         plan_name=plan.name if plan else None,
         display_name=plan.display_name if plan else None,
@@ -680,4 +694,205 @@ def get_tenant_plan(
         max_subaccounts=plan.max_subaccounts if plan else None,
         features=plan.features if plan and plan.features else [],
         credits_balance=tenant.credits or 0,
+        price_monthly=(Decimal(plan.price_monthly) / Decimal("100")) if plan and plan.price_monthly else None,
+        per_minute_rate=per_minute_rate,
+        subscription_status=subscription.status if subscription else None,
+        current_period_end=subscription.current_period_end if subscription else None,
+        cancel_at_period_end=subscription.cancel_at_period_end if subscription else False,
     )
+
+
+@router.post("/billing/portal-session", response_model=SuccessResponse[BillingPortalSessionOut])
+def create_billing_portal_session(
+    current_user: User = Depends(get_current_user_jwt),
+    admin_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Create a Stripe billing-portal session for the caller's current tenant.
+
+    Lets the tenant manage payment methods and view Stripe-hosted invoices
+    through Stripe's own hosted portal (the "Manage Subscription" button).
+
+    Admin-only (not `require_billing`): Stripe's default billing-portal
+    configuration commonly lets the customer cancel the subscription
+    directly through the hosted portal UI, which would let a billing_only
+    user bypass the admin-only /plan/cancel gate below.
+    """
+    if not current_user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No tenant selected"
+        )
+    tenant = db.query(Tenant).filter(Tenant.id == current_user.current_tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    if not tenant.stripe_customer_id:
+        try:
+            stripe_customer_id = StripeService.create_customer(
+                tenant=tenant,
+                email=current_user.email,
+                user=current_user
+            )
+        except Exception as e:
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+        tenant.stripe_customer_id = stripe_customer_id
+        db.commit()
+    else:
+        stripe_customer_id = tenant.stripe_customer_id
+
+    return_url = f"{settings.FRONTEND_URL}/billing"
+    try:
+        portal_session = StripeService.create_portal_session(stripe_customer_id, return_url)
+        return create_success_response(
+            BillingPortalSessionOut(url=portal_session["url"]),
+            "Billing portal session created successfully"
+        )
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+
+
+@router.post("/plan/cancel", response_model=SuccessResponse[CancelPlanOut])
+def cancel_tenant_plan(
+    request: Request,
+    current_user: User = Depends(get_current_user_jwt),
+    admin_user: User = Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Cancel the tenant's active core-plan subscription at the end of the
+    current billing period (the tenant keeps access through what's already
+    paid for). The "Cancel Plan" button.
+    """
+    if not current_user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No tenant selected"
+        )
+    tenant_id = current_user.current_tenant_id
+
+    # Not get_workspace_subscription() — that filters status == "active" only,
+    # which would 404 a trialing/past_due subscription that still has a real
+    # stripe_subscription_id and is clearly cancelable.
+    from app.models.subscription import Subscription
+
+    subscription = (
+        db.query(Subscription)
+        .filter(
+            Subscription.tenant_id == tenant_id,
+            Subscription.crm_type.is_(None),
+            Subscription.status.in_(["active", "trialing", "past_due"]),
+        )
+        .first()
+    )
+    if not subscription or not subscription.stripe_subscription_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No cancelable plan subscription found for this tenant"
+        )
+
+    try:
+        stripe_subscription = StripeService.cancel_subscription(
+            subscription.stripe_subscription_id, at_period_end=True
+        )
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+
+    old_value = {
+        "status": subscription.status,
+        "cancel_at_period_end": subscription.cancel_at_period_end,
+    }
+
+    subscription.cancel_at_period_end = True
+    stripe_status = stripe_subscription.get("status") if isinstance(stripe_subscription, dict) else getattr(stripe_subscription, "status", None)
+    if stripe_status:
+        subscription.status = stripe_status
+    db.commit()
+    db.refresh(subscription)
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="billing.plan_canceled",
+        resource_type="subscription",
+        resource_id=subscription.id,
+        old_value=old_value,
+        new_value={
+            "status": subscription.status,
+            "cancel_at_period_end": subscription.cancel_at_period_end,
+        },
+        actor_user_id=current_user.id,
+    )
+
+    return create_success_response(
+        CancelPlanOut(
+            status=subscription.status,
+            cancel_at_period_end=subscription.cancel_at_period_end,
+            current_period_end=subscription.current_period_end,
+        ),
+        "Plan canceled — access continues through the end of the current billing period"
+    )
+
+
+@router.get("/billing/invoices", response_model=SuccessResponse[InvoiceListOut])
+def get_tenant_invoices(
+    current_user: User = Depends(get_current_user_jwt),
+    billing_user: User = Depends(require_billing),
+    db: Session = Depends(get_db),
+):
+    """
+    Return the tenant's Stripe invoice history (date, invoice number,
+    description, amount, status, hosted PDF download URL).
+    """
+    from datetime import datetime, timezone
+    from decimal import Decimal
+
+    if not current_user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No tenant selected"
+        )
+    tenant = db.query(Tenant).filter(Tenant.id == current_user.current_tenant_id).first()
+    if not tenant:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tenant not found")
+
+    if not tenant.stripe_customer_id:
+        return create_success_response(InvoiceListOut(invoices=[]), "No invoices found")
+
+    try:
+        raw_invoices = StripeService.get_invoices(tenant.stripe_customer_id, limit=10)
+    except Exception as e:
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(e))
+
+    invoices: list[InvoiceOut] = []
+    for inv in raw_invoices:
+        description = inv.get("description") if isinstance(inv, dict) else getattr(inv, "description", None)
+        if not description:
+            lines = inv.get("lines") if isinstance(inv, dict) else getattr(inv, "lines", None)
+            line_data = (lines.get("data") if isinstance(lines, dict) else getattr(lines, "data", None)) if lines else None
+            if line_data:
+                first_line = line_data[0]
+                description = first_line.get("description") if isinstance(first_line, dict) else getattr(first_line, "description", None)
+
+        created = inv.get("created") if isinstance(inv, dict) else getattr(inv, "created", None)
+        created_at = datetime.fromtimestamp(created, tz=timezone.utc) if created else None
+
+        amount_due = inv.get("amount_due") if isinstance(inv, dict) else getattr(inv, "amount_due", None)
+        amount_paid = inv.get("amount_paid") if isinstance(inv, dict) else getattr(inv, "amount_paid", None)
+
+        invoices.append(InvoiceOut(
+            id=inv.get("id") if isinstance(inv, dict) else inv.id,
+            number=inv.get("number") if isinstance(inv, dict) else getattr(inv, "number", None),
+            description=description,
+            status=inv.get("status") if isinstance(inv, dict) else getattr(inv, "status", None),
+            currency=inv.get("currency") if isinstance(inv, dict) else getattr(inv, "currency", None),
+            amount_due=(Decimal(amount_due) / Decimal("100")) if amount_due is not None else None,
+            amount_paid=(Decimal(amount_paid) / Decimal("100")) if amount_paid is not None else None,
+            created_at=created_at,
+            hosted_invoice_url=inv.get("hosted_invoice_url") if isinstance(inv, dict) else getattr(inv, "hosted_invoice_url", None),
+            invoice_pdf=inv.get("invoice_pdf") if isinstance(inv, dict) else getattr(inv, "invoice_pdf", None),
+        ))
+
+    return create_success_response(InvoiceListOut(invoices=invoices), "Invoices fetched successfully")

--- a/app/api/api_v1/endpoints/user.py
+++ b/app/api/api_v1/endpoints/user.py
@@ -80,7 +80,7 @@ def register_user(user_in: UserCreate, db: Session = Depends(get_db)):
         name=tenant_name,
         schema_name=schema_name,
         status="pending_payment",
-        credits=50
+        credits=0
     )
     
     db.add(db_tenant)
@@ -310,7 +310,7 @@ def google_login(
             name=tenant_name,
             schema_name=schema_name,
             status="pending_payment",
-            credits=50
+            credits=0
         )
         db.add(db_tenant)
         db.commit()

--- a/app/api/deps/__init__.py
+++ b/app/api/deps/__init__.py
@@ -55,6 +55,7 @@ from app.api.deps.rbac import (
     require_member,
     require_member_or_admin,
     require_active_subscription,
+    require_workspace_owner,
 )
 from app.api.deps.tokens import issue_tokens_for_user
 
@@ -102,6 +103,7 @@ __all__ = [
     "require_member",
     "require_member_or_admin",
     "require_active_subscription",
+    "require_workspace_owner",
     # tokens
     "issue_tokens_for_user",
 ]

--- a/app/api/deps/rbac.py
+++ b/app/api/deps/rbac.py
@@ -154,6 +154,53 @@ require_member = require_readonly
 require_member_or_admin = require_readonly
 
 
+def require_workspace_owner(
+    user: User = Depends(require_user_tenant),
+    db: Session = Depends(get_db),
+) -> User:
+    """Workspace *creator* only — gates cross-sub-account billing/reporting
+    endpoints that must stay invisible even to an `admin` who isn't the
+    original creator, and to any user (including that sub-account's own
+    creator) operating from a sub-account's own tenant context.
+
+    This is deliberately separate from `_require_rank`/`has_rank`: `is_creator`
+    is a per-membership boolean on `user_tenant_association`, not a rung on
+    the admin>manager>config_only>read_only ladder, so there's no "required"
+    rank to compare against — it's checked directly.
+
+    Also rejects outright (403) when `current_tenant_id` is itself a
+    sub-account (`Tenant.parent_workspace_id is not None`) so this dependency
+    alone is sufficient for any future family-scoped endpoint — a caller
+    can't get "owner-gated" without also getting "must be a family root",
+    rather than relying on every route handler to separately re-check that
+    (see `_workspace_family` in workspace.py, which re-derives the same
+    invariant as defense-in-depth, not as the sole enforcement point).
+    """
+    if not user.current_tenant_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No tenant selected. Please set a current tenant.",
+        )
+    row = db.execute(
+        user_tenant_association.select().where(
+            user_tenant_association.c.user_id == user.id,
+            user_tenant_association.c.tenant_id == user.current_tenant_id,
+        )
+    ).first()
+    if row is None:
+        raise _not_a_member()
+    if not row.is_creator:
+        role_name = role_service.get_membership_role_name(db, user.id, user.current_tenant_id)
+        raise _forbidden("owner", role_name)
+    tenant = db.query(Tenant).filter(Tenant.id == user.current_tenant_id).first()
+    if tenant is not None and tenant.parent_workspace_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Owner-only reporting is only available from the master workspace, not a sub-account.",
+        )
+    return _attach_tenants(user, db)
+
+
 def require_active_subscription(
     user: User = Depends(require_user_tenant),
     db: Session = Depends(get_db),

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -30,6 +30,10 @@ from app.schemas.workspace import (
     RecentActivityOut,
     MonthlyMinutesUsageOut,
     MinutesByMonthOut,
+    WalletSharingUpdate,
+    AutoLinkNewWorkspacesUpdate,
+    LinkedWorkspaceOut,
+    LinkedWorkspacesOut,
 )
 from app.services.credit_service import credit_service
 
@@ -546,6 +550,109 @@ def get_workspace_minutes_by_month_csv(
     )
 
 
+# ── Wallet sharing (agency "master wallet") ──────────────────────────────────
+#
+# PUT /workspace/sub-accounts/{sub_account_id}/wallet-sharing,
+# PUT /workspace/auto-link-new-workspaces, GET /workspace/linked-workspaces.
+# Owner-only (require_workspace_owner — see its docstring in deps/rbac.py),
+# same rationale as the usage/breakdown endpoints above: this is
+# cross-sub-account billing configuration that must stay invisible to a
+# non-creator admin and to anyone operating from a sub-account's own tenant
+# context.
+
+
+@v2_router.put("/sub-accounts/{sub_account_id}/wallet-sharing", response_model=LinkedWorkspaceOut)
+def update_sub_account_wallet_sharing(
+    sub_account_id: uuid.UUID,
+    payload: WalletSharingUpdate,
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    """Toggle whether `sub_account_id` draws call credits from the caller's
+    (parent) wallet ("Using master wallet") or its own ("Using own wallet").
+    `sub_account_id` must be a direct sub-account of the caller's current
+    tenant — never trusted without that check."""
+    parent, family = _workspace_family(db, user.current_tenant_id)
+    sub = db.query(Tenant).filter(
+        Tenant.id == sub_account_id,
+        Tenant.parent_workspace_id == parent.id,
+        Tenant.deleted_at.is_(None),
+    ).first()
+    if sub is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Sub-account not found or does not belong to this workspace.",
+        )
+
+    sub.uses_master_wallet = payload.using_master_wallet
+    db.commit()
+    db.refresh(sub)
+
+    is_branded = db.query(BrandingConfig).filter(BrandingConfig.workspace_id == sub.id).first() is not None
+    return LinkedWorkspaceOut(
+        id=sub.id,
+        name=sub.name,
+        is_master=False,
+        is_branded=is_branded,
+        using_master_wallet=bool(sub.uses_master_wallet),
+    )
+
+
+@v2_router.put("/auto-link-new-workspaces", response_model=AutoLinkNewWorkspacesUpdate)
+def update_auto_link_new_workspaces(
+    payload: AutoLinkNewWorkspacesUpdate,
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    """Toggle the caller's own (parent/agency) `auto_link_new_workspaces` —
+    when on, newly created sub-accounts default to wallet-sharing-on."""
+    tenant = db.query(Tenant).filter(
+        Tenant.id == user.current_tenant_id, Tenant.deleted_at.is_(None)
+    ).first()
+    if tenant is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
+
+    tenant.auto_link_new_workspaces = payload.auto_link_new_workspaces
+    db.commit()
+    db.refresh(tenant)
+
+    return AutoLinkNewWorkspacesUpdate(auto_link_new_workspaces=bool(tenant.auto_link_new_workspaces))
+
+
+@v2_router.get("/linked-workspaces", response_model=LinkedWorkspacesOut)
+def get_linked_workspaces(
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    """Parent workspace + its direct sub-accounts, with branding/wallet-sharing
+    status for the "Linked Workspaces" modal."""
+    parent, family = _workspace_family(db, user.current_tenant_id)
+
+    tenant_ids = [t.id for t in family]
+    branded_ids = {
+        wid
+        for (wid,) in db.query(BrandingConfig.workspace_id).filter(
+            BrandingConfig.workspace_id.in_(tenant_ids)
+        ).all()
+    }
+
+    workspaces = [
+        LinkedWorkspaceOut(
+            id=t.id,
+            name=t.name,
+            is_master=(t.id == parent.id),
+            is_branded=(t.id in branded_ids),
+            using_master_wallet=bool(t.uses_master_wallet),
+        )
+        for t in family
+    ]
+
+    return LinkedWorkspacesOut(
+        auto_link_new_workspaces=bool(parent.auto_link_new_workspaces),
+        workspaces=workspaces,
+    )
+
+
 @v2_router.put("/members/{user_id}/role", response_model=MemberRoleOut)
 def update_member_role(
     user_id: uuid.UUID,
@@ -856,14 +963,17 @@ def create_sub_account(
                     ),
                 )
 
-    # Create Tenant
+    # Create Tenant. When the parent has auto_link_new_workspaces enabled,
+    # the new sub-account defaults to wallet-sharing-on (uses_master_wallet);
+    # otherwise it keeps the column default (False, own-wallet).
     new_tenant = Tenant(
         name=payload.name,
         schema_name=f"sub_{uuid.uuid4().hex[:8]}",
         parent_workspace_id=workspace.id,
         workspace_type="sub_account",
         contact_email=payload.contact_email,
-        status="active"
+        status="active",
+        uses_master_wallet=bool(workspace.auto_link_new_workspaces),
     )
     db.add(new_tenant)
     db.flush()

--- a/app/api/v2/routers/workspace.py
+++ b/app/api/v2/routers/workspace.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
-from app.api.deps import get_db, require_admin, require_billing, get_current_workspace
+from app.api.deps import get_db, require_admin, require_billing, get_current_workspace, require_workspace_owner
 from app.models.branding_configs import BrandingConfig
 from app.models.pricing_configs import PricingConfig
 import secrets
@@ -24,6 +24,12 @@ from app.schemas.workspace import (
     SubAccountOut,
     SubAccountCreateOut,
     SubAccountListOut,
+    WorkspaceBreakdownRowOut,
+    WorkspaceUsageBreakdownOut,
+    RecentActivityItemOut,
+    RecentActivityOut,
+    MonthlyMinutesUsageOut,
+    MinutesByMonthOut,
 )
 from app.services.credit_service import credit_service
 
@@ -188,6 +194,355 @@ def get_workspace_usage(
         overage_minutes=overage_minutes,
         overage_cost=overage_cost,
         available_surcharges=_surcharge_catalog_out(),
+    )
+
+
+# ── Agency billing-dashboard reporting (owner-only) ──────────────────────────
+#
+# GET /workspace/usage/breakdown, /recent-activity, /minutes-by-month, and the
+# .csv variants of the first and third. Scoped to {caller's current tenant} ∪
+# {its direct sub_accounts} — never to all Tenant/UsageRecord rows. Gated by
+# require_workspace_owner (is_creator=True on the caller's membership row for
+# the *current* tenant), not require_admin: per product, a non-creator admin
+# on the parent, and any user (including that sub-account's own creator)
+# viewing from a sub-account's tenant context, must get 403 — "owner" isn't
+# one of the canonical ranked roles, so this can't be expressed with
+# require_admin/has_rank.
+
+
+def _month_bounds(dt):
+    """(start, end_exclusive) of the UTC calendar month containing dt."""
+    start = dt.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    if start.month == 12:
+        end = start.replace(year=start.year + 1, month=1)
+    else:
+        end = start.replace(month=start.month + 1)
+    return start, end
+
+
+def _shift_months(dt, n: int):
+    """dt shifted by n calendar months (n may be negative), day pinned to 1."""
+    month_index = dt.year * 12 + (dt.month - 1) + n
+    year, month = divmod(month_index, 12)
+    return dt.replace(year=year, month=month + 1, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+_SUPPORTED_PERIODS = ("this_month",)
+
+
+def _validate_period(period: str) -> None:
+    """Reject an unrecognized `period` instead of silently serving
+    this_month data for it — only 'this_month' is implemented today."""
+    if period not in _SUPPORTED_PERIODS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unsupported period '{period}'. Supported: {', '.join(_SUPPORTED_PERIODS)}.",
+        )
+
+
+def _workspace_family(db: Session, tenant_id: uuid.UUID) -> tuple[Tenant, list[Tenant]]:
+    """(parent_tenant, [parent, *direct sub_accounts]) — the exact scope every
+    aggregation query below must stay within.
+
+    Family-level billing reporting is only meaningful from the *root*
+    workspace's own tenant context. A sub-account has no sub_accounts of its
+    own, so calling this from a sub-account's context would silently degrade
+    to a harmless single-row response rather than leaking the parent
+    family's data — but product explicitly wants a hard 403 here (even for
+    that sub-account's own creator), so it's rejected outright rather than
+    left to degrade quietly.
+    """
+    parent = db.query(Tenant).filter(Tenant.id == tenant_id, Tenant.deleted_at.is_(None)).first()
+    if parent is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Workspace not found")
+    if parent.parent_workspace_id is not None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Billing breakdown reporting is only available from the master workspace, not a sub-account.",
+        )
+    subs = (
+        db.query(Tenant)
+        .filter(Tenant.parent_workspace_id == parent.id, Tenant.deleted_at.is_(None))
+        .order_by(Tenant.created_at.asc())
+        .all()
+    )
+    return parent, [parent, *subs]
+
+
+def _sums_by_workspace(db: Session, tenant_ids: list, start=None, end=None) -> dict:
+    """{workspace_id: Decimal(sum(credits_charged))} for the given family scope."""
+    from decimal import Decimal
+    from sqlalchemy import func
+
+    if not tenant_ids:
+        return {}
+    q = db.query(UsageRecord.workspace_id, func.coalesce(func.sum(UsageRecord.credits_charged), 0)).filter(
+        UsageRecord.workspace_id.in_(tenant_ids)
+    )
+    if start is not None:
+        q = q.filter(UsageRecord.recorded_at >= start)
+    if end is not None:
+        q = q.filter(UsageRecord.recorded_at < end)
+    return {wid: Decimal(str(total)) for wid, total in q.group_by(UsageRecord.workspace_id).all()}
+
+
+def _build_breakdown(db: Session, parent: Tenant, family: list) -> WorkspaceUsageBreakdownOut:
+    from datetime import datetime, timezone
+    from decimal import Decimal
+
+    now = datetime.now(timezone.utc)
+    this_month_start, this_month_end = _month_bounds(now)
+    last_month_start, last_month_end = _month_bounds(_shift_months(now, -1))
+
+    tenant_ids = [t.id for t in family]
+    this_month_sums = _sums_by_workspace(db, tenant_ids, this_month_start, this_month_end)
+    last_month_sums = _sums_by_workspace(db, tenant_ids, last_month_start, last_month_end)
+    all_time_sums = _sums_by_workspace(db, tenant_ids)
+
+    rows: list[WorkspaceBreakdownRowOut] = []
+    total_this_month = Decimal("0")
+    total_all_time = Decimal("0")
+    total_last_month = Decimal("0")
+    total_avg_monthly = Decimal("0")
+    active_this_month = 0
+
+    for t in family:
+        this_month = this_month_sums.get(t.id, Decimal("0"))
+        last_month = last_month_sums.get(t.id, Decimal("0"))
+        all_time = all_time_sums.get(t.id, Decimal("0"))
+
+        created_at = t.created_at or now
+        months_since_created = max(
+            1, (now.year - created_at.year) * 12 + (now.month - created_at.month) + 1
+        )
+        avg_monthly = all_time / months_since_created
+
+        growth_percent = None
+        if last_month != 0:
+            growth_percent = float((this_month - last_month) / last_month * 100)
+
+        if this_month > 0:
+            active_this_month += 1
+
+        total_this_month += this_month
+        total_all_time += all_time
+        total_last_month += last_month
+        total_avg_monthly += avg_monthly
+
+        rows.append(
+            WorkspaceBreakdownRowOut(
+                workspace_id=t.id,
+                name=t.name,
+                is_master=(t.id == parent.id),
+                this_month=this_month,
+                all_time=all_time,
+                avg_monthly=avg_monthly,
+                growth_percent=growth_percent,
+            )
+        )
+
+    workspace_count = len(family)
+    avg_per_workspace_this_month = (total_this_month / workspace_count) if workspace_count else Decimal("0")
+
+    this_month_growth_percent = None
+    if total_last_month != 0:
+        this_month_growth_percent = float((total_this_month - total_last_month) / total_last_month * 100)
+
+    totals = WorkspaceBreakdownRowOut(
+        workspace_id=None,
+        name="Total",
+        is_master=False,
+        this_month=total_this_month,
+        all_time=total_all_time,
+        avg_monthly=total_avg_monthly,
+        growth_percent=this_month_growth_percent,
+    )
+
+    return WorkspaceUsageBreakdownOut(
+        this_month_total=total_this_month,
+        this_month_growth_percent=this_month_growth_percent,
+        all_time_total=total_all_time,
+        avg_per_workspace_this_month=avg_per_workspace_this_month,
+        workspace_count=workspace_count,
+        active_workspace_count_this_month=active_this_month,
+        rows=rows,
+        totals=totals,
+        period="this_month",
+    )
+
+
+def _build_minutes_by_month(db: Session, family: list) -> MinutesByMonthOut:
+    from datetime import datetime, timezone
+    from decimal import Decimal
+    from sqlalchemy import func
+
+    now = datetime.now(timezone.utc)
+    tenant_ids = [t.id for t in family]
+
+    months: list[MonthlyMinutesUsageOut] = []
+    for offset in (0, -1, -2):
+        ref = _shift_months(now, offset)
+        start, end = _month_bounds(ref)
+
+        row = (
+            db.query(
+                func.coalesce(func.sum(UsageRecord.billable_minutes), 0),
+                func.count(UsageRecord.call_id),
+                func.coalesce(func.sum(UsageRecord.credits_charged), 0),
+            )
+            .filter(
+                UsageRecord.workspace_id.in_(tenant_ids),
+                UsageRecord.recorded_at >= start,
+                UsageRecord.recorded_at < end,
+            )
+            .first()
+        )
+        total_minutes, call_count, total_cost = row if row else (0, 0, 0)
+
+        months.append(
+            MonthlyMinutesUsageOut(
+                month=start.strftime("%Y-%m"),
+                label=start.strftime("%B %Y"),
+                total_minutes=Decimal(str(total_minutes)),
+                call_count=int(call_count or 0),
+                total_cost=Decimal(str(total_cost)),
+            )
+        )
+
+    # Oldest first, matching how "last 3 months" reads left-to-right in the mockup.
+    months.reverse()
+    return MinutesByMonthOut(months=months)
+
+
+def _build_recent_activity(db: Session, family: list) -> RecentActivityOut:
+    tenant_ids = [t.id for t in family]
+
+    records = (
+        db.query(UsageRecord)
+        .filter(UsageRecord.workspace_id.in_(tenant_ids))
+        .order_by(UsageRecord.recorded_at.desc())
+        .limit(10)
+        .all()
+    )
+
+    items = [
+        RecentActivityItemOut(
+            date=r.recorded_at,
+            type="call_usage",
+            description=f"Call ID - {r.call_id}" if r.call_id else f"Call ID - {r.id}",
+            amount=-r.credits_charged,
+        )
+        for r in records
+    ]
+    return RecentActivityOut(items=items)
+
+
+def _csv_response(rows: list[list], header: list[str], filename: str) -> Response:
+    import csv
+    import io
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(header)
+    writer.writerows(rows)
+    return Response(
+        content=buf.getvalue(),
+        media_type="text/csv",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+@v2_router.get("/usage/breakdown", response_model=WorkspaceUsageBreakdownOut)
+def get_workspace_usage_breakdown(
+    period: str = "this_month",
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    """Agency billing-dashboard breakdown: spend per workspace (parent +
+    direct sub-accounts) for the current billing period. Owner-only —
+    `period` is a placeholder for a future selector; only 'this_month' is
+    supported today."""
+    _validate_period(period)
+    parent, family = _workspace_family(db, user.current_tenant_id)
+    return _build_breakdown(db, parent, family)
+
+
+@v2_router.get("/usage/breakdown.csv")
+def get_workspace_usage_breakdown_csv(
+    period: str = "this_month",
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    _validate_period(period)
+    parent, family = _workspace_family(db, user.current_tenant_id)
+    breakdown = _build_breakdown(db, parent, family)
+
+    rows = [
+        [
+            r.name,
+            "Master" if r.is_master else "Sub-Account",
+            str(r.this_month),
+            str(r.all_time),
+            str(r.avg_monthly),
+            "" if r.growth_percent is None else f"{r.growth_percent:.2f}",
+        ]
+        for r in breakdown.rows
+    ]
+    rows.append(
+        [
+            breakdown.totals.name,
+            "",
+            str(breakdown.totals.this_month),
+            str(breakdown.totals.all_time),
+            str(breakdown.totals.avg_monthly),
+            "" if breakdown.totals.growth_percent is None else f"{breakdown.totals.growth_percent:.2f}",
+        ]
+    )
+    return _csv_response(
+        rows,
+        header=["Workspace", "Type", "This Month", "All Time", "Avg Monthly", "Growth %"],
+        filename="workspace-usage-breakdown.csv",
+    )
+
+
+@v2_router.get("/usage/recent-activity", response_model=RecentActivityOut)
+def get_workspace_recent_activity(
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    """Last 10 spend transactions across the parent tenant + its direct
+    sub-accounts. Owner-only."""
+    parent, family = _workspace_family(db, user.current_tenant_id)
+    return _build_recent_activity(db, family)
+
+
+@v2_router.get("/usage/minutes-by-month", response_model=MinutesByMonthOut)
+def get_workspace_minutes_by_month(
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    """Minutes/calls/cost for the last 3 calendar months (current + 2 prior),
+    aggregated across the parent tenant + its direct sub-accounts. Owner-only."""
+    parent, family = _workspace_family(db, user.current_tenant_id)
+    return _build_minutes_by_month(db, family)
+
+
+@v2_router.get("/usage/minutes-by-month.csv")
+def get_workspace_minutes_by_month_csv(
+    user: User = Depends(require_workspace_owner),
+    db: Session = Depends(get_db),
+):
+    parent, family = _workspace_family(db, user.current_tenant_id)
+    minutes = _build_minutes_by_month(db, family)
+
+    rows = [
+        [m.label, str(m.total_minutes), str(m.call_count), str(m.total_cost)]
+        for m in minutes.months
+    ]
+    return _csv_response(
+        rows,
+        header=["Month", "Total Minutes", "Call Count", "Total Cost"],
+        filename="workspace-minutes-by-month.csv",
     )
 
 

--- a/app/core/workspace.py
+++ b/app/core/workspace.py
@@ -29,6 +29,7 @@ class Workspace:
     parent_workspace_id: uuid.UUID | None = None
     workspace_type: str = "standalone"
     contact_email: str | None = None
+    auto_link_new_workspaces: bool = False
 
     @classmethod
     def from_tenant(cls, tenant: Tenant) -> Workspace:
@@ -43,6 +44,7 @@ class Workspace:
             parent_workspace_id=tenant.parent_workspace_id,
             workspace_type=tenant.workspace_type,
             contact_email=tenant.contact_email,
+            auto_link_new_workspaces=bool(tenant.auto_link_new_workspaces),
         )
 
     @classmethod
@@ -64,6 +66,7 @@ class Workspace:
             parent_workspace_id=uuid.UUID(str(data["parent_workspace_id"])) if data.get("parent_workspace_id") else None,
             workspace_type=str(data.get("workspace_type", "standalone")),
             contact_email=data.get("contact_email"),
+            auto_link_new_workspaces=bool(data.get("auto_link_new_workspaces", False)),
         )
 
     def to_cache_dict(self) -> dict[str, Any]:
@@ -78,6 +81,7 @@ class Workspace:
             "parent_workspace_id": str(self.parent_workspace_id) if self.parent_workspace_id else None,
             "workspace_type": self.workspace_type,
             "contact_email": self.contact_email,
+            "auto_link_new_workspaces": self.auto_link_new_workspaces,
         }
 
     @property

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -60,6 +60,7 @@ from app.models.webhook import WebhookEndpoint, WebhookDelivery
 # Branding, pricing, RBAC
 from app.models.branding_configs import BrandingConfig  # noqa: F401
 from app.models.pricing_configs import PricingConfig  # noqa: F401
+from app.models.wallet_auto_recharge_config import WalletAutoRechargeConfig  # noqa: F401
 
 
 # Smart Callback Scheduler

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -12,7 +12,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, text as sa_text
 import uuid
 
 from app.db.base_class import Base
@@ -98,7 +98,15 @@ class CallFlow(Base):
     # voice_analysis_service.analyze_call_transcript. Empty list = feature off;
     # the automatic call-summary generation is unaffected either way.
     post_call_analysis_variables = Column(
-        JSONB, nullable=False, default=list, server_default="'[]'::jsonb"
+        # No explicit `::jsonb` cast here (unlike the Alembic migration for
+        # this column) — Postgres infers the cast from the column's own type
+        # in a DEFAULT clause, and omitting it keeps this portable to the
+        # SQLite dialect used by the unit-test suite (SQLite's parser does
+        # not understand `::` cast syntax at all).
+        JSONB,
+        nullable=False,
+        default=list,
+        server_default=sa_text("'[]'"),
     )
     post_call_analysis_model = Column(String(100), nullable=True)
 

--- a/app/models/tenant.py
+++ b/app/models/tenant.py
@@ -28,6 +28,8 @@ class Tenant(Base):
     )
     contact_email = Column(String, nullable=True)
     workspace_slug = Column(String(100), nullable=True, index=True)
+    uses_master_wallet = Column(Boolean, nullable=False, server_default="false")
+    auto_link_new_workspaces = Column(Boolean, nullable=False, server_default="false")
     
     # Relationships
     users = relationship("User", secondary="user_tenant_association", back_populates="tenants") 
@@ -47,6 +49,7 @@ class Tenant(Base):
     branding_config = relationship("BrandingConfig", uselist=False, back_populates="tenant", cascade="all, delete-orphan")
     pricing_config = relationship("PricingConfig", uselist=False, back_populates="tenant", cascade="all, delete-orphan")
     usage_record = relationship("UsageRecord", back_populates="tenant", cascade="all, delete-orphan")
+    wallet_auto_recharge_config = relationship("WalletAutoRechargeConfig", uselist=False, back_populates="tenant", cascade="all, delete-orphan")
     core_subscriptions = relationship("Subscription", back_populates="tenant")
     sso_config = relationship("SsoConfig", uselist=False, back_populates="workspace", cascade="all, delete-orphan")
 

--- a/app/models/wallet_auto_recharge_config.py
+++ b/app/models/wallet_auto_recharge_config.py
@@ -1,0 +1,45 @@
+from sqlalchemy import Boolean, Column, DateTime, Numeric, String, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+import uuid
+from app.db.base_class import Base
+
+
+class WalletAutoRechargeConfig(Base):
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenant.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+    )
+    enabled = Column(Boolean, server_default="false", nullable=False)
+    min_balance = Column(Numeric(10, 4), server_default="10.00", nullable=False)
+    recharge_amount = Column(Numeric(10, 4), server_default="20.00", nullable=False)
+    stripe_payment_method_id = Column(String, nullable=True)
+    last_triggered_at = Column(DateTime(timezone=True), nullable=True)
+    # Minimal durable trail of the LAST auto-recharge attempt (not a full
+    # ledger — just enough for support to see what happened without cross-
+    # referencing logs). Written in two phases by
+    # CreditService._maybe_trigger_wallet_auto_recharge /
+    # _execute_auto_recharge_charge: (1) last_trigger_status="pending" is set
+    # atomically with the cooldown claim UPDATE, before the Stripe call is
+    # made, so a crash mid-flight still leaves a durable "we attempted this"
+    # record; (2) updated to "succeeded"/"failed" (+ last_payment_intent_id /
+    # last_trigger_error) once the Stripe call resolves.
+    last_payment_intent_id = Column(String, nullable=True)
+    last_trigger_status = Column(String, nullable=True)
+    last_trigger_error = Column(String, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=True,
+    )
+    deleted_at = Column(DateTime(timezone=True), nullable=True)
+
+    tenant = relationship("Tenant", back_populates="wallet_auto_recharge_config")

--- a/app/schemas/tenant.py
+++ b/app/schemas/tenant.py
@@ -40,4 +40,46 @@ class TenantPlanOut(BaseModel):
     features: list[str] = Field(default_factory=list)
     credits_balance: Decimal
 
+    # Subscription/billing summary (image 3/4 of the billing dashboard).
+    price_monthly: Decimal | None = None
+    per_minute_rate: Decimal
+    subscription_status: str | None = None
+    current_period_end: datetime | None = None
+    cancel_at_period_end: bool = False
+
     model_config = ConfigDict(from_attributes=True)
+
+
+class BillingPortalSessionOut(BaseModel):
+    """Response shape for POST /api/v1/tenants/billing/portal-session."""
+
+    url: str
+
+
+class CancelPlanOut(BaseModel):
+    """Response shape for POST /api/v1/tenants/plan/cancel."""
+
+    status: str
+    cancel_at_period_end: bool
+    current_period_end: datetime | None = None
+
+
+class InvoiceOut(BaseModel):
+    """Single Stripe invoice entry for the tenant's billing history."""
+
+    id: str
+    number: str | None = None
+    description: str | None = None
+    status: str | None = None
+    currency: str | None = None
+    amount_due: Decimal | None = None
+    amount_paid: Decimal | None = None
+    created_at: datetime | None = None
+    hosted_invoice_url: str | None = None
+    invoice_pdf: str | None = None
+
+
+class InvoiceListOut(BaseModel):
+    """Response shape for GET /api/v1/tenants/billing/invoices."""
+
+    invoices: list[InvoiceOut] = Field(default_factory=list)

--- a/app/schemas/tenant.py
+++ b/app/schemas/tenant.py
@@ -1,15 +1,18 @@
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from datetime import datetime
 from decimal import Decimal
 import uuid
+
 
 class TenantBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=100)
     # credits: int = Field(default=0, ge=0)  # New field for credit system
 
+
 class TenantCreate(TenantBase):
     # Only name required, schema_name will be set automatically
     pass
+
 
 class TenantOut(TenantBase):
     id: uuid.UUID
@@ -18,8 +21,9 @@ class TenantOut(TenantBase):
     stripe_customer_id: str | None = Field(default=None, exclude=True)
     stripe_subscription_id: str | None = Field(default=None, exclude=True)
     created_at: datetime
-    
+
     model_config = ConfigDict(from_attributes=True)
+
 
 class TenantCreateResponse(BaseModel):
     tenant_id: uuid.UUID
@@ -83,3 +87,68 @@ class InvoiceListOut(BaseModel):
     """Response shape for GET /api/v1/tenants/billing/invoices."""
 
     invoices: list[InvoiceOut] = Field(default_factory=list)
+
+
+class AutoRechargeSettingsOut(BaseModel):
+    """Response shape for GET /api/v1/tenants/billing/auto-recharge."""
+
+    enabled: bool
+    min_balance: Decimal
+    recharge_amount: Decimal
+    stripe_payment_method_id: str | None = None
+    last_triggered_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AutoRechargeSettingsUpsert(BaseModel):
+    """Request body for PUT /api/v1/tenants/billing/auto-recharge."""
+
+    enabled: bool = Field(
+        ...,
+        description=(
+            "When true, requires `stripe_payment_method_id` to also be set — "
+            "auto-recharge can never be enabled without a saved payment "
+            "method to charge off-session."
+        ),
+    )
+    min_balance: Decimal = Field(..., ge=0)
+    recharge_amount: Decimal = Field(..., gt=0)
+    stripe_payment_method_id: str | None = Field(
+        default=None,
+        description=(
+            "Stripe PaymentMethod id to charge off-session when the balance "
+            "drops below min_balance. Required whenever `enabled=true`."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_recharge_config(self) -> "AutoRechargeSettingsUpsert":
+        if self.enabled and not self.stripe_payment_method_id:
+            raise ValueError(
+                "auto-recharge requires a saved payment method — set "
+                "stripe_payment_method_id or leave enabled=false"
+            )
+
+        # Guardrail against a config that would immediately re-trigger every
+        # single cooldown window forever: if the recharge only tops the
+        # balance up to less than half of min_balance above zero, the very
+        # next deduction after the recharge lands is highly likely to drop
+        # the tenant back below min_balance again, re-firing another
+        # off-session charge as soon as the cooldown clears. Requiring
+        # recharge_amount >= 0.5 * min_balance is a conservative floor (not
+        # a guarantee of no re-fire, since usage rate varies) that at least
+        # rules out configs that are clearly too small relative to their own
+        # threshold to be a "top-up" rather than a "trickle recharge." Only
+        # enforced when enabled=True — a disabled config can hold any values
+        # since it will never actually fire a charge.
+        if self.enabled:
+            min_recharge = self.min_balance * Decimal("0.5")
+            if self.recharge_amount < min_recharge:
+                raise ValueError(
+                    f"recharge_amount ({self.recharge_amount}) is too small relative to "
+                    f"min_balance ({self.min_balance}) — must be at least half of "
+                    f"min_balance ({min_recharge}) to avoid re-triggering on almost "
+                    "every cooldown window"
+                )
+        return self

--- a/app/schemas/workspace.py
+++ b/app/schemas/workspace.py
@@ -243,6 +243,40 @@ class MinutesByMonthOut(BaseModel):
     months: list[MonthlyMinutesUsageOut]
 
 
+class WalletSharingUpdate(BaseModel):
+    """Request body for PUT /api/v2/workspace/sub-accounts/{sub_account_id}/wallet-sharing"""
+    using_master_wallet: bool
+
+
+class AutoLinkNewWorkspacesUpdate(BaseModel):
+    """Request body for PUT /api/v2/workspace/auto-link-new-workspaces"""
+    auto_link_new_workspaces: bool
+
+
+class LinkedWorkspaceOut(BaseModel):
+    """One row of the "Linked Workspaces" modal — the parent workspace itself
+    or one of its direct sub-accounts."""
+
+    id: uuid.UUID
+    name: str
+    is_master: bool = False
+    is_branded: bool = Field(
+        description="True when this workspace has its own BrandingConfig row on file."
+    )
+    using_master_wallet: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LinkedWorkspacesOut(BaseModel):
+    """Response for GET /api/v2/workspace/linked-workspaces."""
+
+    auto_link_new_workspaces: bool = Field(
+        description="The parent workspace's own auto-link-new-workspaces setting."
+    )
+    workspaces: list[LinkedWorkspaceOut]
+
+
 class MemberRoleUpdate(BaseModel):
     """Request body for PUT /api/v2/workspace/members/{user_id}/role"""
     role: str

--- a/app/schemas/workspace.py
+++ b/app/schemas/workspace.py
@@ -174,6 +174,75 @@ class SubAccountListOut(BaseModel):
     page_size: int
 
 
+class WorkspaceBreakdownRowOut(BaseModel):
+    """One row of the agency billing-dashboard breakdown table — either a
+    real workspace (the "Master" parent tenant or one of its direct
+    sub-accounts) or the synthetic "Total" summary row."""
+
+    workspace_id: uuid.UUID | None = None
+    name: str
+    is_master: bool = False
+    this_month: Decimal
+    all_time: Decimal
+    avg_monthly: Decimal
+    growth_percent: float | None = Field(
+        default=None,
+        description=(
+            "% change of this-month-to-date spend vs. last full calendar "
+            "month. None when last month had $0 spend (avoids divide-by-zero "
+            "— the mockup renders this as '—')."
+        ),
+    )
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class WorkspaceUsageBreakdownOut(BaseModel):
+    """Response for GET /api/v2/workspace/usage/breakdown."""
+
+    period: str = Field(
+        default="this_month",
+        description="Reserved for a future period selector; only 'this_month' is supported today.",
+    )
+    this_month_total: Decimal
+    this_month_growth_percent: float | None = None
+    all_time_total: Decimal
+    avg_per_workspace_this_month: Decimal
+    workspace_count: int
+    active_workspace_count_this_month: int
+    rows: list[WorkspaceBreakdownRowOut]
+    totals: WorkspaceBreakdownRowOut
+
+
+class RecentActivityItemOut(BaseModel):
+    """One row of the "Recent Activity" table."""
+
+    date: datetime
+    type: str = "call_usage"
+    description: str
+    amount: Decimal = Field(description="Negative — credits deducted for this usage row.")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class RecentActivityOut(BaseModel):
+    items: list[RecentActivityItemOut]
+
+
+class MonthlyMinutesUsageOut(BaseModel):
+    """One row of the "Minutes Usage" table — one calendar month."""
+
+    month: str = Field(description="ISO calendar-month key, e.g. '2026-08'.")
+    label: str = Field(description="Human-readable label, e.g. 'August 2026'.")
+    total_minutes: Decimal
+    call_count: int
+    total_cost: Decimal
+
+
+class MinutesByMonthOut(BaseModel):
+    months: list[MonthlyMinutesUsageOut]
+
+
 class MemberRoleUpdate(BaseModel):
     """Request body for PUT /api/v2/workspace/members/{user_id}/role"""
     role: str

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -253,6 +253,34 @@ class CreditService:
         # Return float for accurate billing (no rounding until final deduction)
         return round(total_credits, 4)  # Round to 4 decimal places for precision
 
+    def _resolve_billing_tenant_id(
+        self, db: Session, tenant_id: uuid.UUID
+    ) -> uuid.UUID:
+        """
+        Resolve which tenant's `Tenant.credits` should actually be touched
+        for a credit-balance check/deduction originating from `tenant_id`.
+
+        Wallet sharing: when `tenant_id` is a sub-account with
+        `uses_master_wallet=True` AND a non-null `parent_workspace_id`, the
+        PARENT tenant's credit balance is billed instead of the sub-account's
+        own. Otherwise (wallet sharing off, or no parent) this is a no-op —
+        the tenant bills itself, as before wallet sharing existed.
+
+        This must NEVER be used for the included-minutes/plan-allowance
+        lookup (`BillingService.get_included_minutes_status`) — that stays
+        keyed on the original calling tenant's own plan/allowance regardless
+        of wallet sharing. Only the actual `Tenant.credits` balance
+        check/mutation is redirected here.
+        """
+        tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+        if (
+            tenant is not None
+            and tenant.uses_master_wallet
+            and tenant.parent_workspace_id is not None
+        ):
+            return tenant.parent_workspace_id
+        return tenant_id
+
     def get_tenant_credits(self, db: Session, tenant_id: uuid.UUID) -> float:
         """
         Get current credit balance for a tenant
@@ -310,10 +338,17 @@ class CreditService:
             is retired; it's always 0.0. `reason` is a short machine/human-readable
             string identifying which rule produced the result (for diagnosable
             rejection logging/messaging at call sites) — "ok" when allowed.
+
+        Wallet sharing: the included-minutes/plan-allowance check below is always
+        against `tenant_id` (the calling tenant's own plan is unaffected by wallet
+        sharing), but the credit-BALANCE check is against the resolved billing
+        tenant (`_resolve_billing_tenant_id`) — the parent's balance when the
+        calling tenant has wallet sharing on, otherwise the calling tenant's own.
         """
         from app.services.billing_service import BillingService
 
-        current_credits = self.get_tenant_credits(db, tenant_id)
+        billing_tenant_id = self._resolve_billing_tenant_id(db, tenant_id)
+        current_credits = self.get_tenant_credits(db, billing_tenant_id)
         _, _, remaining_minutes = BillingService.get_included_minutes_status(
             db, tenant_id
         )
@@ -938,6 +973,13 @@ class CreditService:
 
         db = SessionLocal()
 
+        # Resolved once per call (wallet-sharing config doesn't change mid-call):
+        # which tenant's Tenant.credits actually gets debited. `tenant_id` itself
+        # is still used everywhere else in this loop (included-minutes allowance
+        # lookup, UsageRecord attribution) — only the credit-balance
+        # check/deduction is redirected to the resolved billing tenant.
+        billing_tenant_id = self._resolve_billing_tenant_id(db, tenant_id)
+
         try:
             while True:
                 # Wait for monitoring interval (real-time checks)
@@ -979,6 +1021,7 @@ class CreditService:
                         call_session,
                         tts_provider_slug=tts_provider_slug,
                         is_byo_elevenlabs=is_byo_elevenlabs,
+                        billing_tenant_id=billing_tenant_id,
                     )
                     break
 
@@ -1030,7 +1073,7 @@ class CreditService:
                     total_deduction_float = credits_to_deduct_float + surcharge_float
 
                     deduction_success = True
-                    remaining_credits = self.get_tenant_credits(db, tenant_id)
+                    remaining_credits = self.get_tenant_credits(db, billing_tenant_id)
 
                     if total_deduction_float >= 0.01:
                         description = (
@@ -1040,10 +1083,12 @@ class CreditService:
                         if surcharge_float > 0:
                             description += f" + {surcharge_desc}"
                         # ✅ Deduct accumulated overage + active surcharge credits in one
-                        # combined deduction (updates DB immediately)
+                        # combined deduction (updates DB immediately). Targets the
+                        # RESOLVED billing tenant (parent, if wallet sharing is on) —
+                        # never the calling tenant_id directly.
                         deduction_success, remaining_credits = self.deduct_credits(
                             db=db,
-                            tenant_id=tenant_id,
+                            tenant_id=billing_tenant_id,
                             amount=total_deduction_float,
                             call_session_id=call_session_id,
                             description=description,
@@ -1161,6 +1206,7 @@ class CreditService:
                         call_session,
                         tts_provider_slug=tts_provider_slug,
                         is_byo_elevenlabs=is_byo_elevenlabs,
+                        billing_tenant_id=billing_tenant_id,
                     )
             except Exception as e:
                 logger.error(f"Error in final credit deduction: {e}")
@@ -1190,6 +1236,7 @@ class CreditService:
         call_session: CallSession,
         tts_provider_slug: str | None = None,
         is_byo_elevenlabs: bool = False,
+        billing_tenant_id: uuid.UUID | None = None,
     ):
         """
         Finalize credits for call end - deduct any remaining accumulated time (Vapi-style),
@@ -1204,6 +1251,18 @@ class CreditService:
         the final deduction.
         """
         from app.services.billing_service import BillingService
+
+        # `billing_tenant_id` is passed in by the caller (resolved ONCE at
+        # monitoring-loop start) rather than re-derived here. Re-deriving it
+        # independently at call-end would let a wallet-sharing toggle that
+        # fires mid-call split a single call's cost across two tenants'
+        # wallets (some ticks billed the sub-account, the final catch-up
+        # deduction billed the parent, or vice versa) — the whole call must
+        # be billed against exactly one resolved tenant. The calling
+        # tenant_id is still used for the included-minutes allowance lookup
+        # and UsageRecord attribution below regardless.
+        if billing_tenant_id is None:
+            billing_tenant_id = self._resolve_billing_tenant_id(db, tenant_id)
 
         surcharges = self._resolve_current_surcharges(
             call_session, model_name, tts_provider_slug, is_byo_elevenlabs
@@ -1238,7 +1297,7 @@ class CreditService:
                     description += f" + {surcharge_desc}"
                 success, remaining_credits = self.deduct_credits(
                     db=db,
-                    tenant_id=tenant_id,
+                    tenant_id=billing_tenant_id,
                     amount=total_final,
                     call_session_id=call_session_id,
                     description=description,

--- a/app/services/credit_service.py
+++ b/app/services/credit_service.py
@@ -3,19 +3,21 @@ Credit Service Module
 Vapi-style real-time billing: Per-second accurate credit deduction
 """
 
+from sqlalchemy import or_, update as sa_update
 from sqlalchemy.orm import Session
 from app.models.tenant import Tenant
 from app.models.agent import Agent
 from app.models.call_session import CallSession
 from app.models.call_log import CallLog
 from app.models.pricing_configs import PricingConfig
+from app.models.wallet_auto_recharge_config import WalletAutoRechargeConfig
 from app.core.llm_models import is_openai_realtime_model
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Dict, Any
 import uuid
 import asyncio
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import logging
 
 logger = logging.getLogger(__name__)
@@ -88,11 +90,25 @@ class CreditService:
     # Monitoring interval (check every N seconds for real-time accuracy)
     MONITORING_INTERVAL = 10  # Check every 10 seconds (Vapi-style real-time)
 
+    # Minimum time between wallet-auto-recharge trigger *attempts* for a given
+    # tenant, regardless of whether the attempt succeeds or fails. Guards
+    # against the 10s live-billing tick (and any other `deduct_credits`
+    # caller) firing a real off-session Stripe charge on every single
+    # deduction while the tenant sits below their configured threshold.
+    AUTO_RECHARGE_COOLDOWN_SECONDS = 300  # 5 minutes
+
     def __init__(self):
         self._active_monitors = {}  # {call_session_id: task}
         self._call_start_times = {}  # {call_session_id: start_time}
         self._last_deduction_time = {}  # {call_session_id: last_deduction_timestamp}
         self._accumulated_seconds = {}  # {call_session_id: accumulated_seconds}
+        # Strongly-referenced auto-recharge charge tasks, keyed by a unique
+        # per-attempt id (config_id + claimed last_triggered_at timestamp) so
+        # the underlying `asyncio.to_thread(...)` task is never silently
+        # garbage-collected before it completes — mirrors `_active_monitors`
+        # above. Entries are removed (and any exception logged) by the
+        # done-callback registered in `_maybe_trigger_wallet_auto_recharge`.
+        self._active_auto_recharge_tasks: dict[str, asyncio.Task] = {}
 
     def get_surcharge_catalog(self) -> tuple[ActiveSurcharge, ...]:
         """All surcharges this service knows how to apply, regardless of whether
@@ -198,17 +214,25 @@ class CreditService:
             )
         return float(total), " + ".join(parts)
 
-    def get_effective_rate_per_minute(self, db: Session, tenant_id: uuid.UUID) -> Decimal:
+    def get_effective_rate_per_minute(
+        self, db: Session, tenant_id: uuid.UUID
+    ) -> Decimal:
         """
         Get the effective flat $/min (== credits/min, since 1 credit = $1) rate for a tenant.
         Falls back to DEFAULT_PER_MINUTE_RATE (0.12) if no PricingConfig row exists yet.
         """
-        config = db.query(PricingConfig).filter(PricingConfig.workspace_id == tenant_id).first()
+        config = (
+            db.query(PricingConfig)
+            .filter(PricingConfig.workspace_id == tenant_id)
+            .first()
+        )
         if config and config.per_minute_rate is not None:
             return Decimal(str(config.per_minute_rate))
         return DEFAULT_PER_MINUTE_RATE
 
-    def calculate_credits_for_duration(self, duration_seconds: float, credits_per_minute: float) -> float:
+    def calculate_credits_for_duration(
+        self, duration_seconds: float, credits_per_minute: float
+    ) -> float:
         """
         Calculate credits for a specific duration (Vapi-style: per-second accurate calculation)
 
@@ -232,11 +256,11 @@ class CreditService:
     def get_tenant_credits(self, db: Session, tenant_id: uuid.UUID) -> float:
         """
         Get current credit balance for a tenant
-        
+
         Args:
             db: Database session
             tenant_id: Tenant UUID
-            
+
         Returns:
             Current credit balance (as float)
         """
@@ -244,7 +268,7 @@ class CreditService:
         if not tenant:
             return 0.0
         return float(tenant.credits or 0)
-    
+
     def has_sufficient_credits(
         self,
         db: Session,
@@ -290,7 +314,9 @@ class CreditService:
         from app.services.billing_service import BillingService
 
         current_credits = self.get_tenant_credits(db, tenant_id)
-        _, _, remaining_minutes = BillingService.get_included_minutes_status(db, tenant_id)
+        _, _, remaining_minutes = BillingService.get_included_minutes_status(
+            db, tenant_id
+        )
 
         surcharges = self.get_active_surcharges(
             model_name=model_name,
@@ -323,25 +349,25 @@ class CreditService:
             0.0,
             "blocked: no included minutes remaining and no credit balance",
         )
-    
+
     def deduct_credits(
-        self, 
-        db: Session, 
-        tenant_id: uuid.UUID, 
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
         amount: float,
         call_session_id: uuid.UUID | None = None,
-        description: str = None
+        description: str = None,
     ) -> tuple[bool, float]:
         """
         Deduct credits from tenant account (supports float credits)
-        
+
         Args:
             db: Database session
             tenant_id: Tenant UUID
             amount: Amount of credits to deduct (can be float)
             call_session_id: Optional call session ID for tracking
             description: Optional description of the deduction
-            
+
         Returns:
             Tuple of (success, remaining_credits)
         """
@@ -349,14 +375,16 @@ class CreditService:
         if not tenant:
             logger.error(f"Tenant {tenant_id} not found")
             return (False, 0.0)
-        
+
         current_credits = float(tenant.credits or 0)
-        
+
         # Check if we have sufficient credits to deduct
         if current_credits <= 0:
-            logger.warning(f"Insufficient credits for tenant {tenant_id}: {current_credits} <= 0")
+            logger.warning(
+                f"Insufficient credits for tenant {tenant_id}: {current_credits} <= 0"
+            )
             return (False, current_credits)
-        
+
         # Deduct credits but never allow negative balance
         new_credits = max(0.0, current_credits - amount)
         tenant.credits = new_credits
@@ -364,49 +392,392 @@ class CreditService:
         # If this deduction is associated with a specific call, accumulate per-call cost
         if call_session_id is not None:
             try:
-                call_session = db.query(CallSession).filter(CallSession.id == call_session_id).first()
+                call_session = (
+                    db.query(CallSession)
+                    .filter(CallSession.id == call_session_id)
+                    .first()
+                )
                 if call_session:
                     # Treat 'cost' as "total credits consumed for this call"
                     current_call_cost = float(call_session.cost or 0.0)
                     call_session.cost = current_call_cost + float(amount)
 
                     # Mirror the same value onto the associated CallLog (for dashboards)
-                    call_log = db.query(CallLog).filter(CallLog.call_session_id == call_session_id).first()
+                    call_log = (
+                        db.query(CallLog)
+                        .filter(CallLog.call_session_id == call_session_id)
+                        .first()
+                    )
                     if call_log:
                         current_log_cost = float(call_log.cost or 0.0)
                         call_log.cost = current_log_cost + float(amount)
             except Exception as e:
                 # Do not block credit deduction if cost aggregation fails; just log it.
-                logger.error(f"Failed to track per-call credit cost for session {call_session_id}: {e}", exc_info=True)
-        
+                logger.error(
+                    f"Failed to track per-call credit cost for session {call_session_id}: {e}",
+                    exc_info=True,
+                )
+
         # ✅ IMMEDIATE DATABASE UPDATE - Commit right away
         db.commit()
         db.refresh(tenant)
-        
+
         # Check if credits reached 0 after deduction
-        credits_exhausted = (new_credits == 0 and current_credits > 0)
-        
+        credits_exhausted = new_credits == 0 and current_credits > 0
+
         logger.info(
             f"✅ Deducted {amount:.4f} credits from tenant {tenant_id}. "
             f"Remaining: {float(tenant.credits):.4f} (updated in DB). "
             f"Call: {call_session_id}. "
             f"Description: {description}"
         )
-        logger.info(f"💰 CREDIT DEDUCTION: Deducted {amount:.4f} credits | Remaining: {float(tenant.credits):.4f} | Call: {call_session_id}")
-        
+        logger.info(
+            f"💰 CREDIT DEDUCTION: Deducted {amount:.4f} credits | Remaining: {float(tenant.credits):.4f} | Call: {call_session_id}"
+        )
+
+        # Wallet auto-recharge: fire-and-forget, non-critical side effect. Must
+        # never affect the deduction that just happened above (already
+        # committed) or propagate an exception back to whatever call flow is
+        # deducting credits — mirrors the fail-open pattern documented for
+        # `CallSessionService.update_call_session_status()`'s other post-hooks.
+        try:
+            self._maybe_trigger_wallet_auto_recharge(
+                db, tenant_id, float(tenant.credits)
+            )
+        except Exception as exc:
+            logger.error(
+                f"Wallet auto-recharge trigger check failed for tenant {tenant_id}: {exc}",
+                exc_info=True,
+            )
+
         # Return success=False if credits exhausted (call should end immediately)
         return (not credits_exhausted, float(tenant.credits))
-    
+
+    def _maybe_trigger_wallet_auto_recharge(
+        self, db: Session, tenant_id: uuid.UUID, current_credits: float
+    ) -> None:
+        """
+        After a credit deduction, check whether the tenant has wallet
+        auto-recharge enabled and has just dropped below their configured
+        `min_balance` — if so, atomically claim the trigger (cooldown-guarded)
+        and dispatch the actual Stripe charge.
+
+        Cooldown/idempotency: the live billing loop deducts credits every
+        ~10s during an active call, so without protection a tenant sitting
+        below their threshold would be charged repeatedly every tick until a
+        recharge lands. `last_triggered_at` is updated to "now" via a single
+        conditional `UPDATE ... WHERE last_triggered_at IS NULL OR <
+        cutoff` BEFORE the Stripe charge is attempted (not after) — this is
+        an atomic claim at the DB row level: two concurrent deductions (e.g.
+        two active calls for the same tenant) racing this check will
+        serialize on the row lock, and only the transaction that wins gets
+        `rowcount == 1`, so at most one Stripe charge is dispatched per
+        cooldown window even under concurrency. The claim is committed
+        immediately, independent of whether the charge itself later succeeds
+        or fails, so a slow/hanging Stripe call can never leave the window
+        open for a second concurrent trigger.
+        """
+        config = (
+            db.query(WalletAutoRechargeConfig)
+            .filter(
+                WalletAutoRechargeConfig.workspace_id == tenant_id,
+                WalletAutoRechargeConfig.deleted_at.is_(None),
+            )
+            .first()
+        )
+        if not config or not config.enabled or not config.stripe_payment_method_id:
+            return
+        if current_credits >= float(config.min_balance):
+            return
+
+        now = datetime.now(timezone.utc)
+        cutoff = now - timedelta(seconds=self.AUTO_RECHARGE_COOLDOWN_SECONDS)
+
+        # The claim UPDATE also stamps last_trigger_status="pending" (and
+        # clears any stale last_payment_intent_id/last_trigger_error from a
+        # previous attempt) atomically with the cooldown claim itself — so
+        # even if the process crashes before the Stripe call resolves, there
+        # is a durable "we attempted a charge at `now`" record rather than
+        # only a log line. `now` (the timestamp the claim just set) also
+        # doubles as the per-attempt Stripe idempotency nonce below.
+        claim_stmt = (
+            sa_update(WalletAutoRechargeConfig)
+            .where(
+                WalletAutoRechargeConfig.id == config.id,
+                WalletAutoRechargeConfig.enabled.is_(True),
+                WalletAutoRechargeConfig.stripe_payment_method_id.isnot(None),
+                or_(
+                    WalletAutoRechargeConfig.last_triggered_at.is_(None),
+                    WalletAutoRechargeConfig.last_triggered_at < cutoff,
+                ),
+            )
+            .values(
+                last_triggered_at=now,
+                last_trigger_status="pending",
+                last_payment_intent_id=None,
+                last_trigger_error=None,
+            )
+        )
+        result = db.execute(claim_stmt)
+        db.commit()
+
+        if result.rowcount != 1:
+            # Still in cooldown (or config changed underneath us) — some other
+            # deduction already claimed/attempted a trigger recently.
+            return
+
+        recharge_amount = Decimal(str(config.recharge_amount))
+        stripe_payment_method_id = config.stripe_payment_method_id
+        config_id = config.id
+
+        # Per-attempt Stripe idempotency key, derived from the monotonic
+        # timestamp the claim UPDATE above just wrote. Reusing this same key
+        # on any retry within the same cooldown window (there won't be one,
+        # by construction) or if this exact attempt is somehow re-dispatched
+        # guarantees Stripe returns the original PaymentIntent instead of
+        # creating a second, distinct charge.
+        idempotency_key = f"auto-recharge:{config_id}:{now.isoformat()}"
+
+        logger.warning(
+            f"💳 WALLET AUTO-RECHARGE TRIGGERED: tenant {tenant_id} balance "
+            f"{current_credits:.4f} < threshold {float(config.min_balance):.4f}; "
+            f"dispatching off-session charge of ${recharge_amount} "
+            f"(config {config_id}, idempotency_key={idempotency_key})."
+        )
+
+        # Keep the trigger check itself cheap/synchronous (just the DB read +
+        # claim above); only the actual blocking Stripe network call is
+        # dispatched off the event loop when one is running, so a slow Stripe
+        # response can never stall the 10s billing tick. `deduct_credits` is
+        # called from both sync and async contexts — when there's no running
+        # loop (a genuinely sync caller), fall back to a brief synchronous
+        # Stripe call rather than dropping the charge.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            task_key = idempotency_key
+            task = loop.create_task(
+                asyncio.to_thread(
+                    self._execute_auto_recharge_charge,
+                    tenant_id,
+                    config_id,
+                    recharge_amount,
+                    stripe_payment_method_id,
+                    idempotency_key,
+                )
+            )
+            self._active_auto_recharge_tasks[task_key] = task
+
+            def _on_done(t: asyncio.Task, key: str = task_key) -> None:
+                self._active_auto_recharge_tasks.pop(key, None)
+                exc = None
+                try:
+                    exc = t.exception()
+                except asyncio.CancelledError:
+                    logger.warning(f"💳 AUTO-RECHARGE task cancelled (key={key}).")
+                    return
+                if exc is not None:
+                    logger.error(
+                        f"💳 AUTO-RECHARGE task raised an unhandled exception "
+                        f"(key={key}): {exc}",
+                        exc_info=exc,
+                    )
+
+            task.add_done_callback(_on_done)
+        else:
+            self._execute_auto_recharge_charge(
+                tenant_id,
+                config_id,
+                recharge_amount,
+                stripe_payment_method_id,
+                idempotency_key,
+            )
+
+    def _execute_auto_recharge_charge(
+        self,
+        tenant_id: uuid.UUID,
+        config_id: uuid.UUID,
+        recharge_amount: Decimal,
+        stripe_payment_method_id: str,
+        idempotency_key: str,
+    ) -> None:
+        """
+        Perform the actual off-session Stripe charge for wallet auto-recharge
+        and, on success, grant `recharge_amount` credits (1 credit = $1, same
+        rate as everywhere else in this service). Opens its own DB session
+        since this may run in a background thread (`asyncio.to_thread`)
+        outside any request-scoped session — never raises, this is a
+        fire-and-forget side effect, not part of any caller's control flow.
+        Real money moves automatically here with no human in the loop, so
+        every branch is logged as clearly as the existing credit-deduction
+        logging in this file.
+
+        `idempotency_key` is passed straight through to Stripe so a dropped
+        response after Stripe already confirmed the PaymentIntent can never
+        result in a second, distinct charge on retry.
+
+        `WalletAutoRechargeConfig.last_trigger_status` /
+        `last_payment_intent_id` / `last_trigger_error` are updated to their
+        final outcome before returning on every branch (the "pending" row
+        written by the claim UPDATE is never left stale) — on success this
+        happens in the SAME commit as the credit grant.
+        """
+        from app.db.session import SessionLocal
+        from app.services.stripe_service import StripeService
+
+        db = SessionLocal()
+        try:
+            tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
+            if not tenant or not tenant.stripe_customer_id:
+                error_detail = "tenant has no Stripe customer on file"
+                logger.error(
+                    f"💳 AUTO-RECHARGE FAILED: tenant {tenant_id} has no Stripe "
+                    f"customer on file; cannot charge for auto-recharge (config {config_id})."
+                )
+                self._record_trigger_outcome(
+                    db, config_id, status="failed", error=error_detail
+                )
+                return
+
+            amount_cents = int(round(float(recharge_amount) * 100))
+            try:
+                intent = StripeService.create_off_session_payment_intent(
+                    customer_id=tenant.stripe_customer_id,
+                    payment_method_id=stripe_payment_method_id,
+                    amount_cents=amount_cents,
+                    currency="usd",
+                    description=f"Wallet auto-recharge (+{recharge_amount} credits)",
+                    metadata={
+                        "tenant_id": str(tenant_id),
+                        "purchase_type": "wallet_auto_recharge",
+                        "auto_recharge_config_id": str(config_id),
+                    },
+                    idempotency_key=idempotency_key,
+                )
+            except Exception as exc:
+                logger.error(
+                    f"💳 AUTO-RECHARGE CHARGE FAILED for tenant {tenant_id} "
+                    f"(config {config_id}, amount ${recharge_amount}): {exc}",
+                    exc_info=True,
+                )
+                self._record_trigger_outcome(
+                    db, config_id, status="failed", error=str(exc)[:500]
+                )
+                return
+
+            intent_status = getattr(intent, "status", None)
+            if intent_status is None and isinstance(intent, dict):
+                intent_status = intent.get("status")
+            intent_id = getattr(intent, "id", None) or (
+                intent.get("id") if isinstance(intent, dict) else None
+            )
+
+            if intent_status != "succeeded":
+                logger.error(
+                    f"💳 AUTO-RECHARGE CHARGE NOT SUCCEEDED for tenant {tenant_id} "
+                    f"(config {config_id}): PaymentIntent status={intent_status!r}. No credits granted."
+                )
+                self._record_trigger_outcome(
+                    db,
+                    config_id,
+                    status="failed",
+                    error=f"PaymentIntent status={intent_status!r}",
+                    payment_intent_id=intent_id,
+                )
+                return
+
+            tenant.credits = (tenant.credits or Decimal("0")) + recharge_amount
+            # Capture the post-recharge balance now, before commit — avoids a
+            # post-commit db.refresh() round-trip whose own failure would
+            # otherwise fall into the outer except and mislabel an
+            # already-committed success as "failed" (see credit_service.py
+            # review history).
+            new_balance = tenant.credits
+            # Same transaction as the credit grant: update the trigger trail
+            # to "succeeded" before the single commit below.
+            self._record_trigger_outcome(
+                db,
+                config_id,
+                status="succeeded",
+                error=None,
+                payment_intent_id=intent_id,
+                commit=False,
+            )
+            db.commit()
+
+            logger.warning(
+                f"💳 AUTO-RECHARGE SUCCEEDED: tenant {tenant_id} charged ${recharge_amount} "
+                f"off-session (PaymentIntent {intent_id}); credits now {float(new_balance):.4f}."
+            )
+        except Exception as exc:
+            logger.error(
+                f"💳 AUTO-RECHARGE unexpected error for tenant {tenant_id} "
+                f"(config {config_id}): {exc}",
+                exc_info=True,
+            )
+            try:
+                # A failure inside the try block (e.g. the commit itself)
+                # leaves this session's transaction in a "pending rollback"
+                # state — any further db.execute() without rolling back
+                # first raises PendingRollbackError instead of persisting
+                # the recovery write, silently stranding the row at
+                # last_trigger_status="pending" forever.
+                db.rollback()
+                self._record_trigger_outcome(
+                    db, config_id, status="failed", error=str(exc)[:500]
+                )
+            except Exception:
+                logger.error(
+                    f"💳 AUTO-RECHARGE also failed to persist trigger outcome for "
+                    f"config {config_id}",
+                    exc_info=True,
+                )
+        finally:
+            db.close()
+
+    @staticmethod
+    def _record_trigger_outcome(
+        db: Session,
+        config_id: uuid.UUID,
+        *,
+        status: str,
+        error: str | None,
+        payment_intent_id: str | None = None,
+        commit: bool = True,
+    ) -> None:
+        """
+        Update `WalletAutoRechargeConfig.last_trigger_status` /
+        `last_trigger_error` / `last_payment_intent_id` for `config_id`.
+        `commit=False` lets the success path fold this update into the same
+        transaction/commit as the credit grant in `_execute_auto_recharge_charge`.
+        """
+        values: Dict[str, Any] = {
+            "last_trigger_status": status,
+            "last_trigger_error": error,
+        }
+        if payment_intent_id is not None:
+            values["last_payment_intent_id"] = payment_intent_id
+        db.execute(
+            sa_update(WalletAutoRechargeConfig)
+            .where(WalletAutoRechargeConfig.id == config_id)
+            .values(**values)
+        )
+        if commit:
+            db.commit()
+
     async def start_credit_monitoring(
         self,
         db: Session,
         call_session_id: uuid.UUID,
         tenant_id: uuid.UUID,
-        agent_id: uuid.UUID
+        agent_id: uuid.UUID,
     ):
         """
         Start monitoring and deducting credits for an active call (Vapi-style real-time)
-        
+
         Args:
             db: Database session (used only for initial setup, monitoring creates its own session)
             call_session_id: Call session UUID
@@ -416,7 +787,7 @@ class CreditService:
         if str(call_session_id) in self._active_monitors:
             logger.warning(f"Credit monitor already active for call {call_session_id}")
             return
-        
+
         # Agent/model lookup kept for logging context, and to resolve which
         # surcharges (if any) apply for the full duration of this call.
         agent = db.query(Agent).filter(Agent.id == agent_id).first()
@@ -461,7 +832,9 @@ class CreditService:
             f"Surcharges: {[s.key for s in surcharges] or 'none'} "
             f"(Vapi-style per-second billing with float precision)"
         )
-        logger.info(f"💰 CREDIT MONITORING STARTED: Call {call_session_id} | Model: {model_name} | Rate: {credits_per_minute} credits/min | Float credits enabled")
+        logger.info(
+            f"💰 CREDIT MONITORING STARTED: Call {call_session_id} | Model: {model_name} | Rate: {credits_per_minute} credits/min | Float credits enabled"
+        )
 
         # Create monitoring task (will create its own DB session for thread-safety).
         # NOTE: tts_provider_slug/is_byo_elevenlabs (not a fixed `surcharges` list)
@@ -562,20 +935,25 @@ class CreditService:
 
         # Create dedicated DB session for this async task (Vapi-style: proper session handling)
         from app.db.session import SessionLocal
+
         db = SessionLocal()
-        
+
         try:
             while True:
                 # Wait for monitoring interval (real-time checks)
                 await asyncio.sleep(self.MONITORING_INTERVAL)
-                
+
                 # Check if call is still active
-                call_session = db.query(CallSession).filter(
-                    CallSession.id == call_session_id
-                ).first()
-                
+                call_session = (
+                    db.query(CallSession)
+                    .filter(CallSession.id == call_session_id)
+                    .first()
+                )
+
                 if not call_session:
-                    logger.info(f"Call session {call_session_id} not found, stopping monitor")
+                    logger.info(
+                        f"Call session {call_session_id} not found, stopping monitor"
+                    )
                     break
 
                 # Re-derive active surcharges every tick (not cached from call-start)
@@ -585,10 +963,20 @@ class CreditService:
                 )
 
                 # Only deduct for active call statuses
-                if call_session.status not in ["active", "in-progress", "connected", "answered"]:
+                if call_session.status not in [
+                    "active",
+                    "in-progress",
+                    "connected",
+                    "answered",
+                ]:
                     # Call ended - do final deduction for remaining time
                     await self._finalize_call_credits(
-                        db, call_session_id, tenant_id, model_name, credits_per_minute, call_session,
+                        db,
+                        call_session_id,
+                        tenant_id,
+                        model_name,
+                        credits_per_minute,
+                        call_session,
                         tts_provider_slug=tts_provider_slug,
                         is_byo_elevenlabs=is_byo_elevenlabs,
                     )
@@ -597,11 +985,13 @@ class CreditService:
                 # Calculate duration since last deduction
                 current_time = datetime.now(timezone.utc)
                 last_deduction = self._last_deduction_time.get(call_id_str)
-                
+
                 if not last_deduction:
-                    last_deduction = self._call_start_times.get(call_id_str, current_time)
+                    last_deduction = self._call_start_times.get(
+                        call_id_str, current_time
+                    )
                     self._last_deduction_time[call_id_str] = last_deduction
-                
+
                 # Calculate seconds since last deduction
                 elapsed_seconds = (current_time - last_deduction).total_seconds()
 
@@ -617,19 +1007,25 @@ class CreditService:
                     # remaining included-plan minutes ("free") and the portion beyond it
                     # ("billable") — a call must never be force-ended while fully within
                     # its free allowance, even at a zero credit balance.
-                    _, _, remaining_minutes = BillingService.get_included_minutes_status(db, tenant_id)
+                    _, _, remaining_minutes = (
+                        BillingService.get_included_minutes_status(db, tenant_id)
+                    )
                     remaining_seconds = float(remaining_minutes) * 60.0
                     free_seconds = min(accumulated, remaining_seconds)
                     billable_seconds = max(0.0, accumulated - free_seconds)
 
                     # Calculate credits owed for only the billable (overage) portion
-                    credits_to_deduct_float = self.calculate_credits_for_duration(billable_seconds, credits_per_minute)
+                    credits_to_deduct_float = self.calculate_credits_for_duration(
+                        billable_seconds, credits_per_minute
+                    )
 
                     # Active surcharges (OpenAI Realtime, ElevenLabs TTS, or both,
                     # summed additively) apply to the FULL accumulated seconds
                     # (both the free-allowance and billable portions) — never
                     # waived by the included-minutes pool, unlike the base rate above.
-                    surcharge_float, surcharge_desc = self._describe_surcharges(accumulated, surcharges)
+                    surcharge_float, surcharge_desc = self._describe_surcharges(
+                        accumulated, surcharges
+                    )
 
                     total_deduction_float = credits_to_deduct_float + surcharge_float
 
@@ -668,7 +1064,9 @@ class CreditService:
                             ),
                         )
                     except Exception as exc:
-                        logger.error(f"Failed to record call minutes for {call_session_id}: {exc}")
+                        logger.error(
+                            f"Failed to record call minutes for {call_session_id}: {exc}"
+                        )
 
                     self._accumulated_seconds[call_id_str] = 0.0
                     self._last_deduction_time[call_id_str] = current_time
@@ -676,7 +1074,9 @@ class CreditService:
                     # Only force-end the call if there was a real charge (billable overage
                     # and/or realtime surcharge) AND the deduction failed or exhausted the
                     # tenant's balance.
-                    if total_deduction_float >= 0.01 and (not deduction_success or remaining_credits <= 0):
+                    if total_deduction_float >= 0.01 and (
+                        not deduction_success or remaining_credits <= 0
+                    ):
                         # ✅ CREDITS FINISHED - END CALL IMMEDIATELY
                         logger.warning(
                             f"⛔ Credits finished for call {call_session_id}. "
@@ -689,7 +1089,9 @@ class CreditService:
                         call_session.ended_reason = "Insufficient credits"
 
                         if call_session.start_time:
-                            duration = (call_session.end_time - call_session.start_time).total_seconds()
+                            duration = (
+                                call_session.end_time - call_session.start_time
+                            ).total_seconds()
                             call_session.duration = int(duration)
 
                         # ✅ IMMEDIATE DATABASE UPDATE
@@ -698,13 +1100,18 @@ class CreditService:
                         # Try to end the Twilio call immediately
                         try:
                             await self._end_twilio_call(call_session.twilio_call_sid)
-                            logger.info("✅ Twilio call ended immediately due to insufficient credits")
+                            logger.info(
+                                "✅ Twilio call ended immediately due to insufficient credits"
+                            )
                         except Exception as e:
                             logger.error(f"Error ending Twilio call: {e}")
 
                         # Broadcast call ended event
                         try:
-                            from app.routers.general_websocket import broadcast_call_status_update
+                            from app.routers.general_websocket import (
+                                broadcast_call_status_update,
+                            )
+
                             await broadcast_call_status_update(
                                 call_session_id=str(call_session_id),
                                 status="completed",
@@ -712,8 +1119,8 @@ class CreditService:
                                     "reason": "insufficient_credits",
                                     "message": "Call ended due to insufficient credits",
                                     "remaining_credits": remaining_credits,
-                                    "timestamp": datetime.now(timezone.utc).isoformat()
-                                }
+                                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                                },
                             )
                         except Exception as e:
                             logger.error(f"Error broadcasting call end event: {e}")
@@ -727,23 +1134,31 @@ class CreditService:
                         f"[base {credits_to_deduct_float:.4f} + surcharge {surcharge_float:.4f}]). "
                         f"Remaining: {remaining_credits:.4f}"
                     )
-        
+
         except asyncio.CancelledError:
             logger.info(f"Credit monitor cancelled for call {call_session_id}")
         except Exception as e:
             logger.error(f"Error in credit monitoring for call {call_session_id}: {e}")
             import traceback
+
             traceback.print_exc()
-        
+
         finally:
             # Final deduction for any remaining time
             try:
-                call_session = db.query(CallSession).filter(
-                    CallSession.id == call_session_id
-                ).first()
+                call_session = (
+                    db.query(CallSession)
+                    .filter(CallSession.id == call_session_id)
+                    .first()
+                )
                 if call_session:
                     await self._finalize_call_credits(
-                        db, call_session_id, tenant_id, model_name, credits_per_minute, call_session,
+                        db,
+                        call_session_id,
+                        tenant_id,
+                        model_name,
+                        credits_per_minute,
+                        call_session,
                         tts_provider_slug=tts_provider_slug,
                         is_byo_elevenlabs=is_byo_elevenlabs,
                     )
@@ -752,7 +1167,7 @@ class CreditService:
             finally:
                 # Close DB session (Vapi-style: proper cleanup)
                 db.close()
-            
+
             # Clean up monitor and tracking
             if call_id_str in self._active_monitors:
                 del self._active_monitors[call_id_str]
@@ -762,9 +1177,9 @@ class CreditService:
                 del self._last_deduction_time[call_id_str]
             if call_id_str in self._accumulated_seconds:
                 del self._accumulated_seconds[call_id_str]
-            
+
             logger.info(f"Credit monitor stopped for call {call_session_id}")
-    
+
     async def _finalize_call_credits(
         self,
         db: Session,
@@ -797,16 +1212,22 @@ class CreditService:
         accumulated = self._accumulated_seconds.get(call_id_str, 0.0)
 
         if accumulated > 0:
-            _, _, remaining_minutes = BillingService.get_included_minutes_status(db, tenant_id)
+            _, _, remaining_minutes = BillingService.get_included_minutes_status(
+                db, tenant_id
+            )
             remaining_seconds = float(remaining_minutes) * 60.0
             free_seconds = min(accumulated, remaining_seconds)
             billable_seconds = max(0.0, accumulated - free_seconds)
 
             # Calculate final credits for the billable (overage) portion only
-            final_credits = self.calculate_credits_for_duration(billable_seconds, credits_per_minute)
+            final_credits = self.calculate_credits_for_duration(
+                billable_seconds, credits_per_minute
+            )
 
             # Active surcharges apply to the FULL accumulated seconds.
-            surcharge_final, surcharge_desc = self._describe_surcharges(accumulated, surcharges)
+            surcharge_final, surcharge_desc = self._describe_surcharges(
+                accumulated, surcharges
+            )
 
             total_final = final_credits + surcharge_final
             credits_charged = Decimal("0")
@@ -829,7 +1250,9 @@ class CreditService:
                     f"(base {final_credits:.4f} + surcharge {surcharge_final:.4f}) "
                     f"for {accumulated:.1f}s. Remaining: {remaining_credits:.4f}"
                 )
-                logger.info(f"💰 FINAL CREDIT DEDUCTION: {total_final:.4f} credits for {accumulated:.1f}s | Remaining: {remaining_credits:.4f} | Call: {call_session_id}")
+                logger.info(
+                    f"💰 FINAL CREDIT DEDUCTION: {total_final:.4f} credits for {accumulated:.1f}s | Remaining: {remaining_credits:.4f} | Call: {call_session_id}"
+                )
 
             try:
                 BillingService.record_call_minutes(
@@ -840,31 +1263,34 @@ class CreditService:
                     credits_charged=credits_charged,
                 )
             except Exception as exc:
-                logger.error(f"Failed to record final call minutes for {call_session_id}: {exc}")
+                logger.error(
+                    f"Failed to record final call minutes for {call_session_id}: {exc}"
+                )
 
             self._accumulated_seconds[call_id_str] = 0.0
-    
+
     async def _end_twilio_call(self, twilio_call_sid: str):
         """
         End a Twilio call
-        
+
         Args:
             twilio_call_sid: Twilio call SID
         """
         if not twilio_call_sid:
             return
-        
+
         try:
             from app.services.twilio_service import twilio_service
+
             twilio_service.end_call(twilio_call_sid)
             logger.info(f"Successfully ended Twilio call {twilio_call_sid}")
         except Exception as e:
             logger.error(f"Error ending Twilio call {twilio_call_sid}: {e}")
-    
+
     def stop_credit_monitoring(self, call_session_id: uuid.UUID):
         """
         Stop monitoring credits for a call
-        
+
         Args:
             call_session_id: Call session UUID
         """
@@ -874,7 +1300,7 @@ class CreditService:
             task.cancel()
             del self._active_monitors[call_id_str]
             logger.info(f"Stopped credit monitor for call {call_session_id}")
-    
+
     def get_active_monitors(self) -> Dict[str, Any]:
         """Get list of active credit monitors"""
         return {

--- a/app/services/stripe_service.py
+++ b/app/services/stripe_service.py
@@ -11,6 +11,7 @@ from app.core.logger import logger
 # Initialize Stripe
 stripe.api_key = settings.STRIPE_SECRET_KEY
 
+
 class StripeService:
 
     @staticmethod
@@ -34,30 +35,29 @@ class StripeService:
             return dict(metadata)
         except (TypeError, ValueError):
             return {}
-    
+
     @staticmethod
     def create_customer(tenant: Tenant, email: str, user: User | None = None) -> str:
         """Create a Stripe customer for a tenant"""
         try:
             customer_data = {
-                'email': email,
-                'name': tenant.name,
-                'metadata': {
-                    'tenant_id': str(tenant.id),
-                    'tenant_name': tenant.name
-                }
+                "email": email,
+                "name": tenant.name,
+                "metadata": {"tenant_id": str(tenant.id), "tenant_name": tenant.name},
             }
-            
+
             # Add user information if available
             if user:
-                customer_data['metadata']['user_id'] = str(user.id)
-                customer_data['metadata']['user_name'] = f"{user.first_name} {user.last_name}".strip()
-            
+                customer_data["metadata"]["user_id"] = str(user.id)
+                customer_data["metadata"][
+                    "user_name"
+                ] = f"{user.first_name} {user.last_name}".strip()
+
             customer = stripe.Customer.create(**customer_data)
             return customer.id
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to create Stripe customer: {str(e)}")
-    
+
     @staticmethod
     def get_customer(customer_id: str) -> Dict[str, Any]:
         """Get customer details from Stripe"""
@@ -75,33 +75,32 @@ class StripeService:
             return customer
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to update customer: {str(e)}")
-    
+
     @staticmethod
     def get_customer_payment_methods(customer_id: str) -> List[Dict[str, Any]]:
         """Get all payment methods for a customer"""
         try:
             payment_methods = stripe.PaymentMethod.list(
-                customer=customer_id,
-                type='card'
+                customer=customer_id, type="card"
             )
             return payment_methods.data
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to get payment methods: {str(e)}")
-    
+
     @staticmethod
-    def set_default_payment_method(customer_id: str, payment_method_id: str) -> Dict[str, Any]:
+    def set_default_payment_method(
+        customer_id: str, payment_method_id: str
+    ) -> Dict[str, Any]:
         """Set default payment method for a customer"""
         try:
             customer = stripe.Customer.modify(
                 customer_id,
-                invoice_settings={
-                    'default_payment_method': payment_method_id
-                }
+                invoice_settings={"default_payment_method": payment_method_id},
             )
             return customer
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to set default payment method: {str(e)}")
-    
+
     @staticmethod
     def detach_payment_method(payment_method_id: str) -> Dict[str, Any]:
         """Detach a payment method from a customer"""
@@ -110,7 +109,7 @@ class StripeService:
             return payment_method
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to detach payment method: {str(e)}")
-    
+
     @staticmethod
     def create_checkout_session(
         tenant_id: str,
@@ -118,7 +117,7 @@ class StripeService:
         success_url: str,
         cancel_url: str,
         db: Session,
-        customer_id: str | None = None
+        customer_id: str | None = None,
     ) -> Dict[str, Any]:
         """Create a Stripe checkout session for subscription"""
         try:
@@ -126,38 +125,34 @@ class StripeService:
             plan = db.query(Plan).filter(Plan.id == plan_id).first()
             if not plan:
                 raise Exception("Plan not found")
-            
+
             if not plan.stripe_price_id:
                 raise Exception("No Stripe price ID configured for this plan")
-            
+
             session_params = {
-                'payment_method_types': ['card'],
-                'line_items': [{
-                    'price': plan.stripe_price_id,
-                    'quantity': 1,
-                }],
-                'mode': 'payment',
-                'success_url': success_url,
-                'cancel_url': cancel_url,
-                'metadata': {
-                    'tenant_id': tenant_id,
-                    'plan_id': plan_id
-                }
+                "payment_method_types": ["card"],
+                "line_items": [
+                    {
+                        "price": plan.stripe_price_id,
+                        "quantity": 1,
+                    }
+                ],
+                "mode": "payment",
+                "success_url": success_url,
+                "cancel_url": cancel_url,
+                "metadata": {"tenant_id": tenant_id, "plan_id": plan_id},
             }
-            
+
             # Only add customer if we have an existing customer_id
             # In subscription mode, customers are created automatically if not provided
             if customer_id:
-                session_params['customer'] = customer_id
-            
+                session_params["customer"] = customer_id
+
             session = stripe.checkout.Session.create(**session_params)
-            return {
-                'session_id': session.id,
-                'url': session.url
-            }
+            return {"session_id": session.id, "url": session.url}
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to create checkout session: {str(e)}")
-    
+
     @staticmethod
     def create_portal_session(customer_id: str, return_url: str) -> Dict[str, Any]:
         """Create a Stripe customer portal session"""
@@ -166,12 +161,10 @@ class StripeService:
                 customer=customer_id,
                 return_url=return_url,
             )
-            return {
-                'url': session.url
-            }
+            return {"url": session.url}
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to create portal session: {str(e)}")
-    
+
     @staticmethod
     def get_subscription(subscription_id: str) -> Dict[str, Any]:
         """Get subscription details from Stripe"""
@@ -180,65 +173,66 @@ class StripeService:
             return subscription
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to get subscription: {str(e)}")
-    
+
     @staticmethod
-    def cancel_subscription(subscription_id: str, at_period_end: bool = True) -> Dict[str, Any]:
+    def cancel_subscription(
+        subscription_id: str, at_period_end: bool = True
+    ) -> Dict[str, Any]:
         """Cancel a Stripe subscription"""
         try:
             if at_period_end:
                 subscription = stripe.Subscription.modify(
-                    subscription_id,
-                    cancel_at_period_end=True
+                    subscription_id, cancel_at_period_end=True
                 )
             else:
                 subscription = stripe.Subscription.delete(subscription_id)
             return subscription
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to cancel subscription: {str(e)}")
-    
+
     @staticmethod
-    def update_subscription_plan(subscription_id: str, new_price_id: str) -> Dict[str, Any]:
+    def update_subscription_plan(
+        subscription_id: str, new_price_id: str
+    ) -> Dict[str, Any]:
         """Update subscription to a different plan"""
         try:
             subscription = stripe.Subscription.retrieve(subscription_id)
             stripe.Subscription.modify(
                 subscription_id,
-                items=[{
-                    'id': subscription['items']['data'][0].id,
-                    'price': new_price_id,
-                }],
-                proration_behavior='create_prorations'
+                items=[
+                    {
+                        "id": subscription["items"]["data"][0].id,
+                        "price": new_price_id,
+                    }
+                ],
+                proration_behavior="create_prorations",
             )
             return subscription
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to update subscription: {str(e)}")
-    
+
     @staticmethod
     def pause_subscription(subscription_id: str) -> Dict[str, Any]:
         """Pause a subscription"""
         try:
             subscription = stripe.Subscription.modify(
-                subscription_id,
-                pause_collection={
-                    'behavior': 'void'
-                }
+                subscription_id, pause_collection={"behavior": "void"}
             )
             return subscription
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to pause subscription: {str(e)}")
-    
+
     @staticmethod
     def resume_subscription(subscription_id: str) -> Dict[str, Any]:
         """Resume a paused subscription"""
         try:
             subscription = stripe.Subscription.modify(
-                subscription_id,
-                pause_collection=None
+                subscription_id, pause_collection=None
             )
             return subscription
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to resume subscription: {str(e)}")
-    
+
     @staticmethod
     def get_upcoming_invoice(customer_id: str) -> Dict[str, Any]:
         """Get upcoming invoice for a customer"""
@@ -247,44 +241,44 @@ class StripeService:
             return invoice
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to get upcoming invoice: {str(e)}")
-    
+
     @staticmethod
     def get_invoices(customer_id: str, limit: int = 10) -> List[Dict[str, Any]]:
         """Get recent invoices for a customer"""
         try:
-            invoices = stripe.Invoice.list(
-                customer=customer_id,
-                limit=limit
-            )
+            invoices = stripe.Invoice.list(customer=customer_id, limit=limit)
             return invoices.data
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to get invoices: {str(e)}")
-    
+
     @staticmethod
-    def create_usage_record(subscription_item_id: str, quantity: int, timestamp: int | None = None) -> Dict[str, Any]:
+    def create_usage_record(
+        subscription_item_id: str, quantity: int, timestamp: int | None = None
+    ) -> Dict[str, Any]:
         """Create a usage record for metered billing"""
         try:
             usage_record = stripe.UsageRecord.create(
                 subscription_item=subscription_item_id,
                 quantity=quantity,
-                timestamp=timestamp or int(datetime.now().timestamp())
+                timestamp=timestamp or int(datetime.now().timestamp()),
             )
             return usage_record
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to create usage record: {str(e)}")
-    
+
     @staticmethod
-    def get_usage_records(subscription_item_id: str, limit: int = 10) -> List[Dict[str, Any]]:
+    def get_usage_records(
+        subscription_item_id: str, limit: int = 10
+    ) -> List[Dict[str, Any]]:
         """Get usage records for a subscription item"""
         try:
             usage_records = stripe.UsageRecord.list(
-                subscription_item=subscription_item_id,
-                limit=limit
+                subscription_item=subscription_item_id, limit=limit
             )
             return usage_records.data
         except stripe.error.StripeError as e:
             raise Exception(f"Failed to get usage records: {str(e)}")
-    
+
     @staticmethod
     def construct_webhook_event(payload: bytes, sig_header: str) -> Dict[str, Any]:
         """Construct and verify webhook event"""
@@ -297,7 +291,7 @@ class StripeService:
             raise Exception(f"Invalid payload: {str(e)}")
         except stripe.error.SignatureVerificationError as e:
             raise Exception(f"Invalid signature: {str(e)}")
-    
+
     @staticmethod
     def handle_checkout_completed(event_data: Dict[str, Any], db: Session) -> None:
         """Handle checkout.session.completed event"""
@@ -307,7 +301,9 @@ class StripeService:
         plan_id = metadata.get("plan_id")
 
         if not tenant_id or not plan_id:
-            logger.warning("Tenant ID or Plan ID not found in checkout session metadata")
+            logger.warning(
+                "Tenant ID or Plan ID not found in checkout session metadata"
+            )
             return
 
         tenant = db.query(Tenant).filter(Tenant.id == tenant_id).first()
@@ -322,7 +318,7 @@ class StripeService:
 
         # Add credits from the plan to the tenant's account
         tenant.credits += plan.credits
-        tenant.status = 'active'
+        tenant.status = "active"
         db.commit()
         db.refresh(tenant)
 
@@ -360,6 +356,59 @@ class StripeService:
             raise Exception(f"Failed to create PaymentIntent: {str(e)}")
 
     @staticmethod
+    def create_off_session_payment_intent(
+        customer_id: str,
+        payment_method_id: str,
+        amount_cents: int,
+        currency: str,
+        description: str,
+        metadata: Dict[str, str] | None = None,
+        idempotency_key: str | None = None,
+    ) -> Any:
+        """
+        Create AND confirm a Stripe PaymentIntent for an off-session charge
+        (no user present to complete an interactive/3DS flow) — used for
+        wallet auto-recharge. Distinct from `create_payment_intent` above,
+        which is for the in-call, user-present payment flow and relies on
+        `automatic_payment_methods` + client-side confirmation.
+
+        `idempotency_key` should be supplied for any caller that might retry
+        the same logical charge attempt (e.g. wallet auto-recharge, where a
+        dropped HTTPS response after Stripe already confirmed the intent
+        must never result in a second, distinct charge). Stripe deduplicates
+        by this key for ~24h: a retry with the same key returns the original
+        PaymentIntent instead of creating a new one. Callers should derive it
+        from something monotonic per attempt (e.g. the cooldown-claim
+        timestamp), never regenerate it on each retry.
+
+        Raises on decline/error (including SCA-required cards, which surface
+        as a StripeError with code 'authentication_required') — the caller is
+        expected to treat any exception here as a failed recharge attempt and
+        must not grant credits.
+
+        Returns the raw stripe.PaymentIntent object; check `.status ==
+        "succeeded"` before treating the charge as successful, since some
+        failure modes return without raising.
+        """
+        try:
+            create_kwargs: Dict[str, Any] = dict(
+                amount=amount_cents,
+                currency=currency.lower(),
+                customer=customer_id,
+                payment_method=payment_method_id,
+                off_session=True,
+                confirm=True,
+                description=description or None,
+                metadata=metadata or {},
+            )
+            if idempotency_key:
+                create_kwargs["idempotency_key"] = idempotency_key
+            intent = stripe.PaymentIntent.create(**create_kwargs)
+            return intent
+        except stripe.error.StripeError as e:
+            raise Exception(f"Failed to create off-session PaymentIntent: {str(e)}")
+
+    @staticmethod
     def construct_payment_webhook_event(
         payload: bytes,
         sig_header: str,
@@ -385,4 +434,3 @@ class StripeService:
             raise stripe.SignatureVerificationError(
                 f"Invalid webhook signature: {str(e)}", sig_header
             )
-

--- a/app/services/voice_call_service.py
+++ b/app/services/voice_call_service.py
@@ -252,14 +252,16 @@ async def initiate_call(
                 required_credits,
                 decline_reason,
             )
+            # Don't put the numeric balance in the client-facing message: when
+            # wallet sharing is on, `current_credits` is the PARENT tenant's
+            # balance, not this (sub-account) caller's own — echoing it back
+            # would leak the parent's live wallet balance to any sub-account
+            # API caller. Full detail (including the balance) stays in the
+            # log line above for internal debugging only.
             return _err(
                 status.HTTP_402_PAYMENT_REQUIRED,
                 "insufficient_credits",
-                (
-                    f"Insufficient credits to initiate call. Current balance: "
-                    f"{current_credits} credits. Model: {model_name}. "
-                    f"Reason: {decline_reason}"
-                ),
+                f"Insufficient credits to initiate call. Model: {model_name}. Reason: {decline_reason}",
             )
 
         logger.info(

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -644,6 +644,137 @@ paths:
                 $ref: '#/components/schemas/TenantPlanOut'
       security:
       - HTTPBearer: []
+  /api/v1/tenants/billing/portal-session:
+    post:
+      tags:
+      - tenants
+      summary: Create Billing Portal Session
+      description: 'Create a Stripe billing-portal session for the caller''s current
+        tenant.
+
+
+        Lets the tenant manage payment methods and view Stripe-hosted invoices
+
+        through Stripe''s own hosted portal (the "Manage Subscription" button).
+
+
+        Admin-only (not `require_billing`): Stripe''s default billing-portal
+
+        configuration commonly lets the customer cancel the subscription
+
+        directly through the hosted portal UI, which would let a billing_only
+
+        user bypass the admin-only /plan/cancel gate below.'
+      operationId: create_billing_portal_session_api_v1_tenants_billing_portal_session_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_BillingPortalSessionOut_'
+      security:
+      - HTTPBearer: []
+  /api/v1/tenants/plan/cancel:
+    post:
+      tags:
+      - tenants
+      summary: Cancel Tenant Plan
+      description: 'Cancel the tenant''s active core-plan subscription at the end
+        of the
+
+        current billing period (the tenant keeps access through what''s already
+
+        paid for). The "Cancel Plan" button.'
+      operationId: cancel_tenant_plan_api_v1_tenants_plan_cancel_post
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_CancelPlanOut_'
+      security:
+      - HTTPBearer: []
+  /api/v1/tenants/billing/invoices:
+    get:
+      tags:
+      - tenants
+      summary: Get Tenant Invoices
+      description: 'Return the tenant''s Stripe invoice history (date, invoice number,
+
+        description, amount, status, hosted PDF download URL).'
+      operationId: get_tenant_invoices_api_v1_tenants_billing_invoices_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_InvoiceListOut_'
+      security:
+      - HTTPBearer: []
+  /api/v1/tenants/billing/auto-recharge:
+    get:
+      tags:
+      - tenants
+      summary: Get Auto Recharge Settings
+      description: 'Current wallet auto-recharge configuration for the caller''s active
+        tenant
+
+        (min-balance threshold, recharge amount, saved payment method, cooldown
+
+        state). Returns sensible defaults (enabled=false) when no config row
+
+        exists yet, rather than 404ing — most tenants won''t have configured this.'
+      operationId: get_auto_recharge_settings_api_v1_tenants_billing_auto_recharge_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_AutoRechargeSettingsOut_'
+      security:
+      - HTTPBearer: []
+    put:
+      tags:
+      - tenants
+      summary: Upsert Auto Recharge Settings
+      description: 'Create or update wallet auto-recharge settings for the caller''s
+        active
+
+        tenant. When `stripe_payment_method_id` is provided, it must belong to
+
+        this tenant''s own Stripe customer — verified against Stripe''s own
+
+        payment-method listing so a tenant can''t point auto-recharge at an
+
+        arbitrary/other-customer''s saved card. `min_balance`/`recharge_amount`
+
+        bounds are enforced at the schema level (`AutoRechargeSettingsUpsert`).'
+      operationId: upsert_auto_recharge_settings_api_v1_tenants_billing_auto_recharge_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AutoRechargeSettingsUpsert'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse_AutoRechargeSettingsOut_'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /api/v1/workspace/invite:
     post:
       tags:
@@ -9040,6 +9171,213 @@ paths:
                 $ref: '#/components/schemas/WorkspaceUsageOut'
       security:
       - HTTPBearer: []
+  /api/v2/workspace/usage/breakdown:
+    get:
+      tags:
+      - Workspace Settings
+      summary: Get Workspace Usage Breakdown
+      description: 'Agency billing-dashboard breakdown: spend per workspace (parent
+        +
+
+        direct sub-accounts) for the current billing period. Owner-only —
+
+        `period` is a placeholder for a future selector; only ''this_month'' is
+
+        supported today.'
+      operationId: get_workspace_usage_breakdown_api_v2_workspace_usage_breakdown_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: period
+        in: query
+        required: false
+        schema:
+          type: string
+          default: this_month
+          title: Period
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkspaceUsageBreakdownOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/workspace/usage/breakdown.csv:
+    get:
+      tags:
+      - Workspace Settings
+      summary: Get Workspace Usage Breakdown Csv
+      operationId: get_workspace_usage_breakdown_csv_api_v2_workspace_usage_breakdown_csv_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: period
+        in: query
+        required: false
+        schema:
+          type: string
+          default: this_month
+          title: Period
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/workspace/usage/recent-activity:
+    get:
+      tags:
+      - Workspace Settings
+      summary: Get Workspace Recent Activity
+      description: 'Last 10 spend transactions across the parent tenant + its direct
+
+        sub-accounts. Owner-only.'
+      operationId: get_workspace_recent_activity_api_v2_workspace_usage_recent_activity_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecentActivityOut'
+      security:
+      - HTTPBearer: []
+  /api/v2/workspace/usage/minutes-by-month:
+    get:
+      tags:
+      - Workspace Settings
+      summary: Get Workspace Minutes By Month
+      description: 'Minutes/calls/cost for the last 3 calendar months (current + 2
+        prior),
+
+        aggregated across the parent tenant + its direct sub-accounts. Owner-only.'
+      operationId: get_workspace_minutes_by_month_api_v2_workspace_usage_minutes_by_month_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MinutesByMonthOut'
+      security:
+      - HTTPBearer: []
+  /api/v2/workspace/usage/minutes-by-month.csv:
+    get:
+      tags:
+      - Workspace Settings
+      summary: Get Workspace Minutes By Month Csv
+      operationId: get_workspace_minutes_by_month_csv_api_v2_workspace_usage_minutes_by_month_csv_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+      security:
+      - HTTPBearer: []
+  /api/v2/workspace/sub-accounts/{sub_account_id}/wallet-sharing:
+    put:
+      tags:
+      - Workspace Settings
+      summary: Update Sub Account Wallet Sharing
+      description: 'Toggle whether `sub_account_id` draws call credits from the caller''s
+
+        (parent) wallet ("Using master wallet") or its own ("Using own wallet").
+
+        `sub_account_id` must be a direct sub-account of the caller''s current
+
+        tenant — never trusted without that check.'
+      operationId: update_sub_account_wallet_sharing_api_v2_workspace_sub_accounts__sub_account_id__wallet_sharing_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: sub_account_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Sub Account Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WalletSharingUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LinkedWorkspaceOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/workspace/auto-link-new-workspaces:
+    put:
+      tags:
+      - Workspace Settings
+      summary: Update Auto Link New Workspaces
+      description: 'Toggle the caller''s own (parent/agency) `auto_link_new_workspaces`
+        —
+
+        when on, newly created sub-accounts default to wallet-sharing-on.'
+      operationId: update_auto_link_new_workspaces_api_v2_workspace_auto_link_new_workspaces_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AutoLinkNewWorkspacesUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutoLinkNewWorkspacesUpdate'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
+  /api/v2/workspace/linked-workspaces:
+    get:
+      tags:
+      - Workspace Settings
+      summary: Get Linked Workspaces
+      description: 'Parent workspace + its direct sub-accounts, with branding/wallet-sharing
+
+        status for the "Linked Workspaces" modal.'
+      operationId: get_linked_workspaces_api_v2_workspace_linked_workspaces_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LinkedWorkspacesOut'
+      security:
+      - HTTPBearer: []
   /api/v2/workspace/members/{user_id}/role:
     put:
       tags:
@@ -10476,6 +10814,75 @@ components:
       - ip_address
       - user_agent
       title: AuditEventOut
+    AutoLinkNewWorkspacesUpdate:
+      properties:
+        auto_link_new_workspaces:
+          type: boolean
+          title: Auto Link New Workspaces
+      type: object
+      required:
+      - auto_link_new_workspaces
+      title: AutoLinkNewWorkspacesUpdate
+      description: Request body for PUT /api/v2/workspace/auto-link-new-workspaces
+    AutoRechargeSettingsOut:
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+        min_balance:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Min Balance
+        recharge_amount:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Recharge Amount
+        stripe_payment_method_id:
+          type: string
+          nullable: true
+        last_triggered_at:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - enabled
+      - min_balance
+      - recharge_amount
+      title: AutoRechargeSettingsOut
+      description: Response shape for GET /api/v1/tenants/billing/auto-recharge.
+    AutoRechargeSettingsUpsert:
+      properties:
+        enabled:
+          type: boolean
+          title: Enabled
+          description: When true, requires `stripe_payment_method_id` to also be set
+            — auto-recharge can never be enabled without a saved payment method to
+            charge off-session.
+        min_balance:
+          anyOf:
+          - type: number
+            minimum: 0.0
+          - type: string
+            pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Min Balance
+        recharge_amount:
+          anyOf:
+          - type: number
+            exclusiveMinimum: 0.0
+          - type: string
+            pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Recharge Amount
+        stripe_payment_method_id:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - enabled
+      - min_balance
+      - recharge_amount
+      title: AutoRechargeSettingsUpsert
+      description: Request body for PUT /api/v1/tenants/billing/auto-recharge.
     BatchCallMetrics:
       properties:
         total_batches:
@@ -10665,6 +11072,16 @@ components:
       - percent_complete
       title: BatchJobProgress
       description: Live progress snapshot for GET /batch-calls/{batch_id}/progress.
+    BillingPortalSessionOut:
+      properties:
+        url:
+          type: string
+          title: Url
+      type: object
+      required:
+      - url
+      title: BillingPortalSessionOut
+      description: Response shape for POST /api/v1/tenants/billing/portal-session.
     BindNumberRequest:
       properties:
         number_id:
@@ -12395,6 +12812,24 @@ components:
       - caller_memory_window
       title: CallerMemorySettingsUpdate
       description: Request body for ``PUT /api/v2/flows/{flow_id}/caller-memory-settings``.
+    CancelPlanOut:
+      properties:
+        status:
+          type: string
+          title: Status
+        cancel_at_period_end:
+          type: boolean
+          title: Cancel At Period End
+        current_period_end:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+      required:
+      - status
+      - cancel_at_period_end
+      title: CancelPlanOut
+      description: Response shape for POST /api/v1/tenants/plan/cancel.
     CandidateStatusEnum:
       type: string
       enum:
@@ -13312,6 +13747,56 @@ components:
       - created_at
       - invited_by
       title: InviteOut
+    InvoiceListOut:
+      properties:
+        invoices:
+          items:
+            $ref: '#/components/schemas/InvoiceOut'
+          type: array
+          title: Invoices
+      type: object
+      title: InvoiceListOut
+      description: Response shape for GET /api/v1/tenants/billing/invoices.
+    InvoiceOut:
+      properties:
+        id:
+          type: string
+          title: Id
+        number:
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        status:
+          type: string
+          nullable: true
+        currency:
+          type: string
+          nullable: true
+        amount_due:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          nullable: true
+        amount_paid:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        hosted_invoice_url:
+          type: string
+          nullable: true
+        invoice_pdf:
+          type: string
+          nullable: true
+      type: object
+      required:
+      - id
+      title: InvoiceOut
+      description: Single Stripe invoice entry for the tenant's billing history.
     JobDescriptionCreateManual:
       properties:
         job_title:
@@ -14170,6 +14655,55 @@ components:
       - ar
       - zh
       title: LanguageEnum
+    LinkedWorkspaceOut:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        is_master:
+          type: boolean
+          title: Is Master
+          default: false
+        is_branded:
+          type: boolean
+          title: Is Branded
+          description: True when this workspace has its own BrandingConfig row on
+            file.
+        using_master_wallet:
+          type: boolean
+          title: Using Master Wallet
+      type: object
+      required:
+      - id
+      - name
+      - is_branded
+      - using_master_wallet
+      title: LinkedWorkspaceOut
+      description: 'One row of the "Linked Workspaces" modal — the parent workspace
+        itself
+
+        or one of its direct sub-accounts.'
+    LinkedWorkspacesOut:
+      properties:
+        auto_link_new_workspaces:
+          type: boolean
+          title: Auto Link New Workspaces
+          description: The parent workspace's own auto-link-new-workspaces setting.
+        workspaces:
+          items:
+            $ref: '#/components/schemas/LinkedWorkspaceOut'
+          type: array
+          title: Workspaces
+      type: object
+      required:
+      - auto_link_new_workspaces
+      - workspaces
+      title: LinkedWorkspacesOut
+      description: Response for GET /api/v2/workspace/linked-workspaces.
     LoginRequest:
       properties:
         email:
@@ -14264,6 +14798,17 @@ components:
       - role
       title: MemberRoleUpdate
       description: Request body for PUT /api/v2/workspace/members/{user_id}/role
+    MinutesByMonthOut:
+      properties:
+        months:
+          items:
+            $ref: '#/components/schemas/MonthlyMinutesUsageOut'
+          type: array
+          title: Months
+      type: object
+      required:
+      - months
+      title: MinutesByMonthOut
     ModelCreate:
       properties:
         model_name:
@@ -14419,6 +14964,36 @@ components:
       type: object
       title: ModelUpdate
       description: Schema for updating a model
+    MonthlyMinutesUsageOut:
+      properties:
+        month:
+          type: string
+          title: Month
+          description: ISO calendar-month key, e.g. '2026-08'.
+        label:
+          type: string
+          title: Label
+          description: Human-readable label, e.g. 'August 2026'.
+        total_minutes:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Total Minutes
+        call_count:
+          type: integer
+          title: Call Count
+        total_cost:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Total Cost
+      type: object
+      required:
+      - month
+      - label
+      - total_minutes
+      - call_count
+      - total_cost
+      title: MonthlyMinutesUsageOut
+      description: One row of the "Minutes Usage" table — one calendar month.
     MoveFlowRequest:
       properties:
         targetFolderId:
@@ -15485,6 +16060,42 @@ components:
       - created_at
       - message
       title: PurchasePhoneNumberResponse
+    RecentActivityItemOut:
+      properties:
+        date:
+          type: string
+          format: date-time
+          title: Date
+        type:
+          type: string
+          title: Type
+          default: call_usage
+        description:
+          type: string
+          title: Description
+        amount:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Amount
+          description: Negative — credits deducted for this usage row.
+      type: object
+      required:
+      - date
+      - description
+      - amount
+      title: RecentActivityItemOut
+      description: One row of the "Recent Activity" table.
+    RecentActivityOut:
+      properties:
+        items:
+          items:
+            $ref: '#/components/schemas/RecentActivityItemOut'
+          type: array
+          title: Items
+      type: object
+      required:
+      - items
+      title: RecentActivityOut
     RecordingResponse:
       properties:
         url:
@@ -16949,6 +17560,22 @@ components:
       required:
       - data
       title: SuccessResponse[ApiKeyOut]
+    SuccessResponse_AutoRechargeSettingsOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/AutoRechargeSettingsOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[AutoRechargeSettingsOut]
     SuccessResponse_BatchCallMetrics_:
       properties:
         data:
@@ -16965,6 +17592,22 @@ components:
       required:
       - data
       title: SuccessResponse[BatchCallMetrics]
+    SuccessResponse_BillingPortalSessionOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/BillingPortalSessionOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[BillingPortalSessionOut]
     SuccessResponse_BindingStatusResponse_:
       properties:
         data:
@@ -17205,6 +17848,22 @@ components:
       required:
       - data
       title: SuccessResponse[CallSessionStats]
+    SuccessResponse_CancelPlanOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/CancelPlanOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[CancelPlanOut]
     SuccessResponse_CreatePaymentSessionResponse_:
       properties:
         data:
@@ -17493,6 +18152,22 @@ components:
       required:
       - data
       title: SuccessResponse[InviteOut]
+    SuccessResponse_InvoiceListOut_:
+      properties:
+        data:
+          $ref: '#/components/schemas/InvoiceListOut'
+        message:
+          type: string
+          title: Message
+          default: ''
+        status_code:
+          type: integer
+          title: Status Code
+          default: 200
+      type: object
+      required:
+      - data
+      title: SuccessResponse[InvoiceListOut]
     SuccessResponse_JobDescriptionListOut_:
       properties:
         data:
@@ -19183,11 +19858,31 @@ components:
           type: string
           pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
           title: Credits Balance
+        price_monthly:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          nullable: true
+        per_minute_rate:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Per Minute Rate
+        subscription_status:
+          type: string
+          nullable: true
+        current_period_end:
+          type: string
+          format: date-time
+          nullable: true
+        cancel_at_period_end:
+          type: boolean
+          title: Cancel At Period End
+          default: false
       type: object
       required:
       - minutes_used_this_cycle
       - minutes_remaining
       - credits_balance
+      - per_minute_rate
       title: TenantPlanOut
       description: Response shape for GET /api/v1/tenants/plan — current plan + entitlements.
     TokenResponse:
@@ -19690,6 +20385,16 @@ components:
       - male
       - female
       title: VoiceTypeEnum
+    WalletSharingUpdate:
+      properties:
+        using_master_wallet:
+          type: boolean
+          title: Using Master Wallet
+      type: object
+      required:
+      - using_master_wallet
+      title: WalletSharingUpdate
+      description: Request body for PUT /api/v2/workspace/sub-accounts/{sub_account_id}/wallet-sharing
     WebhookDeliveryOut:
       properties:
         id:
@@ -19786,6 +20491,47 @@ components:
       - ai_dynamic
       - ai_custom
       title: WelcomeMessageTypeEnum
+    WorkspaceBreakdownRowOut:
+      properties:
+        workspace_id:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+          title: Name
+        is_master:
+          type: boolean
+          title: Is Master
+          default: false
+        this_month:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: This Month
+        all_time:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: All Time
+        avg_monthly:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Avg Monthly
+        growth_percent:
+          type: number
+          nullable: true
+      type: object
+      required:
+      - name
+      - this_month
+      - all_time
+      - avg_monthly
+      title: WorkspaceBreakdownRowOut
+      description: 'One row of the agency billing-dashboard breakdown table — either
+        a
+
+        real workspace (the "Master" parent tenant or one of its direct
+
+        sub-accounts) or the synthetic "Total" summary row.'
     WorkspaceCreatedOut:
       properties:
         id:
@@ -19847,6 +20593,53 @@ components:
       title: WorkspaceOut
       description: Full (non-internal) workspace projection. Hides ``deleted_at``,
         ``schema_name`` etc.
+    WorkspaceUsageBreakdownOut:
+      properties:
+        period:
+          type: string
+          title: Period
+          description: Reserved for a future period selector; only 'this_month' is
+            supported today.
+          default: this_month
+        this_month_total:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: This Month Total
+        this_month_growth_percent:
+          type: number
+          nullable: true
+        all_time_total:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: All Time Total
+        avg_per_workspace_this_month:
+          type: string
+          pattern: ^(?!^[-+.]*$)[+-]?0*\d*\.?\d*$
+          title: Avg Per Workspace This Month
+        workspace_count:
+          type: integer
+          title: Workspace Count
+        active_workspace_count_this_month:
+          type: integer
+          title: Active Workspace Count This Month
+        rows:
+          items:
+            $ref: '#/components/schemas/WorkspaceBreakdownRowOut'
+          type: array
+          title: Rows
+        totals:
+          $ref: '#/components/schemas/WorkspaceBreakdownRowOut'
+      type: object
+      required:
+      - this_month_total
+      - all_time_total
+      - avg_per_workspace_this_month
+      - workspace_count
+      - active_workspace_count_this_month
+      - rows
+      - totals
+      title: WorkspaceUsageBreakdownOut
+      description: Response for GET /api/v2/workspace/usage/breakdown.
     WorkspaceUsageOut:
       properties:
         minutes_used_this_cycle:

--- a/tests/api/test_tenant_billing.py
+++ b/tests/api/test_tenant_billing.py
@@ -21,12 +21,16 @@ from fastapi import HTTPException
 from app.api.api_v1.endpoints.tenant import (
     cancel_tenant_plan,
     create_billing_portal_session,
+    get_auto_recharge_settings,
     get_tenant_invoices,
+    upsert_auto_recharge_settings,
 )
 from app.models.plan import Plan
 from app.models.subscription import Subscription
 from app.models.tenant import Tenant
 from app.models.user import User
+from app.models.wallet_auto_recharge_config import WalletAutoRechargeConfig
+from app.schemas.tenant import AutoRechargeSettingsUpsert
 
 
 def _fake_request() -> MagicMock:
@@ -272,3 +276,177 @@ class TestGetTenantInvoices:
         assert invoice.amount_due == Decimal("99")
         assert invoice.amount_paid == Decimal("99")
         assert invoice.hosted_invoice_url == "https://invoice.stripe.test/in_test_1"
+
+
+# ---------------------------------------------------------------------------
+# GET/PUT /tenants/billing/auto-recharge
+# ---------------------------------------------------------------------------
+
+
+class TestAutoRechargeSettings:
+    def test_get_returns_defaults_when_no_config_exists(self, db, tenant, user):
+        result = get_auto_recharge_settings(current_user=user, billing_user=user, db=db)
+        assert result.data.enabled is False
+        assert result.data.min_balance == Decimal("10.00")
+        assert result.data.recharge_amount == Decimal("20.00")
+        assert result.data.stripe_payment_method_id is None
+        assert result.data.last_triggered_at is None
+
+    def test_get_returns_existing_config(self, db, tenant, user):
+        config = WalletAutoRechargeConfig(
+            workspace_id=tenant.id,
+            enabled=True,
+            min_balance=Decimal("15.00"),
+            recharge_amount=Decimal("30.00"),
+            stripe_payment_method_id="pm_existing_123",
+        )
+        db.add(config)
+        db.commit()
+
+        result = get_auto_recharge_settings(current_user=user, billing_user=user, db=db)
+        assert result.data.enabled is True
+        assert result.data.min_balance == Decimal("15.00")
+        assert result.data.recharge_amount == Decimal("30.00")
+        assert result.data.stripe_payment_method_id == "pm_existing_123"
+
+    def test_put_rejects_recharge_amount_not_positive(self):
+        with pytest.raises(Exception):
+            AutoRechargeSettingsUpsert(
+                enabled=True,
+                min_balance=Decimal("10"),
+                recharge_amount=Decimal("0"),
+                stripe_payment_method_id=None,
+            )
+
+    def test_put_rejects_negative_min_balance(self):
+        with pytest.raises(Exception):
+            AutoRechargeSettingsUpsert(
+                enabled=True,
+                min_balance=Decimal("-1"),
+                recharge_amount=Decimal("10"),
+                stripe_payment_method_id=None,
+            )
+
+    def test_put_rejects_payment_method_not_belonging_to_tenant(self, db, tenant, user):
+        tenant.stripe_customer_id = "cus_owned_by_tenant"
+        db.commit()
+
+        payload = AutoRechargeSettingsUpsert(
+            enabled=True,
+            min_balance=Decimal("10"),
+            recharge_amount=Decimal("20"),
+            stripe_payment_method_id="pm_belongs_to_someone_else",
+        )
+
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.get_customer_payment_methods",
+            return_value=[{"id": "pm_actually_owned_123"}],
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                upsert_auto_recharge_settings(
+                    payload=payload, current_user=user, admin_user=user, db=db
+                )
+        assert exc_info.value.status_code == 400
+
+    def test_put_creates_config_with_valid_payment_method(self, db, tenant, user):
+        tenant.stripe_customer_id = "cus_owned_by_tenant"
+        db.commit()
+
+        payload = AutoRechargeSettingsUpsert(
+            enabled=True,
+            min_balance=Decimal("10"),
+            recharge_amount=Decimal("20"),
+            stripe_payment_method_id="pm_actually_owned_123",
+        )
+
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.get_customer_payment_methods",
+            return_value=[{"id": "pm_actually_owned_123"}],
+        ):
+            result = upsert_auto_recharge_settings(
+                payload=payload, current_user=user, admin_user=user, db=db
+            )
+
+        assert result.data.enabled is True
+        assert result.data.stripe_payment_method_id == "pm_actually_owned_123"
+
+        config = (
+            db.query(WalletAutoRechargeConfig)
+            .filter(WalletAutoRechargeConfig.workspace_id == tenant.id)
+            .first()
+        )
+        assert config is not None
+        assert config.min_balance == Decimal("10")
+        assert config.recharge_amount == Decimal("20")
+
+    def test_put_updates_existing_config(self, db, tenant, user):
+        tenant.stripe_customer_id = "cus_owned_by_tenant"
+        config = WalletAutoRechargeConfig(
+            workspace_id=tenant.id,
+            enabled=False,
+            min_balance=Decimal("10.00"),
+            recharge_amount=Decimal("20.00"),
+        )
+        db.add(config)
+        db.commit()
+
+        # enabled=True now requires a payment method (see
+        # AutoRechargeSettingsUpsert._validate_recharge_config).
+        payload = AutoRechargeSettingsUpsert(
+            enabled=True,
+            min_balance=Decimal("25"),
+            recharge_amount=Decimal("50"),
+            stripe_payment_method_id="pm_actually_owned_123",
+        )
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.get_customer_payment_methods",
+            return_value=[{"id": "pm_actually_owned_123"}],
+        ):
+            result = upsert_auto_recharge_settings(
+                payload=payload, current_user=user, admin_user=user, db=db
+            )
+        assert result.data.enabled is True
+        assert result.data.min_balance == Decimal("25")
+        assert result.data.recharge_amount == Decimal("50")
+
+        db.refresh(config)
+        assert config.enabled is True
+        assert config.min_balance == Decimal("25")
+
+    def test_put_rejects_enabled_without_payment_method(self):
+        with pytest.raises(Exception):
+            AutoRechargeSettingsUpsert(
+                enabled=True,
+                min_balance=Decimal("10"),
+                recharge_amount=Decimal("20"),
+                stripe_payment_method_id=None,
+            )
+
+    def test_put_rejects_recharge_amount_too_small_relative_to_min_balance(self):
+        with pytest.raises(Exception):
+            AutoRechargeSettingsUpsert(
+                enabled=True,
+                min_balance=Decimal("100"),
+                recharge_amount=Decimal("10"),  # < 0.5 * min_balance
+                stripe_payment_method_id="pm_test_123",
+            )
+
+    def test_put_allows_recharge_amount_at_exactly_half_min_balance(self):
+        # Boundary: recharge_amount == 0.5 * min_balance must be allowed, not rejected.
+        payload = AutoRechargeSettingsUpsert(
+            enabled=True,
+            min_balance=Decimal("100"),
+            recharge_amount=Decimal("50"),
+            stripe_payment_method_id="pm_test_123",
+        )
+        assert payload.recharge_amount == Decimal("50")
+
+    def test_put_allows_disabled_without_payment_method(self):
+        # enabled=False must never require a payment method, regardless of ratio.
+        payload = AutoRechargeSettingsUpsert(
+            enabled=False,
+            min_balance=Decimal("100"),
+            recharge_amount=Decimal("1"),
+            stripe_payment_method_id=None,
+        )
+        assert payload.enabled is False

--- a/tests/api/test_tenant_billing.py
+++ b/tests/api/test_tenant_billing.py
@@ -1,0 +1,274 @@
+"""Tests for the tenant billing-dashboard endpoints in app/api/api_v1/endpoints/tenant.py:
+
+- POST /tenants/billing/portal-session
+- POST /tenants/plan/cancel
+- GET  /tenants/billing/invoices
+
+Follows the direct-function-call pattern used by
+tests/api/test_tenant_credit_checkout.py rather than spinning up a TestClient,
+since these endpoints have no route-level behavior beyond their dependencies.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.api_v1.endpoints.tenant import (
+    cancel_tenant_plan,
+    create_billing_portal_session,
+    get_tenant_invoices,
+)
+from app.models.plan import Plan
+from app.models.subscription import Subscription
+from app.models.tenant import Tenant
+from app.models.user import User
+
+
+def _fake_request() -> MagicMock:
+    request = MagicMock()
+    request.headers = {"x-forwarded-for": "", "user-agent": "pytest"}
+    request.client = MagicMock(host="127.0.0.1")
+    request.state = MagicMock(api_key_prefix=None)
+    return request
+
+
+@pytest.fixture
+def tenant(db):
+    suffix = uuid.uuid4().hex[:8]
+    t = Tenant(
+        id=uuid.uuid4(),
+        name=f"Billing Dashboard Tenant {suffix}",
+        schema_name=f"billing_dash_{suffix}",
+        status="active",
+        credits=Decimal("0"),
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    return t
+
+
+@pytest.fixture
+def user(db, tenant):
+    suffix = uuid.uuid4().hex[:8]
+    u = User(
+        id=uuid.uuid4(),
+        email=f"billing_dash_{suffix}@example.com",
+        first_name="Test",
+        last_name="User",
+        hashed_password="x",
+        current_tenant_id=tenant.id,
+    )
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture
+def plan(db):
+    suffix = uuid.uuid4().hex[:8]
+    p = Plan(
+        id=uuid.uuid4(),
+        name=f"studio_{suffix}",
+        display_name="Studio",
+        crm_type=None,
+        included_minutes=100,
+        monthly_credits=Decimal("50"),
+        price_monthly=9900,
+    )
+    db.add(p)
+    db.commit()
+    db.refresh(p)
+    return p
+
+
+@pytest.fixture
+def active_subscription(db, tenant, user, plan):
+    sub = Subscription(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        plan_id=plan.id,
+        tenant_id=tenant.id,
+        stripe_subscription_id="sub_test_123",
+        stripe_customer_id="cus_test_123",
+        crm_type=None,
+        status="active",
+        cancel_at_period_end=False,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+
+# ---------------------------------------------------------------------------
+# POST /tenants/billing/portal-session
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBillingPortalSession:
+    def test_lazily_creates_customer_and_returns_url(self, db, tenant, user):
+        assert tenant.stripe_customer_id is None
+
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.create_customer",
+            return_value="cus_new_123",
+        ) as mock_create_customer, patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.create_portal_session",
+            return_value={"url": "https://billing.stripe.test/session_abc"},
+        ) as mock_portal:
+            result = create_billing_portal_session(
+                current_user=user,
+                admin_user=user,
+                db=db,
+            )
+
+        mock_create_customer.assert_called_once()
+        mock_portal.assert_called_once()
+        assert mock_portal.call_args[0][0] == "cus_new_123"
+        assert result.data.url == "https://billing.stripe.test/session_abc"
+
+        db.refresh(tenant)
+        assert tenant.stripe_customer_id == "cus_new_123"
+
+    def test_reuses_existing_customer_id(self, db, tenant, user):
+        tenant.stripe_customer_id = "cus_existing_456"
+        db.commit()
+
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.create_customer"
+        ) as mock_create_customer, patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.create_portal_session",
+            return_value={"url": "https://billing.stripe.test/session_def"},
+        ) as mock_portal:
+            result = create_billing_portal_session(
+                current_user=user,
+                admin_user=user,
+                db=db,
+            )
+
+        mock_create_customer.assert_not_called()
+        mock_portal.assert_called_once()
+        assert mock_portal.call_args[0][0] == "cus_existing_456"
+        assert result.data.url == "https://billing.stripe.test/session_def"
+
+    def test_stripe_failure_returns_502(self, db, tenant, user):
+        tenant.stripe_customer_id = "cus_existing_456"
+        db.commit()
+
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.create_portal_session",
+            side_effect=Exception("stripe down"),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                create_billing_portal_session(
+                    current_user=user,
+                    admin_user=user,
+                    db=db,
+                )
+        assert exc_info.value.status_code == 502
+
+
+# ---------------------------------------------------------------------------
+# POST /tenants/plan/cancel
+# ---------------------------------------------------------------------------
+
+
+class TestCancelTenantPlan:
+    def test_cancels_active_subscription_and_audit_logs(
+        self, db, tenant, user, active_subscription
+    ):
+        request = _fake_request()
+
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.cancel_subscription",
+            return_value={"status": "active"},
+        ) as mock_cancel:
+            result = cancel_tenant_plan(
+                request=request,
+                current_user=user,
+                admin_user=user,
+                db=db,
+            )
+
+        mock_cancel.assert_called_once_with("sub_test_123", at_period_end=True)
+        assert result.data.cancel_at_period_end is True
+
+        db.refresh(active_subscription)
+        assert active_subscription.cancel_at_period_end is True
+
+        from app.models.audit_log import AuditLog
+
+        audit_entry = (
+            db.query(AuditLog)
+            .filter(AuditLog.action == "billing.plan_canceled")
+            .first()
+        )
+        assert audit_entry is not None
+        assert audit_entry.tenant_id == tenant.id
+        assert audit_entry.resource_id == active_subscription.id
+
+    def test_no_active_subscription_returns_404(self, db, tenant, user):
+        request = _fake_request()
+
+        with pytest.raises(HTTPException) as exc_info:
+            cancel_tenant_plan(
+                request=request,
+                current_user=user,
+                admin_user=user,
+                db=db,
+            )
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /tenants/billing/invoices
+# ---------------------------------------------------------------------------
+
+
+class TestGetTenantInvoices:
+    def test_no_stripe_customer_returns_empty_list(self, db, tenant, user):
+        assert tenant.stripe_customer_id is None
+        result = get_tenant_invoices(current_user=user, billing_user=user, db=db)
+        assert result.data.invoices == []
+
+    def test_maps_stripe_invoice_response(self, db, tenant, user):
+        tenant.stripe_customer_id = "cus_existing_789"
+        db.commit()
+
+        fake_invoice = {
+            "id": "in_test_1",
+            "number": "INV-0001",
+            "description": None,
+            "status": "paid",
+            "currency": "usd",
+            "amount_due": 9900,
+            "amount_paid": 9900,
+            "created": 1735689600,
+            "hosted_invoice_url": "https://invoice.stripe.test/in_test_1",
+            "invoice_pdf": "https://invoice.stripe.test/in_test_1.pdf",
+            "lines": {"data": [{"description": "Studio plan - Aug"}]},
+        }
+
+        with patch(
+            "app.api.api_v1.endpoints.tenant.StripeService.get_invoices",
+            return_value=[fake_invoice],
+        ) as mock_get_invoices:
+            result = get_tenant_invoices(current_user=user, billing_user=user, db=db)
+
+        mock_get_invoices.assert_called_once_with("cus_existing_789", limit=10)
+        assert len(result.data.invoices) == 1
+        invoice = result.data.invoices[0]
+        assert invoice.id == "in_test_1"
+        assert invoice.number == "INV-0001"
+        assert invoice.description == "Studio plan - Aug"
+        assert invoice.status == "paid"
+        assert invoice.amount_due == Decimal("99")
+        assert invoice.amount_paid == Decimal("99")
+        assert invoice.hosted_invoice_url == "https://invoice.stripe.test/in_test_1"

--- a/tests/api/v2/test_sub_accounts.py
+++ b/tests/api/v2/test_sub_accounts.py
@@ -238,6 +238,190 @@ def test_create_sub_account_agency_tier_no_cap(db, agency_workspace):
         assert res.status_code == 201
 
 
+def _owner_client(db, workspace: Tenant, owner_user: User) -> TestClient:
+    """Client for the owner-only wallet-sharing endpoints — mirrors
+    tests/api/v2/test_workspace_usage_breakdown.py's convention of exercising
+    require_workspace_owner for real against the DB rather than overriding it."""
+    from app.api.deps import require_user_tenant
+    from app.api.v2.routers.workspace import v2_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(v2_router, prefix="/workspace")
+    mini.dependency_overrides[require_user_tenant] = lambda: owner_user
+    mini.dependency_overrides[get_db] = lambda: db
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _make_owner(db, tenant_id) -> User:
+    from app.models.user import user_tenant_association
+
+    suffix = uuid.uuid4().hex[:8]
+    owner = User(
+        email=f"owner-{suffix}@test.com",
+        current_tenant_id=tenant_id,
+        first_name="Owner",
+        last_name="Test",
+        hashed_password="X",
+    )
+    db.add(owner)
+    db.flush()
+    db.execute(
+        user_tenant_association.insert().values(
+            user_id=owner.id, tenant_id=tenant_id, role_id=None, is_creator=True,
+        )
+    )
+    db.commit()
+    db.refresh(owner)
+    return owner
+
+
+def test_wallet_sharing_toggle_updates_sub_account(db, agency_workspace):
+    owner = _make_owner(db, agency_workspace.id)
+    sub = Tenant(
+        name=f"sub-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="sub_account",
+        parent_workspace_id=agency_workspace.id,
+        status="active",
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+
+    client = _owner_client(db, agency_workspace, owner)
+    res = client.put(
+        f"/workspace/sub-accounts/{sub.id}/wallet-sharing",
+        json={"using_master_wallet": True},
+    )
+    assert res.status_code == 200
+    assert res.json()["using_master_wallet"] is True
+
+    db.refresh(sub)
+    assert sub.uses_master_wallet is True
+
+
+def test_wallet_sharing_toggle_rejects_non_family_sub_account(db, agency_workspace):
+    """A sub_account_id that isn't actually the caller's own sub-account must
+    be rejected, not silently trusted."""
+    owner = _make_owner(db, agency_workspace.id)
+
+    other_agency = Tenant(
+        name=f"agency-b-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="agency",
+        status="active",
+    )
+    db.add(other_agency)
+    db.commit()
+    db.refresh(other_agency)
+
+    foreign_sub = Tenant(
+        name=f"sub-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="sub_account",
+        parent_workspace_id=other_agency.id,
+        status="active",
+        # Explicit — SQLite's handling of the Boolean column's textual
+        # server_default("false") is unreliable in this test harness, unlike
+        # real Postgres.
+        uses_master_wallet=False,
+    )
+    db.add(foreign_sub)
+    db.commit()
+    db.refresh(foreign_sub)
+
+    client = _owner_client(db, agency_workspace, owner)
+    res = client.put(
+        f"/workspace/sub-accounts/{foreign_sub.id}/wallet-sharing",
+        json={"using_master_wallet": True},
+    )
+    assert res.status_code == 404
+
+    db.refresh(foreign_sub)
+    assert foreign_sub.uses_master_wallet is False
+
+
+def test_auto_link_new_workspaces_toggle(db, agency_workspace):
+    owner = _make_owner(db, agency_workspace.id)
+    client = _owner_client(db, agency_workspace, owner)
+
+    res = client.put(
+        "/workspace/auto-link-new-workspaces",
+        json={"auto_link_new_workspaces": True},
+    )
+    assert res.status_code == 200
+    assert res.json()["auto_link_new_workspaces"] is True
+
+    db.refresh(agency_workspace)
+    assert agency_workspace.auto_link_new_workspaces is True
+
+
+def test_linked_workspaces_lists_parent_and_sub_accounts(db, agency_workspace):
+    owner = _make_owner(db, agency_workspace.id)
+    sub = Tenant(
+        name=f"sub-{uuid.uuid4().hex[:8]}",
+        schema_name=f"s_{uuid.uuid4().hex[:8]}",
+        workspace_type="sub_account",
+        parent_workspace_id=agency_workspace.id,
+        status="active",
+        uses_master_wallet=True,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+
+    client = _owner_client(db, agency_workspace, owner)
+    res = client.get("/workspace/linked-workspaces")
+    assert res.status_code == 200
+    body = res.json()
+    ids = {row["id"]: row for row in body["workspaces"]}
+    assert str(agency_workspace.id) in ids
+    assert ids[str(agency_workspace.id)]["is_master"] is True
+    assert str(sub.id) in ids
+    assert ids[str(sub.id)]["using_master_wallet"] is True
+    assert ids[str(sub.id)]["is_master"] is False
+
+
+def test_auto_link_new_workspaces_true_defaults_new_sub_account_to_wallet_sharing_on(
+    db, agency_workspace,
+):
+    agency_workspace.auto_link_new_workspaces = True
+    db.commit()
+
+    client = _client(db, agency_workspace)
+    res = client.post(
+        "/workspace/sub-accounts",
+        json={"name": "Auto Linked Sub", "contact_email": "autolink@example.com"},
+    )
+    assert res.status_code == 201
+    sub_id = res.json()["id"]
+
+    sub = db.query(Tenant).filter(Tenant.id == uuid.UUID(sub_id)).first()
+    assert sub.uses_master_wallet is True
+
+
+def test_auto_link_new_workspaces_false_leaves_new_sub_account_own_wallet(
+    db, agency_workspace,
+):
+    # Explicit — SQLite's handling of the Boolean column's textual
+    # server_default("false") is unreliable in this test harness, unlike
+    # real Postgres.
+    agency_workspace.auto_link_new_workspaces = False
+    db.commit()
+
+    client = _client(db, agency_workspace)
+    res = client.post(
+        "/workspace/sub-accounts",
+        json={"name": "Non Linked Sub", "contact_email": "nolink@example.com"},
+    )
+    assert res.status_code == 201
+    sub_id = res.json()["id"]
+
+    sub = db.query(Tenant).filter(Tenant.id == uuid.UUID(sub_id)).first()
+    assert sub.uses_master_wallet is False
+
+
 def test_create_member_role_post_alias(db, agency_workspace):
     user = User(email=f"test{uuid.uuid4().hex[:8]}@x.com", current_tenant_id=agency_workspace.id, first_name="A", last_name="B", hashed_password="X")
     db.add(user)

--- a/tests/api/v2/test_workspace_usage_breakdown.py
+++ b/tests/api/v2/test_workspace_usage_breakdown.py
@@ -1,0 +1,324 @@
+"""Agency billing-dashboard reporting endpoints:
+
+  GET /api/v2/workspace/usage/breakdown[.csv]
+  GET /api/v2/workspace/usage/recent-activity
+  GET /api/v2/workspace/usage/minutes-by-month[.csv]
+
+Coverage:
+  - Owner (is_creator=True on the parent/master tenant) sees the full
+    breakdown across parent + direct sub-accounts.
+  - A non-owner admin on the same parent tenant gets 403.
+  - A user on a sub-account — even that sub-account's own creator — gets
+    403 when hitting these endpoints from the sub-account's own tenant
+    context.
+  - Growth calculation returns None (not a divide-by-zero) when last month
+    had $0 spend.
+  - A standalone workspace with no sub-accounts returns a valid single-row
+    response.
+  - CSV endpoints return text/csv with the same numbers as the JSON
+    endpoints.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from app.api.deps import get_db, require_user_tenant, require_workspace_owner
+from app.core.exception_handlers import register_exception_handlers
+from app.models.tenant import Tenant
+from app.models.usage_record import UsageRecord
+from app.models.user import User, user_tenant_association
+
+
+def _make_tenant(db, *, workspace_type="standalone", parent_workspace_id=None, created_at=None) -> Tenant:
+    suffix = uuid.uuid4().hex[:8]
+    t = Tenant(
+        id=uuid.uuid4(),
+        name=f"Tenant {suffix}",
+        schema_name=f"t_{suffix}",
+        workspace_type=workspace_type,
+        parent_workspace_id=parent_workspace_id,
+        status="active",
+    )
+    db.add(t)
+    db.commit()
+    db.refresh(t)
+    if created_at is not None:
+        db.query(Tenant).filter(Tenant.id == t.id).update({"created_at": created_at})
+        db.commit()
+        db.refresh(t)
+    return t
+
+
+def _make_member(db, tenant_id, *, is_creator: bool) -> User:
+    suffix = uuid.uuid4().hex[:8]
+    user = User(
+        email=f"user-{suffix}@test.com",
+        first_name="Test",
+        last_name="User",
+        hashed_password="x",
+        current_tenant_id=tenant_id,
+    )
+    db.add(user)
+    db.flush()
+    db.execute(
+        user_tenant_association.insert().values(
+            user_id=user.id, tenant_id=tenant_id, role_id=None, is_creator=is_creator,
+        )
+    )
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _usage(db, workspace_id, *, recorded_at, credits, minutes=Decimal("10"), call_id=None):
+    rec = UsageRecord(
+        id=uuid.uuid4(),
+        workspace_id=workspace_id,
+        call_id=call_id,
+        billable_minutes=minutes,
+        credits_charged=credits,
+        recorded_at=recorded_at,
+    )
+    db.add(rec)
+    db.commit()
+    return rec
+
+
+def _client(db, user: User) -> TestClient:
+    from app.api.v2.routers.workspace import v2_router
+
+    app = FastAPI()
+    register_exception_handlers(app)
+    app.include_router(v2_router, prefix="/workspace")
+
+    # Only bypass the outer JWT resolution — require_workspace_owner itself
+    # runs for real against the DB, so authorization behavior is genuinely
+    # exercised rather than mocked away.
+    app.dependency_overrides[require_user_tenant] = lambda: user
+    app.dependency_overrides[get_db] = lambda: db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def now():
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def parent(db, now):
+    return _make_tenant(db, workspace_type="agency", created_at=now - timedelta(days=200))
+
+
+@pytest.fixture
+def sub_account(db, parent, now):
+    return _make_tenant(
+        db, workspace_type="sub_account", parent_workspace_id=parent.id, created_at=now - timedelta(days=40)
+    )
+
+
+@pytest.fixture
+def owner(db, parent):
+    return _make_member(db, parent.id, is_creator=True)
+
+
+@pytest.fixture
+def non_owner_admin(db, parent):
+    return _make_member(db, parent.id, is_creator=False)
+
+
+# ─────────────────────────────────────────────────────── authorization ──
+
+
+class TestAuthorization:
+    def test_non_owner_admin_gets_403(self, db, parent, sub_account, non_owner_admin):
+        client = _client(db, non_owner_admin)
+        for path in (
+            "/workspace/usage/breakdown",
+            "/workspace/usage/recent-activity",
+            "/workspace/usage/minutes-by-month",
+        ):
+            res = client.get(path)
+            assert res.status_code == 403, path
+
+    def test_sub_account_creator_gets_403_from_sub_account_context(self, db, parent, sub_account, now):
+        # This user IS the creator of the sub-account itself — is_creator=True
+        # for sub_account.id — but must still be rejected because they're not
+        # the master/agency workspace's owner.
+        sub_creator = _make_member(db, sub_account.id, is_creator=True)
+        client = _client(db, sub_creator)
+        for path in (
+            "/workspace/usage/breakdown",
+            "/workspace/usage/recent-activity",
+            "/workspace/usage/minutes-by-month",
+        ):
+            res = client.get(path)
+            assert res.status_code == 403, path
+
+    def test_not_a_member_gets_403(self, db, parent):
+        stray = User(
+            email=f"stray-{uuid.uuid4().hex[:8]}@test.com",
+            first_name="S",
+            last_name="T",
+            hashed_password="x",
+            current_tenant_id=parent.id,
+        )
+        db.add(stray)
+        db.commit()
+        db.refresh(stray)
+        client = _client(db, stray)
+        res = client.get("/workspace/usage/breakdown")
+        assert res.status_code == 403
+
+    def test_require_workspace_owner_unit(self, db, parent, owner, non_owner_admin):
+        assert require_workspace_owner(user=owner, db=db) is owner
+        with pytest.raises(HTTPException) as exc:
+            require_workspace_owner(user=non_owner_admin, db=db)
+        assert exc.value.status_code == 403
+
+
+# ─────────────────────────────────────────────────────────── breakdown ──
+
+
+class TestBreakdown:
+    def test_owner_sees_full_breakdown_across_parent_and_sub_accounts(
+        self, db, parent, sub_account, owner, now
+    ):
+        this_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        _usage(db, parent.id, recorded_at=this_month_start + timedelta(days=1), credits=Decimal("10.00"))
+        _usage(db, sub_account.id, recorded_at=this_month_start + timedelta(days=1), credits=Decimal("5.00"))
+
+        client = _client(db, owner)
+        res = client.get("/workspace/usage/breakdown")
+        assert res.status_code == 200
+        data = res.json()
+
+        assert data["workspace_count"] == 2
+        names_to_master = {r["workspace_id"]: r["is_master"] for r in data["rows"]}
+        assert names_to_master[str(parent.id)] is True
+        assert names_to_master[str(sub_account.id)] is False
+
+        this_month_by_id = {r["workspace_id"]: Decimal(str(r["this_month"])) for r in data["rows"]}
+        assert this_month_by_id[str(parent.id)] == Decimal("10.00")
+        assert this_month_by_id[str(sub_account.id)] == Decimal("5.00")
+
+        assert Decimal(str(data["this_month_total"])) == Decimal("15.00")
+        assert Decimal(str(data["totals"]["this_month"])) == Decimal("15.00")
+
+    def test_growth_is_null_when_no_prior_month_spend(self, db, parent, owner, now):
+        this_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        _usage(db, parent.id, recorded_at=this_month_start + timedelta(days=1), credits=Decimal("20.00"))
+
+        client = _client(db, owner)
+        res = client.get("/workspace/usage/breakdown")
+        assert res.status_code == 200
+        data = res.json()
+        row = next(r for r in data["rows"] if r["workspace_id"] == str(parent.id))
+        assert row["growth_percent"] is None
+        assert data["this_month_growth_percent"] is None
+
+    def test_standalone_workspace_with_no_sub_accounts_returns_single_row(self, db, now):
+        standalone = _make_tenant(db, workspace_type="standalone", created_at=now - timedelta(days=10))
+        owner = _make_member(db, standalone.id, is_creator=True)
+
+        client = _client(db, owner)
+        res = client.get("/workspace/usage/breakdown")
+        assert res.status_code == 200
+        data = res.json()
+        assert data["workspace_count"] == 1
+        assert len(data["rows"]) == 1
+        assert data["rows"][0]["workspace_id"] == str(standalone.id)
+        assert data["rows"][0]["is_master"] is True
+        assert Decimal(str(data["rows"][0]["this_month"])) == Decimal("0")
+
+    def test_breakdown_csv_matches_json_numbers(self, db, parent, sub_account, owner, now):
+        this_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        _usage(db, parent.id, recorded_at=this_month_start + timedelta(days=1), credits=Decimal("10.00"))
+
+        client = _client(db, owner)
+        json_res = client.get("/workspace/usage/breakdown")
+        csv_res = client.get("/workspace/usage/breakdown.csv")
+
+        assert csv_res.status_code == 200
+        assert csv_res.headers["content-type"].startswith("text/csv")
+        assert "attachment; filename=" in csv_res.headers["content-disposition"]
+
+        json_total = str(json_res.json()["this_month_total"])
+        assert json_total in csv_res.text
+
+
+# ────────────────────────────────────────────────────────── activity ──
+
+
+class TestRecentActivity:
+    def test_last_ten_across_family_newest_first(self, db, parent, sub_account, owner, now):
+        for i in range(12):
+            _usage(
+                db,
+                parent.id if i % 2 == 0 else sub_account.id,
+                recorded_at=now - timedelta(hours=i),
+                credits=Decimal(f"{i + 1}.00"),
+                call_id=None,
+            )
+
+        client = _client(db, owner)
+        res = client.get("/workspace/usage/recent-activity")
+        assert res.status_code == 200
+        items = res.json()["items"]
+        assert len(items) == 10
+        # Newest (i=0, credits=1.00) first.
+        assert Decimal(str(items[0]["amount"])) == Decimal("-1.00")
+        assert items[0]["type"] == "call_usage"
+        assert items[0]["description"].startswith("Call ID - ")
+
+
+# ────────────────────────────────────────────────────── minutes-by-month ──
+
+
+class TestMinutesByMonth:
+    def test_three_months_aggregated_across_family(self, db, parent, sub_account, owner, now):
+        this_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        call_id = None
+        _usage(
+            db,
+            parent.id,
+            recorded_at=this_month_start + timedelta(days=1),
+            credits=Decimal("3.00"),
+            minutes=Decimal("15"),
+            call_id=call_id,
+        )
+        _usage(
+            db,
+            sub_account.id,
+            recorded_at=this_month_start + timedelta(days=1),
+            credits=Decimal("2.00"),
+            minutes=Decimal("5"),
+            call_id=call_id,
+        )
+
+        client = _client(db, owner)
+        res = client.get("/workspace/usage/minutes-by-month")
+        assert res.status_code == 200
+        months = res.json()["months"]
+        assert len(months) == 3
+        current = months[-1]
+        assert Decimal(str(current["total_minutes"])) == Decimal("20")
+        assert Decimal(str(current["total_cost"])) == Decimal("5.00")
+
+    def test_minutes_csv_matches_json(self, db, parent, owner, now):
+        this_month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        _usage(db, parent.id, recorded_at=this_month_start + timedelta(days=1), credits=Decimal("4.00"), minutes=Decimal("8"))
+
+        client = _client(db, owner)
+        json_res = client.get("/workspace/usage/minutes-by-month")
+        csv_res = client.get("/workspace/usage/minutes-by-month.csv")
+
+        assert csv_res.status_code == 200
+        assert csv_res.headers["content-type"].startswith("text/csv")
+        current_month_label = json_res.json()["months"][-1]["label"]
+        assert current_month_label in csv_res.text

--- a/tests/integration/test_wallet_auto_recharge_postgres.py
+++ b/tests/integration/test_wallet_auto_recharge_postgres.py
@@ -1,0 +1,169 @@
+"""Wallet auto-recharge cooldown-claim concurrency, against real PostgreSQL.
+
+`CreditService._maybe_trigger_wallet_auto_recharge`'s "only one charge fires
+per cooldown window even under concurrent sessions" claim relies on real
+READ COMMITTED row-lock semantics for its atomic
+`UPDATE ... WHERE last_triggered_at IS NULL OR < cutoff` claim. The
+SQLite-backed unit tests in `tests/services/test_credit_service.py` only
+exercise this sequentially in a single thread/connection, so they trivially
+pass regardless of whether the claim is actually safe under concurrency.
+
+This test races two genuinely concurrent Postgres sessions (separate
+threads, separate connections/transactions) against the same
+`WalletAutoRechargeConfig` row's claim UPDATE and asserts exactly one wins
+(`rowcount == 1`).
+
+Requires TEST_DATABASE_URL. Skipped otherwise.
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import or_
+from sqlalchemy import update as sa_update
+
+from app.models.tenant import Tenant
+from app.models.wallet_auto_recharge_config import WalletAutoRechargeConfig
+from tests.conftest import _INTEGRATION_SKIP
+
+pytestmark = [_INTEGRATION_SKIP, pytest.mark.integration]
+
+
+@pytest.fixture()
+def tenant(pg_session):
+    t = Tenant(
+        name=f"PG Wallet Tenant {uuid.uuid4().hex[:8]}",
+        schema_name=f"pg_wallet_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    pg_session.add(t)
+    pg_session.commit()
+    pg_session.refresh(t)
+    return t
+
+
+@pytest.fixture()
+def auto_recharge_config(pg_session, tenant):
+    config = WalletAutoRechargeConfig(
+        workspace_id=tenant.id,
+        enabled=True,
+        min_balance=Decimal("8.00"),
+        recharge_amount=Decimal("5.00"),
+        stripe_payment_method_id="pm_test_concurrency",
+    )
+    pg_session.add(config)
+    pg_session.commit()
+    pg_session.refresh(config)
+    return config
+
+
+def _claim(
+    pg_session_factory,
+    config_id: uuid.UUID,
+    now: datetime,
+    cutoff: datetime,
+    results: list,
+    index: int,
+):
+    """Runs the exact same atomic claim UPDATE
+    `CreditService._maybe_trigger_wallet_auto_recharge` issues, on its own
+    dedicated session/connection, and records the rowcount it got."""
+    session = pg_session_factory()
+    try:
+        claim_stmt = (
+            sa_update(WalletAutoRechargeConfig)
+            .where(
+                WalletAutoRechargeConfig.id == config_id,
+                WalletAutoRechargeConfig.enabled.is_(True),
+                WalletAutoRechargeConfig.stripe_payment_method_id.isnot(None),
+                or_(
+                    WalletAutoRechargeConfig.last_triggered_at.is_(None),
+                    WalletAutoRechargeConfig.last_triggered_at < cutoff,
+                ),
+            )
+            .values(
+                last_triggered_at=now,
+                last_trigger_status="pending",
+                last_payment_intent_id=None,
+                last_trigger_error=None,
+            )
+        )
+        result = session.execute(claim_stmt)
+        session.commit()
+        results[index] = result.rowcount
+    finally:
+        session.close()
+
+
+def test_concurrent_claim_only_one_thread_wins(
+    pg_session_factory, pg_session, auto_recharge_config
+):
+    """Two threads race the atomic cooldown-claim UPDATE on the same config
+    row (last_triggered_at is NULL, so both threads' WHERE clause initially
+    matches) — real Postgres row-lock/READ COMMITTED semantics must
+    serialize them so exactly one gets rowcount == 1 and the other gets 0."""
+    config_id = auto_recharge_config.id
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=300)
+
+    results: list[int | None] = [None, None]
+    barrier = threading.Barrier(2)
+
+    def _worker(index: int):
+        barrier.wait()  # maximize the chance both threads race the same window
+        _claim(pg_session_factory, config_id, now, cutoff, results, index)
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert None not in results, f"a claim thread did not complete: {results}"
+    assert sorted(results) == [0, 1], (
+        f"expected exactly one thread to claim the trigger (rowcount 1) and the "
+        f"other to lose (rowcount 0), got {results}"
+    )
+
+    # Sanity: the row was actually updated to reflect the winning claim.
+    pg_session.expire_all()
+    refreshed = pg_session.get(WalletAutoRechargeConfig, config_id)
+    assert refreshed.last_triggered_at is not None
+    assert refreshed.last_trigger_status == "pending"
+
+
+def test_concurrent_claim_respects_cooldown_already_claimed(
+    pg_session_factory, pg_session, auto_recharge_config
+):
+    """If the row was already claimed recently (last_triggered_at within the
+    cooldown window), a fresh concurrent claim attempt must never win."""
+    config_id = auto_recharge_config.id
+    now = datetime.now(timezone.utc)
+
+    already_claimed_at = now - timedelta(seconds=30)  # well inside the 300s cooldown
+    auto_recharge_config.last_triggered_at = already_claimed_at
+    pg_session.commit()
+
+    cutoff = now - timedelta(seconds=300)
+    results: list[int | None] = [None, None]
+    barrier = threading.Barrier(2)
+
+    def _worker(index: int):
+        barrier.wait()
+        _claim(pg_session_factory, config_id, now, cutoff, results, index)
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+
+    assert results == [
+        0,
+        0,
+    ], f"expected both claims to lose (still in cooldown), got {results}"

--- a/tests/services/test_credit_service.py
+++ b/tests/services/test_credit_service.py
@@ -14,12 +14,13 @@ Coverage:
     force-ends the call even at tenant.credits == 0; credits exhausted
     mid-overage still force-ends the call (existing behavior preserved).
 """
+
 from __future__ import annotations
 
 import uuid
 from decimal import Decimal
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -172,7 +173,9 @@ def test_effective_rate_uses_configured_pricing(db, tenant, service):
 # ---------------------------------------------------------------------------
 
 
-def test_has_sufficient_credits_allowed_by_plan_even_at_zero_credits(db, tenant, user, service):
+def test_has_sufficient_credits_allowed_by_plan_even_at_zero_credits(
+    db, tenant, user, service
+):
     _activate_plan(db, tenant, user, included_minutes=100)
     tenant.credits = Decimal("0")
     db.commit()
@@ -207,13 +210,17 @@ def test_has_sufficient_credits_realtime_model_blocked_at_zero_credits_despite_p
     tenant.credits = Decimal("0")
     db.commit()
 
-    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id, model_name="gpt-realtime")
+    ok, _, _, reason = service.has_sufficient_credits(
+        db, tenant.id, model_name="gpt-realtime"
+    )
     assert ok is False
     assert "OpenAI Realtime" in reason
 
     tenant.credits = Decimal("1")
     db.commit()
-    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id, model_name="gpt-realtime-2")
+    ok, _, _, reason = service.has_sufficient_credits(
+        db, tenant.id, model_name="gpt-realtime-2"
+    )
     assert ok is True
     assert reason == "ok"
 
@@ -227,7 +234,9 @@ def test_has_sufficient_credits_non_realtime_model_unaffected_at_zero_credits(
     tenant.credits = Decimal("0")
     db.commit()
 
-    ok, _, _, reason = service.has_sufficient_credits(db, tenant.id, model_name="gpt-4o-mini")
+    ok, _, _, reason = service.has_sufficient_credits(
+        db, tenant.id, model_name="gpt-4o-mini"
+    )
     assert ok is True
     assert reason == "ok"
 
@@ -306,7 +315,9 @@ def test_get_active_surcharges_realtime_model_excludes_elevenlabs_check(service)
     assert keys == ["openai_realtime"]
 
 
-def test_get_active_surcharges_non_realtime_elevenlabs_returns_single_surcharge(service):
+def test_get_active_surcharges_non_realtime_elevenlabs_returns_single_surcharge(
+    service,
+):
     surcharges = service.get_active_surcharges(
         model_name="gpt-4o-mini", tts_provider_slug="elevenlabs"
     )
@@ -315,7 +326,12 @@ def test_get_active_surcharges_non_realtime_elevenlabs_returns_single_surcharge(
 
 
 def test_get_active_surcharges_none_when_neither_applies(service):
-    assert service.get_active_surcharges(model_name="gpt-4o-mini", tts_provider_slug="google") == []
+    assert (
+        service.get_active_surcharges(
+            model_name="gpt-4o-mini", tts_provider_slug="google"
+        )
+        == []
+    )
 
 
 def test_get_active_surcharges_byo_elevenlabs_exempted(service):
@@ -331,7 +347,9 @@ def test_get_active_surcharges_platform_elevenlabs_still_charged(service):
     """Sanity counterpart: platform ElevenLabs (is_byo_elevenlabs=False, the
     default) is still charged."""
     surcharges = service.get_active_surcharges(
-        model_name="gpt-4o-mini", tts_provider_slug="elevenlabs", is_byo_elevenlabs=False
+        model_name="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        is_byo_elevenlabs=False,
     )
     keys = [s.key for s in surcharges]
     assert keys == ["elevenlabs_tts"]
@@ -379,13 +397,17 @@ def test_get_active_surcharges_realtime_not_fallen_back_unaffected(service):
 
 
 @pytest.mark.asyncio
-async def test_finalize_within_free_allowance_deducts_zero(db, tenant, user, call_session, service):
+async def test_finalize_within_free_allowance_deducts_zero(
+    db, tenant, user, call_session, service
+):
     _activate_plan(db, tenant, user, included_minutes=10)  # 600s remaining, 0 used
     tenant.credits = Decimal("0")
     db.commit()
 
     call_id_str = str(call_session.id)
-    service._accumulated_seconds[call_id_str] = 120.0  # 2 minutes, well within 600s allowance
+    service._accumulated_seconds[call_id_str] = (
+        120.0  # 2 minutes, well within 600s allowance
+    )
 
     await service._finalize_call_credits(
         db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session
@@ -401,8 +423,12 @@ async def test_finalize_within_free_allowance_deducts_zero(db, tenant, user, cal
 
 
 @pytest.mark.asyncio
-async def test_finalize_overage_charges_only_billable_portion(db, tenant, user, call_session, service):
-    plan, sub = _activate_plan(db, tenant, user, included_minutes=1)  # 60s remaining, 0 used so far
+async def test_finalize_overage_charges_only_billable_portion(
+    db, tenant, user, call_session, service
+):
+    plan, sub = _activate_plan(
+        db, tenant, user, included_minutes=1
+    )  # 60s remaining, 0 used so far
     tenant.credits = Decimal("10")
     db.commit()
 
@@ -424,7 +450,9 @@ async def test_finalize_overage_charges_only_billable_portion(db, tenant, user, 
 
 
 @pytest.mark.asyncio
-async def test_finalize_pay_as_you_go_charges_from_first_second(db, tenant, call_session, service):
+async def test_finalize_pay_as_you_go_charges_from_first_second(
+    db, tenant, call_session, service
+):
     # No active subscription at all.
     tenant.credits = Decimal("5")
     db.commit()
@@ -461,14 +489,23 @@ async def test_finalize_realtime_within_allowance_charges_surcharge_only(
     db.commit()
 
     call_id_str = str(call_session.id)
-    service._accumulated_seconds[call_id_str] = 120.0  # 2 minutes, fully within allowance
+    service._accumulated_seconds[call_id_str] = (
+        120.0  # 2 minutes, fully within allowance
+    )
 
     await service._finalize_call_credits(
-        db, call_session.id, tenant.id, "gpt-realtime", 12.0, call_session,
+        db,
+        call_session.id,
+        tenant.id,
+        "gpt-realtime",
+        12.0,
+        call_session,
     )
 
     db.refresh(tenant)
-    expected_surcharge = Decimal("2") * OPENAI_REALTIME_SURCHARGE_PER_MINUTE  # 2 min * 0.50
+    expected_surcharge = (
+        Decimal("2") * OPENAI_REALTIME_SURCHARGE_PER_MINUTE
+    )  # 2 min * 0.50
     assert tenant.credits == Decimal("10") - expected_surcharge
 
     record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
@@ -492,12 +529,19 @@ async def test_finalize_realtime_overage_charges_base_plus_surcharge(
     service._accumulated_seconds[call_id_str] = 120.0
 
     await service._finalize_call_credits(
-        db, call_session.id, tenant.id, "gpt-realtime-2", 12.0, call_session,
+        db,
+        call_session.id,
+        tenant.id,
+        "gpt-realtime-2",
+        12.0,
+        call_session,
     )
 
     db.refresh(tenant)
     expected_base = Decimal("12")  # 1 billable minute * 12 credits/min
-    expected_surcharge = Decimal("2") * OPENAI_REALTIME_SURCHARGE_PER_MINUTE  # 2 min * 0.50
+    expected_surcharge = (
+        Decimal("2") * OPENAI_REALTIME_SURCHARGE_PER_MINUTE
+    )  # 2 min * 0.50
     expected_total = expected_base + expected_surcharge
     assert tenant.credits == Decimal("100") - expected_total
 
@@ -520,7 +564,12 @@ async def test_finalize_non_realtime_model_unaffected_by_surcharge_logic(
     service._accumulated_seconds[call_id_str] = 120.0
 
     await service._finalize_call_credits(
-        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session,
+        db,
+        call_session.id,
+        tenant.id,
+        "gpt-4o-mini",
+        12.0,
+        call_session,
     )
 
     db.refresh(tenant)
@@ -544,15 +593,24 @@ async def test_finalize_elevenlabs_within_allowance_charges_surcharge_only(
     db.commit()
 
     call_id_str = str(call_session.id)
-    service._accumulated_seconds[call_id_str] = 120.0  # 2 minutes, fully within allowance
+    service._accumulated_seconds[call_id_str] = (
+        120.0  # 2 minutes, fully within allowance
+    )
 
     await service._finalize_call_credits(
-        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session,
+        db,
+        call_session.id,
+        tenant.id,
+        "gpt-4o-mini",
+        12.0,
+        call_session,
         tts_provider_slug="elevenlabs",
     )
 
     db.refresh(tenant)
-    expected_surcharge = Decimal("2") * ELEVENLABS_TTS_SURCHARGE_PER_MINUTE  # 2 min * 0.05
+    expected_surcharge = (
+        Decimal("2") * ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    )  # 2 min * 0.05
     assert tenant.credits == Decimal("10") - expected_surcharge
 
     record = db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
@@ -577,13 +635,20 @@ async def test_finalize_elevenlabs_overage_charges_base_plus_surcharge(
     service._accumulated_seconds[call_id_str] = 120.0
 
     await service._finalize_call_credits(
-        db, call_session.id, tenant.id, "gpt-4o-mini", 12.0, call_session,
+        db,
+        call_session.id,
+        tenant.id,
+        "gpt-4o-mini",
+        12.0,
+        call_session,
         tts_provider_slug="elevenlabs",
     )
 
     db.refresh(tenant)
     expected_base = Decimal("12")  # 1 billable minute * 12 credits/min
-    expected_surcharge = Decimal("2") * ELEVENLABS_TTS_SURCHARGE_PER_MINUTE  # 2 min * 0.05
+    expected_surcharge = (
+        Decimal("2") * ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    )  # 2 min * 0.05
     expected_total = expected_base + expected_surcharge
     assert tenant.credits == Decimal("100") - expected_total
 
@@ -604,7 +669,9 @@ def test_describe_surcharges_stacks_additively_if_both_active(service):
     surcharges = list(service.get_surcharge_catalog())  # both rules, forced
     total, _desc = service._describe_surcharges(60.0, surcharges)  # 1 minute
 
-    expected_surcharge = OPENAI_REALTIME_SURCHARGE_PER_MINUTE + ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    expected_surcharge = (
+        OPENAI_REALTIME_SURCHARGE_PER_MINUTE + ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    )
     assert round(total, 4) == float(expected_surcharge)
 
 
@@ -614,10 +681,14 @@ def test_describe_surcharges_stacks_additively_if_both_active(service):
 
 
 @pytest.mark.asyncio
-async def test_monitor_loop_does_not_force_end_within_free_allowance(db, tenant, user, call_session, service):
+async def test_monitor_loop_does_not_force_end_within_free_allowance(
+    db, tenant, user, call_session, service
+):
     """A tick fully within remaining included minutes must not force-end the
     call, even at tenant.credits == 0."""
-    _activate_plan(db, tenant, user, included_minutes=100)  # far more than one tick's worth
+    _activate_plan(
+        db, tenant, user, included_minutes=100
+    )  # far more than one tick's worth
     tenant.credits = Decimal("0")
     db.commit()
 
@@ -635,27 +706,37 @@ async def test_monitor_loop_does_not_force_end_within_free_allowance(db, tenant,
             # End the loop deterministically after one processed tick by
             # flipping the call to a terminal status for the next iteration's
             # status check (mirrors a real call hangup).
-            fresh = db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            fresh = (
+                db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            )
             fresh.status = "completed"
             fresh.ended_reason = "Customer hung up"
             db.commit()
 
-    with patch("asyncio.sleep", side_effect=_fake_sleep), \
-         patch.object(service, "_end_twilio_call", new=AsyncMock()) as mock_end_twilio, \
-         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()) as mock_broadcast:
-        await service._monitor_and_deduct_credits(call_session.id, tenant.id, "gpt-4o-mini", 12.0)
+    with patch("asyncio.sleep", side_effect=_fake_sleep), patch.object(
+        service, "_end_twilio_call", new=AsyncMock()
+    ) as mock_end_twilio, patch(
+        "app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()
+    ) as mock_broadcast:
+        await service._monitor_and_deduct_credits(
+            call_session.id, tenant.id, "gpt-4o-mini", 12.0
+        )
 
     db.refresh(tenant)
     db.refresh(call_session)
 
     assert tenant.credits == Decimal("0")
-    assert call_session.ended_reason == "Customer hung up"  # not force-ended for credits
+    assert (
+        call_session.ended_reason == "Customer hung up"
+    )  # not force-ended for credits
     mock_end_twilio.assert_not_called()
     mock_broadcast.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_monitor_loop_force_ends_call_when_credits_exhausted_mid_overage(db, tenant, call_session, service):
+async def test_monitor_loop_force_ends_call_when_credits_exhausted_mid_overage(
+    db, tenant, call_session, service
+):
     """Pay-as-you-go tenant with insufficient credits to cover overage must
     still be force-ended (existing behavior, unchanged by the plan split)."""
     tenant.credits = Decimal("0.05")  # not enough to cover the tick
@@ -681,11 +762,16 @@ async def test_monitor_loop_force_ends_call_when_credits_exhausted_mid_overage(d
         def now(cls, tz=None):
             return datetime.utcnow()
 
-    with patch("asyncio.sleep", new=AsyncMock()), \
-         patch.object(service, "_end_twilio_call", new=AsyncMock()) as mock_end_twilio, \
-         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()) as mock_broadcast, \
-         patch("app.services.credit_service.datetime", _NaiveUtcDatetime):
-        await service._monitor_and_deduct_credits(call_session.id, tenant.id, "gpt-4o-mini", 12.0)
+    with patch("asyncio.sleep", new=AsyncMock()), patch.object(
+        service, "_end_twilio_call", new=AsyncMock()
+    ) as mock_end_twilio, patch(
+        "app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()
+    ) as mock_broadcast, patch(
+        "app.services.credit_service.datetime", _NaiveUtcDatetime
+    ):
+        await service._monitor_and_deduct_credits(
+            call_session.id, tenant.id, "gpt-4o-mini", 12.0
+        )
 
     db.refresh(tenant)
     db.refresh(call_session)
@@ -704,7 +790,9 @@ async def test_monitor_loop_force_ends_realtime_call_when_surcharge_exhausts_cre
     """A realtime-model call must still be force-ended when credits run out,
     even while nominally "within the free minutes" for the base rate —
     the surcharge alone can exhaust the balance."""
-    _activate_plan(db, tenant, user, included_minutes=100)  # far more than one tick's worth
+    _activate_plan(
+        db, tenant, user, included_minutes=100
+    )  # far more than one tick's worth
     tenant.credits = Decimal("0.05")  # not enough to cover even one tick's surcharge
     db.commit()
 
@@ -719,10 +807,13 @@ async def test_monitor_loop_force_ends_realtime_call_when_surcharge_exhausts_cre
         def now(cls, tz=None):
             return datetime.utcnow()
 
-    with patch("asyncio.sleep", new=AsyncMock()), \
-         patch.object(service, "_end_twilio_call", new=AsyncMock()) as mock_end_twilio, \
-         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()) as mock_broadcast, \
-         patch("app.services.credit_service.datetime", _NaiveUtcDatetime):
+    with patch("asyncio.sleep", new=AsyncMock()), patch.object(
+        service, "_end_twilio_call", new=AsyncMock()
+    ) as mock_end_twilio, patch(
+        "app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()
+    ) as mock_broadcast, patch(
+        "app.services.credit_service.datetime", _NaiveUtcDatetime
+    ):
         await service._monitor_and_deduct_credits(
             call_session.id, tenant.id, "gpt-realtime", 12.0
         )
@@ -793,22 +884,30 @@ async def test_monitor_loop_switches_surcharge_after_mid_call_realtime_fallback(
         if calls["n"] == 2:
             # Orchestrator falls back mid-call — persist the flag exactly as
             # VoiceOrchestrator._fallback_to_legacy_pipeline_openai does.
-            fresh = db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            fresh = (
+                db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            )
             meta = dict(fresh.call_metadata or {})
             meta["openai_realtime_fallback"] = {"fell_back": True, "reason": "test"}
             fresh.call_metadata = meta
             db.commit()
             # Force a second deterministic ~60s tick.
-            service._last_deduction_time[call_id_str] = datetime.now(timezone.utc) - timedelta(seconds=60)
+            service._last_deduction_time[call_id_str] = datetime.now(
+                timezone.utc
+            ) - timedelta(seconds=60)
         elif calls["n"] >= 3:
-            fresh = db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            fresh = (
+                db.query(CallSession).filter(CallSession.id == call_session.id).first()
+            )
             fresh.status = "completed"
             fresh.ended_reason = "Customer hung up"
             db.commit()
 
-    with patch("asyncio.sleep", side_effect=_fake_sleep), \
-         patch.object(service, "_end_twilio_call", new=AsyncMock()), \
-         patch("app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()):
+    with patch("asyncio.sleep", side_effect=_fake_sleep), patch.object(
+        service, "_end_twilio_call", new=AsyncMock()
+    ), patch(
+        "app.routers.general_websocket.broadcast_call_status_update", new=AsyncMock()
+    ):
         await service._monitor_and_deduct_credits(
             call_session.id,
             tenant.id,
@@ -825,8 +924,255 @@ async def test_monitor_loop_switches_surcharge_after_mid_call_realtime_fallback(
     # Tick 2 (fallen back): ~1 min * $0.05/min ElevenLabs surcharge instead of
     # a second realtime surcharge (which would total ~$1.00 if the bug were
     # still present).
-    expected_total = OPENAI_REALTIME_SURCHARGE_PER_MINUTE + ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    expected_total = (
+        OPENAI_REALTIME_SURCHARGE_PER_MINUTE + ELEVENLABS_TTS_SURCHARGE_PER_MINUTE
+    )
     charged = float(Decimal("10") - tenant.credits)
     assert charged == pytest.approx(float(expected_total), abs=0.01)
-    assert call_session.call_metadata.get("openai_realtime_fallback", {}).get("fell_back") is True
-    assert call_session.ended_reason == "Customer hung up"
+    assert (
+        call_session.call_metadata.get("openai_realtime_fallback", {}).get("fell_back")
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wallet auto-recharge trigger (deduct_credits -> _maybe_trigger_wallet_auto_recharge)
+# ---------------------------------------------------------------------------
+
+
+def _auto_recharge_config(
+    db,
+    tenant,
+    *,
+    enabled=True,
+    min_balance="8",
+    recharge_amount="5",
+    payment_method_id="pm_test_123",
+):
+    from app.models.wallet_auto_recharge_config import WalletAutoRechargeConfig
+
+    config = WalletAutoRechargeConfig(
+        workspace_id=tenant.id,
+        enabled=enabled,
+        min_balance=Decimal(min_balance),
+        recharge_amount=Decimal(recharge_amount),
+        stripe_payment_method_id=payment_method_id,
+    )
+    db.add(config)
+    db.commit()
+    db.refresh(config)
+    return config
+
+
+def test_auto_recharge_not_triggered_when_disabled(db, tenant, service):
+    tenant.credits = Decimal("9")
+    db.commit()
+    _auto_recharge_config(db, tenant, enabled=False)
+
+    with patch.object(service, "_execute_auto_recharge_charge") as mock_charge:
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="test"
+        )
+
+    mock_charge.assert_not_called()
+
+
+def test_auto_recharge_not_triggered_when_balance_still_above_threshold(
+    db, tenant, service
+):
+    tenant.credits = Decimal("9")
+    db.commit()
+    _auto_recharge_config(db, tenant, min_balance="5")
+
+    with patch.object(service, "_execute_auto_recharge_charge") as mock_charge:
+        # 9 -> 8, still >= min_balance (5)
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=1.0, description="test"
+        )
+
+    mock_charge.assert_not_called()
+
+
+def test_auto_recharge_fires_exactly_once_per_cooldown_across_rapid_deductions(
+    db, tenant, service
+):
+    tenant.credits = Decimal("9")
+    db.commit()
+    _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    with patch.object(service, "_execute_auto_recharge_charge") as mock_charge:
+        # First deduction crosses below threshold (9 -> 7 < 8) and should claim
+        # the trigger. Subsequent rapid deductions stay below threshold too,
+        # but must be blocked by the cooldown claimed on the first call.
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="tick 1"
+        )
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=0.5, description="tick 2"
+        )
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=0.5, description="tick 3"
+        )
+
+    assert mock_charge.call_count == 1
+
+
+def test_auto_recharge_successful_charge_grants_exact_amount(db, tenant, service):
+    tenant.credits = Decimal("9")
+    tenant.stripe_customer_id = "cus_test_123"
+    db.commit()
+    _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    fake_intent = MagicMock(status="succeeded", id="pi_test_success")
+
+    with patch(
+        "app.services.stripe_service.StripeService.create_off_session_payment_intent",
+        return_value=fake_intent,
+    ) as mock_stripe_charge:
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="tick"
+        )
+
+    mock_stripe_charge.assert_called_once()
+    db.refresh(tenant)
+    # 9 (start) - 2 (deduction) + 5 (recharge) == 12
+    assert tenant.credits == Decimal("12")
+
+
+def test_auto_recharge_failed_charge_does_not_raise_or_grant_credits(
+    db, tenant, service
+):
+    tenant.credits = Decimal("9")
+    tenant.stripe_customer_id = "cus_test_123"
+    db.commit()
+    _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    with patch(
+        "app.services.stripe_service.StripeService.create_off_session_payment_intent",
+        side_effect=Exception("Your card was declined."),
+    ):
+        success, remaining = service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="tick"
+        )
+
+    # The call-site deduction itself must be unaffected by the recharge failure.
+    assert success is True
+    assert remaining == pytest.approx(7.0)
+
+    db.refresh(tenant)
+    # No credits granted — balance reflects only the deduction, not +5 recharge.
+    assert tenant.credits == Decimal("7")
+
+
+def test_auto_recharge_success_threads_idempotency_key_and_persists_trigger_trail(
+    db, tenant, service
+):
+    """Fix #1 + #2: the Stripe call must receive a per-attempt idempotency_key
+    derived from the claimed last_triggered_at, and the config row must be
+    durably updated to status=succeeded with the PaymentIntent id."""
+    tenant.credits = Decimal("9")
+    tenant.stripe_customer_id = "cus_test_123"
+    db.commit()
+    config = _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    fake_intent = MagicMock(status="succeeded", id="pi_test_idem")
+
+    with patch(
+        "app.services.stripe_service.StripeService.create_off_session_payment_intent",
+        return_value=fake_intent,
+    ) as mock_stripe_charge:
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="tick"
+        )
+
+    mock_stripe_charge.assert_called_once()
+    _, kwargs = mock_stripe_charge.call_args
+    assert kwargs.get("idempotency_key"), "idempotency_key must be passed to Stripe"
+    assert kwargs["idempotency_key"].startswith(f"auto-recharge:{config.id}:")
+
+    db.refresh(config)
+    assert config.last_trigger_status == "succeeded"
+    assert config.last_payment_intent_id == "pi_test_idem"
+    assert config.last_trigger_error is None
+
+
+def test_auto_recharge_pending_status_set_before_stripe_call_resolves(
+    db, tenant, service
+):
+    """Fix #2: last_trigger_status must be "pending" as soon as the trigger is
+    claimed, atomically with the cooldown claim UPDATE, before the Stripe call
+    is even dispatched — so a crash mid-flight still leaves a durable trail."""
+    tenant.credits = Decimal("9")
+    tenant.stripe_customer_id = "cus_test_123"
+    db.commit()
+    config = _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    with patch.object(service, "_execute_auto_recharge_charge") as mock_charge:
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="tick"
+        )
+
+    mock_charge.assert_called_once()
+    db.refresh(config)
+    assert config.last_trigger_status == "pending"
+    assert config.last_triggered_at is not None
+
+
+def test_auto_recharge_failure_persists_trigger_trail_with_error(db, tenant, service):
+    """Fix #2: a failed Stripe call must update last_trigger_status="failed"
+    with error detail, not just log it."""
+    tenant.credits = Decimal("9")
+    tenant.stripe_customer_id = "cus_test_123"
+    db.commit()
+    config = _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    with patch(
+        "app.services.stripe_service.StripeService.create_off_session_payment_intent",
+        side_effect=Exception("Your card was declined."),
+    ):
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="tick"
+        )
+
+    db.refresh(config)
+    assert config.last_trigger_status == "failed"
+    assert config.last_trigger_error and "declined" in config.last_trigger_error
+
+
+async def test_auto_recharge_task_tracked_and_cleaned_up_on_completion(
+    db, tenant, service
+):
+    """Fix #3: in an async context, the dispatched charge task must be
+    strongly referenced in `_active_auto_recharge_tasks` until it completes,
+    and removed afterward (mirroring `_active_monitors` cleanup)."""
+    import asyncio
+
+    tenant.credits = Decimal("9")
+    tenant.stripe_customer_id = "cus_test_123"
+    db.commit()
+    _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    fake_intent = MagicMock(status="succeeded", id="pi_test_tracked")
+    seen_task_present = {}
+
+    async def _await_and_check():
+        # Give the dispatched task a moment to be registered, then assert it's tracked.
+        await asyncio.sleep(0)
+        seen_task_present["during"] = len(service._active_auto_recharge_tasks) == 1
+
+    with patch(
+        "app.services.stripe_service.StripeService.create_off_session_payment_intent",
+        return_value=fake_intent,
+    ):
+        service.deduct_credits(
+            db=db, tenant_id=tenant.id, amount=2.0, description="tick"
+        )
+        await _await_and_check()
+        # Let the to_thread task finish.
+        for _ in range(50):
+            if not service._active_auto_recharge_tasks:
+                break
+            await asyncio.sleep(0.02)
+
+    assert seen_task_present.get("during") is True
+    assert service._active_auto_recharge_tasks == {}

--- a/tests/services/test_credit_service.py
+++ b/tests/services/test_credit_service.py
@@ -1139,6 +1139,276 @@ def test_auto_recharge_failure_persists_trigger_trail_with_error(db, tenant, ser
     assert config.last_trigger_error and "declined" in config.last_trigger_error
 
 
+def _sub_account(db, parent, *, uses_master_wallet):
+    suffix = uuid.uuid4().hex[:8]
+    sub = Tenant(
+        id=uuid.uuid4(),
+        name=f"Sub Account {suffix}",
+        schema_name=f"credit_test_sub_{suffix}",
+        status="active",
+        credits=Decimal("0"),
+        parent_workspace_id=parent.id,
+        workspace_type="sub_account",
+        uses_master_wallet=uses_master_wallet,
+    )
+    db.add(sub)
+    db.commit()
+    db.refresh(sub)
+    return sub
+
+
+# ---------------------------------------------------------------------------
+# Wallet sharing — _resolve_billing_tenant_id and its effect on
+# has_sufficient_credits / the live billing loop / auto-recharge.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_billing_tenant_id_sharing_off_resolves_to_self(db, tenant, service):
+    sub = _sub_account(db, tenant, uses_master_wallet=False)
+    assert service._resolve_billing_tenant_id(db, sub.id) == sub.id
+
+
+def test_resolve_billing_tenant_id_sharing_on_resolves_to_parent(db, tenant, service):
+    sub = _sub_account(db, tenant, uses_master_wallet=True)
+    assert service._resolve_billing_tenant_id(db, sub.id) == tenant.id
+
+
+def test_resolve_billing_tenant_id_sharing_on_but_no_parent_resolves_to_self(
+    db, tenant, service
+):
+    """Guards against a data anomaly: uses_master_wallet=True with no
+    parent_workspace_id must never resolve to itself-as-parent or blow up."""
+    tenant.uses_master_wallet = True
+    db.commit()
+    assert service._resolve_billing_tenant_id(db, tenant.id) == tenant.id
+
+
+def test_has_sufficient_credits_wallet_sharing_gates_on_parent_balance(
+    db, tenant, user, service
+):
+    """Sub-account has 0 credits of its own but the parent has plenty —
+    wallet sharing must gate the balance check on the PARENT, and the
+    included-minutes allowance check must still use the sub-account's own
+    (absent) plan."""
+    sub = _sub_account(db, tenant, uses_master_wallet=True)
+    sub.credits = Decimal("0")
+    tenant.credits = Decimal("50")
+    db.commit()
+
+    ok, current_credits, _, reason = service.has_sufficient_credits(db, sub.id)
+    assert ok is True
+    assert current_credits == 50.0
+    assert reason == "ok"
+
+
+def test_has_sufficient_credits_wallet_sharing_off_regression(
+    db, tenant, user, service
+):
+    """Wallet sharing OFF: sub-account bills itself as before — a 0-balance
+    sub-account is blocked even if its parent has plenty of credits."""
+    sub = _sub_account(db, tenant, uses_master_wallet=False)
+    sub.credits = Decimal("0")
+    tenant.credits = Decimal("50")
+    db.commit()
+
+    ok, current_credits, _, reason = service.has_sufficient_credits(db, sub.id)
+    assert ok is False
+    assert current_credits == 0.0
+
+
+@pytest.mark.asyncio
+async def test_finalize_wallet_sharing_drains_parent_not_sub_account(
+    db, tenant, user, service
+):
+    """A wallet-sharing sub-account's overage call must drain the PARENT's
+    Tenant.credits — the sub-account's own balance (0) must stay untouched —
+    while the included-minutes usage is still recorded against the
+    sub-account itself."""
+    sub = _sub_account(db, tenant, uses_master_wallet=True)
+    sub.credits = Decimal("0")
+    tenant.credits = Decimal("50")
+    db.commit()
+
+    agent = Agent(tenant_id=sub.id, name="Sub Agent")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+
+    cs = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=sub.id,
+        start_time=datetime.now(timezone.utc),
+        status="active",
+        call_type="inbound",
+        twilio_call_sid="CA_wallet_sharing_test",
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+
+    call_id_str = str(cs.id)
+    # No plan/subscription for the sub-account -> pay-as-you-go, fully billable.
+    service._accumulated_seconds[call_id_str] = 30.0  # 0.5 min
+
+    await service._finalize_call_credits(db, cs.id, sub.id, "gpt-4o-mini", 12.0, cs)
+
+    db.refresh(tenant)
+    db.refresh(sub)
+
+    # 0.5 min * 12 credits/min = 6 credits, deducted from the PARENT.
+    assert tenant.credits == Decimal("50") - Decimal("6")
+    assert sub.credits == Decimal("0")  # sub-account's own balance untouched
+
+    # Usage/minutes are still recorded against the CALLING (sub-account) tenant.
+    record = db.query(UsageRecord).filter(UsageRecord.workspace_id == sub.id).first()
+    assert record is not None
+    assert round(float(record.credits_charged), 2) == 6.0
+    assert (
+        db.query(UsageRecord).filter(UsageRecord.workspace_id == tenant.id).first()
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_wallet_sharing_included_minutes_still_own_plan(
+    db, tenant, user, service
+):
+    """Included-minutes allowance must still be checked/depleted against the
+    sub-account's OWN plan regardless of wallet-sharing status — the parent
+    having its own separate plan must not matter here."""
+    sub = _sub_account(db, tenant, uses_master_wallet=True)
+    _activate_plan(db, sub, user, included_minutes=10)  # 600s remaining, own plan
+    sub.credits = Decimal("0")
+    tenant.credits = Decimal("50")
+    db.commit()
+
+    agent = Agent(tenant_id=sub.id, name="Sub Agent")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+
+    cs = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=sub.id,
+        start_time=datetime.now(timezone.utc),
+        status="active",
+        call_type="inbound",
+        twilio_call_sid="CA_wallet_sharing_allowance_test",
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+
+    call_id_str = str(cs.id)
+    service._accumulated_seconds[call_id_str] = 120.0  # 2 min, well within 600s
+
+    await service._finalize_call_credits(db, cs.id, sub.id, "gpt-4o-mini", 12.0, cs)
+
+    db.refresh(tenant)
+    db.refresh(sub)
+
+    # Fully within the sub-account's own included minutes -> 0 credits charged,
+    # neither the sub-account's nor the parent's balance moves.
+    assert tenant.credits == Decimal("50")
+    assert sub.credits == Decimal("0")
+
+
+@pytest.mark.asyncio
+async def test_finalize_uses_billing_tenant_pinned_at_call_start_not_current_toggle(
+    db, tenant, user, service
+):
+    """Regression: _finalize_call_credits must bill against the
+    billing_tenant_id resolved ONCE at monitoring-loop start (passed in
+    explicitly), not re-derive it from the CURRENT uses_master_wallet value.
+    Otherwise a wallet-sharing toggle that fires mid-call (a real, owner-only
+    action) would split a single call's cost across two tenants' wallets:
+    ticks before the toggle bill one tenant, the final catch-up deduction
+    re-reads the new toggle state and bills the other."""
+    sub = _sub_account(db, tenant, uses_master_wallet=True)
+    sub.credits = Decimal("100")
+    tenant.credits = Decimal("50")
+    db.commit()
+
+    agent = Agent(tenant_id=sub.id, name="Sub Agent")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+
+    cs = CallSession(
+        user_id=user.id,
+        agent_id=agent.id,
+        tenant_id=sub.id,
+        start_time=datetime.now(timezone.utc),
+        status="active",
+        call_type="inbound",
+        twilio_call_sid="CA_wallet_sharing_toggle_mid_call",
+    )
+    db.add(cs)
+    db.commit()
+    db.refresh(cs)
+
+    # Billing tenant resolved at call start, while wallet sharing is still ON.
+    billing_tenant_id_at_start = service._resolve_billing_tenant_id(db, sub.id)
+    assert billing_tenant_id_at_start == tenant.id
+
+    # Parent (owner-only action) toggles wallet sharing OFF mid-call.
+    sub.uses_master_wallet = False
+    db.commit()
+
+    call_id_str = str(cs.id)
+    service._accumulated_seconds[call_id_str] = 30.0  # 0.5 min
+
+    # Finalize is called the way _monitor_and_deduct_credits actually calls
+    # it: with the pinned billing_tenant_id from call start, NOT re-derived.
+    await service._finalize_call_credits(
+        db,
+        cs.id,
+        sub.id,
+        "gpt-4o-mini",
+        12.0,
+        cs,
+        billing_tenant_id=billing_tenant_id_at_start,
+    )
+
+    db.refresh(tenant)
+    db.refresh(sub)
+
+    # 0.5 min * 12 credits/min = 6 credits — still charged to the PARENT
+    # (the pinned billing tenant), even though the toggle is now OFF.
+    assert tenant.credits == Decimal("50") - Decimal("6")
+    assert sub.credits == Decimal("100")  # untouched despite toggle now being off
+
+
+def test_auto_recharge_triggers_against_parent_config_for_wallet_sharing_sub_account(
+    db, tenant, service
+):
+    """The parent may have its own WalletAutoRechargeConfig while the
+    sub-account has none configured at all — deduct_credits called with the
+    resolved billing tenant (the parent) must trigger the PARENT's config,
+    since deduct_credits has no notion of wallet sharing itself."""
+    sub = _sub_account(db, tenant, uses_master_wallet=True)
+    tenant.credits = Decimal("9")
+    tenant.stripe_customer_id = "cus_test_parent"
+    db.commit()
+    _auto_recharge_config(db, tenant, min_balance="8", recharge_amount="5")
+
+    billing_tenant_id = service._resolve_billing_tenant_id(db, sub.id)
+    assert billing_tenant_id == tenant.id
+
+    with patch.object(service, "_execute_auto_recharge_charge") as mock_charge:
+        # Simulates what the billing loop now does: deduct against the
+        # resolved billing tenant, not the calling sub-account.
+        service.deduct_credits(
+            db=db, tenant_id=billing_tenant_id, amount=2.0, description="tick"
+        )
+
+    mock_charge.assert_called_once()
+    args, _ = mock_charge.call_args
+    assert args[0] == tenant.id  # triggered for the PARENT, not the sub-account
+
+
 async def test_auto_recharge_task_tracked_and_cleaned_up_on_completion(
     db, tenant, service
 ):


### PR DESCRIPTION
## Summary

Follow-up to #217 (already merged) — builds out the full tenant billing-dashboard backend on the same branch:

- `GET /tenants/plan` now also reports monthly price, effective per-minute rate, subscription status, and next billing date.
- `POST /tenants/billing/portal-session` (Stripe billing portal, admin-only), `POST /tenants/plan/cancel` (cancel at period end, audit-logged), `GET /tenants/billing/invoices` (Stripe invoice history).
- Owner-only (workspace-creator-only) cross-workspace usage reporting: `GET /workspace/usage/breakdown(.csv)`, `/recent-activity`, `/minutes-by-month(.csv)` — spend/minutes aggregated across an agency tenant and its direct sub-accounts, gated by a new `require_workspace_owner` dependency that rejects both non-creator admins and sub-account contexts.
- Wallet auto-recharge: tenants can configure a minimum-balance threshold and recharge amount; once `tenant.credits` drops below it, the platform automatically charges their saved Stripe payment method off-session (idempotency-keyed, cooldown-protected via an atomic claim UPDATE verified race-safe against real concurrent Postgres sessions, with a durable trigger trail and a tracked async task so no outcome is silently lost).
- Wallet sharing: a sub-account can be toggled to draw call overage/surcharge credits from its parent tenant's balance instead of its own (its own plan's included-minutes allowance still applies independently), with parent-controlled settings endpoints and an `auto_link_new_workspaces` default for newly created sub-accounts.

## Test plan
- [x] `pytest tests/` — 1268+ passed across affected suites, 0 failed (full-suite run also completed clean earlier in the branch's history)
- [x] Migrations applied and verified against real Postgres (disposable containers), including a dedicated concurrency test proving the auto-recharge cooldown claim is race-safe under genuinely concurrent sessions
- [x] `ruff check .` clean on all touched files
- [x] Every feature went through implementation → code review → fix pass; the two money-moving features (auto-recharge, wallet sharing) got a second review round given real-money risk — findings included and fixed: a Stripe idempotency gap (double-charge risk), an untracked fire-and-forget task, a mid-call wallet-sharing toggle race that could split one call's billing across two tenants, and a balance-leak in the outbound-call 402 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPN1hgjPzsVUTcvCDnR1vW