### PR TITLE
fix(billing): new tenants start with 0 credits instead of 50

### DIFF
--- a/app/api/api_v1/endpoints/tenant.py
+++ b/app/api/api_v1/endpoints/tenant.py
@@ -78,8 +78,7 @@ def create_tenant(tenant_in: TenantCreate, current_user: User = Depends(get_curr
     db_tenant = Tenant(
         name=tenant_in.name,
         schema_name=schema_name,
-        status="pending_payment",
-        credits=50
+        status="pending_payment"
     )
     
     db.add(db_tenant)

--- a/app/api/api_v1/endpoints/user.py
+++ b/app/api/api_v1/endpoints/user.py
@@ -79,8 +79,7 @@ def register_user(user_in: UserCreate, db: Session = Depends(get_db)):
     db_tenant = Tenant(
         name=tenant_name,
         schema_name=schema_name,
-        status="pending_payment",
-        credits=50
+        status="pending_payment"
     )
     
     db.add(db_tenant)
@@ -309,8 +308,7 @@ def google_login(
         db_tenant = Tenant(
             name=tenant_name,
             schema_name=schema_name,
-            status="pending_payment",
-            credits=50
+            status="pending_payment"
         )
         db.add(db_tenant)
         db.commit()


### PR DESCRIPTION
## Summary
- Removes the hardcoded `credits=50` grant at all three tenant-creation call sites: `POST /api/v1/tenant/create`, `POST /api/v1/user/register`, and Google OAuth first-time signup in `user.py::google_login`
- New tenants now fall through to `Tenant.credits`'s existing column default of `0`
- Targets `feat/studio-agency-billing-plans` (the branch this logic currently lives on)

## Test plan
- [ ] Confirm a freshly registered tenant (email signup) has `credits == 0`
- [ ] Confirm a Google OAuth first-time signup tenant has `credits == 0`
- [ ] Confirm manually creating an additional tenant via `/api/v1/tenant/create` has `credits == 0`

https://claude.ai/code/session_01FP58Xx97NrqBev9T9BszrJ