### PR TITLE
feat: Implement Call Screening Detection Settings & Real-Time Pipeline Wiring

### DIFF
--- a/alembic/versions/b3e81a942cd1_add_call_screening_action_to_call_flow.py
+++ b/alembic/versions/b3e81a942cd1_add_call_screening_action_to_call_flow.py
@@ -1,0 +1,36 @@
+"""add_call_screening_action_to_call_flow
+
+Revision ID: b3e81a942cd1
+Revises: 9a4d8c12b7f0
+Create Date: 2026-08-25 18:03:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b3e81a942cd1'
+down_revision: Union[str, Sequence[str], None] = '9a4d8c12b7f0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'call_screening_action',
+            sa.String(length=50),
+            server_default='respond',
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('callflow', 'call_screening_action')

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -48,6 +48,8 @@ from app.schemas.ab_testing import (
 from app.schemas.call_flow import (
     CallerMemorySettingsResponse,
     CallerMemorySettingsUpdate,
+    CallScreeningSettingsResponse,
+    CallScreeningSettingsUpdate,
     PaginatedSystemWebhookDeliveries,
     PostCallActionsSettingsResponse,
     PostCallActionsSettingsUpdate,
@@ -297,6 +299,68 @@ def get_voicemail_settings(
     db: Session = Depends(get_db),
 ) -> VoicemailSettingsResponse:
     return call_flow_service.get_voicemail_settings(
+        db, flow_id, _tenant_id(principal)
+    )
+
+
+@router.put(
+    "/{flow_id}/call-screening-settings",
+    response_model=CallScreeningSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Configure Call Screening Detection settings on a call flow",
+    description=(
+        "Configures the action to take when an automated call screener "
+        "(Google Call Screen, Apple/iOS Call Screen, Samsung Smart Call, IVR screeners) "
+        "answers an outbound call.\n\n"
+        "- **Action** (`call_screening_action`): `respond` (agent states who is calling and why) "
+        "or `hang_up` (disconnect immediately).\n\n"
+        "Requires admin rank."
+    ),
+)
+def update_call_screening_settings(
+    flow_id: uuid.UUID,
+    body: CallScreeningSettingsUpdate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> CallScreeningSettingsResponse:
+    tenant_id = _tenant_id(principal)
+    result = call_flow_service.update_call_screening_settings(
+        db, flow_id, tenant_id, body
+    )
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="call_screening_settings.updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        new_value={
+            "call_screening_action": result.call_screening_action,
+        },
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.get(
+    "/{flow_id}/call-screening-settings",
+    response_model=CallScreeningSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the currently-saved Call Screening Detection settings for a call flow",
+    description=(
+        "Returns the currently-saved Call Screening configuration for this call flow "
+        "(action: respond or hang_up). "
+        "Read-only rank is sufficient since no secret keys are exposed."
+    ),
+)
+def get_call_screening_settings(
+    flow_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> CallScreeningSettingsResponse:
+    return call_flow_service.get_call_screening_settings(
         db, flow_id, _tenant_id(principal)
     )
 

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -186,6 +186,11 @@ class CallFlow(Base):
         Integer, default=5, nullable=False, server_default="5"
     )
 
+    # Call Screening Detection Settings: action when automated screener (Google, Samsung, IVR) answers
+    call_screening_action = Column(
+        String(50), default="respond", nullable=False, server_default="respond"
+    )
+
     hipaa_compliance = Column(
         Boolean, default=False, nullable=False, server_default="false"
     )

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -1227,6 +1227,10 @@ class BidirectionalStreamHandler(
                 if await self._check_and_end_call_if_voicemail(transcript):
                     return  # Stop processing - call is ending
 
+                # 🎯 Check for call screening detection - end call if action is hang_up
+                if await self._check_and_handle_call_screener(transcript):
+                    return  # Stop processing - call is ending
+
                 # 🎯 Send "in-progress" status when confident word is detected (like "hello")
                 if (
                     not self._in_progress_sent

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -319,6 +319,30 @@ class VoicemailSettingsResponse(BaseModel):
     voicemail_detection_timeout: int = 5
 
 
+class CallScreeningActionEnum(str, Enum):
+    RESPOND = "respond"
+    HANG_UP = "hang_up"
+
+
+class CallScreeningSettingsUpdate(BaseModel):
+    """Request body for ``PUT /api/v2/flows/{flow_id}/call-screening-settings``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    call_screening_action: CallScreeningActionEnum = Field(
+        default=CallScreeningActionEnum.RESPOND,
+        description="Action to take when an automated call screener is detected: respond or hang_up.",
+    )
+
+
+class CallScreeningSettingsResponse(BaseModel):
+    """Response body for ``GET/PUT /api/v2/flows/{flow_id}/call-screening-settings``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    call_screening_action: str = "respond"
+
+
 class SystemWebhooksSettingsUpdate(BaseModel):
     """Request body for ``PUT /api/v2/flows/{flow_id}/system-webhooks-settings``.
 

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -33,6 +33,8 @@ from app.schemas.call_flow import (
     CallFlowListItem,
     CallFlowOut,
     AgentRef,
+    CallScreeningSettingsResponse,
+    CallScreeningSettingsUpdate,
     CallerMemorySettingsResponse,
     CallerMemorySettingsUpdate,
     CallFlowSettingsUpdate,
@@ -839,6 +841,47 @@ class CallFlowService:
             voicemail_message=flow.voicemail_message,
             voicemail_advanced_detection_enabled=bool(flow.voicemail_advanced_detection_enabled),
             voicemail_detection_timeout=flow.voicemail_detection_timeout or 5,
+        )
+
+    # ── Call Screening Detection Settings ───────────────────────────────────
+
+    def update_call_screening_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: CallScreeningSettingsUpdate,
+    ) -> CallScreeningSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        repo = CallFlowRepository(db)
+        action_val = (
+            body.call_screening_action.value
+            if hasattr(body.call_screening_action, "value")
+            else str(body.call_screening_action)
+        )
+        flow = repo.update(
+            flow,
+            {
+                "call_screening_action": action_val,
+            },
+        )
+        db.commit()
+        db.refresh(flow)
+        return CallScreeningSettingsResponse(
+            call_screening_action=flow.call_screening_action or "respond",
+        )
+
+    def get_call_screening_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> CallScreeningSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        return CallScreeningSettingsResponse(
+            call_screening_action=flow.call_screening_action or "respond",
         )
 
     # ── System Webhooks (pre-inbound / dynamic routing / post-call / status) ──

--- a/app/voice/call_control_mixin.py
+++ b/app/voice/call_control_mixin.py
@@ -479,6 +479,115 @@ class CallControlMixin:
                     return False
         
         return False
+
+    async def _check_and_handle_call_screener(self, transcript: str) -> bool:
+        """
+        Check if transcript contains automated call screening phrases and execute configured action.
+        Returns True if call was ended (hang_up action), False otherwise (respond action / no screener).
+
+        Supported call screening services:
+        - Google Call Screen / Assistant Call Screening
+        - Apple / iOS Call Screen
+        - Samsung Smart Call / Bixby Call Assist
+        - Automated IVR screening
+        """
+        if self._call_ended:
+            return False
+
+        screener_keywords = [
+            "using a screening service",
+            "screening service from google",
+            "screening service",
+            "google call screen",
+            "go ahead and say why you're calling",
+            "state your name and why you're calling",
+            "who is calling and why",
+            "please say your name and reason for calling",
+        ]
+
+        transcript_lower = transcript.lower().strip()
+        for keyword in screener_keywords:
+            if keyword in transcript_lower:
+                flow = getattr(self, "call_flow", None)
+                if flow is None and self.call_session and self.call_session.call_flow_id and getattr(self, "db", None):
+                    try:
+                        from app.models.call_flow import CallFlow
+
+                        flow = self.db.get(CallFlow, self.call_session.call_flow_id)
+                    except Exception:
+                        flow = None
+
+                action = (
+                    getattr(flow, "call_screening_action", "respond")
+                    if flow
+                    else "respond"
+                )
+
+                if action == "hang_up":
+                    try:
+                        self._call_ended = True
+
+                        if self.call_session:
+                            updated = call_session_service.update_call_session_status(
+                                self.db,
+                                self.call_session.id,
+                                "completed",
+                                ended_reason="Call screener detected",
+                            )
+                            if updated:
+                                self.call_session = updated
+
+                        if self.call_sid and self.call_session:
+                            try:
+                                account_sid, auth_token = get_twilio_credentials_for_call(
+                                    self.db, self.call_session
+                                )
+                                twilio_service.end_call_with_credentials(
+                                    self.call_sid, account_sid, auth_token
+                                )
+                            except Exception as end_err:
+                                logger.warning(
+                                    "Could not end Twilio call with DB credentials "
+                                    "(call_sid=%s, session=%s): %s",
+                                    self.call_sid,
+                                    self.call_session.id if self.call_session else None,
+                                    end_err,
+                                )
+
+                        if self.call_session:
+                            try:
+                                await broadcast_call_status_update(
+                                    call_session_id=str(self.call_session.id),
+                                    status="completed",
+                                    metadata={
+                                        "call_sid": self.call_sid,
+                                        "stream_sid": self.stream_sid,
+                                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                                        "message": "call_ended",
+                                        "event": "call_screener_detected",
+                                        "detected_phrase": keyword,
+                                        "transcript": transcript,
+                                        "reason": "Call screener detected",
+                                    },
+                                )
+                            except Exception as e:
+                                logger.debug(f"WebSocket broadcast failed after screener detection: {e}")
+
+                        asyncio.create_task(self._full_shutdown())
+                        return True
+
+                    except Exception as e:
+                        logger.error(f"Error ending call after call screener detection: {e}", exc_info=True)
+                        return False
+                else:
+                    # action == "respond" -> do not hang up, allow conversation to proceed
+                    logger.info(
+                        "Call screener detected ('%s'); responding to screener per call flow configuration",
+                        keyword,
+                    )
+                    return False
+
+        return False
     
     async def _add_to_transcript(
         self,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9029,6 +9029,83 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/call-screening-settings:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Configure Call Screening Detection settings on a call flow
+      description: 'Configures the action to take when an automated call screener
+        (Google Call Screen, Apple/iOS Call Screen, Samsung Smart Call, IVR screeners)
+        answers an outbound call.
+
+
+        - **Action** (`call_screening_action`): `respond` (agent states who is calling
+        and why) or `hang_up` (disconnect immediately).
+
+
+        Requires admin rank.'
+      operationId: update_call_screening_settings_api_v2_flows__flow_id__call_screening_settings_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallScreeningSettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallScreeningSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - A/B Prompt Testing
+      summary: Get the currently-saved Call Screening Detection settings for a call
+        flow
+      description: 'Returns the currently-saved Call Screening configuration for this
+        call flow (action: respond or hang_up). Read-only rank is sufficient since
+        no secret keys are exposed.'
+      operationId: get_call_screening_settings_api_v2_flows__flow_id__call_screening_settings_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallScreeningSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/system-webhooks-settings:
     put:
       tags:
@@ -12911,6 +12988,32 @@ components:
       required:
       - memory_context
       title: CallMemoryContextResponse
+    CallScreeningActionEnum:
+      type: string
+      enum:
+      - respond
+      - hang_up
+      title: CallScreeningActionEnum
+    CallScreeningSettingsResponse:
+      properties:
+        call_screening_action:
+          type: string
+          title: Call Screening Action
+          default: respond
+      type: object
+      title: CallScreeningSettingsResponse
+      description: Response body for ``GET/PUT /api/v2/flows/{flow_id}/call-screening-settings``.
+    CallScreeningSettingsUpdate:
+      properties:
+        call_screening_action:
+          $ref: '#/components/schemas/CallScreeningActionEnum'
+          description: 'Action to take when an automated call screener is detected:
+            respond or hang_up.'
+          default: respond
+      additionalProperties: false
+      type: object
+      title: CallScreeningSettingsUpdate
+      description: Request body for ``PUT /api/v2/flows/{flow_id}/call-screening-settings``.
     CallSessionList:
       properties:
         sessions:

--- a/tests/api/v2/test_call_screening_settings.py
+++ b/tests/api/v2/test_call_screening_settings.py
@@ -1,0 +1,349 @@
+"""Tests for PUT and GET /api/v2/flows/{flow_id}/call-screening-settings.
+
+Coverage:
+  - Admin/API-key principal can configure call_screening_action ('respond', 'hang_up')
+  - Default value on fresh flows is 'respond'
+  - Validation: invalid action rejected (400)
+  - Extra fields rejected (extra="forbid")
+  - Non-admin (config_only, read_only, billing_only) principals forbidden on PUT (403)
+  - Read-only rank is sufficient to view settings via GET (200)
+  - Tenant isolation: unknown flow_id or other tenant flow returns 404 on PUT and GET
+  - Audit event logged on successful PUT (action="call_screening_settings.updated")
+  - GET round-trips prior PUT updates accurately
+  - GET handles null/none attribute fallback
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_admin_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_admin_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_admin_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_readonly_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_readonly_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_readonly_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_app_for_real_rank_check(db_override, principal):
+    from app.api.deps import get_db, require_tenant
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    mini.dependency_overrides[require_tenant] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _with_effective_role(role_name: str):
+    return patch(
+        "app.api.deps.rbac.rbac_cache_service.get_effective_role",
+        return_value=role_name,
+    )
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"CallScreenWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"call_screen_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def other_workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"OtherCallScreenWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"other_call_screen_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Call Screen Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, workspace, agent):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=workspace.id,
+        agent_id=agent.id,
+        name="Call Screen Test Flow",
+        direction="outbound",
+        status="active",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+class TestUpdateCallScreeningSettings:
+    def test_admin_can_set_hang_up_action(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-screening-settings",
+            json={"call_screening_action": "hang_up"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["call_screening_action"] == "hang_up"
+
+        db.refresh(flow)
+        assert flow.call_screening_action == "hang_up"
+
+    def test_admin_can_set_respond_action(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-screening-settings",
+            json={"call_screening_action": "respond"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["call_screening_action"] == "respond"
+
+        db.refresh(flow)
+        assert flow.call_screening_action == "respond"
+
+    def test_invalid_action_returns_400(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-screening-settings",
+            json={"call_screening_action": "invalid_action"},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_extra_fields_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-screening-settings",
+            json={
+                "call_screening_action": "respond",
+                "unknown_extra_field": "disallowed",
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{uuid.uuid4()}/call-screening-settings",
+            json={"call_screening_action": "hang_up"},
+        )
+        assert resp.status_code == 404
+
+    def test_flow_from_other_tenant_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_app(db, foreign_principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-screening-settings",
+            json={"call_screening_action": "hang_up"},
+        )
+        assert resp.status_code == 404
+
+    def test_update_fires_audit_event(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        with patch("app.api.v2.routers.flows.log_audit_event") as mock_audit:
+            resp = client.put(
+                f"/flows/{flow.id}/call-screening-settings",
+                json={"call_screening_action": "hang_up"},
+            )
+            assert resp.status_code == 200
+
+        mock_audit.assert_called_once()
+        _, kwargs = mock_audit.call_args
+        assert kwargs["action"] == "call_screening_settings.updated"
+        assert kwargs["resource_type"] == "call_flow"
+        assert kwargs["resource_id"] == flow.id
+        assert kwargs["new_value"] == {
+            "call_screening_action": "hang_up",
+        }
+
+    def test_non_admin_forbidden_on_put(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for non_admin_role in ["config_only", "read_only", "billing_only"]:
+            with _with_effective_role(non_admin_role):
+                resp = client.put(
+                    f"/flows/{flow.id}/call-screening-settings",
+                    json={"call_screening_action": "hang_up"},
+                )
+                assert resp.status_code == 403, (
+                    f"Expected 403 for role '{non_admin_role}', got {resp.status_code}"
+                )
+
+
+class TestGetCallScreeningSettings:
+    def test_fresh_flow_returns_default_settings(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{flow.id}/call-screening-settings")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body == {
+            "call_screening_action": "respond",
+        }
+
+    def test_get_round_trips_prior_put_update(self, db, workspace, flow):
+        admin_principal = _principal(workspace.id)
+        admin_client = _build_app(db, admin_principal)
+
+        put_resp = admin_client.put(
+            f"/flows/{flow.id}/call-screening-settings",
+            json={"call_screening_action": "hang_up"},
+        )
+        assert put_resp.status_code == 200
+
+        readonly_principal = _principal(workspace.id)
+        readonly_client = _build_readonly_app(db, readonly_principal)
+
+        get_resp = readonly_client.get(f"/flows/{flow.id}/call-screening-settings")
+        assert get_resp.status_code == 200
+        assert get_resp.json() == put_resp.json()
+
+    def test_readonly_user_can_access_get(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for role in ["read_only", "config_only", "manager", "admin", "owner"]:
+            with _with_effective_role(role):
+                resp = client.get(f"/flows/{flow.id}/call-screening-settings")
+                assert resp.status_code == 200, (
+                    f"Expected 200 for role '{role}', got {resp.status_code}"
+                )
+
+    def test_get_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{uuid.uuid4()}/call-screening-settings")
+        assert resp.status_code == 404
+
+    def test_get_flow_from_other_tenant_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_readonly_app(db, foreign_principal)
+
+        resp = client.get(f"/flows/{flow.id}/call-screening-settings")
+        assert resp.status_code == 404
+
+    def test_get_handles_none_attribute_on_flow_object(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        mock_flow = MagicMock()
+        mock_flow.id = flow.id
+        mock_flow.tenant_id = workspace.id
+        mock_flow.call_screening_action = None
+
+        with patch(
+            "app.services.call_flow_service.call_flow_service._get_flow_or_404",
+            return_value=mock_flow,
+        ):
+            resp = client.get(f"/flows/{flow.id}/call-screening-settings")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["call_screening_action"] == "respond"

--- a/tests/services/test_call_screening_runtime.py
+++ b/tests/services/test_call_screening_runtime.py
@@ -1,0 +1,126 @@
+"""Unit and runtime integration tests for Call Screening Detection.
+
+Coverage:
+  - Detection of automated call screener phrases (Google, iOS, Samsung, IVR)
+  - Execution of hang_up action (ends call immediately with ended_reason='Call screener detected')
+  - Execution of respond action (continues conversation without disconnecting)
+  - Non-screener speech passes through normally
+  - Fallback default behavior (respond) when no flow attached
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.voice.call_control_mixin import CallControlMixin
+
+
+class DummyHostHandler(CallControlMixin):
+    def __init__(self, db=None, call_session=None, call_flow=None, call_sid="CA123", stream_sid="MZ123"):
+        self.db = db
+        self.call_session = call_session
+        self.call_flow = call_flow
+        self.call_sid = call_sid
+        self.stream_sid = stream_sid
+        self._call_ended = False
+        self._play_tts_message = AsyncMock()
+        self._full_shutdown = AsyncMock()
+
+
+class TestCallScreeningRuntime:
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "The person you're calling is using a screening service, please say your name",
+            "This is a screening service from google. Please state your name and why you're calling.",
+            "I'm using google call screen to screen this call.",
+            "Go ahead and say why you're calling.",
+            "State your name and why you're calling.",
+            "Who is calling and why?",
+            "Please say your name and reason for calling after the tone.",
+        ],
+    )
+    @pytest.mark.anyio
+    async def test_screener_detected_with_hang_up_action_ends_call(self, phrase):
+        flow = MagicMock(spec=CallFlow)
+        flow.call_screening_action = "hang_up"
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+
+        with (
+            patch("app.voice.call_control_mixin.call_session_service.update_call_session_status") as mock_update,
+            patch("app.voice.call_control_mixin.get_twilio_credentials_for_call", return_value=("AC123", "token")),
+            patch("app.voice.call_control_mixin.twilio_service.end_call_with_credentials") as mock_end_call,
+            patch("app.voice.call_control_mixin.broadcast_call_status_update") as mock_broadcast,
+        ):
+            result = await handler._check_and_handle_call_screener(phrase)
+
+        assert result is True
+        assert handler._call_ended is True
+        mock_update.assert_called_once_with(
+            handler.db, session.id, "completed", ended_reason="Call screener detected"
+        )
+        mock_end_call.assert_called_once_with("CA123", "AC123", "token")
+        mock_broadcast.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "The person you're calling is using a screening service, please say your name",
+            "This is a screening service from google. Please state your name and why you're calling.",
+            "I'm using google call screen to screen this call.",
+            "Go ahead and say why you're calling.",
+            "State your name and why you're calling.",
+            "Who is calling and why?",
+            "Please say your name and reason for calling after the tone.",
+        ],
+    )
+    @pytest.mark.anyio
+    async def test_screener_detected_with_respond_action_allows_call_to_proceed(self, phrase):
+        flow = MagicMock(spec=CallFlow)
+        flow.call_screening_action = "respond"
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        result = await handler._check_and_handle_call_screener(phrase)
+
+        assert result is False
+        assert handler._call_ended is False
+
+    @pytest.mark.anyio
+    async def test_normal_human_speech_does_not_trigger_screener_action(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.call_screening_action = "hang_up"
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        result = await handler._check_and_handle_call_screener("Hello, this is John speaking. How can I help you today?")
+
+        assert result is False
+        assert handler._call_ended is False
+
+    @pytest.mark.anyio
+    async def test_fallback_when_no_flow_attached_defaults_to_respond(self):
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = None
+
+        handler = DummyHostHandler(call_session=session, call_flow=None)
+        result = await handler._check_and_handle_call_screener("The person is using a screening service.")
+
+        assert result is False
+        assert handler._call_ended is False


### PR DESCRIPTION
### 📌 Summary of Changes

This PR implements persistent configuration and real-time streaming runtime detection for **Call Screening** on Call Flows:
1. **Action Configuration (`call_screening_action`)**:
   - `respond` (Default) — Voice agent provides a concise introduction explaining who is calling and why.
   - `hang_up` — Disconnects the call immediately upon detecting automated screeners.
2. **Real-Time Screener Detection**:
   - Live stream keyword detection for Google Call Screen, Apple/iOS Call Screen, Samsung Smart Call/Bixby, and automated IVR screeners.

---

### 🛠️ Scope of Changes

1. **Database & Alembic Migration**:
   - Added `call_screening_action` column to `CallFlow` (`app/models/call_flow.py`).
   - Created Alembic migration `b3e81a942cd1_add_call_screening_action_to_call_flow.py`.

2. **Pydantic Schemas & API Endpoints**:
   - `CallScreeningActionEnum`, `CallScreeningSettingsUpdate` (`extra="forbid"`), and `CallScreeningSettingsResponse` (`app/schemas/call_flow.py`).
   - `PUT /api/v2/flows/{flow_id}/call-screening-settings` with admin authorization and audit logging `action="call_screening_settings.updated"` (`app/api/v2/routers/flows.py`).
   - `GET /api/v2/flows/{flow_id}/call-screening-settings` with read-only authorization (`app/api/v2/routers/flows.py`).
   - `update_call_screening_settings` and `get_call_screening_settings` service methods (`app/services/call_flow_service.py`).
   - OpenAPI specifications in `docs/api/openapi.yaml`.

3. **Real-Time Voice Pipeline**:
   - `_check_and_handle_call_screener` method added to `CallControlMixin` (`app/voice/call_control_mixin.py`).
   - Injected into turn pipeline in `BidirectionalStreamHandler` (`app/routers/bidirectional_stream.py`).
   - Sets `ended_reason="Call screener detected"` and broadcasts WebSocket status updates on disconnect.

---

### 🧪 Test Suites & Verification

- **API Settings Suite**: `tests/api/v2/test_call_screening_settings.py` (10 passed)
- **Runtime Screener Detection Suite**: `tests/services/test_call_screening_runtime.py` (20 passed)
- **Full API v2 Suite**: 392 passed
- **Linter**: `ruff check` 100% clean