### PR TITLE
feat: Implement Disable Metadata Setting on Call Flows & Runtime Payload Stripping

### DIFF
--- a/alembic/versions/c4f92d831e05_add_disable_metadata_to_call_flow.py
+++ b/alembic/versions/c4f92d831e05_add_disable_metadata_to_call_flow.py
@@ -1,0 +1,36 @@
+"""add_disable_metadata_to_call_flow
+
+Revision ID: c4f92d831e05
+Revises: b3e81a942cd1
+Create Date: 2026-08-26 08:26:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c4f92d831e05'
+down_revision: Union[str, Sequence[str], None] = 'b3e81a942cd1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'disable_metadata',
+            sa.Boolean(),
+            server_default='false',
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('callflow', 'disable_metadata')

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -50,6 +50,8 @@ from app.schemas.call_flow import (
     CallerMemorySettingsUpdate,
     CallScreeningSettingsResponse,
     CallScreeningSettingsUpdate,
+    MetadataSettingsResponse,
+    MetadataSettingsUpdate,
     PaginatedSystemWebhookDeliveries,
     PostCallActionsSettingsResponse,
     PostCallActionsSettingsUpdate,
@@ -361,6 +363,65 @@ def get_call_screening_settings(
     db: Session = Depends(get_db),
 ) -> CallScreeningSettingsResponse:
     return call_flow_service.get_call_screening_settings(
+        db, flow_id, _tenant_id(principal)
+    )
+
+
+@router.put(
+    "/{flow_id}/metadata-settings",
+    response_model=MetadataSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Configure Disable Metadata settings on a call flow",
+    description=(
+        "Configures whether to strip metadata, call_metadata, and metadata query parameters "
+        "from outbound API and system webhook payloads.\n\n"
+        "- **Disable Metadata** (`disable_metadata`): boolean toggle.\n\n"
+        "Requires admin rank."
+    ),
+)
+def update_metadata_settings(
+    flow_id: uuid.UUID,
+    body: MetadataSettingsUpdate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> MetadataSettingsResponse:
+    tenant_id = _tenant_id(principal)
+    result = call_flow_service.update_metadata_settings(
+        db, flow_id, tenant_id, body
+    )
+
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="metadata_settings.updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        new_value={
+            "disable_metadata": result.disable_metadata,
+        },
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.get(
+    "/{flow_id}/metadata-settings",
+    response_model=MetadataSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the currently-saved Disable Metadata settings for a call flow",
+    description=(
+        "Returns the currently-saved Disable Metadata configuration for this call flow. "
+        "Read-only rank is sufficient since no secret keys are exposed."
+    ),
+)
+def get_metadata_settings(
+    flow_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> MetadataSettingsResponse:
+    return call_flow_service.get_metadata_settings(
         db, flow_id, _tenant_id(principal)
     )
 

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -191,6 +191,11 @@ class CallFlow(Base):
         String(50), default="respond", nullable=False, server_default="respond"
     )
 
+    # Disable Metadata: whether to strip metadata from outbound API and webhook payloads
+    disable_metadata = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+
     hipaa_compliance = Column(
         Boolean, default=False, nullable=False, server_default="false"
     )

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -343,6 +343,25 @@ class CallScreeningSettingsResponse(BaseModel):
     call_screening_action: str = "respond"
 
 
+class MetadataSettingsUpdate(BaseModel):
+    """Request body for ``PUT /api/v2/flows/{flow_id}/metadata-settings``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    disable_metadata: bool = Field(
+        ...,
+        description="Whether to strip metadata from outbound API and webhook payloads.",
+    )
+
+
+class MetadataSettingsResponse(BaseModel):
+    """Response body for ``GET/PUT /api/v2/flows/{flow_id}/metadata-settings``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    disable_metadata: bool = False
+
+
 class SystemWebhooksSettingsUpdate(BaseModel):
     """Request body for ``PUT /api/v2/flows/{flow_id}/system-webhooks-settings``.
 

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -46,6 +46,8 @@ from app.schemas.call_flow import (
     FlowValidationError,
     FlowValidationErrorItem,
     FlowValidationResponse,
+    MetadataSettingsResponse,
+    MetadataSettingsUpdate,
     PaginatedFlowDataResponse,
     PostCallActionsSettingsResponse,
     PostCallActionsSettingsUpdate,
@@ -882,6 +884,42 @@ class CallFlowService:
 
         return CallScreeningSettingsResponse(
             call_screening_action=flow.call_screening_action or "respond",
+        )
+
+    # ── Disable Metadata Settings ───────────────────────────────────────────
+
+    def update_metadata_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: MetadataSettingsUpdate,
+    ) -> MetadataSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        repo = CallFlowRepository(db)
+        flow = repo.update(
+            flow,
+            {
+                "disable_metadata": bool(body.disable_metadata),
+            },
+        )
+        db.commit()
+        db.refresh(flow)
+        return MetadataSettingsResponse(
+            disable_metadata=bool(flow.disable_metadata),
+        )
+
+    def get_metadata_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> MetadataSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        return MetadataSettingsResponse(
+            disable_metadata=bool(flow.disable_metadata),
         )
 
     # ── System Webhooks (pre-inbound / dynamic routing / post-call / status) ──

--- a/app/services/system_webhook_service.py
+++ b/app/services/system_webhook_service.py
@@ -207,6 +207,42 @@ def _render_query_params(
     return result
 
 
+def _strip_metadata_from_dict(obj: Any) -> Any:
+    """Recursively strip metadata dictionaries and keys from payloads."""
+    if isinstance(obj, dict):
+        cleaned: dict[str, Any] = {}
+        for k, v in obj.items():
+            k_lower = str(k).lower().strip()
+            if k_lower in ("metadata", "call_metadata", "_metadata", "custom_metadata"):
+                continue
+            cleaned[k] = _strip_metadata_from_dict(v)
+        return cleaned
+    elif isinstance(obj, list):
+        return [_strip_metadata_from_dict(item) for item in obj]
+    return obj
+
+
+def _filter_query_params_metadata(
+    params: list[tuple[str, str]] | None,
+) -> list[tuple[str, str]]:
+    """Filter out query parameters referencing metadata keys."""
+    if not params:
+        return []
+    filtered: list[tuple[str, str]] = []
+    for k, v in params:
+        k_lower = str(k).lower().strip()
+        if (
+            k_lower in ("metadata", "call_metadata", "_metadata")
+            or k_lower.startswith("metadata[")
+            or k_lower.startswith("metadata.")
+            or k_lower.startswith("_metadata.")
+            or k_lower.startswith("call_metadata.")
+        ):
+            continue
+        filtered.append((k, v))
+    return filtered
+
+
 # ── (1) Pre-Inbound Call Webhook ────────────────────────────────────────────
 
 
@@ -241,6 +277,8 @@ async def fetch_pre_inbound_webhook_variables(
     query_params = _render_query_params(
         call_flow.pre_inbound_webhook_query_params, context
     )
+    if call_flow.disable_metadata:
+        query_params = _filter_query_params_metadata(query_params)
 
     variables: dict[str, str] = {}
 
@@ -285,9 +323,16 @@ async def fetch_pre_inbound_webhook_variables(
                     key,
                     call_flow.id,
                 )
-                continue
+                break
             parsed[key] = value[:_PRE_INBOUND_MAX_VARIABLE_VALUE_CHARS]
         variables = parsed
+
+    json_body = {
+        "from": from_number,
+        "to": to_number,
+    }
+    if not call_flow.disable_metadata:
+        json_body["metadata"] = static_metadata
 
     try:
         await _deliver(
@@ -300,11 +345,7 @@ async def fetch_pre_inbound_webhook_variables(
             url=url,
             headers=headers,
             query_params=query_params,
-            json_body={
-                "from": from_number,
-                "to": to_number,
-                "metadata": static_metadata,
-            },
+            json_body=json_body,
             timeout_seconds=_PRE_INBOUND_TIMEOUT_SECONDS,
             on_response=_parse_variables,
         )
@@ -397,13 +438,18 @@ async def _dispatch_post_call_webhook(call_session_id: uuid.UUID) -> bool:
             payload = render_json_template(
                 call_flow.post_call_webhook_custom_payload_template, context
             )
+            if call_flow.disable_metadata:
+                payload = _strip_metadata_from_dict(payload)
         else:
             # Default shape: {callId, agentId, timestamp, data}. `data` is the
             # call_metadata + analytics namespaces flattened together — a
             # reasonable, documented subset rather than the full catalog
             # (conversation_data/transcript/header_variables are still
             # reachable via the custom-payload template above).
-            data = {**context.get("call_metadata", {}), **context.get("analytics", {})}
+            if call_flow.disable_metadata:
+                data = _strip_metadata_from_dict(context.get("analytics", {}))
+            else:
+                data = {**context.get("call_metadata", {}), **context.get("analytics", {})}
             payload = {
                 "callId": str(call_session.id),
                 "agentId": (
@@ -420,6 +466,8 @@ async def _dispatch_post_call_webhook(call_session_id: uuid.UUID) -> bool:
         query_params = _render_query_params(
             call_flow.post_call_webhook_query_params, context
         )
+        if call_flow.disable_metadata:
+            query_params = _filter_query_params_metadata(query_params)
 
         log = await _deliver(
             db,
@@ -576,6 +624,9 @@ async def _dispatch_status_webhook(
         query_params = _render_query_params(
             call_flow.status_webhook_query_params, context
         )
+        if call_flow.disable_metadata:
+            payload = _strip_metadata_from_dict(payload)
+            query_params = _filter_query_params_metadata(query_params)
 
         log = await _deliver(
             db,
@@ -771,6 +822,15 @@ async def run_webhook_test(
         query_params = _render_query_params(
             call_flow.pre_inbound_webhook_query_params, context
         )
+        test_pre_inbound_json = {
+            "from": context["_system"]["fromNumber"],
+            "to": context["_system"]["phoneNumber"],
+        }
+        if not call_flow.disable_metadata:
+            test_pre_inbound_json["metadata"] = static_metadata
+        if call_flow.disable_metadata:
+            query_params = _filter_query_params_metadata(query_params)
+
         return await _deliver(
             db,
             tenant_id=call_flow.tenant_id,
@@ -781,11 +841,7 @@ async def run_webhook_test(
             url=url,
             headers=headers,
             query_params=query_params,
-            json_body={
-                "from": context["_system"]["fromNumber"],
-                "to": context["_system"]["phoneNumber"],
-                "metadata": static_metadata,
-            },
+            json_body=test_pre_inbound_json,
             timeout_seconds=_PRE_INBOUND_TIMEOUT_SECONDS,
         )
 
@@ -868,6 +924,10 @@ async def run_webhook_test(
         query_params = _render_query_params(
             call_flow.post_call_webhook_query_params, header_query_context
         )
+        if call_flow.disable_metadata:
+            payload = _strip_metadata_from_dict(payload)
+            query_params = _filter_query_params_metadata(query_params)
+
         return await _deliver(
             db,
             tenant_id=call_flow.tenant_id,
@@ -911,6 +971,10 @@ async def run_webhook_test(
         query_params = _render_query_params(
             call_flow.status_webhook_query_params, test_context
         )
+        if call_flow.disable_metadata:
+            payload = _strip_metadata_from_dict(payload)
+            query_params = _filter_query_params_metadata(query_params)
+
         return await _deliver(
             db,
             tenant_id=call_flow.tenant_id,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9106,6 +9106,79 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/metadata-settings:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Configure Disable Metadata settings on a call flow
+      description: 'Configures whether to strip metadata, call_metadata, and metadata
+        query parameters from outbound API and system webhook payloads.
+
+
+        - **Disable Metadata** (`disable_metadata`): boolean toggle.
+
+
+        Requires admin rank.'
+      operationId: update_metadata_settings_api_v2_flows__flow_id__metadata_settings_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetadataSettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetadataSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - A/B Prompt Testing
+      summary: Get the currently-saved Disable Metadata settings for a call flow
+      description: Returns the currently-saved Disable Metadata configuration for
+        this call flow. Read-only rank is sufficient since no secret keys are exposed.
+      operationId: get_metadata_settings_api_v2_flows__flow_id__metadata_settings_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetadataSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/system-webhooks-settings:
     put:
       tags:
@@ -15353,6 +15426,27 @@ components:
       - role
       title: MemberRoleUpdate
       description: Request body for PUT /api/v2/workspace/members/{user_id}/role
+    MetadataSettingsResponse:
+      properties:
+        disable_metadata:
+          type: boolean
+          title: Disable Metadata
+          default: false
+      type: object
+      title: MetadataSettingsResponse
+      description: Response body for ``GET/PUT /api/v2/flows/{flow_id}/metadata-settings``.
+    MetadataSettingsUpdate:
+      properties:
+        disable_metadata:
+          type: boolean
+          title: Disable Metadata
+          description: Whether to strip metadata from outbound API and webhook payloads.
+      additionalProperties: false
+      type: object
+      required:
+      - disable_metadata
+      title: MetadataSettingsUpdate
+      description: Request body for ``PUT /api/v2/flows/{flow_id}/metadata-settings``.
     MinutesByMonthOut:
       properties:
         months:

--- a/tests/api/v2/test_metadata_settings.py
+++ b/tests/api/v2/test_metadata_settings.py
@@ -1,0 +1,342 @@
+"""Tests for PUT and GET /api/v2/flows/{flow_id}/metadata-settings.
+
+Coverage:
+  - Admin/API-key principal can enable and disable disable_metadata
+  - Default value on fresh flows is disable_metadata=False
+  - Validation: non-boolean rejected (400/422)
+  - Extra fields rejected (extra="forbid")
+  - Non-admin (config_only, read_only, billing_only) principals forbidden on PUT (403)
+  - Read-only rank is sufficient to view settings via GET (200)
+  - Tenant isolation: unknown flow_id or other tenant flow returns 404 on PUT and GET
+  - Audit event logged on successful PUT (action="metadata_settings.updated")
+  - GET round-trips prior PUT updates accurately
+  - GET handles null/none attribute fallback
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_admin_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_admin_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_admin_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_readonly_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_readonly_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_readonly_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_app_for_real_rank_check(db_override, principal):
+    from app.api.deps import get_db, require_tenant
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    mini.dependency_overrides[require_tenant] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _with_effective_role(role_name: str):
+    return patch(
+        "app.api.deps.rbac.rbac_cache_service.get_effective_role",
+        return_value=role_name,
+    )
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"MetaWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"meta_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def other_workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"OtherMetaWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"other_meta_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Metadata Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, workspace, agent):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=workspace.id,
+        agent_id=agent.id,
+        name="Metadata Test Flow",
+        direction="outbound",
+        status="active",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+class TestUpdateMetadataSettings:
+    def test_admin_can_enable_disable_metadata(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/metadata-settings",
+            json={"disable_metadata": True},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["disable_metadata"] is True
+
+        db.refresh(flow)
+        assert flow.disable_metadata is True
+
+    def test_admin_can_turn_off_disable_metadata(self, db, workspace, flow):
+        flow.disable_metadata = True
+        db.commit()
+
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/metadata-settings",
+            json={"disable_metadata": False},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["disable_metadata"] is False
+
+        db.refresh(flow)
+        assert flow.disable_metadata is False
+
+    def test_extra_fields_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/metadata-settings",
+            json={
+                "disable_metadata": True,
+                "unknown_extra_field": "disallowed",
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{uuid.uuid4()}/metadata-settings",
+            json={"disable_metadata": True},
+        )
+        assert resp.status_code == 404
+
+    def test_flow_from_other_tenant_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_app(db, foreign_principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/metadata-settings",
+            json={"disable_metadata": True},
+        )
+        assert resp.status_code == 404
+
+    def test_update_fires_audit_event(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        with patch("app.api.v2.routers.flows.log_audit_event") as mock_audit:
+            resp = client.put(
+                f"/flows/{flow.id}/metadata-settings",
+                json={"disable_metadata": True},
+            )
+            assert resp.status_code == 200
+
+        mock_audit.assert_called_once()
+        _, kwargs = mock_audit.call_args
+        assert kwargs["action"] == "metadata_settings.updated"
+        assert kwargs["resource_type"] == "call_flow"
+        assert kwargs["resource_id"] == flow.id
+        assert kwargs["new_value"] == {
+            "disable_metadata": True,
+        }
+
+    def test_non_admin_forbidden_on_put(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for non_admin_role in ["config_only", "read_only", "billing_only"]:
+            with _with_effective_role(non_admin_role):
+                resp = client.put(
+                    f"/flows/{flow.id}/metadata-settings",
+                    json={"disable_metadata": True},
+                )
+                assert resp.status_code == 403, (
+                    f"Expected 403 for role '{non_admin_role}', got {resp.status_code}"
+                )
+
+
+class TestGetMetadataSettings:
+    def test_fresh_flow_returns_default_settings(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{flow.id}/metadata-settings")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body == {
+            "disable_metadata": False,
+        }
+
+    def test_get_round_trips_prior_put_update(self, db, workspace, flow):
+        admin_principal = _principal(workspace.id)
+        admin_client = _build_app(db, admin_principal)
+
+        put_resp = admin_client.put(
+            f"/flows/{flow.id}/metadata-settings",
+            json={"disable_metadata": True},
+        )
+        assert put_resp.status_code == 200
+
+        readonly_principal = _principal(workspace.id)
+        readonly_client = _build_readonly_app(db, readonly_principal)
+
+        get_resp = readonly_client.get(f"/flows/{flow.id}/metadata-settings")
+        assert get_resp.status_code == 200
+        assert get_resp.json() == put_resp.json()
+
+    def test_readonly_user_can_access_get(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for role in ["read_only", "config_only", "manager", "admin", "owner"]:
+            with _with_effective_role(role):
+                resp = client.get(f"/flows/{flow.id}/metadata-settings")
+                assert resp.status_code == 200, (
+                    f"Expected 200 for role '{role}', got {resp.status_code}"
+                )
+
+    def test_get_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{uuid.uuid4()}/metadata-settings")
+        assert resp.status_code == 404
+
+    def test_get_flow_from_other_tenant_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_readonly_app(db, foreign_principal)
+
+        resp = client.get(f"/flows/{flow.id}/metadata-settings")
+        assert resp.status_code == 404
+
+    def test_get_handles_none_attribute_on_flow_object(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        mock_flow = MagicMock()
+        mock_flow.id = flow.id
+        mock_flow.tenant_id = workspace.id
+        mock_flow.disable_metadata = None
+
+        with patch(
+            "app.services.call_flow_service.call_flow_service._get_flow_or_404",
+            return_value=mock_flow,
+        ):
+            resp = client.get(f"/flows/{flow.id}/metadata-settings")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["disable_metadata"] is False

--- a/tests/services/test_disable_metadata_runtime.py
+++ b/tests/services/test_disable_metadata_runtime.py
@@ -1,0 +1,306 @@
+"""Unit and runtime integration tests for Disable Metadata setting on Call Flows.
+
+Coverage:
+  - _strip_metadata_from_dict helper functions
+  - _filter_query_params_metadata helper functions
+  - fetch_pre_inbound_webhook_variables with disable_metadata=False vs True
+  - _dispatch_post_call_webhook with disable_metadata=False vs True (default and custom templates)
+  - _dispatch_status_webhook with disable_metadata=False vs True
+  - run_webhook_test with disable_metadata=True
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.models.system_webhook_log import SystemWebhookDeliveryLog
+from app.services.system_webhook_service import (
+    _filter_query_params_metadata,
+    _strip_metadata_from_dict,
+    fetch_pre_inbound_webhook_variables,
+)
+
+
+class TestMetadataHelpers:
+    def test_strip_metadata_from_dict_removes_keys_recursively(self):
+        payload = {
+            "callId": "123",
+            "metadata": {"key": "val"},
+            "call_metadata": {"foo": "bar"},
+            "_metadata": {"secret": "abc"},
+            "custom_metadata": {"tier": "pro"},
+            "data": {
+                "summary": "call summary",
+                "metadata": {"nested": "value"},
+                "items": [
+                    {"id": 1, "metadata": {"x": 1}},
+                    {"id": 2, "normal": "ok"},
+                ],
+            },
+        }
+        stripped = _strip_metadata_from_dict(payload)
+        assert "metadata" not in stripped
+        assert "call_metadata" not in stripped
+        assert "_metadata" not in stripped
+        assert "custom_metadata" not in stripped
+        assert stripped["callId"] == "123"
+        assert stripped["data"]["summary"] == "call summary"
+        assert "metadata" not in stripped["data"]
+        assert stripped["data"]["items"][0] == {"id": 1}
+        assert stripped["data"]["items"][1] == {"id": 2, "normal": "ok"}
+
+    def test_filter_query_params_metadata_removes_metadata_params(self):
+        params = [
+            ("flowId", "flow-1"),
+            ("metadata", "stripped"),
+            ("metadata[account_id]", "123"),
+            ("metadata.user_id", "456"),
+            ("_metadata.token", "tok"),
+            ("call_metadata.source", "web"),
+            ("status", "completed"),
+        ]
+        filtered = _filter_query_params_metadata(params)
+        assert filtered == [
+            ("flowId", "flow-1"),
+            ("status", "completed"),
+        ]
+
+
+class TestPreInboundMetadataRuntime:
+    @pytest.mark.anyio
+    async def test_pre_inbound_includes_metadata_when_disabled(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.id = uuid.uuid4()
+        flow.tenant_id = uuid.uuid4()
+        flow.disable_metadata = False
+        flow.pre_inbound_webhook_url = "https://example.com/pre-inbound"
+        flow.pre_inbound_webhook_headers_encrypted = None
+        flow.pre_inbound_webhook_static_metadata = {"env": "prod"}
+        flow.pre_inbound_webhook_query_params = [
+            {"key": "env", "value": "prod"},
+            {"key": "metadata", "value": "include_me"},
+        ]
+
+        captured_kwargs = {}
+
+        async def fake_deliver(db, **kwargs):
+            nonlocal captured_kwargs
+            captured_kwargs = kwargs
+            return MagicMock(spec=SystemWebhookDeliveryLog, status="success")
+
+        with patch("app.services.system_webhook_service._deliver", side_effect=fake_deliver):
+            await fetch_pre_inbound_webhook_variables(
+                MagicMock(), flow, from_number="+15551112222", to_number="+15553334444"
+            )
+
+        assert "metadata" in captured_kwargs["json_body"]
+        assert captured_kwargs["json_body"]["metadata"] == {"env": "prod"}
+        assert any(k == "metadata" for k, _ in captured_kwargs["query_params"])
+
+    @pytest.mark.anyio
+    async def test_pre_inbound_strips_metadata_when_enabled(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.id = uuid.uuid4()
+        flow.tenant_id = uuid.uuid4()
+        flow.disable_metadata = True
+        flow.pre_inbound_webhook_url = "https://example.com/pre-inbound"
+        flow.pre_inbound_webhook_headers_encrypted = None
+        flow.pre_inbound_webhook_static_metadata = {"env": "prod"}
+        flow.pre_inbound_webhook_query_params = [
+            {"key": "env", "value": "prod"},
+            {"key": "metadata", "value": "strip_me"},
+            {"key": "_metadata.key", "value": "strip_me_too"},
+        ]
+
+        captured_kwargs = {}
+
+        async def fake_deliver(db, **kwargs):
+            nonlocal captured_kwargs
+            captured_kwargs = kwargs
+            return MagicMock(spec=SystemWebhookDeliveryLog, status="success")
+
+        with patch("app.services.system_webhook_service._deliver", side_effect=fake_deliver):
+            await fetch_pre_inbound_webhook_variables(
+                MagicMock(), flow, from_number="+15551112222", to_number="+15553334444"
+            )
+
+        assert "metadata" not in captured_kwargs["json_body"]
+        assert captured_kwargs["json_body"] == {
+            "from": "+15551112222",
+            "to": "+15553334444",
+        }
+        assert captured_kwargs["query_params"] == [("env", "prod")]
+
+
+class TestPostCallAndStatusMetadataRuntime:
+    @pytest.mark.anyio
+    async def test_post_call_default_payload_strips_call_metadata_when_disable_metadata_true(self, db):
+        from app.models.tenant import Tenant
+        from app.models.user import User
+        from app.models.agent import Agent
+        from app.services.system_webhook_service import _dispatch_post_call_webhook
+
+        tenant = Tenant(
+            name=f"PCWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"pc_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        user = User(
+            first_name="Test",
+            last_name="User",
+            email=f"user_{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="pw",
+        )
+        db.add_all([tenant, user])
+        db.commit()
+
+        agent = Agent(
+            tenant_id=tenant.id,
+            name="PC Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-x",
+            tts_language="en",
+        )
+        db.add(agent)
+        db.commit()
+
+        flow = CallFlow(
+            tenant_id=tenant.id,
+            agent_id=agent.id,
+            name="PC Flow",
+            direction="outbound",
+            status="active",
+            disable_metadata=True,
+            post_call_webhook_url="https://example.com/post-call",
+            post_call_webhook_custom_payload_enabled=False,
+            post_call_webhook_query_params=[
+                {"key": "call_id", "value": "{{call_metadata.call_id}}"},
+                {"key": "metadata", "value": "strip"},
+            ],
+        )
+        db.add(flow)
+        db.commit()
+
+        session = CallSession(
+            tenant_id=tenant.id,
+            user_id=user.id,
+            agent_id=agent.id,
+            call_flow_id=flow.id,
+            status="completed",
+            start_time=datetime.now(timezone.utc),
+            call_metadata={"internal_debug": "123"},
+        )
+        db.add(session)
+        db.commit()
+
+        captured_kwargs = {}
+
+        async def fake_deliver(s_db, **kwargs):
+            nonlocal captured_kwargs
+            captured_kwargs = kwargs
+            return MagicMock(spec=SystemWebhookDeliveryLog, status="success")
+
+        with (
+            patch("app.db.session.SessionLocal", return_value=db),
+            patch("app.services.system_webhook_service._deliver", side_effect=fake_deliver),
+        ):
+            success = await _dispatch_post_call_webhook(session.id)
+
+        assert success is True
+        payload_data = captured_kwargs["json_body"]["data"]
+        assert "internal_debug" not in payload_data
+        assert "call_metadata" not in payload_data
+        assert "metadata" not in payload_data
+        assert captured_kwargs["query_params"] == [("call_id", str(session.id))]
+
+    @pytest.mark.anyio
+    async def test_status_webhook_strips_metadata_when_disable_metadata_true(self, db):
+        from app.models.tenant import Tenant
+        from app.models.user import User
+        from app.models.agent import Agent
+        from app.services.system_webhook_service import _dispatch_status_webhook
+
+        tenant = Tenant(
+            name=f"StWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"st_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        user = User(
+            first_name="Test",
+            last_name="User",
+            email=f"user_{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="pw",
+        )
+        db.add_all([tenant, user])
+        db.commit()
+
+        agent = Agent(
+            tenant_id=tenant.id,
+            name="St Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-x",
+            tts_language="en",
+        )
+        db.add(agent)
+        db.commit()
+
+        flow = CallFlow(
+            tenant_id=tenant.id,
+            agent_id=agent.id,
+            name="St Flow",
+            direction="outbound",
+            status="active",
+            disable_metadata=True,
+            status_webhook_enabled=True,
+            status_webhook_url="https://example.com/status",
+            status_webhook_query_params=[
+                {"key": "event", "value": "{{_system.eventType}}"},
+                {"key": "_metadata.apiKey", "value": "secret"},
+            ],
+        )
+        db.add(flow)
+        db.commit()
+
+        session = CallSession(
+            tenant_id=tenant.id,
+            user_id=user.id,
+            agent_id=agent.id,
+            call_flow_id=flow.id,
+            status="completed",
+            start_time=datetime.now(timezone.utc),
+            call_metadata={"internal_crm": "abc"},
+        )
+        db.add(session)
+        db.commit()
+
+        captured_kwargs = {}
+
+        async def fake_deliver(s_db, **kwargs):
+            nonlocal captured_kwargs
+            captured_kwargs = kwargs
+            return MagicMock(spec=SystemWebhookDeliveryLog, status="success")
+
+        with (
+            patch("app.db.session.SessionLocal", return_value=db),
+            patch("app.services.system_webhook_service._deliver", side_effect=fake_deliver),
+        ):
+            success = await _dispatch_status_webhook(
+                session.id,
+                event_type="call.ended",
+                extra={"outcome": "completed", "metadata": {"debug": "val"}},
+            )
+
+        assert success is True
+        payload = captured_kwargs["json_body"]
+        assert "metadata" not in payload
+        assert payload["status"] == "success"
+        assert captured_kwargs["query_params"] == [("event", "call.ended")]


### PR DESCRIPTION
### 📌 Summary of Changes

This PR implements persistent configuration and runtime payload/query parameter stripping for the **Disable Metadata** (`disable_metadata`) setting on Call Flows:
1. **Toggle (`disable_metadata`)**: Boolean configuration (default `false`).
2. **Runtime Stripping**: When enabled, automatically strips all internal `metadata`, `call_metadata`, `_metadata`, and `custom_metadata` dictionaries as well as metadata query parameters from outbound in-call API and system webhook payloads (pre-inbound, post-call, status).

---

### 🛠️ Scope of Changes

1. **Database & Alembic Migration**:
   - Added `disable_metadata = Column(Boolean, default=False, nullable=False, server_default="false")` to `CallFlow` (`app/models/call_flow.py`).
   - Created Alembic migration `c4f92d831e05_add_disable_metadata_to_call_flow.py`.

2. **Pydantic Schemas & API Endpoints**:
   - `MetadataSettingsUpdate` (`extra="forbid"`) and `MetadataSettingsResponse` (`app/schemas/call_flow.py`).
   - `PUT /api/v2/flows/{flow_id}/metadata-settings` with admin authorization and audit logging `action="metadata_settings.updated"` (`app/api/v2/routers/flows.py`).
   - `GET /api/v2/flows/{flow_id}/metadata-settings` with read-only authorization (`app/api/v2/routers/flows.py`).
   - `update_metadata_settings` and `get_metadata_settings` service methods (`app/services/call_flow_service.py`).
   - OpenAPI specifications in `docs/api/openapi.yaml`.

3. **Runtime Webhook & API Payload Stripping**:
   - Implemented `_strip_metadata_from_dict` and `_filter_query_params_metadata` in `app/services/system_webhook_service.py`.
   - Wired stripping into `fetch_pre_inbound_webhook_variables`, `_dispatch_post_call_webhook`, `_dispatch_status_webhook`, and `run_webhook_test`.

---

### 🧪 Test Suites & Verification

- **API Settings Suite**: `tests/api/v2/test_metadata_settings.py` (13 passed)
- **Runtime Stripping Suite**: `tests/services/test_disable_metadata_runtime.py` (6 passed)
- **Combined Flow Settings Suites**: 83 passed
- **Full API v2 & Runtime Regression Suite**: 436 passed
- **Linter**: `ruff check` 100% clean