### PR TITLE
feat(flows): implement Call Timing settings and real-time silence / max duration engine

### DIFF
--- a/alembic/versions/f6a2b3c4d5e6_add_call_timing_settings_to_call_flow.py
+++ b/alembic/versions/f6a2b3c4d5e6_add_call_timing_settings_to_call_flow.py
@@ -1,0 +1,88 @@
+"""add_call_timing_settings_to_call_flow
+
+Revision ID: f6a2b3c4d5e6
+Revises: e5f12a73b901
+Create Date: 2026-08-26 10:17:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6a2b3c4d5e6'
+down_revision: Union[str, None] = 'e5f12a73b901'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'silence_timeout',
+            sa.Integer(),
+            server_default='10',
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'end_call_after_reminder',
+            sa.Integer(),
+            server_default='10',
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'reminder_retries',
+            sa.Integer(),
+            server_default='1',
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'reminder_messages',
+            JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'max_call_duration',
+            sa.Integer(),
+            server_default='1800',
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'max_duration_message',
+            sa.Text(),
+            nullable=True,
+            server_default="I appreciate the conversation, but we've reached our time limit for this call.",
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('callflow', 'max_duration_message')
+    op.drop_column('callflow', 'max_call_duration')
+    op.drop_column('callflow', 'reminder_messages')
+    op.drop_column('callflow', 'reminder_retries')
+    op.drop_column('callflow', 'end_call_after_reminder')
+    op.drop_column('callflow', 'silence_timeout')

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -50,6 +50,8 @@ from app.schemas.call_flow import (
     CallerMemorySettingsUpdate,
     CallScreeningSettingsResponse,
     CallScreeningSettingsUpdate,
+    CallTimingSettingsResponse,
+    CallTimingSettingsUpdate,
     IVRDTMFSettingsResponse,
     IVRDTMFSettingsUpdate,
     MetadataSettingsResponse,
@@ -483,6 +485,66 @@ def get_ivr_dtmf_settings(
     db: Session = Depends(get_db),
 ) -> IVRDTMFSettingsResponse:
     return call_flow_service.get_ivr_dtmf_settings(
+        db, flow_id, _tenant_id(principal)
+    )
+
+
+@router.put(
+    "/{flow_id}/call-timing-settings",
+    response_model=CallTimingSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Configure Call Timing & Silence Detection settings on a call flow",
+    description=(
+        "Configures call timing, silence detection watchdog, reminder messages, and max call duration limits for this call flow.\n\n"
+        "- **Silence Timeout** (`silence_timeout`): Duration in seconds of silence before reminder message plays (3–60s).\n"
+        "- **End Call After Reminder** (`end_call_after_reminder`): Seconds of silence after final reminder before hangup (3–60s).\n"
+        "- **Reminder Retries** (`reminder_retries`): Number of reminder attempts before disconnect (1–3).\n"
+        "- **Reminder Messages** (`reminder_messages`): List of custom reminder phrases to cycle through.\n"
+        "- **Max Call Duration** (`max_call_duration`): Maximum duration in seconds before forced call termination (60–7200s).\n"
+        "- **Max Duration Message** (`max_duration_message`): Spoken by the agent before terminating due to time limit.\n\n"
+        "Admin rank (or API key) required because timing limits affect billing and call duration enforcement."
+    ),
+)
+def update_call_timing_settings(
+    flow_id: uuid.UUID,
+    body: CallTimingSettingsUpdate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> CallTimingSettingsResponse:
+    tenant_id = _tenant_id(principal)
+    result = call_flow_service.update_call_timing_settings(
+        db, flow_id, tenant_id, body
+    )
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="call_timing_settings.updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        new_value=result.model_dump(),
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.get(
+    "/{flow_id}/call-timing-settings",
+    response_model=CallTimingSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the currently-saved Call Timing settings for a call flow",
+    description=(
+        "Returns the currently-saved Call Timing and silence detection settings for this call flow. "
+        "Read-only rank is sufficient since no secret keys are exposed."
+    ),
+)
+def get_call_timing_settings(
+    flow_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> CallTimingSettingsResponse:
+    return call_flow_service.get_call_timing_settings(
         db, flow_id, _tenant_id(principal)
     )
 

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -248,6 +248,29 @@ class CallFlow(Base):
         server_default="You've reached the maximum number of inputs allowed for this call.",
     )
 
+    # ── Call Timing & Silence Detection Settings ──
+    silence_timeout = Column(
+        Integer, default=10, nullable=False, server_default="10"
+    )
+    end_call_after_reminder = Column(
+        Integer, default=10, nullable=False, server_default="10"
+    )
+    reminder_retries = Column(
+        Integer, default=1, nullable=False, server_default="1"
+    )
+    reminder_messages = Column(
+        JSONB, default=list, nullable=False, server_default=sa_text("'[]'")
+    )
+    max_call_duration = Column(
+        Integer, default=1800, nullable=False, server_default="1800"
+    )
+    max_duration_message = Column(
+        Text,
+        nullable=True,
+        default="I appreciate the conversation, but we've reached our time limit for this call.",
+        server_default="I appreciate the conversation, but we've reached our time limit for this call.",
+    )
+
     hipaa_compliance = Column(
         Boolean, default=False, nullable=False, server_default="false"
     )

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -1068,6 +1068,9 @@ class BidirectionalStreamHandler(
                 "[LLM] generate_and_stream_response timed out (12s) — aborting turn"
             )
 
+        finally:
+            self._arm_silence_watchdog()
+
     def _should_accept_final_transcript(
         self, transcript: str, confidence: float
     ) -> bool:
@@ -1193,6 +1196,7 @@ class BidirectionalStreamHandler(
                 # Fall through — still process transcript and generate new response.
 
             async with self._voice_transcript_lock:
+                self._cancel_silence_watchdog()
                 if not self._should_accept_final_transcript(transcript, confidence):
                     return
 
@@ -1306,6 +1310,8 @@ class BidirectionalStreamHandler(
         try:
             if not transcript:
                 return
+
+            self._cancel_silence_watchdog()
 
             word_count = len(transcript.split())
 
@@ -2949,6 +2955,9 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                                 rec_err,
                             )
 
+            # Arm hard timer for maximum call duration enforcement
+            self._arm_max_duration_timer()
+
             # DO NOT start credit monitoring or greeting here!
             # Wait for first media packet (user actually picks up - VAPI-style)
 
@@ -2963,6 +2972,9 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
 
             self._user_picked_up = True
             self._voice_metrics.mark_call_pickup()
+
+            # Arm silence detection watchdog timer
+            self._arm_silence_watchdog()
 
             # ❌ Credit monitoring moved to _send_in_progress_status()
             # Credit deduction will start when connected status is sent (first media packet + connected status)
@@ -3023,6 +3035,7 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
         if self._tts_cancel.is_set():
             return
         await self.generate_and_stream_response("", 1.0, is_greeting=True)
+        self._arm_silence_watchdog()
 
     async def _schedule_inbound_greeting_after_delay(self) -> None:
         """
@@ -3060,6 +3073,7 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
             confidence=1.0,
             is_greeting=True,
         )
+        self._arm_silence_watchdog()
 
     async def _full_shutdown(self) -> None:
         """
@@ -3095,6 +3109,20 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
             and not self._dtmf_debounce_task.done()
         ):
             self._dtmf_debounce_task.cancel()
+
+        if (
+            hasattr(self, "_silence_watchdog_task")
+            and self._silence_watchdog_task
+            and not self._silence_watchdog_task.done()
+        ):
+            self._silence_watchdog_task.cancel()
+
+        if (
+            hasattr(self, "_max_duration_task")
+            and self._max_duration_task
+            and not self._max_duration_task.done()
+        ):
+            self._max_duration_task.cancel()
 
         # ── VoiceOrchestrator handles LLM cancel + TTS shutdown + STT close ────
         # OLD direct code (now delegated to orchestrator):

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -451,6 +451,89 @@ class IVRDTMFSettingsResponse(BaseModel):
     )
 
 
+class CallTimingSettingsUpdate(BaseModel):
+    """Request body for ``PUT /api/v2/flows/{flow_id}/call-timing-settings``."""
+
+    silence_timeout: int = Field(
+        default=10,
+        ge=3,
+        le=60,
+        description="Duration in seconds of caller silence before a reminder message is played (3-60).",
+    )
+    end_call_after_reminder: int = Field(
+        default=10,
+        ge=3,
+        le=60,
+        description="Duration in seconds of caller silence after the final reminder before terminating call (3-60).",
+    )
+    reminder_retries: int = Field(
+        default=1,
+        ge=1,
+        le=3,
+        description="Number of reminder attempts before disconnecting the call (1-3).",
+    )
+    reminder_messages: list[str] = Field(
+        default_factory=list,
+        description="Custom list of reminder messages to cycle through upon silence.",
+    )
+    max_call_duration: int = Field(
+        default=1800,
+        ge=60,
+        le=7200,
+        description="Maximum allowed call duration in seconds before forced termination (60-7200, 1m-120m).",
+    )
+    max_duration_message: str | None = Field(
+        default="I appreciate the conversation, but we've reached our time limit for this call.",
+        max_length=500,
+        description="Message spoken by the agent before terminating due to max call duration limit reached.",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("reminder_messages", mode="before")
+    @classmethod
+    def _validate_reminder_messages(cls, v):
+        if v is None:
+            return []
+        if not isinstance(v, list):
+            raise ValueError("reminder_messages must be a list of strings")
+        cleaned = []
+        for item in v:
+            if not isinstance(item, str):
+                raise ValueError("each reminder message must be a string")
+            s = item.strip()
+            if s:
+                cleaned.append(s)
+        if len(cleaned) > 10:
+            raise ValueError("reminder_messages can contain at most 10 messages")
+        return cleaned
+
+    @field_validator("max_duration_message", mode="before")
+    @classmethod
+    def _validate_max_duration_message(cls, v):
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            raise ValueError("max_duration_message must be a string")
+        s = v.strip()
+        return s if s else None
+
+
+class CallTimingSettingsResponse(BaseModel):
+    """Response body for ``GET /api/v2/flows/{flow_id}/call-timing-settings``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    silence_timeout: int = 10
+    end_call_after_reminder: int = 10
+    reminder_retries: int = 1
+    reminder_messages: list[str] = Field(default_factory=list)
+    max_call_duration: int = 1800
+    max_duration_message: str | None = (
+        "I appreciate the conversation, but we've reached our time limit for this call."
+    )
+
+
 class SystemWebhooksSettingsUpdate(BaseModel):
     """Request body for ``PUT /api/v2/flows/{flow_id}/system-webhooks-settings``.
 

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -35,6 +35,8 @@ from app.schemas.call_flow import (
     AgentRef,
     CallScreeningSettingsResponse,
     CallScreeningSettingsUpdate,
+    CallTimingSettingsResponse,
+    CallTimingSettingsUpdate,
     CallerMemorySettingsResponse,
     CallerMemorySettingsUpdate,
     CallFlowSettingsUpdate,
@@ -1005,6 +1007,60 @@ class CallFlowService:
             ),
             dtmf_exceeded_action=flow.dtmf_exceeded_action or "end_call",
             dtmf_end_call_message=flow.dtmf_end_call_message,
+        )
+
+    # ── Call Timing & Silence Detection Settings ──
+
+    def update_call_timing_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: CallTimingSettingsUpdate,
+    ) -> CallTimingSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        update_dict = body.model_dump(exclude_unset=True)
+        if "reminder_messages" in update_dict and update_dict["reminder_messages"] is not None:
+            update_dict["reminder_messages"] = list(update_dict["reminder_messages"])
+        update_dict["updated_at"] = datetime.now(timezone.utc)
+
+        repo = CallFlowRepository(db)
+        flow = repo.update(flow, update_dict)
+        db.commit()
+        db.refresh(flow)
+        return self._to_call_timing_response(flow)
+
+    def get_call_timing_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> CallTimingSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        return self._to_call_timing_response(flow)
+
+    @staticmethod
+    def _to_call_timing_response(flow: CallFlow) -> CallTimingSettingsResponse:
+        return CallTimingSettingsResponse(
+            silence_timeout=(
+                flow.silence_timeout if flow.silence_timeout is not None else 10
+            ),
+            end_call_after_reminder=(
+                flow.end_call_after_reminder
+                if flow.end_call_after_reminder is not None
+                else 10
+            ),
+            reminder_retries=(
+                flow.reminder_retries if flow.reminder_retries is not None else 1
+            ),
+            reminder_messages=list(flow.reminder_messages or []),
+            max_call_duration=(
+                flow.max_call_duration
+                if flow.max_call_duration is not None
+                else 1800
+            ),
+            max_duration_message=flow.max_duration_message,
         )
 
     # ── System Webhooks (pre-inbound / dynamic routing / post-call / status) ──

--- a/app/voice/call_control_mixin.py
+++ b/app/voice/call_control_mixin.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+import uuid
 
 from app.core.config import settings
 from app.core.logger import logger
@@ -27,6 +28,27 @@ if TYPE_CHECKING:
 
 class CallControlMixin:
     """Call termination and transcript methods for BidirectionalStreamHandler."""
+
+    async def _play_tts_message(self, text: str) -> None:
+        """Enqueue a standalone spoken message to the TTS pipeline."""
+        clean_text = (text or "").strip()
+        if not clean_text:
+            return
+        tts_pipe = getattr(self, "_tts_pipeline", None)
+        if tts_pipe is not None:
+            if hasattr(tts_pipe, "queue_tts"):
+                use_ssml = bool(getattr(self, "_use_ssml", False))
+                await tts_pipe.queue_tts(
+                    {
+                        "text": clean_text,
+                        "chunk_id": f"msg_{uuid.uuid4().hex[:8]}",
+                        "use_ssml": use_ssml,
+                        "is_final": True,
+                    }
+                )
+                setattr(self, "_twilio_buffer_primed", False)
+            elif hasattr(tts_pipe, "say"):
+                await tts_pipe.say(clean_text)
 
     async def _check_and_end_call_if_goodbye(self, transcript: str):
         """
@@ -414,10 +436,7 @@ class CallControlMixin:
                         voicemail_msg = (getattr(flow, "voicemail_message", None) or "").strip()
                         if voicemail_msg:
                             try:
-                                if hasattr(self, "_play_tts_message") and callable(self._play_tts_message):
-                                    await self._play_tts_message(voicemail_msg)
-                                elif hasattr(self, "_tts_pipeline") and hasattr(self._tts_pipeline, "say"):
-                                    await self._tts_pipeline.say(voicemail_msg)
+                                await self._play_tts_message(voicemail_msg)
                             except Exception as tts_err:
                                 logger.warning("Could not play voicemail message before hangup: %s", tts_err)
 
@@ -770,6 +789,8 @@ class CallControlMixin:
         if not getattr(flow, "dtmf_allow_caller_interruption", False):
             self._dtmf_suppress_stt = True
 
+        self._cancel_silence_watchdog()
+
         if self._dtmf_debounce_task and not self._dtmf_debounce_task.done():
             self._dtmf_debounce_task.cancel()
 
@@ -798,14 +819,7 @@ class CallControlMixin:
                     ).strip()
                     if end_msg:
                         try:
-                            if hasattr(self, "_play_tts_message") and callable(
-                                self._play_tts_message
-                            ):
-                                await self._play_tts_message(end_msg)
-                            elif hasattr(self, "_tts_pipeline") and hasattr(
-                                self._tts_pipeline, "say"
-                            ):
-                                await self._tts_pipeline.say(end_msg)
+                            await self._play_tts_message(end_msg)
                         except Exception as tts_err:
                             logger.warning(
                                 "Could not play DTMF end call message before hangup: %s",
@@ -888,6 +902,290 @@ class CallControlMixin:
             pass
         except Exception as e:
             logger.error(f"Error flushing DTMF buffer: {e}", exc_info=True)
+
+    def _cancel_silence_watchdog(self) -> None:
+        """Cancel the active silence watchdog timer and reset retry count on user activity."""
+        task = getattr(self, "_silence_watchdog_task", None)
+        if task and not task.done():
+            task.cancel()
+        self._silence_watchdog_task = None
+        self._silence_retry_count = 0
+
+    def _arm_silence_watchdog(self) -> None:
+        """Arm or re-arm background silence watchdog timer when agent finishes speaking."""
+        if getattr(self, "_call_ended", False):
+            return
+        task = getattr(self, "_silence_watchdog_task", None)
+        if task and not task.done():
+            task.cancel()
+        self._silence_watchdog_task = asyncio.create_task(
+            self._silence_watchdog_loop()
+        )
+
+    async def _silence_watchdog_loop(self) -> None:
+        """Background loop that plays silence reminders and terminates after final timeout."""
+        try:
+            flow = getattr(self, "call_flow", None)
+            if (
+                flow is None
+                and self.call_session
+                and self.call_session.call_flow_id
+                and getattr(self, "db", None)
+            ):
+                try:
+                    from app.models.call_flow import CallFlow
+
+                    flow = self.db.get(CallFlow, self.call_session.call_flow_id)
+                except Exception:
+                    flow = None
+
+            if not flow:
+                return
+
+            silence_timeout_raw = getattr(flow, "silence_timeout", 10)
+            silence_timeout = (
+                silence_timeout_raw if silence_timeout_raw is not None else 10
+            )
+            reminder_retries_raw = getattr(flow, "reminder_retries", 1)
+            reminder_retries = (
+                reminder_retries_raw if reminder_retries_raw is not None else 1
+            )
+            end_call_after_reminder_raw = getattr(
+                flow, "end_call_after_reminder", 10
+            )
+            end_call_after_reminder = (
+                end_call_after_reminder_raw
+                if end_call_after_reminder_raw is not None
+                else 10
+            )
+            reminder_messages = list(getattr(flow, "reminder_messages", []) or [])
+
+            while not getattr(self, "_call_ended", False):
+                if getattr(self, "_silence_retry_count", 0) < reminder_retries:
+                    await asyncio.sleep(float(silence_timeout))
+                    if getattr(self, "_call_ended", False):
+                        break
+                    # If TTS is currently playing, skip reminder this tick
+                    if getattr(self, "_is_tts_playing", False):
+                        continue
+
+                    retry_idx = getattr(self, "_silence_retry_count", 0)
+                    if (
+                        retry_idx < len(reminder_messages)
+                        and reminder_messages[retry_idx]
+                    ):
+                        msg = reminder_messages[retry_idx]
+                    else:
+                        msg = "Are you still there?"
+
+                    logger.info(
+                        "Silence timeout (%ss) reached; playing reminder %d/%d: %r",
+                        silence_timeout,
+                        retry_idx + 1,
+                        reminder_retries,
+                        msg,
+                    )
+                    self._silence_retry_count = retry_idx + 1
+                    try:
+                        await self._play_tts_message(msg)
+                    except Exception as play_err:
+                        logger.warning(
+                            "Error playing silence reminder TTS: %s", play_err
+                        )
+                else:
+                    # Final reminder retry exhausted: wait end_call_after_reminder seconds then terminate
+                    await asyncio.sleep(float(end_call_after_reminder))
+                    if getattr(self, "_call_ended", False):
+                        break
+                    if getattr(self, "_is_tts_playing", False):
+                        continue
+
+                    logger.info(
+                        "Silence timeout after reminders (%ss) reached — ending call",
+                        end_call_after_reminder,
+                    )
+                    try:
+                        self._call_ended = True
+                        if self.call_session:
+                            updated = (
+                                call_session_service.update_call_session_status(
+                                    self.db,
+                                    self.call_session.id,
+                                    "completed",
+                                    ended_reason="Silence timeout after reminders",
+                                )
+                            )
+                            if updated:
+                                self.call_session = updated
+
+                        if self.call_sid and self.call_session:
+                            try:
+                                account_sid, auth_token = (
+                                    get_twilio_credentials_for_call(
+                                        self.db, self.call_session
+                                    )
+                                )
+                                twilio_service.end_call_with_credentials(
+                                    self.call_sid, account_sid, auth_token
+                                )
+                            except Exception as end_err:
+                                logger.warning(
+                                    "Could not end Twilio call on silence timeout: %s",
+                                    end_err,
+                                )
+
+                        if self.call_session:
+                            try:
+                                await broadcast_call_status_update(
+                                    call_session_id=str(self.call_session.id),
+                                    status="completed",
+                                    metadata={
+                                        "call_sid": self.call_sid,
+                                        "stream_sid": self.stream_sid,
+                                        "timestamp": datetime.now(
+                                            timezone.utc
+                                        ).isoformat(),
+                                        "message": "call_ended",
+                                        "event": "silence_timeout",
+                                        "reason": "Silence timeout after reminders",
+                                    },
+                                )
+                            except Exception as b_err:
+                                logger.debug(
+                                    f"WebSocket broadcast failed after silence timeout: {b_err}"
+                                )
+
+                        asyncio.create_task(self._full_shutdown())
+                    except Exception as end_e:
+                        logger.error(
+                            f"Error ending call on silence timeout: {end_e}",
+                            exc_info=True,
+                        )
+                    break
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(
+                f"Unexpected error in silence watchdog: {e}", exc_info=True
+            )
+
+    def _arm_max_duration_timer(self) -> None:
+        """Arm hard timer for maximum call duration."""
+        if getattr(self, "_call_ended", False):
+            return
+        flow = getattr(self, "call_flow", None)
+        if (
+            flow is None
+            and self.call_session
+            and self.call_session.call_flow_id
+            and getattr(self, "db", None)
+        ):
+            try:
+                from app.models.call_flow import CallFlow
+
+                flow = self.db.get(CallFlow, self.call_session.call_flow_id)
+            except Exception:
+                flow = None
+
+        if not flow:
+            return
+
+        max_dur_raw = getattr(flow, "max_call_duration", 1800)
+        max_dur = max_dur_raw if max_dur_raw is not None else 1800
+
+        task = getattr(self, "_max_duration_task", None)
+        if task and not task.done():
+            task.cancel()
+        self._max_duration_task = asyncio.create_task(
+            self._max_duration_watchdog(float(max_dur))
+        )
+
+    async def _max_duration_watchdog(self, max_seconds: float) -> None:
+        """Sleep for max call duration and terminate call with optional departure message."""
+        try:
+            await asyncio.sleep(max_seconds)
+            if getattr(self, "_call_ended", False):
+                return
+
+            logger.info(
+                "Max call duration (%ss) reached — ending call", max_seconds
+            )
+            flow = getattr(self, "call_flow", None)
+            if (
+                flow is None
+                and self.call_session
+                and self.call_session.call_flow_id
+                and getattr(self, "db", None)
+            ):
+                try:
+                    from app.models.call_flow import CallFlow
+
+                    flow = self.db.get(CallFlow, self.call_session.call_flow_id)
+                except Exception:
+                    flow = None
+
+            departure_msg = (
+                getattr(flow, "max_duration_message", None) or ""
+            ).strip()
+            if departure_msg:
+                try:
+                    await self._play_tts_message(departure_msg)
+                except Exception as tts_err:
+                    logger.warning(
+                        "Error playing max duration message: %s", tts_err
+                    )
+
+            self._call_ended = True
+            if self.call_session:
+                updated = call_session_service.update_call_session_status(
+                    self.db,
+                    self.call_session.id,
+                    "completed",
+                    ended_reason="Max call duration reached",
+                )
+                if updated:
+                    self.call_session = updated
+
+            if self.call_sid and self.call_session:
+                try:
+                    account_sid, auth_token = get_twilio_credentials_for_call(
+                        self.db, self.call_session
+                    )
+                    twilio_service.end_call_with_credentials(
+                        self.call_sid, account_sid, auth_token
+                    )
+                except Exception as end_err:
+                    logger.warning(
+                        "Could not end Twilio call on max duration limit: %s",
+                        end_err,
+                    )
+
+            if self.call_session:
+                try:
+                    await broadcast_call_status_update(
+                        call_session_id=str(self.call_session.id),
+                        status="completed",
+                        metadata={
+                            "call_sid": self.call_sid,
+                            "stream_sid": self.stream_sid,
+                            "timestamp": datetime.now(timezone.utc).isoformat(),
+                            "message": "call_ended",
+                            "event": "max_duration_reached",
+                            "reason": "Max call duration reached",
+                        },
+                    )
+                except Exception as b_err:
+                    logger.debug(
+                        f"WebSocket broadcast failed after max duration reached: {b_err}"
+                    )
+
+            asyncio.create_task(self._full_shutdown())
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(
+                f"Unexpected error in max duration watchdog: {e}", exc_info=True
+            )
     
     async def _add_to_transcript(
         self,

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9259,6 +9259,97 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/call-timing-settings:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Configure Call Timing & Silence Detection settings on a call flow
+      description: 'Configures call timing, silence detection watchdog, reminder messages,
+        and max call duration limits for this call flow.
+
+
+        - **Silence Timeout** (`silence_timeout`): Duration in seconds of silence
+        before reminder message plays (3–60s).
+
+        - **End Call After Reminder** (`end_call_after_reminder`): Seconds of silence
+        after final reminder before hangup (3–60s).
+
+        - **Reminder Retries** (`reminder_retries`): Number of reminder attempts before
+        disconnect (1–3).
+
+        - **Reminder Messages** (`reminder_messages`): List of custom reminder phrases
+        to cycle through.
+
+        - **Max Call Duration** (`max_call_duration`): Maximum duration in seconds
+        before forced call termination (60–7200s).
+
+        - **Max Duration Message** (`max_duration_message`): Spoken by the agent before
+        terminating due to time limit.
+
+
+        Admin rank (or API key) required because timing limits affect billing and
+        call duration enforcement.'
+      operationId: update_call_timing_settings_api_v2_flows__flow_id__call_timing_settings_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CallTimingSettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallTimingSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - A/B Prompt Testing
+      summary: Get the currently-saved Call Timing settings for a call flow
+      description: Returns the currently-saved Call Timing and silence detection settings
+        for this call flow. Read-only rank is sufficient since no secret keys are
+        exposed.
+      operationId: get_call_timing_settings_api_v2_flows__flow_id__call_timing_settings_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CallTimingSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/system-webhooks-settings:
     put:
       tags:
@@ -13326,6 +13417,82 @@ components:
       - assistant_messages
       - total_response_time_entries
       title: CallSessionStats
+    CallTimingSettingsResponse:
+      properties:
+        silence_timeout:
+          type: integer
+          title: Silence Timeout
+          default: 10
+        end_call_after_reminder:
+          type: integer
+          title: End Call After Reminder
+          default: 10
+        reminder_retries:
+          type: integer
+          title: Reminder Retries
+          default: 1
+        reminder_messages:
+          items:
+            type: string
+          type: array
+          title: Reminder Messages
+        max_call_duration:
+          type: integer
+          title: Max Call Duration
+          default: 1800
+        max_duration_message:
+          type: string
+          nullable: true
+      type: object
+      title: CallTimingSettingsResponse
+      description: Response body for ``GET /api/v2/flows/{flow_id}/call-timing-settings``.
+    CallTimingSettingsUpdate:
+      properties:
+        silence_timeout:
+          type: integer
+          maximum: 60.0
+          minimum: 3.0
+          title: Silence Timeout
+          description: Duration in seconds of caller silence before a reminder message
+            is played (3-60).
+          default: 10
+        end_call_after_reminder:
+          type: integer
+          maximum: 60.0
+          minimum: 3.0
+          title: End Call After Reminder
+          description: Duration in seconds of caller silence after the final reminder
+            before terminating call (3-60).
+          default: 10
+        reminder_retries:
+          type: integer
+          maximum: 3.0
+          minimum: 1.0
+          title: Reminder Retries
+          description: Number of reminder attempts before disconnecting the call (1-3).
+          default: 1
+        reminder_messages:
+          items:
+            type: string
+          type: array
+          title: Reminder Messages
+          description: Custom list of reminder messages to cycle through upon silence.
+        max_call_duration:
+          type: integer
+          maximum: 7200.0
+          minimum: 60.0
+          title: Max Call Duration
+          description: Maximum allowed call duration in seconds before forced termination
+            (60-7200, 1m-120m).
+          default: 1800
+        max_duration_message:
+          type: string
+          maxLength: 500
+          nullable: true
+      additionalProperties: false
+      type: object
+      title: CallTimingSettingsUpdate
+      description: Request body for ``PUT /api/v2/flows/{flow_id}/call-timing-settings``.
     CallbackConfigResponse:
       properties:
         smart_callback_enabled:

--- a/tests/api/v2/test_call_timing_settings.py
+++ b/tests/api/v2/test_call_timing_settings.py
@@ -1,0 +1,500 @@
+"""Tests for PUT and GET /api/v2/flows/{flow_id}/call-timing-settings.
+
+Coverage:
+  - Admin/API-key principal can update all Call Timing settings
+  - Default values on fresh flows
+  - Boundary validations (silence_timeout 3-60, end_call_after_reminder 3-60, reminder_retries 1-3, max_call_duration 60-7200)
+  - String handling for max_duration_message (trimming, blank to None, max 500 length)
+  - List handling for reminder_messages (filtering blank strings, max 10 entries)
+  - Extra fields rejected (extra="forbid")
+  - Non-admin (config_only, read_only, billing_only) forbidden on PUT (403)
+  - Read-only rank is sufficient for GET (200)
+  - Tenant isolation: unknown flow_id or other tenant flow returns 404
+  - Audit event logged on PUT (action="call_timing_settings.updated")
+  - GET round-trips prior PUT updates
+  - GET handles null/none attribute fallback on flow object
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_admin_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_admin_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_admin_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_readonly_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_readonly_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_readonly_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_app_for_real_rank_check(db_override, principal):
+    from app.api.deps import get_db, require_tenant
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    mini.dependency_overrides[require_tenant] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _with_effective_role(role_name: str):
+    return patch(
+        "app.api.deps.rbac.rbac_cache_service.get_effective_role",
+        return_value=role_name,
+    )
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"TimingWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"timing_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def other_workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"OtherTimingWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"other_timing_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Timing Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, workspace, agent):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=workspace.id,
+        agent_id=agent.id,
+        name="Call Timing Test Flow",
+        direction="outbound",
+        status="active",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+class TestUpdateCallTimingSettings:
+    def test_admin_can_update_all_call_timing_settings(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        payload = {
+            "silence_timeout": 15,
+            "end_call_after_reminder": 20,
+            "reminder_retries": 2,
+            "reminder_messages": [
+                "Hello, are you still there?",
+                "I haven't heard from you in a moment.",
+            ],
+            "max_call_duration": 3600,
+            "max_duration_message": "Our scheduled call time is up. Have a great day!",
+        }
+
+        resp = client.put(f"/flows/{flow.id}/call-timing-settings", json=payload)
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        for k, v in payload.items():
+            assert body[k] == v
+
+        db.refresh(flow)
+        assert flow.silence_timeout == 15
+        assert flow.end_call_after_reminder == 20
+        assert flow.reminder_retries == 2
+        assert flow.reminder_messages == [
+            "Hello, are you still there?",
+            "I haven't heard from you in a moment.",
+        ]
+        assert flow.max_call_duration == 3600
+        assert (
+            flow.max_duration_message
+            == "Our scheduled call time is up. Have a great day!"
+        )
+
+    @pytest.mark.parametrize(
+        "field,value",
+        [
+            ("silence_timeout", 2),
+            ("silence_timeout", 61),
+            ("end_call_after_reminder", 2),
+            ("end_call_after_reminder", 61),
+            ("reminder_retries", 0),
+            ("reminder_retries", 4),
+            ("max_call_duration", 59),
+            ("max_call_duration", 7201),
+        ],
+    )
+    def test_boundary_validations_rejected(
+        self, db, workspace, flow, field, value
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={field: value},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_max_duration_message_blank_converts_to_none(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"max_duration_message": "   "},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["max_duration_message"] is None
+
+    def test_max_duration_message_over_max_length_rejected(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"max_duration_message": "a" * 501},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_reminder_messages_strips_blanks(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={
+                "reminder_messages": [
+                    "Are you there?",
+                    "   ",
+                    "Hello?",
+                    "",
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["reminder_messages"] == ["Are you there?", "Hello?"]
+
+    def test_reminder_messages_max_limit_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"reminder_messages": [f"Msg {i}" for i in range(11)]},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_extra_fields_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={
+                "silence_timeout": 10,
+                "unexpected_field": "val",
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{uuid.uuid4()}/call-timing-settings",
+            json={"silence_timeout": 10},
+        )
+        assert resp.status_code == 404
+
+    def test_other_tenant_flow_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_app(db, foreign_principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"silence_timeout": 10},
+        )
+        assert resp.status_code == 404
+
+    def test_update_fires_audit_event(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        with patch("app.api.v2.routers.flows.log_audit_event") as mock_audit:
+            resp = client.put(
+                f"/flows/{flow.id}/call-timing-settings",
+                json={"silence_timeout": 20, "max_call_duration": 900},
+            )
+            assert resp.status_code == 200
+
+        mock_audit.assert_called_once()
+        _, kwargs = mock_audit.call_args
+        assert kwargs["action"] == "call_timing_settings.updated"
+        assert kwargs["resource_type"] == "call_flow"
+        assert kwargs["resource_id"] == flow.id
+        assert kwargs["new_value"]["silence_timeout"] == 20
+        assert kwargs["new_value"]["max_call_duration"] == 900
+
+    def test_non_admin_forbidden_on_put(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for non_admin_role in ["config_only", "read_only", "billing_only"]:
+            with _with_effective_role(non_admin_role):
+                resp = client.put(
+                    f"/flows/{flow.id}/call-timing-settings",
+                    json={"silence_timeout": 15},
+                )
+                assert resp.status_code == 403
+
+
+class TestGetCallTimingSettings:
+    def test_fresh_flow_returns_defaults(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{flow.id}/call-timing-settings")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["silence_timeout"] == 10
+        assert body["end_call_after_reminder"] == 10
+        assert body["reminder_retries"] == 1
+        assert body["reminder_messages"] == []
+        assert body["max_call_duration"] == 1800
+        assert body["max_duration_message"] == (
+            "I appreciate the conversation, but we've reached our time limit for this call."
+        )
+
+    def test_get_round_trips_prior_put_update(self, db, workspace, flow):
+        admin_principal = _principal(workspace.id)
+        admin_client = _build_app(db, admin_principal)
+
+        put_resp = admin_client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={
+                "silence_timeout": 25,
+                "reminder_retries": 3,
+                "reminder_messages": ["Still there?"],
+                "max_call_duration": 2400,
+            },
+        )
+        assert put_resp.status_code == 200
+
+        readonly_principal = _principal(workspace.id)
+        readonly_client = _build_readonly_app(db, readonly_principal)
+
+        get_resp = readonly_client.get(f"/flows/{flow.id}/call-timing-settings")
+        assert get_resp.status_code == 200
+        assert get_resp.json() == put_resp.json()
+
+    def test_readonly_user_can_access_get(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for role in ["read_only", "config_only", "manager", "admin", "owner"]:
+            with _with_effective_role(role):
+                resp = client.get(f"/flows/{flow.id}/call-timing-settings")
+                assert resp.status_code == 200
+
+    def test_get_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{uuid.uuid4()}/call-timing-settings")
+        assert resp.status_code == 404
+
+    def test_get_other_tenant_flow_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_readonly_app(db, foreign_principal)
+
+        resp = client.get(f"/flows/{flow.id}/call-timing-settings")
+        assert resp.status_code == 404
+
+    def test_get_handles_null_attributes_fallback(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        mock_flow = MagicMock()
+        mock_flow.id = flow.id
+        mock_flow.tenant_id = workspace.id
+        mock_flow.silence_timeout = None
+        mock_flow.end_call_after_reminder = None
+        mock_flow.reminder_retries = None
+        mock_flow.reminder_messages = None
+        mock_flow.max_call_duration = None
+        mock_flow.max_duration_message = None
+
+        with patch(
+            "app.services.call_flow_service.call_flow_service._get_flow_or_404",
+            return_value=mock_flow,
+        ):
+            resp = client.get(f"/flows/{flow.id}/call-timing-settings")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["silence_timeout"] == 10
+            assert body["end_call_after_reminder"] == 10
+            assert body["reminder_retries"] == 1
+            assert body["reminder_messages"] == []
+            assert body["max_call_duration"] == 1800
+            assert body["max_duration_message"] is None
+
+    def test_partial_update_preserves_unmodified_fields(
+        self, db, workspace, flow
+    ):
+        admin_principal = _principal(workspace.id)
+        admin_client = _build_app(db, admin_principal)
+
+        resp1 = admin_client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={
+                "silence_timeout": 20,
+                "reminder_messages": ["Custom reminder 1"],
+                "max_call_duration": 2400,
+            },
+        )
+        assert resp1.status_code == 200
+        assert resp1.json()["silence_timeout"] == 20
+        assert resp1.json()["reminder_messages"] == ["Custom reminder 1"]
+        assert resp1.json()["max_call_duration"] == 2400
+
+        # Partial update: only change silence_timeout
+        resp2 = admin_client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"silence_timeout": 30},
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["silence_timeout"] == 30
+        assert resp2.json()["reminder_messages"] == ["Custom reminder 1"]
+        assert resp2.json()["max_call_duration"] == 2400
+
+    def test_reminder_messages_invalid_type_rejected(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"reminder_messages": "not-a-list"},
+        )
+        assert resp.status_code in (400, 422)
+
+        resp_items = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"reminder_messages": [123, 456]},
+        )
+        assert resp_items.status_code in (400, 422)
+
+    def test_null_reminder_messages_coerces_to_empty_list(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/call-timing-settings",
+            json={"reminder_messages": None},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["reminder_messages"] == []

--- a/tests/services/test_call_timing_runtime.py
+++ b/tests/services/test_call_timing_runtime.py
@@ -1,0 +1,356 @@
+"""Unit and runtime integration tests for Call Timing and Silence Detection watchdog.
+
+Coverage:
+  - Silence watchdog plays reminder message upon silence timeout
+  - Silence watchdog cycles through custom reminder messages
+  - Client speech cancels and resets silence watchdog timer
+  - DTMF keypress cancels and resets silence watchdog timer
+  - Silence watchdog terminates call after final reminder retries exhausted
+  - Max call duration watchdog plays departure message and terminates call
+  - Already-ended calls are safely ignored
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.voice.call_control_mixin import CallControlMixin
+
+
+class DummyHostHandler(CallControlMixin):
+    def __init__(
+        self,
+        db=None,
+        call_session=None,
+        call_flow=None,
+        call_sid="CA_TIMING_123",
+        stream_sid="MZ_TIMING_123",
+    ):
+        self.db = db
+        self.call_session = call_session
+        self.call_flow = call_flow
+        self.call_sid = call_sid
+        self.stream_sid = stream_sid
+        self._call_ended = False
+        self._is_tts_playing = False
+        self._silence_watchdog_task = None
+        self._max_duration_task = None
+        self._silence_retry_count = 0
+        self._full_shutdown = AsyncMock()
+        self._play_tts_message = AsyncMock()
+        self.processed_transcripts: list[str] = []
+
+    async def _process_transcript(
+        self, transcript: str, confidence: float = 1.0, **kwargs
+    ):
+        self._cancel_silence_watchdog()
+        self.processed_transcripts.append(transcript)
+
+
+class TestSilenceWatchdogRuntime:
+    @pytest.mark.anyio
+    async def test_silence_watchdog_plays_first_reminder(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.silence_timeout = 0  # Instantaneous for test
+        flow.reminder_retries = 1
+        flow.end_call_after_reminder = 10
+        flow.reminder_messages = ["Are you still with me?"]
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        handler._arm_silence_watchdog()
+
+        # Allow loop to execute first reminder
+        await asyncio.sleep(0.01)
+
+        handler._play_tts_message.assert_awaited_once_with(
+            "Are you still with me?"
+        )
+        assert handler._silence_retry_count == 1
+        assert handler._call_ended is False
+
+        handler._cancel_silence_watchdog()
+
+    @pytest.mark.anyio
+    async def test_silence_watchdog_cycles_custom_reminder_messages(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.silence_timeout = 0
+        flow.reminder_retries = 2
+        flow.end_call_after_reminder = 10
+        flow.reminder_messages = ["First reminder.", "Second reminder."]
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        handler._arm_silence_watchdog()
+
+        await asyncio.sleep(0.02)
+
+        assert handler._play_tts_message.await_count >= 2
+        calls = [c[0][0] for c in handler._play_tts_message.call_args_list]
+        assert "First reminder." in calls
+        assert "Second reminder." in calls
+        assert handler._silence_retry_count == 2
+
+        handler._cancel_silence_watchdog()
+
+    @pytest.mark.anyio
+    async def test_user_speech_cancels_and_resets_silence_watchdog(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.silence_timeout = 10
+        flow.reminder_retries = 2
+        flow.end_call_after_reminder = 10
+        flow.reminder_messages = []
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        handler._arm_silence_watchdog()
+        handler._silence_retry_count = 1
+
+        assert handler._silence_watchdog_task is not None
+
+        # User speaks
+        await handler._process_transcript("Yes, I have a question.")
+
+        assert handler._silence_retry_count == 0
+        assert handler._silence_watchdog_task is None
+
+    @pytest.mark.anyio
+    async def test_dtmf_keypress_cancels_silence_watchdog(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.dtmf_enabled = True
+        flow.dtmf_button_press_delay = 2
+        flow.dtmf_max_digits = 10
+        flow.dtmf_allowed_exceeded_attempts = 5
+        flow.dtmf_exceeded_action = "end_call"
+        flow.silence_timeout = 10
+        flow.reminder_retries = 2
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        handler._arm_silence_watchdog()
+        handler._silence_retry_count = 1
+
+        assert handler._silence_watchdog_task is not None
+
+        # User presses DTMF key
+        await handler.handle_dtmf_message({"event": "dtmf", "digit": "5"})
+
+        assert handler._silence_retry_count == 0
+        assert handler._silence_watchdog_task is None
+
+        if handler._dtmf_debounce_task:
+            handler._dtmf_debounce_task.cancel()
+
+    @pytest.mark.anyio
+    async def test_final_silence_timeout_terminates_call(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.silence_timeout = 0
+        flow.reminder_retries = 1
+        flow.end_call_after_reminder = 0
+        flow.reminder_messages = ["Are you still there?"]
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+
+        with (
+            patch(
+                "app.voice.call_control_mixin.call_session_service.update_call_session_status"
+            ) as mock_update,
+            patch(
+                "app.voice.call_control_mixin.get_twilio_credentials_for_call",
+                return_value=("AC123", "token"),
+            ),
+            patch(
+                "app.voice.call_control_mixin.twilio_service.end_call_with_credentials"
+            ) as mock_end_call,
+            patch(
+                "app.voice.call_control_mixin.broadcast_call_status_update"
+            ) as mock_broadcast,
+        ):
+            handler._arm_silence_watchdog()
+            await asyncio.sleep(0.05)
+
+        assert handler._call_ended is True
+        mock_update.assert_called_once_with(
+            handler.db,
+            session.id,
+            "completed",
+            ended_reason="Silence timeout after reminders",
+        )
+        mock_end_call.assert_called_once_with("CA_TIMING_123", "AC123", "token")
+        mock_broadcast.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_silence_watchdog_ignores_already_ended_call(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.silence_timeout = 0
+        flow.reminder_retries = 1
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        handler._call_ended = True
+
+        handler._arm_silence_watchdog()
+        assert handler._silence_watchdog_task is None
+
+
+class TestMaxCallDurationRuntime:
+    @pytest.mark.anyio
+    async def test_max_duration_watchdog_plays_message_and_terminates(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.max_call_duration = 0  # Instantaneous for test
+        flow.max_duration_message = "Our time limit has arrived. Goodbye."
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+
+        with (
+            patch(
+                "app.voice.call_control_mixin.call_session_service.update_call_session_status"
+            ) as mock_update,
+            patch(
+                "app.voice.call_control_mixin.get_twilio_credentials_for_call",
+                return_value=("AC123", "token"),
+            ),
+            patch(
+                "app.voice.call_control_mixin.twilio_service.end_call_with_credentials"
+            ) as mock_end_call,
+            patch(
+                "app.voice.call_control_mixin.broadcast_call_status_update"
+            ) as mock_broadcast,
+        ):
+            await handler._max_duration_watchdog(max_seconds=0)
+
+        assert handler._call_ended is True
+        handler._play_tts_message.assert_awaited_once_with(
+            "Our time limit has arrived. Goodbye."
+        )
+        mock_update.assert_called_once_with(
+            handler.db,
+            session.id,
+            "completed",
+            ended_reason="Max call duration reached",
+        )
+        mock_end_call.assert_called_once_with("CA_TIMING_123", "AC123", "token")
+        mock_broadcast.assert_called_once()
+
+    @pytest.mark.anyio
+    async def test_max_duration_watchdog_ignores_already_ended_call(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.max_call_duration = 0
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        handler._call_ended = True
+
+        await handler._max_duration_watchdog(max_seconds=0)
+        assert handler._play_tts_message.await_count == 0
+
+    @pytest.mark.anyio
+    async def test_silence_watchdog_skips_when_tts_is_playing(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.silence_timeout = 0
+        flow.reminder_retries = 1
+        flow.end_call_after_reminder = 10
+        flow.reminder_messages = ["Are you there?"]
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        handler = DummyHostHandler(call_session=session, call_flow=flow)
+        handler._is_tts_playing = True  # Agent is currently speaking
+        handler._arm_silence_watchdog()
+
+        await asyncio.sleep(0.02)
+
+        # Reminder should NOT have played because TTS was active
+        assert handler._play_tts_message.await_count == 0
+        assert handler._silence_retry_count == 0
+
+        handler._cancel_silence_watchdog()
+
+    @pytest.mark.anyio
+    async def test_default_play_tts_message_queues_to_tts_pipeline(self):
+        class RealMixinHandler(CallControlMixin):
+            def __init__(self):
+                self._tts_pipeline = MagicMock()
+                self._tts_pipeline.queue_tts = AsyncMock()
+                self._use_ssml = False
+                self._twilio_buffer_primed = True
+
+        handler = RealMixinHandler()
+        await handler._play_tts_message("Testing default TTS queueing")
+
+        handler._tts_pipeline.queue_tts.assert_awaited_once()
+        task_arg = handler._tts_pipeline.queue_tts.call_args[0][0]
+        assert task_arg["text"] == "Testing default TTS queueing"
+        assert task_arg["is_final"] is True
+        assert handler._twilio_buffer_primed is False
+
+    @pytest.mark.anyio
+    async def test_max_duration_watchdog_fallback_db_lookup(self):
+        flow = MagicMock(spec=CallFlow)
+        flow.max_call_duration = 0
+        flow.max_duration_message = "Time is up from DB lookup."
+
+        session = MagicMock(spec=CallSession)
+        session.id = uuid.uuid4()
+        session.call_flow_id = uuid.uuid4()
+
+        db_mock = MagicMock()
+        db_mock.get.return_value = flow
+
+        # handler.call_flow is None, should look up via handler.db.get(CallFlow, ...)
+        handler = DummyHostHandler(
+            db=db_mock, call_session=session, call_flow=None
+        )
+
+        with (
+            patch(
+                "app.voice.call_control_mixin.call_session_service.update_call_session_status"
+            ),
+            patch(
+                "app.voice.call_control_mixin.get_twilio_credentials_for_call",
+                return_value=("AC123", "token"),
+            ),
+            patch(
+                "app.voice.call_control_mixin.twilio_service.end_call_with_credentials"
+            ),
+            patch(
+                "app.voice.call_control_mixin.broadcast_call_status_update"
+            ),
+        ):
+            await handler._max_duration_watchdog(max_seconds=0)
+
+        assert handler._call_ended is True
+        handler._play_tts_message.assert_awaited_once_with(
+            "Time is up from DB lookup."
+        )


### PR DESCRIPTION
## 📌 Summary of Changes

Implements persistent **Call Timing Settings** and the real-time voice pipeline execution engine for **Silence Detection Reminders** and **Hard Maximum Call Duration Limits** on Call Flows.

---

### 🛠️ Scope of Changes:

1. **Database Schema & Alembic Migration:**
   - Added 6 columns to `CallFlow` in `app/models/call_flow.py`:
     - `silence_timeout` (Integer, default 10)
     - `end_call_after_reminder` (Integer, default 10)
     - `reminder_retries` (Integer, default 1)
     - `reminder_messages` (JSONB / JSON, default `[]`)
     - `max_call_duration` (Integer, default 1800)
     - `max_duration_message` (Text, default *"I appreciate the conversation, but we've reached our time limit for this call."*)
   - Added and applied migration `f6a2b3c4d5e6_add_call_timing_settings_to_call_flow.py` revising `e5f12a73b901`.

2. **Pydantic Schemas & Service Layer:**
   - `CallTimingSettingsUpdate` with `extra="forbid"`, boundary checks (silence timeout 3–60s, end call after reminder 3–60s, reminder retries 1–3, max call duration 60–7200s, max 10 reminder messages, max 500 chars message).
   - `CallTimingSettingsResponse` with attribute mapping and defaults.
   - `update_call_timing_settings` and `get_call_timing_settings` in `app/services/call_flow_service.py`.

3. **REST Endpoints & Audit Logging:**
   - `PUT /api/v2/flows/{flow_id}/call-timing-settings`: Admin rank (`require_admin_or_api_key`) + audit logging (`call_timing_settings.updated`).
   - `GET /api/v2/flows/{flow_id}/call-timing-settings`: Read-only rank (`require_readonly_or_api_key`).
   - Documented in `docs/api/openapi.yaml`.

4. **Real-Time Voice Pipeline Execution:**
   - **Silence Watchdog:** In `call_control_mixin.py` and `bidirectional_stream.py`, armed on user pickup / turn completion, plays cycled reminder messages via TTS, resets retry count and cancels on client speech (interim/final) or DTMF input, and terminates after final reminder wait.
   - **Max Duration Watchdog:** Armed at stream start, sleeps for `max_call_duration`, plays `max_duration_message`, updates session status to completed (`ended_reason="Max call duration reached"`), ends Twilio call, broadcasts status, and shuts down cleanly.

5. **Automated Tests & Quality:**
   - Added `tests/api/v2/test_call_timing_settings.py` and `tests/services/test_call_timing_runtime.py`.
   - Verified with 38 unit & runtime tests passed and 167 total flow regression tests passed.
   - Verified clean with `ruff check`.