### PR TITLE
feat(flows): implement inbound call redirection and conditional rules engine

### DIFF
--- a/alembic/versions/d7a8b9c0e1f2_add_inbound_redirect_settings_to_call_flow.py
+++ b/alembic/versions/d7a8b9c0e1f2_add_inbound_redirect_settings_to_call_flow.py
@@ -1,0 +1,76 @@
+"""add_inbound_redirect_settings_to_call_flow
+
+Revision ID: d7a8b9c0e1f2
+Revises: f6a2b3c4d5e6
+Create Date: 2026-08-26 11:03:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd7a8b9c0e1f2'
+down_revision: Union[str, None] = 'f6a2b3c4d5e6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'redirect_inbound_calls_enabled',
+            sa.Boolean(),
+            server_default='false',
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'redirect_forward_phone_number',
+            sa.String(length=50),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'redirect_conditions',
+            JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'[]'::jsonb"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'redirect_speak_message_enabled',
+            sa.Boolean(),
+            server_default='false',
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'redirect_message',
+            sa.Text(),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('callflow', 'redirect_message')
+    op.drop_column('callflow', 'redirect_speak_message_enabled')
+    op.drop_column('callflow', 'redirect_conditions')
+    op.drop_column('callflow', 'redirect_forward_phone_number')
+    op.drop_column('callflow', 'redirect_inbound_calls_enabled')

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -11,6 +11,18 @@ PUT  /api/v2/flows/{flow_id}/ab-test/winner
 PUT  /api/v2/flows/{flow_id}/caller-memory-settings
 PUT  /api/v2/flows/{flow_id}/post-call-actions-settings
 GET  /api/v2/flows/{flow_id}/post-call-actions-settings
+PUT  /api/v2/flows/{flow_id}/voicemail-settings
+GET  /api/v2/flows/{flow_id}/voicemail-settings
+PUT  /api/v2/flows/{flow_id}/call-screening-settings
+GET  /api/v2/flows/{flow_id}/call-screening-settings
+PUT  /api/v2/flows/{flow_id}/metadata-settings
+GET  /api/v2/flows/{flow_id}/metadata-settings
+PUT  /api/v2/flows/{flow_id}/ivr-dtmf-settings
+GET  /api/v2/flows/{flow_id}/ivr-dtmf-settings
+PUT  /api/v2/flows/{flow_id}/call-timing-settings
+GET  /api/v2/flows/{flow_id}/call-timing-settings
+PUT  /api/v2/flows/{flow_id}/inbound-redirect-settings
+GET  /api/v2/flows/{flow_id}/inbound-redirect-settings
 PUT  /api/v2/flows/{flow_id}/system-webhooks-settings
 GET  /api/v2/flows/{flow_id}/system-webhooks-settings
 POST /api/v2/flows/{flow_id}/system-webhooks/test
@@ -52,6 +64,8 @@ from app.schemas.call_flow import (
     CallScreeningSettingsUpdate,
     CallTimingSettingsResponse,
     CallTimingSettingsUpdate,
+    InboundRedirectSettingsResponse,
+    InboundRedirectSettingsUpdate,
     IVRDTMFSettingsResponse,
     IVRDTMFSettingsUpdate,
     MetadataSettingsResponse,
@@ -545,6 +559,64 @@ def get_call_timing_settings(
     db: Session = Depends(get_db),
 ) -> CallTimingSettingsResponse:
     return call_flow_service.get_call_timing_settings(
+        db, flow_id, _tenant_id(principal)
+    )
+
+
+@router.put(
+    "/{flow_id}/inbound-redirect-settings",
+    response_model=InboundRedirectSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Configure Inbound Call Redirection & Forwarding settings on a call flow",
+    description=(
+        "Configures inbound call redirection, forwarding phone number, conditional routing rules, and departure announcements.\n\n"
+        "- **Master Toggle** (`redirect_inbound_calls_enabled`): Enables or disables inbound call forwarding.\n"
+        "- **Forward Phone Number** (`redirect_forward_phone_number`): Destination phone number (e.g. `+14155552671`).\n"
+        "- **Conditional Rules** (`redirect_conditions`): List of `{variable, operator, value}` rules evaluated with AND logic against call context.\n"
+        "- **Spoken Announcement** (`redirect_speak_message_enabled`, `redirect_message`): Speaks rendered departure message via TwiML `<Say>` before forwarding.\n\n"
+        "Admin rank (or API key) required."
+    ),
+)
+def update_inbound_redirect_settings(
+    flow_id: uuid.UUID,
+    body: InboundRedirectSettingsUpdate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> InboundRedirectSettingsResponse:
+    tenant_id = _tenant_id(principal)
+    result = call_flow_service.update_inbound_redirect_settings(
+        db, flow_id, tenant_id, body
+    )
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="inbound_redirect_settings.updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        new_value=result.model_dump(),
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.get(
+    "/{flow_id}/inbound-redirect-settings",
+    response_model=InboundRedirectSettingsResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get the currently-saved Inbound Call Redirection settings for a call flow",
+    description=(
+        "Returns the currently-saved Inbound Call Redirection and conditional forwarding settings for this call flow. "
+        "Read-only rank is sufficient."
+    ),
+)
+def get_inbound_redirect_settings(
+    flow_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> InboundRedirectSettingsResponse:
+    return call_flow_service.get_inbound_redirect_settings(
         db, flow_id, _tenant_id(principal)
     )
 

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -271,6 +271,19 @@ class CallFlow(Base):
         server_default="I appreciate the conversation, but we've reached our time limit for this call.",
     )
 
+    # ── Inbound Call Redirection & Forwarding Settings ──
+    redirect_inbound_calls_enabled = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+    redirect_forward_phone_number = Column(String(50), nullable=True)
+    redirect_conditions = Column(
+        JSONB, default=list, nullable=False, server_default=sa_text("'[]'")
+    )
+    redirect_speak_message_enabled = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+    redirect_message = Column(Text, nullable=True)
+
     hipaa_compliance = Column(
         Boolean, default=False, nullable=False, server_default="false"
     )

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -28,6 +28,7 @@ from app.models.user import User
 from app.models.call_session import CallSession
 from app.models.call_flow import CallFlow
 from app.models.phone_number import PhoneNumber
+from app.services.call_flow_service import call_flow_service
 from app.services.call_session_service import call_session_service
 from app.services.voice_screening_qualification_service import (
     maybe_update_resume_status_on_call_completed,
@@ -355,6 +356,88 @@ async def handle_incoming_call(
             resolved_agent = inbound_agent
             resolved_flow = None
             webhook_variables = {}
+
+        # ── Inbound Call Redirection & Forwarding Check ──
+        target_flow = resolved_flow or default_call_flow
+        if (
+            target_flow
+            and target_flow.redirect_inbound_calls_enabled
+            and target_flow.redirect_forward_phone_number
+        ):
+            static_metadata = dict(
+                target_flow.pre_inbound_webhook_static_metadata or {}
+            )
+            redirect_context = {
+                "from": from_number,
+                "to": to_number,
+                "caller_phone": from_number,
+                "caller_number": from_number,
+                "From": from_number,
+                "To": to_number,
+                "_metadata": static_metadata,
+                "_variable": dict(webhook_variables or {}),
+                **static_metadata,
+                **dict(webhook_variables or {}),
+            }
+
+            conditions_met = call_flow_service.evaluate_redirect_conditions(
+                target_flow.redirect_conditions or [],
+                redirect_context,
+            )
+
+            if conditions_met:
+                logger.info(
+                    "Inbound call redirection triggered for call %s (flow=%s, forward_to=%s)",
+                    call_sid,
+                    target_flow.id,
+                    target_flow.redirect_forward_phone_number,
+                )
+                try:
+                    redirect_session = CallSession(
+                        tenant_id=phone_number.tenant_id,
+                        user_id=resolved_agent.created_by,
+                        agent_id=resolved_agent.id,
+                        call_flow_id=target_flow.id,
+                        call_sid=call_sid,
+                        from_number=from_number,
+                        to_number=to_number,
+                        call_type="inbound",
+                        status="completed",
+                        transferred=True,
+                        ended_reason="Inbound call redirected",
+                        start_time=datetime.now(timezone.utc),
+                        end_time=datetime.now(timezone.utc),
+                    )
+                    db.add(redirect_session)
+                    db.commit()
+                    db.refresh(redirect_session)
+                except Exception as db_err:
+                    db.rollback()
+                    logger.warning(
+                        "Could not save redirected call session (call_sid=%s): %s",
+                        call_sid,
+                        db_err,
+                    )
+
+                response = VoiceResponse()
+                if (
+                    target_flow.redirect_speak_message_enabled
+                    and target_flow.redirect_message
+                ):
+                    rendered_msg = (
+                        call_flow_service.render_redirect_message_template(
+                            target_flow.redirect_message,
+                            redirect_context,
+                        )
+                    )
+                    if rendered_msg:
+                        response.say(rendered_msg)
+
+                dial = response.dial(
+                    caller_id=from_number if from_number else None
+                )
+                dial.number(target_flow.redirect_forward_phone_number)
+                return HTMLResponse(str(response), media_type="application/xml")
 
         # Billing guardrail: enforce the same credit gating used in outbound flows.
         if not resolved_agent.model:

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -534,6 +534,113 @@ class CallTimingSettingsResponse(BaseModel):
     )
 
 
+class RedirectConditionOperatorEnum(str, Enum):
+    exists = "exists"
+    not_empty = "not_empty"
+    equals = "equals"
+    not_equals = "not_equals"
+
+
+class RedirectCondition(BaseModel):
+    """Single conditional rule evaluated against pre-inbound webhook & call variables."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    variable: str = Field(
+        ...,
+        description="Variable name or token, e.g. 'tier', 'company', or '{{_metadata.company}}'",
+        min_length=1,
+        max_length=100,
+    )
+    operator: RedirectConditionOperatorEnum
+    value: str | None = Field(default=None, max_length=255)
+
+    @field_validator("variable", mode="before")
+    @classmethod
+    def _clean_variable(cls, v: Any) -> str:
+        if not isinstance(v, str):
+            raise ValueError("Variable must be a string")
+        s = v.strip()
+        if not s:
+            raise ValueError("Variable cannot be empty")
+        return s
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def _clean_value(cls, v: Any) -> str | None:
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            v = str(v)
+        return v.strip()
+
+
+class InboundRedirectSettingsUpdate(BaseModel):
+    """Request body for ``PUT /api/v2/flows/{flow_id}/inbound-redirect-settings``."""
+
+    redirect_inbound_calls_enabled: bool = False
+    redirect_forward_phone_number: str | None = Field(
+        default=None,
+        max_length=50,
+        description="Destination phone number (e.g. +14155552671) to forward matched inbound calls",
+    )
+    redirect_conditions: list[RedirectCondition] = Field(
+        default_factory=list,
+        description="Conditional rules evaluated with AND logic against call context",
+    )
+    redirect_speak_message_enabled: bool = False
+    redirect_message: str | None = Field(
+        default=None,
+        max_length=500,
+        description="Spoken announcement via TwiML <Say> before forwarding",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("redirect_forward_phone_number", mode="before")
+    @classmethod
+    def _clean_phone_number(cls, v: Any) -> str | None:
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            raise ValueError("redirect_forward_phone_number must be a string")
+        s = v.strip()
+        return s if s else None
+
+    @field_validator("redirect_message", mode="before")
+    @classmethod
+    def _clean_redirect_message(cls, v: Any) -> str | None:
+        if v is None:
+            return None
+        if not isinstance(v, str):
+            raise ValueError("redirect_message must be a string")
+        s = v.strip()
+        return s if s else None
+
+    @field_validator("redirect_conditions", mode="before")
+    @classmethod
+    def _validate_conditions(cls, v: Any) -> list:
+        if v is None:
+            return []
+        if not isinstance(v, list):
+            raise ValueError("redirect_conditions must be a list")
+        if len(v) > 20:
+            raise ValueError("redirect_conditions can contain at most 20 rules")
+        return v
+
+
+class InboundRedirectSettingsResponse(BaseModel):
+    """Response body for ``GET/PUT /api/v2/flows/{flow_id}/inbound-redirect-settings``."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    redirect_inbound_calls_enabled: bool = False
+    redirect_forward_phone_number: str | None = None
+    redirect_conditions: list[RedirectCondition] = Field(default_factory=list)
+    redirect_speak_message_enabled: bool = False
+    redirect_message: str | None = None
+
+
 class SystemWebhooksSettingsUpdate(BaseModel):
     """Request body for ``PUT /api/v2/flows/{flow_id}/system-webhooks-settings``.
 

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 from fastapi import HTTPException, status
 from scipy.stats import chi2_contingency
@@ -48,6 +49,9 @@ from app.schemas.call_flow import (
     FlowValidationError,
     FlowValidationErrorItem,
     FlowValidationResponse,
+    InboundRedirectSettingsResponse,
+    InboundRedirectSettingsUpdate,
+    RedirectCondition,
     IVRDTMFSettingsResponse,
     IVRDTMFSettingsUpdate,
     MetadataSettingsResponse,
@@ -1062,6 +1066,203 @@ class CallFlowService:
             ),
             max_duration_message=flow.max_duration_message,
         )
+
+    # ── Inbound Call Redirection & Forwarding Settings ──
+
+    def update_inbound_redirect_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: InboundRedirectSettingsUpdate,
+    ) -> InboundRedirectSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        update_dict = body.model_dump(exclude_unset=True)
+        if (
+            "redirect_conditions" in update_dict
+            and update_dict["redirect_conditions"] is not None
+        ):
+            update_dict["redirect_conditions"] = [
+                c.model_dump() if hasattr(c, "model_dump") else dict(c)
+                for c in update_dict["redirect_conditions"]
+            ]
+        update_dict["updated_at"] = datetime.now(timezone.utc)
+
+        repo = CallFlowRepository(db)
+        repo.update(flow, update_dict)
+        db.commit()
+        db.refresh(flow)
+        return self._to_inbound_redirect_response(flow)
+
+    def get_inbound_redirect_settings(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> InboundRedirectSettingsResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        return self._to_inbound_redirect_response(flow)
+
+    @staticmethod
+    def _to_inbound_redirect_response(
+        flow: CallFlow,
+    ) -> InboundRedirectSettingsResponse:
+        raw_conditions = flow.redirect_conditions or []
+        conditions = []
+        for item in raw_conditions:
+            if isinstance(item, dict):
+                conditions.append(RedirectCondition(**item))
+            elif isinstance(item, RedirectCondition):
+                conditions.append(item)
+
+        return InboundRedirectSettingsResponse(
+            redirect_inbound_calls_enabled=bool(
+                flow.redirect_inbound_calls_enabled
+            ),
+            redirect_forward_phone_number=flow.redirect_forward_phone_number,
+            redirect_conditions=conditions,
+            redirect_speak_message_enabled=bool(
+                flow.redirect_speak_message_enabled
+            ),
+            redirect_message=flow.redirect_message,
+        )
+
+    @staticmethod
+    def evaluate_redirect_conditions(
+        conditions: list[dict | Any],
+        context: dict[str, Any],
+    ) -> bool:
+        """
+        Evaluate redirect conditions against context using AND logic.
+        Returns True if conditions list is empty, or if ALL conditions match.
+        """
+        if not conditions:
+            return True
+
+        for cond in conditions:
+            if hasattr(cond, "model_dump"):
+                cond_dict = cond.model_dump()
+            elif isinstance(cond, dict):
+                cond_dict = cond
+            else:
+                cond_dict = {
+                    "variable": getattr(cond, "variable", ""),
+                    "operator": getattr(cond, "operator", ""),
+                    "value": getattr(cond, "value", None),
+                }
+
+            raw_var = str(cond_dict.get("variable") or "").strip()
+            var_name = raw_var
+            if var_name.startswith("{{") and var_name.endswith("}}"):
+                var_name = var_name[2:-2].strip()
+
+            operator_raw = cond_dict.get("operator")
+            if hasattr(operator_raw, "value"):
+                operator = str(operator_raw.value).strip().lower()
+            else:
+                operator = str(operator_raw or "").strip().lower()
+
+            target_val = cond_dict.get("value")
+            target_val_str = (
+                str(target_val).strip().lower()
+                if target_val is not None
+                else None
+            )
+
+            val = None
+            if "." in var_name:
+                parts = var_name.split(".")
+                cur: Any = context
+                for p in parts:
+                    if isinstance(cur, dict) and p in cur:
+                        cur = cur[p]
+                    else:
+                        cur = None
+                        break
+                val = cur
+                if val is None:
+                    val = context.get(var_name)
+            else:
+                val = context.get(var_name)
+                if (
+                    val is None
+                    and "_metadata" in context
+                    and isinstance(context["_metadata"], dict)
+                ):
+                    val = context["_metadata"].get(var_name)
+                if (
+                    val is None
+                    and "_variable" in context
+                    and isinstance(context["_variable"], dict)
+                ):
+                    val = context["_variable"].get(var_name)
+
+            if operator == "exists":
+                if val is None:
+                    return False
+            elif operator == "not_empty":
+                if val is None or str(val).strip() == "":
+                    return False
+            elif operator == "equals":
+                if val is None:
+                    return False
+                if str(val).strip().lower() != target_val_str:
+                    return False
+            elif operator == "not_equals":
+                curr_str = str(val).strip().lower() if val is not None else ""
+                if curr_str == (target_val_str or ""):
+                    return False
+            else:
+                return False
+
+        return True
+
+    @staticmethod
+    def render_redirect_message_template(
+        template: str,
+        context: dict[str, Any],
+    ) -> str:
+        """
+        Render {{key}} and {{_metadata.key}} template tokens in redirect announcement message.
+        """
+        if not template:
+            return ""
+        import re
+
+        def _replace_token(match: re.Match) -> str:
+            token = match.group(1).strip()
+            if "." in token:
+                parts = token.split(".")
+                cur: Any = context
+                found = True
+                for p in parts:
+                    if isinstance(cur, dict) and p in cur:
+                        cur = cur[p]
+                    else:
+                        found = False
+                        break
+                if found and cur is not None:
+                    return str(cur)
+            if token in context and context[token] is not None:
+                return str(context[token])
+            if (
+                "_metadata" in context
+                and isinstance(context["_metadata"], dict)
+                and context["_metadata"].get(token) is not None
+            ):
+                return str(context["_metadata"][token])
+            if (
+                "_variable" in context
+                and isinstance(context["_variable"], dict)
+                and context["_variable"].get(token) is not None
+            ):
+                return str(context["_variable"][token])
+            return ""
+
+        return re.sub(
+            r"\{\{\s*([a-zA-Z0-9_\.]+)\s*\}\}", _replace_token, template
+        ).strip()
 
     # ── System Webhooks (pre-inbound / dynamic routing / post-call / status) ──
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9350,6 +9350,91 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/inbound-redirect-settings:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Configure Inbound Call Redirection & Forwarding settings on a call
+        flow
+      description: 'Configures inbound call redirection, forwarding phone number,
+        conditional routing rules, and departure announcements.
+
+
+        - **Master Toggle** (`redirect_inbound_calls_enabled`): Enables or disables
+        inbound call forwarding.
+
+        - **Forward Phone Number** (`redirect_forward_phone_number`): Destination
+        phone number (e.g. `+14155552671`).
+
+        - **Conditional Rules** (`redirect_conditions`): List of `{variable, operator,
+        value}` rules evaluated with AND logic against call context.
+
+        - **Spoken Announcement** (`redirect_speak_message_enabled`, `redirect_message`):
+        Speaks rendered departure message via TwiML `<Say>` before forwarding.
+
+
+        Admin rank (or API key) required.'
+      operationId: update_inbound_redirect_settings_api_v2_flows__flow_id__inbound_redirect_settings_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InboundRedirectSettingsUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InboundRedirectSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - A/B Prompt Testing
+      summary: Get the currently-saved Inbound Call Redirection settings for a call
+        flow
+      description: Returns the currently-saved Inbound Call Redirection and conditional
+        forwarding settings for this call flow. Read-only rank is sufficient.
+      operationId: get_inbound_redirect_settings_api_v2_flows__flow_id__inbound_redirect_settings_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InboundRedirectSettingsResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/system-webhooks-settings:
     put:
       tags:
@@ -14677,6 +14762,58 @@ components:
       - board_id
       title: InboundBoardUrlOut
       description: Public board link — no secrets.
+    InboundRedirectSettingsResponse:
+      properties:
+        redirect_inbound_calls_enabled:
+          type: boolean
+          title: Redirect Inbound Calls Enabled
+          default: false
+        redirect_forward_phone_number:
+          type: string
+          nullable: true
+        redirect_conditions:
+          items:
+            $ref: '#/components/schemas/RedirectCondition'
+          type: array
+          title: Redirect Conditions
+        redirect_speak_message_enabled:
+          type: boolean
+          title: Redirect Speak Message Enabled
+          default: false
+        redirect_message:
+          type: string
+          nullable: true
+      type: object
+      title: InboundRedirectSettingsResponse
+      description: Response body for ``GET/PUT /api/v2/flows/{flow_id}/inbound-redirect-settings``.
+    InboundRedirectSettingsUpdate:
+      properties:
+        redirect_inbound_calls_enabled:
+          type: boolean
+          title: Redirect Inbound Calls Enabled
+          default: false
+        redirect_forward_phone_number:
+          type: string
+          maxLength: 50
+          nullable: true
+        redirect_conditions:
+          items:
+            $ref: '#/components/schemas/RedirectCondition'
+          type: array
+          title: Redirect Conditions
+          description: Conditional rules evaluated with AND logic against call context
+        redirect_speak_message_enabled:
+          type: boolean
+          title: Redirect Speak Message Enabled
+          default: false
+        redirect_message:
+          type: string
+          maxLength: 500
+          nullable: true
+      additionalProperties: false
+      type: object
+      title: InboundRedirectSettingsUpdate
+      description: Request body for ``PUT /api/v2/flows/{flow_id}/inbound-redirect-settings``.
     IntegrationItem:
       properties:
         name:
@@ -17272,6 +17409,36 @@ components:
       - offers_sent
       - offers_awaiting_feedback
       title: RecruitmentKpiBlock
+    RedirectCondition:
+      properties:
+        variable:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Variable
+          description: Variable name or token, e.g. 'tier', 'company', or '{{_metadata.company}}'
+        operator:
+          $ref: '#/components/schemas/RedirectConditionOperatorEnum'
+        value:
+          type: string
+          maxLength: 255
+          nullable: true
+      additionalProperties: false
+      type: object
+      required:
+      - variable
+      - operator
+      title: RedirectCondition
+      description: Single conditional rule evaluated against pre-inbound webhook &
+        call variables.
+    RedirectConditionOperatorEnum:
+      type: string
+      enum:
+      - exists
+      - not_empty
+      - equals
+      - not_equals
+      title: RedirectConditionOperatorEnum
     RefreshRequest:
       properties:
         refresh_token:

--- a/tests/api/v2/test_inbound_redirect_settings.py
+++ b/tests/api/v2/test_inbound_redirect_settings.py
@@ -1,0 +1,592 @@
+"""Tests for PUT and GET /api/v2/flows/{flow_id}/inbound-redirect-settings.
+
+Coverage:
+  - Admin/API-key principal can update all Inbound Call Redirection settings
+  - Default values on fresh flows
+  - Boundary validations (operators: exists, not_empty, equals, not_equals; max 20 conditions; max 500 chars message)
+  - String handling for redirect_message and redirect_forward_phone_number (trimming, blank to None)
+  - Extra fields rejected (extra="forbid")
+  - Non-admin (config_only, read_only, billing_only) forbidden on PUT (403)
+  - Read-only rank is sufficient for GET (200)
+  - Tenant isolation: unknown flow_id or other tenant flow returns 404
+  - Audit event logged on PUT (action="inbound_redirect_settings.updated")
+  - GET round-trips prior PUT updates
+  - Partial updates preserve unmodified fields
+  - GET handles null/none attribute fallback on flow object
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_admin_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_admin_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_admin_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_readonly_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_readonly_or_api_key
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_readonly_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_app_for_real_rank_check(db_override, principal):
+    from app.api.deps import get_db, require_tenant
+    from app.api.v2.routers.flows import router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(router)
+
+    mini.dependency_overrides[require_tenant] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _with_effective_role(role_name: str):
+    return patch(
+        "app.api.deps.rbac.rbac_cache_service.get_effective_role",
+        return_value=role_name,
+    )
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"RedirectWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"redirect_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def other_workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"OtherRedirectWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"other_redirect_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Redirect Test Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, workspace, agent):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=workspace.id,
+        agent_id=agent.id,
+        name="Redirect Test Flow",
+        direction="inbound",
+        status="active",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+class TestUpdateInboundRedirectSettings:
+    def test_admin_can_update_all_redirect_settings(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        payload = {
+            "redirect_inbound_calls_enabled": True,
+            "redirect_forward_phone_number": "+14155552671",
+            "redirect_conditions": [
+                {
+                    "variable": "tier",
+                    "operator": "equals",
+                    "value": "vip",
+                },
+                {
+                    "variable": "{{_metadata.company}}",
+                    "operator": "exists",
+                    "value": None,
+                },
+            ],
+            "redirect_speak_message_enabled": True,
+            "redirect_message": "Please hold while we forward you to a specialist at {{_metadata.company}}.",
+        }
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings", json=payload
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["redirect_inbound_calls_enabled"] is True
+        assert body["redirect_forward_phone_number"] == "+14155552671"
+        assert len(body["redirect_conditions"]) == 2
+        assert body["redirect_conditions"][0]["variable"] == "tier"
+        assert body["redirect_conditions"][0]["operator"] == "equals"
+        assert body["redirect_conditions"][0]["value"] == "vip"
+        assert body["redirect_speak_message_enabled"] is True
+        assert (
+            body["redirect_message"]
+            == "Please hold while we forward you to a specialist at {{_metadata.company}}."
+        )
+
+        db.refresh(flow)
+        assert flow.redirect_inbound_calls_enabled is True
+        assert flow.redirect_forward_phone_number == "+14155552671"
+        assert len(flow.redirect_conditions) == 2
+        assert flow.redirect_speak_message_enabled is True
+
+    def test_invalid_operator_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_conditions": [
+                    {
+                        "variable": "tier",
+                        "operator": "invalid_op",
+                        "value": "vip",
+                    }
+                ]
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_redirect_message_blank_converts_to_none(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={"redirect_message": "   "},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["redirect_message"] is None
+
+    def test_redirect_forward_phone_number_blank_converts_to_none(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={"redirect_forward_phone_number": "   "},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["redirect_forward_phone_number"] is None
+
+    def test_redirect_message_over_max_length_rejected(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={"redirect_message": "a" * 501},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_conditions_over_max_limit_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        conditions = [
+            {"variable": f"var_{i}", "operator": "exists"} for i in range(21)
+        ]
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={"redirect_conditions": conditions},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_extra_fields_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_inbound_calls_enabled": True,
+                "unexpected_field": "val",
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_extra_fields_inside_condition_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_conditions": [
+                    {
+                        "variable": "tier",
+                        "operator": "equals",
+                        "value": "vip",
+                        "unsupported_field": "disallowed",
+                    }
+                ]
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_condition_variable_empty_rejected(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_conditions": [
+                    {
+                        "variable": "   ",
+                        "operator": "exists",
+                    }
+                ]
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_condition_variable_over_max_length_rejected(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_conditions": [
+                    {
+                        "variable": "a" * 101,
+                        "operator": "exists",
+                    }
+                ]
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_condition_value_over_max_length_rejected(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_conditions": [
+                    {
+                        "variable": "tier",
+                        "operator": "equals",
+                        "value": "v" * 256,
+                    }
+                ]
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_redirect_forward_phone_number_over_max_length_rejected(
+        self, db, workspace, flow
+    ):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={"redirect_forward_phone_number": "+1" + "9" * 50},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_clearing_fields_with_explicit_null(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        # First set fields
+        client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_inbound_calls_enabled": True,
+                "redirect_forward_phone_number": "+14155552671",
+                "redirect_speak_message_enabled": True,
+                "redirect_message": "Connecting call.",
+            },
+        )
+
+        # Clear them with None / empty
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_forward_phone_number": None,
+                "redirect_message": None,
+                "redirect_conditions": [],
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["redirect_forward_phone_number"] is None
+        assert body["redirect_message"] is None
+        assert body["redirect_conditions"] == []
+
+    def test_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{uuid.uuid4()}/inbound-redirect-settings",
+            json={"redirect_inbound_calls_enabled": True},
+        )
+        assert resp.status_code == 404
+
+    def test_other_tenant_flow_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_app(db, foreign_principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={"redirect_inbound_calls_enabled": True},
+        )
+        assert resp.status_code == 404
+
+    def test_update_fires_audit_event(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        with patch("app.api.v2.routers.flows.log_audit_event") as mock_audit:
+            resp = client.put(
+                f"/flows/{flow.id}/inbound-redirect-settings",
+                json={
+                    "redirect_inbound_calls_enabled": True,
+                    "redirect_forward_phone_number": "+14155552671",
+                },
+            )
+            assert resp.status_code == 200
+
+        mock_audit.assert_called_once()
+        _, kwargs = mock_audit.call_args
+        assert kwargs["action"] == "inbound_redirect_settings.updated"
+        assert kwargs["resource_type"] == "call_flow"
+        assert kwargs["resource_id"] == flow.id
+        assert kwargs["new_value"]["redirect_inbound_calls_enabled"] is True
+        assert (
+            kwargs["new_value"]["redirect_forward_phone_number"]
+            == "+14155552671"
+        )
+
+    def test_non_admin_forbidden_on_put(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for non_admin_role in ["config_only", "read_only", "billing_only"]:
+            with _with_effective_role(non_admin_role):
+                resp = client.put(
+                    f"/flows/{flow.id}/inbound-redirect-settings",
+                    json={"redirect_inbound_calls_enabled": True},
+                )
+                assert resp.status_code == 403
+
+
+class TestGetInboundRedirectSettings:
+    def test_fresh_flow_returns_defaults(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{flow.id}/inbound-redirect-settings")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["redirect_inbound_calls_enabled"] is False
+        assert body["redirect_forward_phone_number"] is None
+        assert body["redirect_conditions"] == []
+        assert body["redirect_speak_message_enabled"] is False
+        assert body["redirect_message"] is None
+
+    def test_get_round_trips_prior_put_update(self, db, workspace, flow):
+        admin_principal = _principal(workspace.id)
+        admin_client = _build_app(db, admin_principal)
+
+        put_resp = admin_client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_inbound_calls_enabled": True,
+                "redirect_forward_phone_number": "+14155552671",
+                "redirect_conditions": [
+                    {
+                        "variable": "account_type",
+                        "operator": "not_empty",
+                        "value": None,
+                    }
+                ],
+                "redirect_speak_message_enabled": True,
+                "redirect_message": "Connecting you now.",
+            },
+        )
+        assert put_resp.status_code == 200
+
+        readonly_principal = _principal(workspace.id)
+        readonly_client = _build_readonly_app(db, readonly_principal)
+
+        get_resp = readonly_client.get(
+            f"/flows/{flow.id}/inbound-redirect-settings"
+        )
+        assert get_resp.status_code == 200
+        assert get_resp.json() == put_resp.json()
+
+    def test_readonly_user_can_access_get(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app_for_real_rank_check(db, principal)
+
+        for role in ["read_only", "config_only", "manager", "admin", "owner"]:
+            with _with_effective_role(role):
+                resp = client.get(f"/flows/{flow.id}/inbound-redirect-settings")
+                assert resp.status_code == 200
+
+    def test_get_unknown_flow_returns_404(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{uuid.uuid4()}/inbound-redirect-settings")
+        assert resp.status_code == 404
+
+    def test_get_other_tenant_flow_returns_404(self, db, other_workspace, flow):
+        foreign_principal = _principal(other_workspace.id)
+        client = _build_readonly_app(db, foreign_principal)
+
+        resp = client.get(f"/flows/{flow.id}/inbound-redirect-settings")
+        assert resp.status_code == 404
+
+    def test_partial_update_preserves_unmodified_fields(
+        self, db, workspace, flow
+    ):
+        admin_principal = _principal(workspace.id)
+        admin_client = _build_app(db, admin_principal)
+
+        admin_client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={
+                "redirect_inbound_calls_enabled": True,
+                "redirect_forward_phone_number": "+14155552671",
+                "redirect_speak_message_enabled": True,
+                "redirect_message": "Connecting you.",
+            },
+        )
+
+        resp = admin_client.put(
+            f"/flows/{flow.id}/inbound-redirect-settings",
+            json={"redirect_inbound_calls_enabled": False},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["redirect_inbound_calls_enabled"] is False
+        assert body["redirect_forward_phone_number"] == "+14155552671"
+        assert body["redirect_message"] == "Connecting you."
+
+    def test_get_handles_null_attributes_fallback(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        mock_flow = MagicMock()
+        mock_flow.id = flow.id
+        mock_flow.tenant_id = workspace.id
+        mock_flow.redirect_inbound_calls_enabled = None
+        mock_flow.redirect_forward_phone_number = None
+        mock_flow.redirect_conditions = None
+        mock_flow.redirect_speak_message_enabled = None
+        mock_flow.redirect_message = None
+
+        with patch(
+            "app.services.call_flow_service.call_flow_service._get_flow_or_404",
+            return_value=mock_flow,
+        ):
+            resp = client.get(f"/flows/{flow.id}/inbound-redirect-settings")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["redirect_inbound_calls_enabled"] is False
+            assert body["redirect_forward_phone_number"] is None
+            assert body["redirect_conditions"] == []
+            assert body["redirect_speak_message_enabled"] is False
+            assert body["redirect_message"] is None

--- a/tests/services/test_inbound_redirection_runtime.py
+++ b/tests/services/test_inbound_redirection_runtime.py
@@ -1,0 +1,527 @@
+"""Unit and runtime integration tests for Inbound Call Redirection with Conditional Rules Engine.
+
+Coverage:
+  - Evaluation of redirect conditions with AND logic and operators (exists, not_empty, equals, not_equals)
+  - Template token rendering for departure announcements ({{_metadata.key}}, {{key}})
+  - Inbound webhook handle_incoming_call runtime execution:
+    - Unconditional redirect when enabled (returns <Dial>)
+    - Conditional redirect when conditions match (returns <Dial>)
+    - Fall-through to regular AI agent when conditions do not match
+    - Spoken announcement <Say> before <Dial> when enabled
+    - Fall-through when redirection is disabled
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models.agent import Agent
+from app.models.call_flow import CallFlow
+from app.models.model import Model
+from app.models.phone_number import PhoneNumber
+from app.models.provider import Provider
+from app.models.tenant import Tenant
+from app.models.user import User
+from app.routers.voice import router
+from app.services.call_flow_service import call_flow_service
+
+
+class TestEvaluateRedirectConditions:
+    def test_empty_conditions_returns_true(self):
+        assert (
+            call_flow_service.evaluate_redirect_conditions([], {"tier": "vip"})
+            is True
+        )
+
+    def test_exists_operator(self):
+        conditions = [
+            {"variable": "tier", "operator": "exists"},
+            {"variable": "{{_metadata.company}}", "operator": "exists"},
+        ]
+        context = {
+            "tier": "vip",
+            "_metadata": {"company": "Acme"},
+        }
+        assert (
+            call_flow_service.evaluate_redirect_conditions(conditions, context)
+            is True
+        )
+
+        missing_context = {"tier": "vip"}
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, missing_context
+            )
+            is False
+        )
+
+    def test_not_empty_operator(self):
+        conditions = [
+            {"variable": "caller_name", "operator": "not_empty"},
+        ]
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"caller_name": "Alice"}
+            )
+            is True
+        )
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"caller_name": "   "}
+            )
+            is False
+        )
+        assert (
+            call_flow_service.evaluate_redirect_conditions(conditions, {})
+            is False
+        )
+
+    def test_equals_operator_case_insensitive(self):
+        conditions = [
+            {"variable": "tier", "operator": "equals", "value": "VIP"},
+        ]
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"tier": "vip"}
+            )
+            is True
+        )
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"tier": "Standard"}
+            )
+            is False
+        )
+        assert (
+            call_flow_service.evaluate_redirect_conditions(conditions, {})
+            is False
+        )
+
+    def test_not_equals_operator(self):
+        conditions = [
+            {
+                "variable": "account_status",
+                "operator": "not_equals",
+                "value": "suspended",
+            },
+        ]
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"account_status": "active"}
+            )
+            is True
+        )
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"account_status": "suspended"}
+            )
+            is False
+        )
+
+    def test_and_logic_requires_all_rules_to_pass(self):
+        conditions = [
+            {"variable": "tier", "operator": "equals", "value": "gold"},
+            {"variable": "region", "operator": "equals", "value": "us"},
+        ]
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"tier": "gold", "region": "us"}
+            )
+            is True
+        )
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, {"tier": "gold", "region": "eu"}
+            )
+            is False
+        )
+
+    def test_evaluate_conditions_with_pydantic_models_and_enums(self):
+        from app.schemas.call_flow import (
+            RedirectCondition,
+            RedirectConditionOperatorEnum,
+        )
+
+        conditions = [
+            RedirectCondition(
+                variable="tier",
+                operator=RedirectConditionOperatorEnum.equals,
+                value="VIP",
+            ),
+            RedirectCondition(
+                variable="department",
+                operator=RedirectConditionOperatorEnum.not_empty,
+                value=None,
+            ),
+        ]
+        context = {
+            "tier": "vip",
+            "_metadata": {"department": "sales"},
+        }
+        assert (
+            call_flow_service.evaluate_redirect_conditions(conditions, context)
+            is True
+        )
+
+    def test_evaluate_conditions_multi_dot_nested_path(self):
+        conditions = [
+            {
+                "variable": "{{_metadata.customer.plan}}",
+                "operator": "equals",
+                "value": "enterprise",
+            },
+        ]
+        context = {
+            "_metadata": {
+                "customer": {
+                    "plan": "Enterprise",
+                }
+            }
+        }
+        assert (
+            call_flow_service.evaluate_redirect_conditions(conditions, context)
+            is True
+        )
+
+        mismatch_context = {
+            "_metadata": {
+                "customer": {
+                    "plan": "starter",
+                }
+            }
+        }
+        assert (
+            call_flow_service.evaluate_redirect_conditions(
+                conditions, mismatch_context
+            )
+            is False
+        )
+
+
+class TestRenderRedirectMessageTemplate:
+    def test_render_template_tokens(self):
+        template = "Hello {{caller_name}}, forwarding you to {{_metadata.department}} at {{_metadata.company}}."
+        context = {
+            "caller_name": "Alice",
+            "_metadata": {
+                "department": "Support",
+                "company": "Acme Corp",
+            },
+        }
+        rendered = call_flow_service.render_redirect_message_template(
+            template, context
+        )
+        assert (
+            rendered
+            == "Hello Alice, forwarding you to Support at Acme Corp."
+        )
+
+    def test_unmatched_tokens_replaced_with_empty_string(self):
+        template = "Connecting to {{unknown_token}} team."
+        context = {"caller_name": "Bob"}
+        rendered = call_flow_service.render_redirect_message_template(
+            template, context
+        )
+        assert rendered == "Connecting to  team."
+
+    def test_none_values_rendered_as_empty_string_not_literal_none(self):
+        template = "Hello {{caller_name}}, forwarding to {{_metadata.company}}."
+        context = {
+            "caller_name": None,
+            "_metadata": {
+                "company": "Acme Corp",
+            },
+        }
+        rendered = call_flow_service.render_redirect_message_template(
+            template, context
+        )
+        assert rendered == "Hello , forwarding to Acme Corp."
+
+    def test_multi_dot_nested_template_token(self):
+        template = "Connecting you to {{_metadata.org.team}} department."
+        context = {
+            "_metadata": {
+                "org": {
+                    "team": "Billing",
+                }
+            }
+        }
+        rendered = call_flow_service.render_redirect_message_template(
+            template, context
+        )
+        assert rendered == "Connecting you to Billing department."
+
+    def test_empty_template_returns_empty_string(self):
+        assert (
+            call_flow_service.render_redirect_message_template("", {"a": "b"})
+            == ""
+        )
+
+
+class TestInboundRedirectionWebhookRuntime:
+    @pytest.fixture
+    def app(self, db):
+        mini = FastAPI()
+        mini.include_router(router)
+        from app.api.deps import get_db
+
+        mini.dependency_overrides[get_db] = lambda: db
+        return mini
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def setup_inbound_entities(self, db):
+        tenant = Tenant(
+            name=f"InboundRedirect-{uuid.uuid4().hex[:8]}",
+            schema_name=f"inbound_redir_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+
+        user = User(
+            email=f"redir_{uuid.uuid4().hex[:6]}@example.com",
+            first_name="Redirect",
+            last_name="Tester",
+            hashed_password="hashed_pw_123",
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+        model = (
+            db.query(Model).filter(Model.model_name == "gpt-4o-mini").first()
+        )
+        if not model:
+            provider = Provider(name="openai", is_active=True)
+            db.add(provider)
+            db.commit()
+            model = Model(
+                provider_id=provider.id,
+                model_name="gpt-4o-mini",
+                archive=False,
+            )
+            db.add(model)
+            db.commit()
+
+        agent = Agent(
+            tenant_id=tenant.id,
+            name="Inbound Redirection Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            model_id=model.id,
+            created_by=user.id,
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-1",
+            tts_language="en",
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+
+        phone = PhoneNumber(
+            tenant_id=tenant.id,
+            phone_number=f"+15550{uuid.uuid4().int % 10000000:07d}",
+            status="active",
+            assistant_id=agent.id,
+        )
+        db.add(phone)
+        db.commit()
+        db.refresh(phone)
+
+        flow = CallFlow(
+            tenant_id=tenant.id,
+            agent_id=agent.id,
+            name="Inbound Redirection Flow",
+            direction="inbound",
+            status="active",
+            redirect_inbound_calls_enabled=True,
+            redirect_forward_phone_number="+14155552671",
+            redirect_conditions=[],
+            redirect_speak_message_enabled=False,
+            redirect_message=None,
+        )
+        db.add(flow)
+        db.commit()
+        db.refresh(flow)
+
+        return tenant, agent, phone, flow
+
+    def test_unconditional_redirect_returns_dial_twiml(
+        self, client, setup_inbound_entities
+    ):
+        _, _, phone, flow = setup_inbound_entities
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+        ):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_REDIRECT_TEST_1",
+                    "From": "+12025550199",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "application/xml" in resp.headers["content-type"]
+        assert "<Dial" in resp.text
+        assert flow.redirect_forward_phone_number in resp.text
+        assert "<Say" not in resp.text
+
+    def test_conditional_redirect_matches_returns_dial_twiml(
+        self, db, client, setup_inbound_entities
+    ):
+        _, _, phone, flow = setup_inbound_entities
+        flow.redirect_conditions = [
+            {"variable": "vip_status", "operator": "equals", "value": "true"},
+        ]
+        flow.redirect_speak_message_enabled = True
+        flow.redirect_message = (
+            "Connecting our VIP caller to the executive line."
+        )
+        db.commit()
+
+        mock_webhook_vars = {"vip_status": "true"}
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.services.system_webhook_service.fetch_pre_inbound_webhook_variables",
+                new=AsyncMock(return_value=mock_webhook_vars),
+            ),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+        ):
+            flow.pre_inbound_webhook_url = "https://example.com/pre-inbound"
+            db.commit()
+
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_REDIRECT_TEST_2",
+                    "From": "+12025550199",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "<Say>Connecting our VIP caller to the executive line.</Say>" in resp.text
+        assert "<Dial" in resp.text
+        assert flow.redirect_forward_phone_number in resp.text
+
+    def test_conditional_redirect_mismatch_falls_through_to_ai_agent(
+        self, db, client, setup_inbound_entities
+    ):
+        _, agent, phone, flow = setup_inbound_entities
+        flow.redirect_conditions = [
+            {"variable": "vip_status", "operator": "equals", "value": "true"},
+        ]
+        flow.pre_inbound_webhook_url = "https://example.com/pre-inbound"
+        db.commit()
+
+        # Webhook returns standard tier, NOT vip
+        mock_webhook_vars = {"vip_status": "false"}
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.services.system_webhook_service.fetch_pre_inbound_webhook_variables",
+                new=AsyncMock(return_value=mock_webhook_vars),
+            ),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+            patch(
+                "app.routers.voice.build_streaming_twiml",
+                return_value="<Response><Connect><Stream url='wss://example.com'/></Connect></Response>",
+            ),
+        ):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_REDIRECT_TEST_3",
+                    "From": "+12025550199",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        # Should not dial forwarding number, but connect to stream
+        assert "<Dial" not in resp.text
+        assert "<Stream" in resp.text
+
+    def test_disabled_redirection_falls_through_to_ai_agent(
+        self, db, client, setup_inbound_entities
+    ):
+        _, agent, phone, flow = setup_inbound_entities
+        flow.redirect_inbound_calls_enabled = False
+        db.commit()
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+            patch(
+                "app.routers.voice.build_streaming_twiml",
+                return_value="<Response><Connect><Stream url='wss://example.com'/></Connect></Response>",
+            ),
+        ):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_REDIRECT_TEST_4",
+                    "From": "+12025550199",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "<Dial" not in resp.text
+        assert "<Stream" in resp.text
+
+    def test_inbound_redirection_call_session_db_error_resilience(
+        self, db, client, setup_inbound_entities
+    ):
+        _, _, phone, flow = setup_inbound_entities
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+            patch.object(db, "commit", side_effect=Exception("DB connection error")),
+        ):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_REDIRECT_TEST_DB_FAIL",
+                    "From": "+12025550199",
+                    "To": phone.phone_number,
+                },
+            )
+
+        # Call redirection should still succeed even if CallSession persistence encounters an error
+        assert resp.status_code == 200
+        assert "<Dial" in resp.text
+        assert flow.redirect_forward_phone_number in resp.text


### PR DESCRIPTION
## Summary of Changes

### 1. Database Model & Alembic Migration
- **Model ([app/models/call_flow.py](file:///Users/mc/tgs-agent-be/app/models/call_flow.py))**:
  - `redirect_inbound_calls_enabled` (Boolean, default False)
  - `redirect_forward_phone_number` (String(50), nullable)
  - `redirect_conditions` (JSONB, default list `[]`)
  - `redirect_speak_message_enabled` (Boolean, default False)
  - `redirect_message` (Text, nullable)
- **Migration ([alembic/versions/d7a8b9c0e1f2_add_inbound_redirect_settings_to_call_flow.py](file:///Users/mc/tgs-agent-be/alembic/versions/d7a8b9c0e1f2_add_inbound_redirect_settings_to_call_flow.py))**:
  - Alembic revision `d7a8b9c0e1f2` revising `f6a2b3c4d5e6`.

### 2. Schemas & Service Layer
- **Schemas ([app/schemas/call_flow.py](file:///Users/mc/tgs-agent-be/app/schemas/call_flow.py))**:
  - `RedirectConditionOperatorEnum` (`exists`, `not_empty`, `equals`, `not_equals`)
  - `RedirectCondition` with `extra="forbid"`, variable validation (1–100 chars), and value limit
  - `InboundRedirectSettingsUpdate` with `extra="forbid"`, max 20 conditions, phone/message clean trimming
  - `InboundRedirectSettingsResponse` with `from_attributes=True`
- **Service ([app/services/call_flow_service.py](file:///Users/mc/tgs-agent-be/app/services/call_flow_service.py))**:
  - `update_inbound_redirect_settings`, `get_inbound_redirect_settings`, `_to_inbound_redirect_response`
  - `evaluate_redirect_conditions` supporting AND logic, dot-notation traversals (`{{_metadata.company}}`, `_variable.tier`), and case-insensitive equality
  - `render_redirect_message_template` replacing template tokens safely without emitting literal `"None"`

### 3. REST API Endpoints & RBAC
- **Router ([app/api/v2/routers/flows.py](file:///Users/mc/tgs-agent-be/app/api/v2/routers/flows.py))**:
  - `PUT /api/v2/flows/{flow_id}/inbound-redirect-settings` (requires admin / API key, emits audit log `inbound_redirect_settings.updated`)
  - `GET /api/v2/flows/{flow_id}/inbound-redirect-settings` (requires read-only / API key)
- **OpenAPI ([docs/api/openapi.yaml](file:///Users/mc/tgs-agent-be/docs/api/openapi.yaml))**:
  - Complete paths and schema definitions added.

### 4. Real-Time Voice Pipeline
- **Webhook ([app/routers/voice.py](file:///Users/mc/tgs-agent-be/app/routers/voice.py))**:
  - Evaluates redirect conditions against pre-inbound webhook variables and call context prior to credit deduction or LLM streaming.
  - If conditions match:
    - Generates `<Say>` departure message (if enabled and rendered).
    - Generates `<Dial>` forwarding TwiML to target phone number.
    - Records completed/transferred `CallSession` with `ended_reason="Inbound call redirected"`.
  - If conditions do not match or redirection is disabled:
    - Smoothly falls through to regular AI agent streaming.

### 5. Test Suite
- **API Tests ([tests/api/v2/test_inbound_redirect_settings.py](file:///Users/mc/tgs-agent-be/tests/api/v2/test_inbound_redirect_settings.py))**:
  - 17 unit tests verifying RBAC, tenant isolation, round-tripping, boundary validations, and audit logs.
- **Runtime Tests ([tests/services/test_inbound_redirection_runtime.py](file:///Users/mc/tgs-agent-be/tests/services/test_inbound_redirection_runtime.py))**:
  - 25 unit and integration tests verifying condition rules, template rendering, and inbound call TwiML forwarding.