### PR TITLE
feat(flow): Workspace Inbound Rules & Blocklist Rule Sets on Call Flows

### DIFF
--- a/alembic/versions/e8b9c0d1e2f3_add_inbound_rules_and_blocklist_tables.py
+++ b/alembic/versions/e8b9c0d1e2f3_add_inbound_rules_and_blocklist_tables.py
@@ -1,0 +1,154 @@
+"""add_inbound_rules_and_blocklist_tables
+
+Revision ID: e8b9c0d1e2f3
+Revises: d7a8b9c0e1f2
+Create Date: 2026-08-26 11:36:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e8b9c0d1e2f3'
+down_revision: Union[str, None] = 'd7a8b9c0e1f2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # 1. Create inboundruleset table
+    op.create_table(
+        'inboundruleset',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            'tenant_id',
+            UUID(as_uuid=True),
+            sa.ForeignKey('tenant.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column('name', sa.String(length=100), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column(
+            'is_deleted',
+            sa.Boolean(),
+            server_default='false',
+            nullable=False,
+        ),
+        sa.Column(
+            'created_by',
+            UUID(as_uuid=True),
+            sa.ForeignKey('user.id'),
+            nullable=True,
+        ),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index('ix_inboundruleset_id', 'inboundruleset', ['id'])
+    op.create_index(
+        'ix_inboundruleset_tenant_id', 'inboundruleset', ['tenant_id']
+    )
+
+    # 2. Create inboundrule table
+    op.create_table(
+        'inboundrule',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            'tenant_id',
+            UUID(as_uuid=True),
+            sa.ForeignKey('tenant.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column(
+            'rule_set_id',
+            UUID(as_uuid=True),
+            sa.ForeignKey('inboundruleset.id', ondelete='CASCADE'),
+            nullable=False,
+        ),
+        sa.Column(
+            'phone_number_pattern', sa.String(length=50), nullable=False
+        ),
+        sa.Column('normalized_digits', sa.String(length=50), nullable=False),
+        sa.Column('label', sa.String(length=100), nullable=True),
+        sa.Column(
+            'action',
+            sa.String(length=20),
+            server_default='deny',
+            nullable=False,
+        ),
+        sa.Column(
+            'is_deleted',
+            sa.Boolean(),
+            server_default='false',
+            nullable=False,
+        ),
+        sa.Column(
+            'created_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            'updated_at',
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index('ix_inboundrule_id', 'inboundrule', ['id'])
+    op.create_index('ix_inboundrule_tenant_id', 'inboundrule', ['tenant_id'])
+    op.create_index(
+        'ix_inboundrule_rule_set_id', 'inboundrule', ['rule_set_id']
+    )
+    op.create_index(
+        'ix_inboundrule_normalized_digits', 'inboundrule', ['normalized_digits']
+    )
+    op.create_index(
+        'ix_inboundrule_tenant_normalized',
+        'inboundrule',
+        ['tenant_id', 'normalized_digits'],
+    )
+    op.create_index(
+        'ix_inboundrule_set_normalized',
+        'inboundrule',
+        ['rule_set_id', 'normalized_digits'],
+    )
+
+    # 3. Add inbound_rule_set_id to callflow
+    op.add_column(
+        'callflow',
+        sa.Column(
+            'inbound_rule_set_id',
+            UUID(as_uuid=True),
+            sa.ForeignKey('inboundruleset.id', ondelete='SET NULL'),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        'ix_callflow_inbound_rule_set_id',
+        'callflow',
+        ['inbound_rule_set_id'],
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index('ix_callflow_inbound_rule_set_id', table_name='callflow')
+    op.drop_column('callflow', 'inbound_rule_set_id')
+    op.drop_table('inboundrule')
+    op.drop_table('inboundruleset')

--- a/app/api/v2/api.py
+++ b/app/api/v2/api.py
@@ -16,6 +16,7 @@ from app.api.v2.routers.hipaa import workspace_router as hipaa_workspace_router
 from app.api.v2.routers.workspace import router as workspace_gdpr_router
 from app.api.v2.routers.calendly_integration import router as calendly_integration_router
 from app.api.v2.routers.calendly_integration import calendar_router as calendly_calendar_router
+from app.api.v2.routers.inbound_rules import router as inbound_rules_router
 from app.api.v2.routers.telephony import router as telephony_router
 
 v2_router = APIRouter()
@@ -27,6 +28,7 @@ v2_router.include_router(webhooks_router)
 v2_router.include_router(cb_agents_router)
 v2_router.include_router(cb_calls_router)
 v2_router.include_router(ab_flows_router)
+v2_router.include_router(inbound_rules_router)
 v2_router.include_router(flow_data_router)
 v2_router.include_router(post_call_analysis_router)
 v2_router.include_router(workspace_router, prefix="/workspace", tags=["Workspace Settings"])

--- a/app/api/v2/routers/flows.py
+++ b/app/api/v2/routers/flows.py
@@ -64,6 +64,8 @@ from app.schemas.call_flow import (
     CallScreeningSettingsUpdate,
     CallTimingSettingsResponse,
     CallTimingSettingsUpdate,
+    FlowInboundRulesResponse,
+    FlowInboundRulesUpdate,
     InboundRedirectSettingsResponse,
     InboundRedirectSettingsUpdate,
     IVRDTMFSettingsResponse,
@@ -617,6 +619,60 @@ def get_inbound_redirect_settings(
     db: Session = Depends(get_db),
 ) -> InboundRedirectSettingsResponse:
     return call_flow_service.get_inbound_redirect_settings(
+        db, flow_id, _tenant_id(principal)
+    )
+
+
+@router.put(
+    "/{flow_id}/inbound-rules",
+    response_model=FlowInboundRulesResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Assign or detach Inbound Rules & Blocklist Rule Set on a call flow",
+    description=(
+        "Attaches an existing inbound rule set (blocklist) to this call flow or detaches it by setting inbound_rule_set_id to null.\n\n"
+        "Admin rank (or API key) required."
+    ),
+)
+def update_flow_inbound_rules(
+    flow_id: uuid.UUID,
+    body: FlowInboundRulesUpdate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> FlowInboundRulesResponse:
+    tenant_id = _tenant_id(principal)
+    result = call_flow_service.update_flow_inbound_rules(
+        db, flow_id, tenant_id, body
+    )
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="flow_inbound_rules.updated",
+        resource_type="call_flow",
+        resource_id=flow_id,
+        new_value=result.model_dump(),
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.get(
+    "/{flow_id}/inbound-rules",
+    response_model=FlowInboundRulesResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get Inbound Rules & Blocklist Rule Set info for a call flow",
+    description=(
+        "Returns the active inbound rule set ID, name, and active rules count attached to this call flow. "
+        "Read-only rank is sufficient."
+    ),
+)
+def get_flow_inbound_rules(
+    flow_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> FlowInboundRulesResponse:
+    return call_flow_service.get_flow_inbound_rules(
         db, flow_id, _tenant_id(principal)
     )
 

--- a/app/api/v2/routers/inbound_rules.py
+++ b/app/api/v2/routers/inbound_rules.py
@@ -1,0 +1,184 @@
+"""Inbound Rules & Number Blocklist Rule Sets v2 API Router."""
+
+from __future__ import annotations
+
+import uuid
+from typing import List
+
+from fastapi import APIRouter, Depends, Request, status
+from sqlalchemy.orm import Session
+
+from app.api.deps import (
+    get_db,
+    require_admin_or_api_key,
+    require_readonly_or_api_key,
+)
+from app.core.request_auth import ApiKeyPrincipal
+from app.models.user import User
+from app.schemas.inbound_rule import (
+    InboundRuleImportRequest,
+    InboundRuleImportResponse,
+    InboundRuleSetCreate,
+    InboundRuleSetListItem,
+    InboundRuleSetResponse,
+    InboundRuleSetUpdate,
+)
+from app.services.audit_service import log_audit_event
+from app.services.inbound_rules_service import inbound_rules_service
+
+router = APIRouter(prefix="/inbound-rules", tags=["Inbound Rules & Blocklist"])
+
+
+def _tenant_id(principal: User | ApiKeyPrincipal) -> uuid.UUID:
+    return getattr(principal, "current_tenant_id", None) or getattr(
+        principal, "tenant_id", None
+    )
+
+
+@router.get(
+    "/sets",
+    response_model=List[InboundRuleSetListItem],
+    status_code=status.HTTP_200_OK,
+    summary="List all Inbound Rule Sets for the workspace",
+    description="Returns all non-deleted inbound rule sets with active rules count for current workspace. Read-only rank is sufficient.",
+)
+def list_rule_sets(
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> List[InboundRuleSetListItem]:
+    tenant_id = _tenant_id(principal)
+    return inbound_rules_service.list_rule_sets(db, tenant_id)
+
+
+@router.post(
+    "/sets",
+    response_model=InboundRuleSetResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a new Inbound Rule Set",
+    description="Creates a new rule set and optionally initializes it with number rules. Admin rank or API key required.",
+)
+def create_rule_set(
+    body: InboundRuleSetCreate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> InboundRuleSetResponse:
+    tenant_id = _tenant_id(principal)
+    user_id = principal.id if isinstance(principal, User) else None
+    result = inbound_rules_service.create_rule_set(
+        db, tenant_id, user_id, body
+    )
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="inbound_rule_set.created",
+        resource_type="inbound_rule_set",
+        resource_id=result.id,
+        new_value=result.model_dump(),
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.get(
+    "/sets/{set_id}",
+    response_model=InboundRuleSetResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Get single Inbound Rule Set with rules list",
+    description="Returns rule set details and all its active number rules. Read-only rank is sufficient.",
+)
+def get_rule_set(
+    set_id: uuid.UUID,
+    principal: User | ApiKeyPrincipal = Depends(require_readonly_or_api_key),
+    db: Session = Depends(get_db),
+) -> InboundRuleSetResponse:
+    tenant_id = _tenant_id(principal)
+    return inbound_rules_service.get_rule_set(db, tenant_id, set_id)
+
+
+@router.put(
+    "/sets/{set_id}",
+    response_model=InboundRuleSetResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Update Inbound Rule Set",
+    description="Updates name/description and batch replaces number rules if rules array is provided. Admin rank or API key required.",
+)
+def update_rule_set(
+    set_id: uuid.UUID,
+    body: InboundRuleSetUpdate,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> InboundRuleSetResponse:
+    tenant_id = _tenant_id(principal)
+    result = inbound_rules_service.update_rule_set(
+        db, tenant_id, set_id, body
+    )
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="inbound_rule_set.updated",
+        resource_type="inbound_rule_set",
+        resource_id=result.id,
+        new_value=result.model_dump(),
+        actor_user_id=principal.id,
+    )
+    return result
+
+
+@router.delete(
+    "/sets/{set_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Delete an Inbound Rule Set",
+    description="Soft deletes the rule set and its rules, detaching it from any call flows. Admin rank or API key required.",
+)
+def delete_rule_set(
+    set_id: uuid.UUID,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> None:
+    tenant_id = _tenant_id(principal)
+    inbound_rules_service.delete_rule_set(db, tenant_id, set_id)
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="inbound_rule_set.deleted",
+        resource_type="inbound_rule_set",
+        resource_id=set_id,
+        actor_user_id=principal.id,
+    )
+
+
+@router.post(
+    "/sets/import",
+    response_model=InboundRuleImportResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Bulk import number rules from CSV / text",
+    description="Imports number rules from multiline text or CSV data with optional labels into an existing or new rule set. Admin rank or API key required.",
+)
+def import_rules(
+    body: InboundRuleImportRequest,
+    request: Request,
+    principal: User | ApiKeyPrincipal = Depends(require_admin_or_api_key),
+    db: Session = Depends(get_db),
+) -> InboundRuleImportResponse:
+    tenant_id = _tenant_id(principal)
+    user_id = principal.id if isinstance(principal, User) else None
+    result = inbound_rules_service.import_rules_from_text(
+        db, tenant_id, user_id, body
+    )
+    log_audit_event(
+        db,
+        request=request,
+        tenant_id=tenant_id,
+        action="inbound_rule_set.imported",
+        resource_type="inbound_rule_set",
+        resource_id=result.rule_set.id,
+        new_value=result.model_dump(),
+        actor_user_id=principal.id,
+    )
+    return result

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -39,6 +39,7 @@ from app.models.call_flow import CallFlow
 from app.models.prompt_version import PromptVersion
 from app.models.folder import Folder
 from app.models.folder_flow import FolderFlow
+from app.models.inbound_rule import InboundRuleSet, InboundRule  # noqa: F401
 
 # Recruiting / resumes
 from app.models.resume import Resume

--- a/app/models/call_flow.py
+++ b/app/models/call_flow.py
@@ -284,6 +284,14 @@ class CallFlow(Base):
     )
     redirect_message = Column(Text, nullable=True)
 
+    # ── Inbound Rules & Blocklist Rule Set ──
+    inbound_rule_set_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("inboundruleset.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
     hipaa_compliance = Column(
         Boolean, default=False, nullable=False, server_default="false"
     )
@@ -333,6 +341,11 @@ class CallFlow(Base):
         post_update=True,
     )
     call_sessions = relationship("CallSession", back_populates="call_flow")
+    inbound_rule_set = relationship(
+        "InboundRuleSet",
+        foreign_keys=[inbound_rule_set_id],
+        back_populates="call_flows",
+    )
 
     __table_args__ = (
         Index("ix_callflow_tenant_id", "tenant_id"),

--- a/app/models/inbound_rule.py
+++ b/app/models/inbound_rule.py
@@ -1,0 +1,123 @@
+"""Inbound Rules & Number Blocking Rule Sets models."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from app.db.base_class import Base
+
+
+class InboundRuleSet(Base):
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    tenant_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenant.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name = Column(String(100), nullable=False)
+    description = Column(Text, nullable=True)
+    is_deleted = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+    created_by = Column(
+        UUID(as_uuid=True), ForeignKey("user.id"), nullable=True
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    rules = relationship(
+        "InboundRule",
+        back_populates="rule_set",
+        cascade="all, delete-orphan",
+        order_by="InboundRule.created_at.desc()",
+    )
+    call_flows = relationship("CallFlow", back_populates="inbound_rule_set")
+
+
+class InboundRule(Base):
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True,
+    )
+    tenant_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tenant.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    rule_set_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("inboundruleset.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    phone_number_pattern = Column(String(50), nullable=False)
+    normalized_digits = Column(String(50), nullable=False, index=True)
+    label = Column(String(100), nullable=True)
+    action = Column(
+        String(20), default="deny", nullable=False, server_default="deny"
+    )
+    is_deleted = Column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    rule_set = relationship("InboundRuleSet", back_populates="rules")
+
+    __table_args__ = (
+        Index(
+            "ix_inboundrule_tenant_normalized",
+            "tenant_id",
+            "normalized_digits",
+        ),
+        Index(
+            "ix_inboundrule_set_normalized",
+            "rule_set_id",
+            "normalized_digits",
+        ),
+    )

--- a/app/routers/voice.py
+++ b/app/routers/voice.py
@@ -30,6 +30,7 @@ from app.models.call_flow import CallFlow
 from app.models.phone_number import PhoneNumber
 from app.services.call_flow_service import call_flow_service
 from app.services.call_session_service import call_session_service
+from app.services.inbound_rules_service import inbound_rules_service
 from app.services.voice_screening_qualification_service import (
     maybe_update_resume_status_on_call_completed,
 )
@@ -357,8 +358,60 @@ async def handle_incoming_call(
             resolved_flow = None
             webhook_variables = {}
 
-        # ── Inbound Call Redirection & Forwarding Check ──
         target_flow = resolved_flow or default_call_flow
+
+        # ── Inbound Rules & Number Blocking Check ──
+        if target_flow and target_flow.inbound_rule_set_id:
+            is_blocked, matched_rule = (
+                inbound_rules_service.is_number_blocked(
+                    db=db,
+                    tenant_id=phone_number.tenant_id,
+                    rule_set_id=target_flow.inbound_rule_set_id,
+                    phone_number=from_number,
+                )
+            )
+            if is_blocked:
+                logger.info(
+                    "Inbound call %s from %s blocked by rule set %s (rule: %s, label: %s)",
+                    call_sid,
+                    from_number,
+                    target_flow.inbound_rule_set_id,
+                    matched_rule.id if matched_rule else None,
+                    matched_rule.label if matched_rule else None,
+                )
+                try:
+                    blocked_session = CallSession(
+                        tenant_id=phone_number.tenant_id,
+                        user_id=resolved_agent.created_by,
+                        agent_id=resolved_agent.id,
+                        call_flow_id=target_flow.id,
+                        twilio_call_sid=call_sid,
+                        from_number=from_number,
+                        to_number=to_number,
+                        customer_phone_number=from_number,
+                        assistant_phone_number=to_number,
+                        call_type="inbound",
+                        status="completed",
+                        ended_reason="Blocked by inbound rule set",
+                        start_time=datetime.now(timezone.utc),
+                        end_time=datetime.now(timezone.utc),
+                    )
+                    db.add(blocked_session)
+                    db.commit()
+                    db.refresh(blocked_session)
+                except Exception as db_err:
+                    db.rollback()
+                    logger.warning(
+                        "Could not save blocked call session (call_sid=%s): %s",
+                        call_sid,
+                        db_err,
+                    )
+
+                response = VoiceResponse()
+                response.reject(reason="busy")
+                return HTMLResponse(str(response), media_type="application/xml")
+
+        # ── Inbound Call Redirection & Forwarding Check ──
         if (
             target_flow
             and target_flow.redirect_inbound_calls_enabled
@@ -398,9 +451,11 @@ async def handle_incoming_call(
                         user_id=resolved_agent.created_by,
                         agent_id=resolved_agent.id,
                         call_flow_id=target_flow.id,
-                        call_sid=call_sid,
+                        twilio_call_sid=call_sid,
                         from_number=from_number,
                         to_number=to_number,
+                        customer_phone_number=from_number,
+                        assistant_phone_number=to_number,
                         call_type="inbound",
                         status="completed",
                         transferred=True,

--- a/app/schemas/call_flow.py
+++ b/app/schemas/call_flow.py
@@ -14,6 +14,10 @@ from pydantic import (
     model_validator,
 )
 
+from app.schemas.inbound_rule import (
+    FlowInboundRulesResponse,  # noqa: F401
+    FlowInboundRulesUpdate,  # noqa: F401
+)
 from app.schemas.prompt_version import PromptVersionOut
 from app.utils.ssrf import assert_public_url
 
@@ -639,6 +643,10 @@ class InboundRedirectSettingsResponse(BaseModel):
     redirect_conditions: list[RedirectCondition] = Field(default_factory=list)
     redirect_speak_message_enabled: bool = False
     redirect_message: str | None = None
+
+
+# FlowInboundRulesUpdate and FlowInboundRulesResponse are imported from app.schemas.inbound_rule
+
 
 
 class SystemWebhooksSettingsUpdate(BaseModel):

--- a/app/schemas/inbound_rule.py
+++ b/app/schemas/inbound_rule.py
@@ -1,0 +1,215 @@
+"""Pydantic schemas for Inbound Rules & Blocklist Rule Sets."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def normalize_phone_digits(phone: str) -> str:
+    """Strip all non-digit characters from phone number string."""
+    return re.sub(r"\D", "", phone or "")
+
+
+class InboundRuleItem(BaseModel):
+    id: Optional[uuid.UUID] = None
+    phone_number_pattern: str = Field(
+        ...,
+        min_length=1,
+        max_length=50,
+        description="Raw phone number or pattern, e.g. '+1 (555) 987-6543'",
+    )
+    normalized_digits: Optional[str] = Field(
+        None,
+        description="Digits-only sanitized string for fast matching",
+    )
+    label: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Optional descriptive label, e.g. 'Robocaller' or 'Spam'",
+    )
+    action: str = Field(
+        default="deny",
+        description="Rule action, default is 'deny'",
+    )
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True, extra="forbid")
+
+    @field_validator("phone_number_pattern")
+    @classmethod
+    def validate_phone_pattern(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("phone_number_pattern cannot be empty or whitespace")
+        digits = normalize_phone_digits(s)
+        if not digits:
+            raise ValueError("phone_number_pattern must contain at least one digit")
+        return s
+
+    @field_validator("label")
+    @classmethod
+    def clean_label(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        s = v.strip()
+        return s if s else None
+
+
+class InboundRuleSetCreate(BaseModel):
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Name of the rule set, e.g. 'Global Spammers'",
+    )
+    description: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Optional description of the rule set",
+    )
+    rules: List[InboundRuleItem] = Field(
+        default_factory=list,
+        description="Initial list of number rules to add",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("name")
+    @classmethod
+    def clean_name(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("name cannot be empty or whitespace")
+        return s
+
+    @field_validator("description")
+    @classmethod
+    def clean_description(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        s = v.strip()
+        return s if s else None
+
+
+class InboundRuleSetUpdate(BaseModel):
+    name: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=100,
+        description="Updated name of the rule set",
+    )
+    description: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Updated description of the rule set",
+    )
+    rules: Optional[List[InboundRuleItem]] = Field(
+        None,
+        description="Full replacement list of number rules (if provided)",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("name")
+    @classmethod
+    def clean_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        s = v.strip()
+        if not s:
+            raise ValueError("name cannot be empty or whitespace")
+        return s
+
+    @field_validator("description")
+    @classmethod
+    def clean_description(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        s = v.strip()
+        return s if s else None
+
+
+class InboundRuleSetListItem(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: Optional[str] = None
+    rules_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InboundRuleSetResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: Optional[str] = None
+    rules_count: int = 0
+    rules: List[InboundRuleItem] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InboundRuleImportRequest(BaseModel):
+    raw_text: Optional[str] = Field(
+        None,
+        description="Multiline text containing phone numbers, CSV data, or comma-separated rows with optional labels",
+    )
+    rule_set_id: Optional[uuid.UUID] = Field(
+        None,
+        description="Existing rule set ID to append imported rules to",
+    )
+    new_rule_set_name: Optional[str] = Field(
+        None,
+        max_length=100,
+        description="Name of the new rule set to create if rule_set_id is not provided",
+    )
+    new_rule_set_description: Optional[str] = Field(
+        None,
+        max_length=500,
+        description="Description of the new rule set if created",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("new_rule_set_name")
+    @classmethod
+    def clean_name(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return None
+        s = v.strip()
+        return s if s else None
+
+
+class InboundRuleImportResponse(BaseModel):
+    rule_set: InboundRuleSetResponse
+    imported_count: int
+    skipped_count: int
+    total_rules_count: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FlowInboundRulesUpdate(BaseModel):
+    inbound_rule_set_id: Optional[uuid.UUID] = Field(
+        None,
+        description="Inbound rule set ID to attach to the flow, or null to detach",
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class FlowInboundRulesResponse(BaseModel):
+    inbound_rule_set_id: Optional[uuid.UUID] = None
+    inbound_rule_set_name: Optional[str] = None
+    active_rules_count: int = 0
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/services/call_flow_service.py
+++ b/app/services/call_flow_service.py
@@ -16,6 +16,7 @@ from app.core.logger import logger
 from app.models.agent import Agent
 from app.models.call_flow import CallFlow
 from app.models.call_session import CallSession
+from app.models.inbound_rule import InboundRule, InboundRuleSet
 from app.models.model import Model
 from app.models.prompt_version import PromptVersion
 from app.repositories.call_flow_repository import CallFlowRepository
@@ -46,6 +47,8 @@ from app.schemas.call_flow import (
     FlowDataResponse,
     FlowDataSaveResponse,
     FlowDataUpdate,
+    FlowInboundRulesResponse,
+    FlowInboundRulesUpdate,
     FlowValidationError,
     FlowValidationErrorItem,
     FlowValidationResponse,
@@ -1263,6 +1266,102 @@ class CallFlowService:
         return re.sub(
             r"\{\{\s*([a-zA-Z0-9_\.]+)\s*\}\}", _replace_token, template
         ).strip()
+
+    # ── Flow Inbound Rules & Blocklist Rule Set Assignment ──
+
+    def update_flow_inbound_rules(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+        body: FlowInboundRulesUpdate,
+    ) -> FlowInboundRulesResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+
+        if body.inbound_rule_set_id is not None:
+            rs = (
+                db.execute(
+                    select(InboundRuleSet).where(
+                        InboundRuleSet.id == body.inbound_rule_set_id,
+                        InboundRuleSet.tenant_id == tenant_id,
+                        InboundRuleSet.is_deleted.is_(False),
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if not rs:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Inbound rule set {body.inbound_rule_set_id} not found",
+                )
+
+        update_dict = {
+            "inbound_rule_set_id": body.inbound_rule_set_id,
+            "updated_at": datetime.now(timezone.utc),
+        }
+
+        repo = CallFlowRepository(db)
+        repo.update(flow, update_dict)
+        db.commit()
+        db.refresh(flow)
+        return self._to_flow_inbound_rules_response(db, flow)
+
+    def get_flow_inbound_rules(
+        self,
+        db: Session,
+        flow_id: uuid.UUID,
+        tenant_id: uuid.UUID,
+    ) -> FlowInboundRulesResponse:
+        flow = self._get_flow_or_404(db, flow_id, tenant_id)
+        return self._to_flow_inbound_rules_response(db, flow)
+
+    @staticmethod
+    def _to_flow_inbound_rules_response(
+        db: Session,
+        flow: CallFlow,
+    ) -> FlowInboundRulesResponse:
+        if not flow.inbound_rule_set_id:
+            return FlowInboundRulesResponse(
+                inbound_rule_set_id=None,
+                inbound_rule_set_name=None,
+                active_rules_count=0,
+            )
+
+        rs = (
+            db.execute(
+                select(InboundRuleSet).where(
+                    InboundRuleSet.id == flow.inbound_rule_set_id,
+                    InboundRuleSet.tenant_id == flow.tenant_id,
+                    InboundRuleSet.is_deleted.is_(False),
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if not rs:
+            return FlowInboundRulesResponse(
+                inbound_rule_set_id=flow.inbound_rule_set_id,
+                inbound_rule_set_name=None,
+                active_rules_count=0,
+            )
+
+        count = (
+            db.execute(
+                select(func.count(InboundRule.id)).where(
+                    InboundRule.rule_set_id == rs.id,
+                    InboundRule.tenant_id == flow.tenant_id,
+                    InboundRule.is_deleted.is_(False),
+                )
+            ).scalar()
+            or 0
+        )
+
+        return FlowInboundRulesResponse(
+            inbound_rule_set_id=rs.id,
+            inbound_rule_set_name=rs.name,
+            active_rules_count=count,
+        )
 
     # ── System Webhooks (pre-inbound / dynamic routing / post-call / status) ──
 

--- a/app/services/inbound_rules_service.py
+++ b/app/services/inbound_rules_service.py
@@ -1,0 +1,432 @@
+"""Inbound Rules & Blocklist Rule Sets service."""
+
+from __future__ import annotations
+
+import csv
+import io
+import uuid
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.models.call_flow import CallFlow
+from app.models.inbound_rule import InboundRule, InboundRuleSet
+from app.schemas.inbound_rule import (
+    InboundRuleImportRequest,
+    InboundRuleImportResponse,
+    InboundRuleItem,
+    InboundRuleSetCreate,
+    InboundRuleSetListItem,
+    InboundRuleSetResponse,
+    InboundRuleSetUpdate,
+    normalize_phone_digits,
+)
+
+
+class InboundRulesService:
+    def list_rule_sets(
+        self, db: Session, tenant_id: uuid.UUID
+    ) -> List[InboundRuleSetListItem]:
+        """List all non-deleted rule sets with active rules count for tenant."""
+        rule_sets = (
+            db.execute(
+                select(InboundRuleSet)
+                .where(
+                    InboundRuleSet.tenant_id == tenant_id,
+                    InboundRuleSet.is_deleted.is_(False),
+                )
+                .order_by(InboundRuleSet.created_at.desc())
+            )
+            .scalars()
+            .all()
+        )
+
+        result: List[InboundRuleSetListItem] = []
+        for rs in rule_sets:
+            count = (
+                db.execute(
+                    select(func.count(InboundRule.id)).where(
+                        InboundRule.rule_set_id == rs.id,
+                        InboundRule.tenant_id == tenant_id,
+                        InboundRule.is_deleted.is_(False),
+                    )
+                ).scalar()
+                or 0
+            )
+            result.append(
+                InboundRuleSetListItem(
+                    id=rs.id,
+                    name=rs.name,
+                    description=rs.description,
+                    rules_count=count,
+                    created_at=rs.created_at,
+                    updated_at=rs.updated_at,
+                )
+            )
+        return result
+
+    def get_rule_set(
+        self, db: Session, tenant_id: uuid.UUID, rule_set_id: uuid.UUID
+    ) -> InboundRuleSetResponse:
+        """Get single rule set with full rules list."""
+        rs = self._get_rule_set_or_404(db, tenant_id, rule_set_id)
+        return self._to_rule_set_response(db, rs)
+
+    def create_rule_set(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        user_id: Optional[uuid.UUID],
+        body: InboundRuleSetCreate,
+    ) -> InboundRuleSetResponse:
+        """Create new rule set and optionally its initial rules."""
+        rs = InboundRuleSet(
+            tenant_id=tenant_id,
+            name=body.name,
+            description=body.description,
+            created_by=user_id,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        db.add(rs)
+        db.flush()
+
+        seen_digits = set()
+        for item in body.rules:
+            digits = normalize_phone_digits(item.phone_number_pattern)
+            if not digits or digits in seen_digits:
+                continue
+            seen_digits.add(digits)
+            rule = InboundRule(
+                tenant_id=tenant_id,
+                rule_set_id=rs.id,
+                phone_number_pattern=item.phone_number_pattern.strip(),
+                normalized_digits=digits,
+                label=item.label,
+                action=item.action or "deny",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+            db.add(rule)
+
+        db.commit()
+        db.refresh(rs)
+        return self._to_rule_set_response(db, rs)
+
+    def update_rule_set(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        rule_set_id: uuid.UUID,
+        body: InboundRuleSetUpdate,
+    ) -> InboundRuleSetResponse:
+        """Update rule set name/description and batch replace rules if provided."""
+        rs = self._get_rule_set_or_404(db, tenant_id, rule_set_id)
+
+        if body.name is not None:
+            rs.name = body.name
+        if body.description is not None:
+            rs.description = body.description
+        rs.updated_at = datetime.now(timezone.utc)
+
+        if body.rules is not None:
+            # Mark existing rules as deleted or delete
+            existing_rules = (
+                db.execute(
+                    select(InboundRule).where(
+                        InboundRule.rule_set_id == rs.id,
+                        InboundRule.tenant_id == tenant_id,
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for er in existing_rules:
+                db.delete(er)
+            db.flush()
+
+            seen_digits = set()
+            for item in body.rules:
+                digits = normalize_phone_digits(item.phone_number_pattern)
+                if not digits or digits in seen_digits:
+                    continue
+                seen_digits.add(digits)
+                rule = InboundRule(
+                    tenant_id=tenant_id,
+                    rule_set_id=rs.id,
+                    phone_number_pattern=item.phone_number_pattern.strip(),
+                    normalized_digits=digits,
+                    label=item.label,
+                    action=item.action or "deny",
+                    created_at=datetime.now(timezone.utc),
+                    updated_at=datetime.now(timezone.utc),
+                )
+                db.add(rule)
+
+        db.commit()
+        db.refresh(rs)
+        return self._to_rule_set_response(db, rs)
+
+    def delete_rule_set(
+        self, db: Session, tenant_id: uuid.UUID, rule_set_id: uuid.UUID
+    ) -> None:
+        """Soft delete a rule set and nullify flow references."""
+        rs = self._get_rule_set_or_404(db, tenant_id, rule_set_id)
+        rs.is_deleted = True
+        rs.updated_at = datetime.now(timezone.utc)
+
+        # Mark rules as deleted
+        rules = (
+            db.execute(
+                select(InboundRule).where(
+                    InboundRule.rule_set_id == rs.id,
+                    InboundRule.tenant_id == tenant_id,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for r in rules:
+            r.is_deleted = True
+            r.updated_at = datetime.now(timezone.utc)
+
+        # Detach from any call flows
+        flows = (
+            db.execute(
+                select(CallFlow).where(
+                    CallFlow.tenant_id == tenant_id,
+                    CallFlow.inbound_rule_set_id == rs.id,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for f in flows:
+            f.inbound_rule_set_id = None
+            f.updated_at = datetime.now(timezone.utc)
+
+        db.commit()
+
+    def import_rules_from_text(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        user_id: Optional[uuid.UUID],
+        body: InboundRuleImportRequest,
+    ) -> InboundRuleImportResponse:
+        """Bulk import rules from multiline text / CSV string."""
+        raw_text = (body.raw_text or "").strip()
+        if not raw_text:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="raw_text cannot be empty",
+            )
+
+        # Resolve or create target rule set
+        if body.rule_set_id is not None:
+            rs = self._get_rule_set_or_404(db, tenant_id, body.rule_set_id)
+        else:
+            name = (
+                body.new_rule_set_name
+                or f"Imported Blocklist - {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M')}"
+            )
+            rs = InboundRuleSet(
+                tenant_id=tenant_id,
+                name=name,
+                description=body.new_rule_set_description,
+                created_by=user_id,
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+            db.add(rs)
+            db.flush()
+
+        # Fetch existing normalized digits in this rule set
+        existing_rules = (
+            db.execute(
+                select(InboundRule).where(
+                    InboundRule.rule_set_id == rs.id,
+                    InboundRule.tenant_id == tenant_id,
+                    InboundRule.is_deleted.is_(False),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        existing_digits = {r.normalized_digits for r in existing_rules}
+
+        # Parse lines / CSV
+        parsed_rows: List[Tuple[str, Optional[str]]] = []
+        reader = csv.reader(io.StringIO(raw_text))
+        for row in reader:
+            if not row or not any(field.strip() for field in row):
+                continue
+            phone_raw = row[0].strip()
+            label_raw = row[1].strip() if len(row) > 1 else None
+            # Skip header lines if present (e.g. 'phone_number,label', 'Phone,Label', 'caller_id,tag')
+            clean_header = (
+                phone_raw.lower()
+                .replace(" ", "")
+                .replace("_", "")
+                .replace("-", "")
+            )
+            if clean_header in (
+                "phone",
+                "phonenumber",
+                "phonenumbers",
+                "number",
+                "numbers",
+                "callerid",
+                "telephone",
+                "telephonenumber",
+            ):
+                continue
+            parsed_rows.append((phone_raw, label_raw if label_raw else None))
+
+        imported_count = 0
+        skipped_count = 0
+        seen_import_digits = set()
+
+        for phone_raw, label in parsed_rows:
+            digits = normalize_phone_digits(phone_raw)
+            if not digits:
+                skipped_count += 1
+                continue
+            if digits in existing_digits or digits in seen_import_digits:
+                skipped_count += 1
+                continue
+
+            seen_import_digits.add(digits)
+            clean_label = label.strip()[:100] if label and label.strip() else None
+            rule = InboundRule(
+                tenant_id=tenant_id,
+                rule_set_id=rs.id,
+                phone_number_pattern=phone_raw[:50],
+                normalized_digits=digits[:50],
+                label=clean_label,
+                action="deny",
+                created_at=datetime.now(timezone.utc),
+                updated_at=datetime.now(timezone.utc),
+            )
+            db.add(rule)
+            imported_count += 1
+
+        rs.updated_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(rs)
+
+        resp = self._to_rule_set_response(db, rs)
+        return InboundRuleImportResponse(
+            rule_set=resp,
+            imported_count=imported_count,
+            skipped_count=skipped_count,
+            total_rules_count=resp.rules_count,
+        )
+
+    def is_number_blocked(
+        self,
+        db: Session,
+        tenant_id: uuid.UUID,
+        rule_set_id: uuid.UUID,
+        phone_number: str,
+    ) -> Tuple[bool, Optional[InboundRule]]:
+        """
+        Check if a caller phone number is denied in the given rule set.
+        Matching handles exact digits, 10-digit national variants (with/without country code 1).
+        """
+        if not phone_number or not rule_set_id:
+            return False, None
+
+        digits = normalize_phone_digits(phone_number)
+        if not digits:
+            return False, None
+
+        # Build search variants (e.g. 15551234567, 5551234567)
+        candidates = {digits}
+        if len(digits) == 11 and digits.startswith("1"):
+            candidates.add(digits[1:])
+        elif len(digits) == 10:
+            candidates.add("1" + digits)
+
+        matched_rule = (
+            db.execute(
+                select(InboundRule).where(
+                    InboundRule.rule_set_id == rule_set_id,
+                    InboundRule.tenant_id == tenant_id,
+                    InboundRule.is_deleted.is_(False),
+                    InboundRule.action == "deny",
+                    InboundRule.normalized_digits.in_(list(candidates)),
+                )
+            )
+            .scalars()
+            .first()
+        )
+
+        if matched_rule:
+            return True, matched_rule
+        return False, None
+
+    def _get_rule_set_or_404(
+        self, db: Session, tenant_id: uuid.UUID, rule_set_id: uuid.UUID
+    ) -> InboundRuleSet:
+        rs = (
+            db.execute(
+                select(InboundRuleSet).where(
+                    InboundRuleSet.id == rule_set_id,
+                    InboundRuleSet.tenant_id == tenant_id,
+                    InboundRuleSet.is_deleted.is_(False),
+                )
+            )
+            .scalars()
+            .first()
+        )
+        if not rs:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Inbound rule set {rule_set_id} not found",
+            )
+        return rs
+
+    def _to_rule_set_response(
+        self, db: Session, rs: InboundRuleSet
+    ) -> InboundRuleSetResponse:
+        rules = (
+            db.execute(
+                select(InboundRule)
+                .where(
+                    InboundRule.rule_set_id == rs.id,
+                    InboundRule.tenant_id == rs.tenant_id,
+                    InboundRule.is_deleted.is_(False),
+                )
+                .order_by(InboundRule.created_at.desc())
+            )
+            .scalars()
+            .all()
+        )
+        rule_items = [
+            InboundRuleItem(
+                id=r.id,
+                phone_number_pattern=r.phone_number_pattern,
+                normalized_digits=r.normalized_digits,
+                label=r.label,
+                action=r.action,
+                created_at=r.created_at,
+                updated_at=r.updated_at,
+            )
+            for r in rules
+        ]
+        return InboundRuleSetResponse(
+            id=rs.id,
+            name=rs.name,
+            description=rs.description,
+            rules_count=len(rule_items),
+            rules=rule_items,
+            created_at=rs.created_at,
+            updated_at=rs.updated_at,
+        )
+
+
+inbound_rules_service = InboundRulesService()

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -9435,6 +9435,76 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/flows/{flow_id}/inbound-rules:
+    put:
+      tags:
+      - A/B Prompt Testing
+      summary: Assign or detach Inbound Rules & Blocklist Rule Set on a call flow
+      description: 'Attaches an existing inbound rule set (blocklist) to this call
+        flow or detaches it by setting inbound_rule_set_id to null.
+
+
+        Admin rank (or API key) required.'
+      operationId: update_flow_inbound_rules_api_v2_flows__flow_id__inbound_rules_put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FlowInboundRulesUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowInboundRulesResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    get:
+      tags:
+      - A/B Prompt Testing
+      summary: Get Inbound Rules & Blocklist Rule Set info for a call flow
+      description: Returns the active inbound rule set ID, name, and active rules
+        count attached to this call flow. Read-only rank is sufficient.
+      operationId: get_flow_inbound_rules_api_v2_flows__flow_id__inbound_rules_get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: flow_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Flow Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowInboundRulesResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v2/flows/{flow_id}/system-webhooks-settings:
     put:
       tags:
@@ -9626,6 +9696,176 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/inbound-rules/sets:
+    get:
+      tags:
+      - Inbound Rules & Blocklist
+      summary: List all Inbound Rule Sets for the workspace
+      description: Returns all non-deleted inbound rule sets with active rules count
+        for current workspace. Read-only rank is sufficient.
+      operationId: list_rule_sets_api_v2_inbound_rules_sets_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/InboundRuleSetListItem'
+                type: array
+                title: Response List Rule Sets Api V2 Inbound Rules Sets Get
+      security:
+      - HTTPBearer: []
+    post:
+      tags:
+      - Inbound Rules & Blocklist
+      summary: Create a new Inbound Rule Set
+      description: Creates a new rule set and optionally initializes it with number
+        rules. Admin rank or API key required.
+      operationId: create_rule_set_api_v2_inbound_rules_sets_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InboundRuleSetCreate'
+        required: true
+      responses:
+        '201':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InboundRuleSetResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
+  /api/v2/inbound-rules/sets/{set_id}:
+    get:
+      tags:
+      - Inbound Rules & Blocklist
+      summary: Get single Inbound Rule Set with rules list
+      description: Returns rule set details and all its active number rules. Read-only
+        rank is sufficient.
+      operationId: get_rule_set_api_v2_inbound_rules_sets__set_id__get
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: set_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Set Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InboundRuleSetResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    put:
+      tags:
+      - Inbound Rules & Blocklist
+      summary: Update Inbound Rule Set
+      description: Updates name/description and batch replaces number rules if rules
+        array is provided. Admin rank or API key required.
+      operationId: update_rule_set_api_v2_inbound_rules_sets__set_id__put
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: set_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Set Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InboundRuleSetUpdate'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InboundRuleSetResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+    delete:
+      tags:
+      - Inbound Rules & Blocklist
+      summary: Delete an Inbound Rule Set
+      description: Soft deletes the rule set and its rules, detaching it from any
+        call flows. Admin rank or API key required.
+      operationId: delete_rule_set_api_v2_inbound_rules_sets__set_id__delete
+      security:
+      - HTTPBearer: []
+      parameters:
+      - name: set_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Set Id
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v2/inbound-rules/sets/import:
+    post:
+      tags:
+      - Inbound Rules & Blocklist
+      summary: Bulk import number rules from CSV / text
+      description: Imports number rules from multiline text or CSV data with optional
+        labels into an existing or new rule set. Admin rank or API key required.
+      operationId: import_rules_api_v2_inbound_rules_sets_import_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InboundRuleImportRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InboundRuleImportResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - HTTPBearer: []
   /api/v2/flows/flow-data:
     get:
       tags:
@@ -14153,6 +14393,30 @@ components:
       - flowData
       title: FlowDataUpdate
       description: Request body for ``PUT /api/v2/flows/{flow_id}/flow-data``.
+    FlowInboundRulesResponse:
+      properties:
+        inbound_rule_set_id:
+          type: string
+          format: uuid
+          nullable: true
+        inbound_rule_set_name:
+          type: string
+          nullable: true
+        active_rules_count:
+          type: integer
+          title: Active Rules Count
+          default: 0
+      type: object
+      title: FlowInboundRulesResponse
+    FlowInboundRulesUpdate:
+      properties:
+        inbound_rule_set_id:
+          type: string
+          format: uuid
+          nullable: true
+      additionalProperties: false
+      type: object
+      title: FlowInboundRulesUpdate
     FlowKbUpdate:
       properties:
         kb_ids:
@@ -14814,6 +15078,192 @@ components:
       type: object
       title: InboundRedirectSettingsUpdate
       description: Request body for ``PUT /api/v2/flows/{flow_id}/inbound-redirect-settings``.
+    InboundRuleImportRequest:
+      properties:
+        raw_text:
+          type: string
+          nullable: true
+        rule_set_id:
+          type: string
+          format: uuid
+          nullable: true
+        new_rule_set_name:
+          type: string
+          maxLength: 100
+          nullable: true
+        new_rule_set_description:
+          type: string
+          maxLength: 500
+          nullable: true
+      additionalProperties: false
+      type: object
+      title: InboundRuleImportRequest
+    InboundRuleImportResponse:
+      properties:
+        rule_set:
+          $ref: '#/components/schemas/InboundRuleSetResponse'
+        imported_count:
+          type: integer
+          title: Imported Count
+        skipped_count:
+          type: integer
+          title: Skipped Count
+        total_rules_count:
+          type: integer
+          title: Total Rules Count
+      type: object
+      required:
+      - rule_set
+      - imported_count
+      - skipped_count
+      - total_rules_count
+      title: InboundRuleImportResponse
+    InboundRuleItem:
+      properties:
+        id:
+          type: string
+          format: uuid
+          nullable: true
+        phone_number_pattern:
+          type: string
+          maxLength: 50
+          minLength: 1
+          title: Phone Number Pattern
+          description: Raw phone number or pattern, e.g. '+1 (555) 987-6543'
+        normalized_digits:
+          type: string
+          nullable: true
+        label:
+          type: string
+          maxLength: 100
+          nullable: true
+        action:
+          type: string
+          title: Action
+          description: Rule action, default is 'deny'
+          default: deny
+        created_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+      type: object
+      required:
+      - phone_number_pattern
+      title: InboundRuleItem
+    InboundRuleSetCreate:
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          minLength: 1
+          title: Name
+          description: Name of the rule set, e.g. 'Global Spammers'
+        description:
+          type: string
+          maxLength: 500
+          nullable: true
+        rules:
+          items:
+            $ref: '#/components/schemas/InboundRuleItem'
+          type: array
+          title: Rules
+          description: Initial list of number rules to add
+      additionalProperties: false
+      type: object
+      required:
+      - name
+      title: InboundRuleSetCreate
+    InboundRuleSetListItem:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        description:
+          type: string
+          nullable: true
+        rules_count:
+          type: integer
+          title: Rules Count
+          default: 0
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - id
+      - name
+      - created_at
+      - updated_at
+      title: InboundRuleSetListItem
+    InboundRuleSetResponse:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        name:
+          type: string
+          title: Name
+        description:
+          type: string
+          nullable: true
+        rules_count:
+          type: integer
+          title: Rules Count
+          default: 0
+        rules:
+          items:
+            $ref: '#/components/schemas/InboundRuleItem'
+          type: array
+          title: Rules
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - id
+      - name
+      - created_at
+      - updated_at
+      title: InboundRuleSetResponse
+    InboundRuleSetUpdate:
+      properties:
+        name:
+          type: string
+          maxLength: 100
+          minLength: 1
+          nullable: true
+        description:
+          type: string
+          maxLength: 500
+          nullable: true
+        rules:
+          items:
+            $ref: '#/components/schemas/InboundRuleItem'
+          type: array
+          nullable: true
+      additionalProperties: false
+      type: object
+      title: InboundRuleSetUpdate
     IntegrationItem:
       properties:
         name:

--- a/tests/api/v2/test_inbound_rules_api.py
+++ b/tests/api/v2/test_inbound_rules_api.py
@@ -1,0 +1,692 @@
+"""Tests for Inbound Rules & Blocklist Rule Sets API and Flow Assignment endpoints.
+
+Coverage:
+  - CRUD for /api/v2/inbound-rules/sets
+  - Bulk import via /api/v2/inbound-rules/sets/import
+  - Flow assignment /api/v2/flows/{flow_id}/inbound-rules (PUT/GET)
+  - RBAC (Admin required for mutations, Read-Only sufficient for GET)
+  - Tenant isolation (404 for other workspace resources)
+  - Audit logging events
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI, HTTPException, status
+from fastapi.testclient import TestClient
+
+from app.core.exception_handlers import register_exception_handlers
+
+
+def _build_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import (
+        get_db,
+        require_admin_or_api_key,
+        require_readonly_or_api_key,
+    )
+    from app.api.v2.routers.flows import router as flows_router
+    from app.api.v2.routers.inbound_rules import router as inbound_rules_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(flows_router)
+    mini.include_router(inbound_rules_router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_admin_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_admin_or_api_key] = lambda: principal
+        mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_readonly_app(db_override, principal, *, forbidden=False):
+    from app.api.deps import get_db, require_readonly_or_api_key
+    from app.api.v2.routers.flows import router as flows_router
+    from app.api.v2.routers.inbound_rules import router as inbound_rules_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(flows_router)
+    mini.include_router(inbound_rules_router)
+
+    if forbidden:
+
+        def _raise_forbidden():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden"
+            )
+
+        mini.dependency_overrides[require_readonly_or_api_key] = _raise_forbidden
+    else:
+        mini.dependency_overrides[require_readonly_or_api_key] = lambda: principal
+
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _build_app_for_real_rank_check(db_override, principal):
+    from app.api.deps import get_db, require_tenant
+    from app.api.v2.routers.flows import router as flows_router
+    from app.api.v2.routers.inbound_rules import router as inbound_rules_router
+
+    mini = FastAPI()
+    register_exception_handlers(mini)
+    mini.include_router(flows_router)
+    mini.include_router(inbound_rules_router)
+
+    mini.dependency_overrides[require_tenant] = lambda: principal
+    mini.dependency_overrides[get_db] = lambda: db_override
+
+    return TestClient(mini, raise_server_exceptions=False)
+
+
+def _with_effective_role(role_name: str):
+    return patch(
+        "app.api.deps.rbac.rbac_cache_service.get_effective_role",
+        return_value=role_name,
+    )
+
+
+def _principal(tenant_id: uuid.UUID) -> MagicMock:
+    principal = MagicMock()
+    principal.id = uuid.uuid4()
+    principal.current_tenant_id = tenant_id
+    return principal
+
+
+@pytest.fixture
+def workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"InboundRulesWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"inbound_rules_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def other_workspace(db):
+    from app.models.tenant import Tenant
+
+    tenant = Tenant(
+        name=f"OtherInboundRulesWS-{uuid.uuid4().hex[:8]}",
+        schema_name=f"other_inbound_rules_ws_{uuid.uuid4().hex[:8]}",
+        status="active",
+    )
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+    return tenant
+
+
+@pytest.fixture
+def agent(db, workspace):
+    from app.models.agent import Agent
+
+    a = Agent(
+        tenant_id=workspace.id,
+        name="Inbound Rules Agent",
+        status="active",
+        llm_model="gpt-4o-mini",
+        tts_provider_slug="elevenlabs",
+        tts_voice_external_id="voice-x",
+        tts_language="en",
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+@pytest.fixture
+def flow(db, workspace, agent):
+    from app.models.call_flow import CallFlow
+
+    f = CallFlow(
+        tenant_id=workspace.id,
+        agent_id=agent.id,
+        name="Inbound Rules Flow",
+        direction="inbound",
+        status="active",
+    )
+    db.add(f)
+    db.commit()
+    db.refresh(f)
+    return f
+
+
+class TestInboundRuleSetsCRUD:
+    def test_create_rule_set_with_rules(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        payload = {
+            "name": "Global Robocallers",
+            "description": "Blocklist of known spam numbers",
+            "rules": [
+                {
+                    "phone_number_pattern": "+1 (555) 987-6543",
+                    "label": "Telemarketer",
+                },
+                {
+                    "phone_number_pattern": "+15551234567",
+                    "label": "Scam Caller",
+                },
+            ],
+        }
+
+        resp = client.post("/inbound-rules/sets", json=payload)
+        assert resp.status_code == 201, resp.text
+        data = resp.json()
+        assert data["name"] == "Global Robocallers"
+        assert data["description"] == "Blocklist of known spam numbers"
+        assert data["rules_count"] == 2
+        assert len(data["rules"]) == 2
+        assert any(r["normalized_digits"] == "15559876543" for r in data["rules"])
+        assert any(r["normalized_digits"] == "15551234567" for r in data["rules"])
+
+    def test_list_rule_sets(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        # Create two sets
+        admin_client = _build_app(db, principal)
+        admin_client.post(
+            "/inbound-rules/sets",
+            json={"name": "Set A", "rules": [{"phone_number_pattern": "5551112222"}]},
+        )
+        admin_client.post(
+            "/inbound-rules/sets",
+            json={"name": "Set B", "rules": []},
+        )
+
+        resp = client.get("/inbound-rules/sets")
+        assert resp.status_code == 200
+        items = resp.json()
+        assert len(items) >= 2
+        set_a = next(s for s in items if s["name"] == "Set A")
+        assert set_a["rules_count"] == 1
+
+    def test_get_single_rule_set(self, db, workspace):
+        principal = _principal(workspace.id)
+        admin_client = _build_app(db, principal)
+        create_resp = admin_client.post(
+            "/inbound-rules/sets",
+            json={"name": "Set Detail", "description": "Desc", "rules": [{"phone_number_pattern": "5553334444", "label": "Tag"}]},
+        )
+        set_id = create_resp.json()["id"]
+
+        readonly_client = _build_readonly_app(db, principal)
+        resp = readonly_client.get(f"/inbound-rules/sets/{set_id}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == set_id
+        assert body["name"] == "Set Detail"
+        assert len(body["rules"]) == 1
+        assert body["rules"][0]["label"] == "Tag"
+
+    def test_update_rule_set_and_replace_rules(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        create_resp = client.post(
+            "/inbound-rules/sets",
+            json={"name": "Initial Set", "rules": [{"phone_number_pattern": "5551111111"}]},
+        )
+        set_id = create_resp.json()["id"]
+
+        update_resp = client.put(
+            f"/inbound-rules/sets/{set_id}",
+            json={
+                "name": "Updated Set Name",
+                "rules": [
+                    {"phone_number_pattern": "5552222222", "label": "New Rule 1"},
+                    {"phone_number_pattern": "5553333333", "label": "New Rule 2"},
+                ],
+            },
+        )
+        assert update_resp.status_code == 200
+        body = update_resp.json()
+        assert body["name"] == "Updated Set Name"
+        assert body["rules_count"] == 2
+
+    def test_delete_rule_set_detaches_flow(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        create_resp = client.post(
+            "/inbound-rules/sets",
+            json={"name": "Set to Delete", "rules": [{"phone_number_pattern": "5559999999"}]},
+        )
+        set_id = create_resp.json()["id"]
+
+        # Attach to flow
+        client.put(f"/flows/{flow.id}/inbound-rules", json={"inbound_rule_set_id": set_id})
+
+        # Delete set
+        del_resp = client.delete(f"/inbound-rules/sets/{set_id}")
+        assert del_resp.status_code == 204
+
+        # Flow should be detached
+        flow_rules_resp = client.get(f"/flows/{flow.id}/inbound-rules")
+        assert flow_rules_resp.status_code == 200
+        assert flow_rules_resp.json()["inbound_rule_set_id"] is None
+
+        # Getting deleted set should return 404
+        get_resp = client.get(f"/inbound-rules/sets/{set_id}")
+        assert get_resp.status_code == 404
+
+    def test_tenant_isolation_rule_sets(self, db, other_workspace, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+        create_resp = client.post("/inbound-rules/sets", json={"name": "Tenant A Set"})
+        set_id = create_resp.json()["id"]
+
+        foreign_principal = _principal(other_workspace.id)
+        foreign_client = _build_app(db, foreign_principal)
+
+        assert foreign_client.get(f"/inbound-rules/sets/{set_id}").status_code == 404
+        assert foreign_client.put(f"/inbound-rules/sets/{set_id}", json={"name": "Hacked"}).status_code == 404
+        assert foreign_client.delete(f"/inbound-rules/sets/{set_id}").status_code == 404
+
+
+class TestInboundRulesBulkImport:
+    def test_bulk_import_new_set(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        raw_csv = """phone_number,label
++1 (555) 100-2000,Spammer A
++1 (555) 300-4000,Spammer B
+5555006000
++1 (555) 100-2000,Duplicate Should Skip
+"""
+
+        resp = client.post(
+            "/inbound-rules/sets/import",
+            json={
+                "raw_text": raw_csv,
+                "new_rule_set_name": "CSV Imported Blocklist",
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["imported_count"] == 3
+        assert body["skipped_count"] == 1
+        assert body["total_rules_count"] == 3
+        assert body["rule_set"]["name"] == "CSV Imported Blocklist"
+
+    def test_bulk_import_append_to_existing_set(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        create_resp = client.post(
+            "/inbound-rules/sets",
+            json={"name": "Existing Set", "rules": [{"phone_number_pattern": "5551110000"}]},
+        )
+        set_id = create_resp.json()["id"]
+
+        raw_text = """5551110000,Existing Number Skip
+5552220000,New Number
+5553330000,New Number 2
+"""
+        resp = client.post(
+            "/inbound-rules/sets/import",
+            json={
+                "rule_set_id": set_id,
+                "raw_text": raw_text,
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["imported_count"] == 2
+        assert body["skipped_count"] == 1
+        assert body["total_rules_count"] == 3
+
+
+class TestFlowInboundRulesAssignment:
+    def test_get_flow_inbound_rules_default(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_readonly_app(db, principal)
+
+        resp = client.get(f"/flows/{flow.id}/inbound-rules")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["inbound_rule_set_id"] is None
+        assert body["inbound_rule_set_name"] is None
+        assert body["active_rules_count"] == 0
+
+    def test_assign_and_detach_rule_set_on_flow(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        create_resp = client.post(
+            "/inbound-rules/sets",
+            json={
+                "name": "Flow Blocklist",
+                "rules": [
+                    {"phone_number_pattern": "5550001111"},
+                    {"phone_number_pattern": "5550002222"},
+                ],
+            },
+        )
+        set_id = create_resp.json()["id"]
+
+        # Assign
+        put_resp = client.put(
+            f"/flows/{flow.id}/inbound-rules",
+            json={"inbound_rule_set_id": set_id},
+        )
+        assert put_resp.status_code == 200
+        body = put_resp.json()
+        assert body["inbound_rule_set_id"] == set_id
+        assert body["inbound_rule_set_name"] == "Flow Blocklist"
+        assert body["active_rules_count"] == 2
+
+        # Detach
+        detach_resp = client.put(
+            f"/flows/{flow.id}/inbound-rules",
+            json={"inbound_rule_set_id": None},
+        )
+        assert detach_resp.status_code == 200
+        assert detach_resp.json()["inbound_rule_set_id"] is None
+        assert detach_resp.json()["active_rules_count"] == 0
+
+    def test_assign_invalid_rule_set_returns_404(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-rules",
+            json={"inbound_rule_set_id": str(uuid.uuid4())},
+        )
+        assert resp.status_code == 404
+
+    def test_assign_foreign_rule_set_returns_404(
+        self, db, workspace, other_workspace, flow
+    ):
+        foreign_principal = _principal(other_workspace.id)
+        foreign_client = _build_app(db, foreign_principal)
+        create_resp = foreign_client.post(
+            "/inbound-rules/sets",
+            json={"name": "Foreign Blocklist"},
+        )
+        foreign_set_id = create_resp.json()["id"]
+
+        # Attempt to assign foreign rule set to our flow
+        client = _build_app(db, _principal(workspace.id))
+        resp = client.put(
+            f"/flows/{flow.id}/inbound-rules",
+            json={"inbound_rule_set_id": foreign_set_id},
+        )
+        assert resp.status_code == 404
+
+    def test_foreign_tenant_cannot_access_flow_inbound_rules(
+        self, db, other_workspace, flow
+    ):
+        foreign_principal = _principal(other_workspace.id)
+        foreign_client = _build_app(db, foreign_principal)
+
+        assert (
+            foreign_client.get(f"/flows/{flow.id}/inbound-rules").status_code
+            == 404
+        )
+        assert (
+            foreign_client.put(
+                f"/flows/{flow.id}/inbound-rules",
+                json={"inbound_rule_set_id": None},
+            ).status_code
+            == 404
+        )
+
+
+class TestInboundRulesRBAC:
+    def test_readonly_user_forbidden_on_mutations(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        forbidden_client = _build_app(db, principal, forbidden=True)
+
+        # POST /inbound-rules/sets -> 403
+        resp = forbidden_client.post(
+            "/inbound-rules/sets", json={"name": "Test Set"}
+        )
+        assert resp.status_code == 403
+
+        # PUT /inbound-rules/sets/{id} -> 403
+        resp = forbidden_client.put(
+            f"/inbound-rules/sets/{uuid.uuid4()}", json={"name": "New Name"}
+        )
+        assert resp.status_code == 403
+
+        # DELETE /inbound-rules/sets/{id} -> 403
+        resp = forbidden_client.delete(f"/inbound-rules/sets/{uuid.uuid4()}")
+        assert resp.status_code == 403
+
+        # POST /inbound-rules/sets/import -> 403
+        resp = forbidden_client.post(
+            "/inbound-rules/sets/import",
+            json={"raw_text": "5551234567"},
+        )
+        assert resp.status_code == 403
+
+        # PUT /flows/{flow_id}/inbound-rules -> 403
+        resp = forbidden_client.put(
+            f"/flows/{flow.id}/inbound-rules",
+            json={"inbound_rule_set_id": None},
+        )
+        assert resp.status_code == 403
+
+    def test_readonly_user_allowed_on_get(self, db, workspace, flow):
+        principal = _principal(workspace.id)
+        # Create a set as admin first
+        admin_client = _build_app(db, principal)
+        create_resp = admin_client.post(
+            "/inbound-rules/sets",
+            json={"name": "Read-Only Check Set"},
+        )
+        set_id = create_resp.json()["id"]
+
+        readonly_client = _build_readonly_app(db, principal)
+
+        # GET /inbound-rules/sets -> 200
+        resp = readonly_client.get("/inbound-rules/sets")
+        assert resp.status_code == 200
+
+        # GET /inbound-rules/sets/{id} -> 200
+        resp = readonly_client.get(f"/inbound-rules/sets/{set_id}")
+        assert resp.status_code == 200
+
+        # GET /flows/{id}/inbound-rules -> 200
+        resp = readonly_client.get(f"/flows/{flow.id}/inbound-rules")
+        assert resp.status_code == 200
+
+
+class TestInboundRulesAuditLogging:
+    def test_audit_logs_recorded_for_all_mutations(self, db, workspace, flow):
+        from app.models.audit_log import AuditLog
+
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        # 1. Create rule set
+        create_resp = client.post(
+            "/inbound-rules/sets",
+            json={
+                "name": "Audit Test Set",
+                "rules": [{"phone_number_pattern": "5551112222", "label": "Tag"}],
+            },
+        )
+        assert create_resp.status_code == 201
+        set_id = create_resp.json()["id"]
+
+        log_created = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.action == "inbound_rule_set.created",
+                AuditLog.tenant_id == workspace.id,
+            )
+            .order_by(AuditLog.timestamp.desc())
+            .first()
+        )
+        assert log_created is not None
+        assert str(log_created.resource_id) == set_id
+        assert log_created.resource_type == "inbound_rule_set"
+
+        # 2. Update rule set
+        update_resp = client.put(
+            f"/inbound-rules/sets/{set_id}",
+            json={"name": "Audit Test Set Updated"},
+        )
+        assert update_resp.status_code == 200
+
+        log_updated = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.action == "inbound_rule_set.updated",
+                AuditLog.tenant_id == workspace.id,
+            )
+            .order_by(AuditLog.timestamp.desc())
+            .first()
+        )
+        assert log_updated is not None
+        assert str(log_updated.resource_id) == set_id
+
+        # 3. Import rules
+        import_resp = client.post(
+            "/inbound-rules/sets/import",
+            json={
+                "rule_set_id": set_id,
+                "raw_text": "5553334444,Imported Tag\n5555556666",
+            },
+        )
+        assert import_resp.status_code == 200
+
+        log_imported = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.action == "inbound_rule_set.imported",
+                AuditLog.tenant_id == workspace.id,
+            )
+            .order_by(AuditLog.timestamp.desc())
+            .first()
+        )
+        assert log_imported is not None
+        assert str(log_imported.resource_id) == set_id
+
+        # 4. Assign flow inbound rules
+        flow_resp = client.put(
+            f"/flows/{flow.id}/inbound-rules",
+            json={"inbound_rule_set_id": set_id},
+        )
+        assert flow_resp.status_code == 200
+
+        log_flow = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.action == "flow_inbound_rules.updated",
+                AuditLog.tenant_id == workspace.id,
+            )
+            .order_by(AuditLog.timestamp.desc())
+            .first()
+        )
+        assert log_flow is not None
+        assert str(log_flow.resource_id) == str(flow.id)
+        assert log_flow.resource_type == "call_flow"
+
+        # 5. Delete rule set
+        del_resp = client.delete(f"/inbound-rules/sets/{set_id}")
+        assert del_resp.status_code == 204
+
+        log_deleted = (
+            db.query(AuditLog)
+            .filter(
+                AuditLog.action == "inbound_rule_set.deleted",
+                AuditLog.tenant_id == workspace.id,
+            )
+            .order_by(AuditLog.timestamp.desc())
+            .first()
+        )
+        assert log_deleted is not None
+        assert str(log_deleted.resource_id) == set_id
+
+
+class TestSchemaValidationAndEdgeCases:
+    def test_empty_or_whitespace_name_rejected(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.post("/inbound-rules/sets", json={"name": "   "})
+        assert resp.status_code in (400, 422)
+
+    def test_invalid_pattern_no_digits_rejected(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.post(
+            "/inbound-rules/sets",
+            json={
+                "name": "Invalid Number Set",
+                "rules": [{"phone_number_pattern": "no-digits-here"}],
+            },
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_extra_forbidden_fields_rejected(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.post(
+            "/inbound-rules/sets",
+            json={"name": "Valid Name", "extra_bad_field": "disallowed"},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_import_empty_text_rejected(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        resp = client.post(
+            "/inbound-rules/sets/import",
+            json={"raw_text": "   "},
+        )
+        assert resp.status_code in (400, 422)
+
+    def test_import_various_csv_headers_and_quotes(self, db, workspace):
+        principal = _principal(workspace.id)
+        client = _build_app(db, principal)
+
+        csv_content = """\"Phone Number\",\"Label\"
+\"+1 (555) 777-8888\",\"Important Spammer\"
+\"+1 (555) 999-0000\",
+5551239999,\"Another Label\"
+"""
+        resp = client.post(
+            "/inbound-rules/sets/import",
+            json={
+                "raw_text": csv_content,
+                "new_rule_set_name": "Header Variations Set",
+            },
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["imported_count"] == 3
+        assert body["skipped_count"] == 0
+

--- a/tests/services/test_inbound_rules_runtime.py
+++ b/tests/services/test_inbound_rules_runtime.py
@@ -1,0 +1,367 @@
+"""Unit and runtime integration tests for Inbound Rules & Number Blocking Engine.
+
+Coverage:
+  - Caller matching with digit normalization and national variants (+1, 10-digit, 11-digit)
+  - Twilio incoming call rejection (<Reject reason="busy"/>) when caller is denied
+  - CallSession recording with ended_reason="Blocked by inbound rule set"
+  - Fall-through to regular AI voice agent when caller is not in rule set
+  - Fall-through when flow has no rule set or rule set is deleted
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models.agent import Agent
+from app.models.call_flow import CallFlow
+from app.models.call_session import CallSession
+from app.models.inbound_rule import InboundRule, InboundRuleSet
+from app.models.model import Model
+from app.models.phone_number import PhoneNumber
+from app.models.provider import Provider
+from app.models.tenant import Tenant
+from app.models.user import User
+from app.routers.voice import router
+from app.services.inbound_rules_service import inbound_rules_service
+
+
+class TestInboundRulesServiceUnit:
+    def test_is_number_blocked_exact_and_variants(self, db):
+        tenant = Tenant(
+            name=f"UnitWS-{uuid.uuid4().hex[:8]}",
+            schema_name=f"unit_ws_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(tenant)
+        db.commit()
+
+        rs = InboundRuleSet(
+            tenant_id=tenant.id,
+            name="Blocklist Unit",
+        )
+        db.add(rs)
+        db.commit()
+
+        # Rule added with 10 digits
+        r1 = InboundRule(
+            tenant_id=tenant.id,
+            rule_set_id=rs.id,
+            phone_number_pattern="5559876543",
+            normalized_digits="5559876543",
+            action="deny",
+        )
+        db.add(r1)
+        db.commit()
+
+        # Check with 10 digits
+        blocked, rule = inbound_rules_service.is_number_blocked(
+            db, tenant.id, rs.id, "5559876543"
+        )
+        assert blocked is True
+        assert rule.id == r1.id
+
+        # Check with +1 E.164
+        blocked, rule = inbound_rules_service.is_number_blocked(
+            db, tenant.id, rs.id, "+15559876543"
+        )
+        assert blocked is True
+
+        # Check with formatted string
+        blocked, rule = inbound_rules_service.is_number_blocked(
+            db, tenant.id, rs.id, "+1 (555) 987-6543"
+        )
+        assert blocked is True
+
+        # Check unblocked number
+        blocked, rule = inbound_rules_service.is_number_blocked(
+            db, tenant.id, rs.id, "+15550009999"
+        )
+        assert blocked is False
+        assert rule is None
+
+        # Check international number (+44)
+        r_uk = InboundRule(
+            tenant_id=tenant.id,
+            rule_set_id=rs.id,
+            phone_number_pattern="+44 20 7946 0958",
+            normalized_digits="442079460958",
+            action="deny",
+        )
+        db.add(r_uk)
+        db.commit()
+
+        blocked, rule = inbound_rules_service.is_number_blocked(
+            db, tenant.id, rs.id, "+44 20 7946 0958"
+        )
+        assert blocked is True
+        assert rule.id == r_uk.id
+
+        # Check soft-deleted rule is NOT blocked
+        r_uk.is_deleted = True
+        db.commit()
+
+        blocked, rule = inbound_rules_service.is_number_blocked(
+            db, tenant.id, rs.id, "+44 20 7946 0958"
+        )
+        assert blocked is False
+        assert rule is None
+
+        # Check empty or non-digit input
+        assert (
+            inbound_rules_service.is_number_blocked(
+                db, tenant.id, rs.id, ""
+            )[0]
+            is False
+        )
+        assert (
+            inbound_rules_service.is_number_blocked(
+                db, tenant.id, rs.id, "anonymous"
+            )[0]
+            is False
+        )
+
+
+class TestInboundRulesWebhookRuntime:
+    @pytest.fixture
+    def app(self, db):
+        mini = FastAPI()
+        mini.include_router(router)
+        from app.api.deps import get_db
+
+        mini.dependency_overrides[get_db] = lambda: db
+        return mini
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app, raise_server_exceptions=False)
+
+    @pytest.fixture
+    def setup_inbound_entities(self, db):
+        tenant = Tenant(
+            name=f"InboundBlock-{uuid.uuid4().hex[:8]}",
+            schema_name=f"inbound_block_{uuid.uuid4().hex[:8]}",
+            status="active",
+        )
+        db.add(tenant)
+        db.commit()
+        db.refresh(tenant)
+
+        user = User(
+            email=f"block_{uuid.uuid4().hex[:6]}@example.com",
+            first_name="Block",
+            last_name="Tester",
+            hashed_password="pw",
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+        model = (
+            db.query(Model).filter(Model.model_name == "gpt-4o-mini").first()
+        )
+        if not model:
+            provider = Provider(name="openai", is_active=True)
+            db.add(provider)
+            db.commit()
+            model = Model(
+                provider_id=provider.id,
+                model_name="gpt-4o-mini",
+                archive=False,
+            )
+            db.add(model)
+            db.commit()
+
+        agent = Agent(
+            tenant_id=tenant.id,
+            name="Inbound Block Agent",
+            status="active",
+            llm_model="gpt-4o-mini",
+            model_id=model.id,
+            created_by=user.id,
+            tts_provider_slug="elevenlabs",
+            tts_voice_external_id="voice-1",
+            tts_language="en",
+        )
+        db.add(agent)
+        db.commit()
+        db.refresh(agent)
+
+        phone = PhoneNumber(
+            tenant_id=tenant.id,
+            phone_number=f"+15550{uuid.uuid4().int % 10000000:07d}",
+            status="active",
+            assistant_id=agent.id,
+        )
+        db.add(phone)
+        db.commit()
+        db.refresh(phone)
+
+        rule_set = InboundRuleSet(
+            tenant_id=tenant.id,
+            name="Test Spammers",
+        )
+        db.add(rule_set)
+        db.commit()
+        db.refresh(rule_set)
+
+        blocked_rule = InboundRule(
+            tenant_id=tenant.id,
+            rule_set_id=rule_set.id,
+            phone_number_pattern="+1 (555) 999-8888",
+            normalized_digits="15559998888",
+            label="Spam Robocall",
+            action="deny",
+        )
+        db.add(blocked_rule)
+        db.commit()
+
+        flow = CallFlow(
+            tenant_id=tenant.id,
+            agent_id=agent.id,
+            name="Inbound Block Flow",
+            direction="inbound",
+            status="active",
+            inbound_rule_set_id=rule_set.id,
+        )
+        db.add(flow)
+        db.commit()
+        db.refresh(flow)
+
+        return tenant, agent, phone, flow, rule_set
+
+    def test_inbound_call_from_blocked_number_rejected(
+        self, db, client, setup_inbound_entities
+    ):
+        tenant, agent, phone, flow, rule_set = setup_inbound_entities
+
+        with patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_BLOCK_TEST_1",
+                    "From": "+1 (555) 999-8888",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "application/xml" in resp.headers["content-type"]
+        assert "<Reject" in resp.text
+        assert 'reason="busy"' in resp.text
+
+        # Verify CallSession persistence
+        session = (
+            db.query(CallSession)
+            .filter(CallSession.twilio_call_sid == "CA_BLOCK_TEST_1")
+            .first()
+        )
+        assert session is not None
+        assert session.tenant_id == tenant.id
+        assert session.agent_id == agent.id
+        assert session.call_flow_id == flow.id
+        assert session.from_number == "+1 (555) 999-8888"
+        assert session.customer_phone_number == "+1 (555) 999-8888"
+        assert session.to_number == phone.phone_number
+        assert session.assistant_phone_number == phone.phone_number
+        assert session.call_type == "inbound"
+        assert session.status == "completed"
+        assert session.ended_reason == "Blocked by inbound rule set"
+
+    def test_inbound_call_from_unblocked_number_proceeds(
+        self, client, setup_inbound_entities
+    ):
+        _, _, phone, flow, _ = setup_inbound_entities
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+            patch(
+                "app.routers.voice.build_streaming_twiml",
+                return_value="<Response><Connect><Stream url='wss://example.com'/></Connect></Response>",
+            ),
+        ):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_BLOCK_TEST_2",
+                    "From": "+1 (555) 111-2222",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "<Reject" not in resp.text
+        assert "<Stream" in resp.text
+
+    def test_inbound_call_when_no_ruleset_attached(
+        self, db, client, setup_inbound_entities
+    ):
+        _, _, phone, flow, _ = setup_inbound_entities
+        flow.inbound_rule_set_id = None
+        db.commit()
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+            patch(
+                "app.routers.voice.build_streaming_twiml",
+                return_value="<Response><Connect><Stream url='wss://example.com'/></Connect></Response>",
+            ),
+        ):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_BLOCK_TEST_3",
+                    "From": "+1 (555) 999-8888",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "<Reject" not in resp.text
+        assert "<Stream" in resp.text
+
+    def test_inbound_call_when_ruleset_deleted_proceeds(
+        self, db, client, setup_inbound_entities
+    ):
+        _, _, phone, flow, rule_set = setup_inbound_entities
+        # Soft delete the rule set and its rules
+        rule_set.is_deleted = True
+        for r in rule_set.rules:
+            r.is_deleted = True
+        db.commit()
+
+        with (
+            patch("app.routers.voice.settings.ALLOW_UNAUTHENTICATED_WEBHOOKS", True),
+            patch(
+                "app.routers.voice.credit_service.has_sufficient_credits",
+                return_value=(True, 100, 1, None),
+            ),
+            patch(
+                "app.routers.voice.build_streaming_twiml",
+                return_value="<Response><Connect><Stream url='wss://example.com'/></Connect></Response>",
+            ),
+        ):
+            resp = client.post(
+                "/incoming",
+                data={
+                    "CallSid": "CA_BLOCK_TEST_4",
+                    "From": "+1 (555) 999-8888",
+                    "To": phone.phone_number,
+                },
+            )
+
+        assert resp.status_code == 200
+        assert "<Reject" not in resp.text
+        assert "<Stream" in resp.text


### PR DESCRIPTION
## Summary
Implements full persistent configuration, bulk CSV/multiline paste import, REST API endpoints, flow assignment, and real-time voice pipeline pre-answer rejection for **Inbound Rules & Number Blocklist Rule Sets** on Call Flows.

---

### 🛠️ Scope of Changes:
1. **Database Models & Alembic Migration**:
   - Created `InboundRuleSet` and `InboundRule` models using standard `Base` class table resolution (`inboundruleset` and `inboundrule`), cascade foreign keys, and composite indexes on `tenant_id, normalized_digits` and `rule_set_id, normalized_digits`.
   - Added `inbound_rule_set_id` (with FK to `inboundruleset.id`, `ondelete="SET NULL"`, `index=True`) and `inbound_rule_set` relationship to `CallFlow`.
   - Registered models in `app/db/base.py`.
   - Migration `e8b9c0d1e2f3` created, tested, and applied.

2. **Pydantic Schemas**:
   - Created `InboundRuleItem`, `InboundRuleSetCreate`, `InboundRuleSetUpdate`, `InboundRuleSetListItem`, `InboundRuleSetResponse`, `InboundRuleImportRequest`, `InboundRuleImportResponse`, `FlowInboundRulesUpdate`, and `FlowInboundRulesResponse` in `app/schemas/inbound_rule.py` with strict input boundaries (`extra="forbid"`) and response serialization (`ConfigDict(from_attributes=True)`).
   - Re-exported in `app/schemas/call_flow.py`.

3. **Service Layer**:
   - Implemented `InboundRulesService` with CRUD operations, active rule aggregation, soft-delete cascades, and call flow detachment.
   - Bulk CSV & multiline import parsing with standard quote handling, header skipping, deduplication within input and existing rules, and detailed stats reporting.
   - Fast digit-normalized matching (`is_number_blocked`) supporting E.164, 10-digit national variants (+1), and international numbers.
   - Flow assignment methods `update_flow_inbound_rules` and `get_flow_inbound_rules` in `CallFlowService`.

4. **API Endpoints & Audit Logging**:
   - Mounted `/api/v2/inbound-rules` router:
     - `GET /sets` (Read-only)
     - `POST /sets` (Admin)
     - `GET /sets/{set_id}` (Read-only)
     - `PUT /sets/{set_id}` (Admin)
     - `DELETE /sets/{set_id}` (Admin)
     - `POST /sets/import` (Admin)
   - Added to `/api/v2/flows/{flow_id}/inbound-rules`:
     - `PUT` (Admin)
     - `GET` (Read-only)
   - Recorded audit log entries for all mutations: `inbound_rule_set.created`, `inbound_rule_set.updated`, `inbound_rule_set.deleted`, `inbound_rule_set.imported`, and `flow_inbound_rules.updated`.

5. **🎙️ Real-Time Twilio Voice Rejection Engine**:
   - In `app/routers/voice.py` (`handle_incoming_call`), checks incoming caller against the flow's attached `inbound_rule_set_id`.
   - When matched, logs the blocked call, records a completed `CallSession` audit row (`ended_reason="Blocked by inbound rule set"`, `twilio_call_sid=call_sid`), and immediately returns TwiML `<Response><Reject reason="busy"/></Response>` before initiating live streaming or deducting credits.

6. **Documentation & Verification**:
   - Documented all endpoints and schemas in `docs/api/openapi.yaml`.
   - Comprehensive test suites in `tests/api/v2/test_inbound_rules_api.py` and `tests/services/test_inbound_rules_runtime.py` (26/26 tests passing).
   - Full regression suite verified (1,489 passed).
   - Code formatting & linting verified via `ruff check` (0 errors).