### PR TITLE
Voice pipeline: barge-in fixes, backchannel classifier, and TTS humanization parity

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -721,7 +721,7 @@ class Settings(BaseSettings):
     # Deepgram fires many more partials than classic Google STT. Running LLM on every
     # interim → double replies + TTS "breaks." Default: final STT only (one reply per
     # utterance). Set True for lower first-token latency at the cost of stability.
-    VOICE_ENABLE_INTERIM_LLM: bool = True
+    VOICE_ENABLE_INTERIM_LLM: bool = False
     # When interim LLM is enabled, these gates reduce junk triggers ("I'm", "Do you", …)
     VOICE_MIN_INTERIM_WORDS: int = 2
     VOICE_MIN_INTERIM_CONFIDENCE: float = 0.14

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -743,7 +743,7 @@ class Settings(BaseSettings):
     # Min STT confidence when word count >= VOICE_BARGE_IN_MIN_WORDS.
     VOICE_BARGE_IN_MIN_CONFIDENCE: float = 0.26
     # Only used when VOICE_BARGE_IN_MIN_WORDS == 1 (one-word interrupts like "stop").
-    VOICE_BARGE_IN_MIN_CONFIDENCE_1W: float = 0.52
+    VOICE_BARGE_IN_MIN_CONFIDENCE_1W: float = 0.36
     VOICE_HISTORY_MAX_MESSAGES: int = 50
     VOICE_TTS_FLUSH_MIN_WORDS: int = 4
     # Smaller max keeps per-chunk synthesis short (~300ms for ElevenLabs) so the

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -366,7 +366,7 @@ class BidirectionalStreamHandler(
         )
         self._twilio_buffer_primed = False  # Track if jitter buffer has been primed
         self._tts_pipeline: TtsPipeline | None = None
-        self._use_ssml = True  # Enable SSML by default
+        self._use_ssml = False  # Disabled by default; only enabled if provider explicitly supports SSML
         # Quick-ack dedup guard: prevent repeated acknowledgements for the same
         # user turn when interim/final regeneration paths overlap.
         self._last_quick_ack_user_norm: str = ""
@@ -487,6 +487,7 @@ class BidirectionalStreamHandler(
             False  # True after first interim triggers LLM for this turn
         )
         self._turn_response_seed_text = ""
+        self._interim_task_response_produced = False
         # In-flight LLM+TTS; wrapped in a task so barge-in can cancel while we await (like dev, but cancelable)
         self._llm_response_task: asyncio.Task | None = None
         self._auto_greeting_sent = False
@@ -655,6 +656,15 @@ class BidirectionalStreamHandler(
                 # Lazy safety net: ensure prompt KB exists for older agents
                 # created before auto-ingest rollout.
                 agent_service.ensure_agent_prompt_ingested(self.db, self.agent)
+                if self.agent:
+                    from app.core.agent_runtime import resolve_tts_runtime
+
+                    runtime = resolve_tts_runtime(self.agent, db=self.db)
+                    # SSML is only supported for non-streaming Google Cloud TTS
+                    self._use_ssml = (
+                        (runtime.adapter_slug or "").lower() == "google"
+                        and not getattr(settings, "VOICE_TTS_STREAMING_ENABLED", True)
+                    )
 
             if self.call_session and self.call_session.call_flow_id:
                 from app.models.call_flow import CallFlow
@@ -920,6 +930,7 @@ class BidirectionalStreamHandler(
         """Stop background LLM+TTS for this turn (barge-in or final regen)."""
         t = self._llm_response_task
         self._llm_response_task = None
+        self._interim_task_response_produced = False
         if t and not t.done():
             t.cancel()
             try:
@@ -995,6 +1006,7 @@ class BidirectionalStreamHandler(
         # ── Phase 1: state check (inside lock, fast) ──────────────────────────
         _should_generate = False
         _need_cancel = False
+        _wait_for_interim_task = None
 
         async with self._llm_turn_serial_lock:
             _now_m = time.monotonic()
@@ -1019,15 +1031,32 @@ class BidirectionalStreamHandler(
                 self._turn_response_started = False
                 self._turn_response_seed_text = ""
                 self._last_interim_text = ""
-                if should_regenerate:
+
+                interim_task = self._llm_response_task
+                if should_regenerate or interim_task is None:
                     _should_generate = True
                     _need_cancel = True
                     self._llm_last_answered_transcript = tstrip
                     self._llm_last_answered_ts = _now_m
+                elif interim_task.done():
+                    interim_res = None
+                    if not interim_task.cancelled() and interim_task.exception() is None:
+                        try:
+                            interim_res = interim_task.result()
+                        except Exception:
+                            interim_res = None
+
+                    if interim_res and str(interim_res).strip():
+                        # Interim LLM task for this turn completed with a valid, committed response.
+                        return
+                    else:
+                        # Interim finished without producing a valid response — generate for final!
+                        _should_generate = True
+                        _need_cancel = True
+                        self._llm_last_answered_transcript = tstrip
+                        self._llm_last_answered_ts = _now_m
                 else:
-                    # Interim LLM already running with the correct transcript —
-                    # let it finish without a second generation.
-                    return
+                    _wait_for_interim_task = interim_task
             else:
                 self._turn_response_seed_text = ""
                 self._last_interim_text = ""
@@ -1036,6 +1065,32 @@ class BidirectionalStreamHandler(
                 self._llm_last_answered_transcript = tstrip
                 self._llm_last_answered_ts = _now_m
         # ── Lock released ──────────────────────────────────────────────────────
+
+        # If an interim task was in-flight and considered a continuation, wait for it outside the lock.
+        if _wait_for_interim_task is not None:
+            interim_res = None
+            if not _wait_for_interim_task.done():
+                try:
+                    interim_res = await asyncio.wait_for(asyncio.shield(_wait_for_interim_task), timeout=12.0)
+                except (asyncio.CancelledError, asyncio.TimeoutError, Exception) as exc:
+                    logger.debug("[LLM] In-flight interim task failed/timed out/cancelled: %s", exc)
+            elif not _wait_for_interim_task.cancelled() and _wait_for_interim_task.exception() is None:
+                try:
+                    interim_res = _wait_for_interim_task.result()
+                except Exception:
+                    interim_res = None
+
+            if interim_res and str(interim_res).strip():
+                # THIS specific interim task completed and committed a valid response!
+                return
+
+            # Interim task did not produce a valid response (failed, cancelled, or empty) —
+            # Fall back and generate for the authoritative final transcript!
+            _should_generate = True
+            _need_cancel = True
+            async with self._llm_turn_serial_lock:
+                self._llm_last_answered_transcript = tstrip
+                self._llm_last_answered_ts = time.monotonic()
 
         if not _should_generate:
             return
@@ -1442,13 +1497,23 @@ class BidirectionalStreamHandler(
             self._last_interim_sent_ts = now
             self._turn_response_started = True
             self._turn_response_seed_text = transcript
+            self._interim_task_response_produced = False
 
-            async def _run_interim() -> None:
-                await self.generate_and_stream_response(
-                    transcript,
-                    confidence,
-                    is_greeting=False,
-                )
+            async def _run_interim() -> str | None:
+                try:
+                    resp = await self.generate_and_stream_response(
+                        transcript,
+                        confidence,
+                        is_greeting=False,
+                    )
+                    if resp and str(resp).strip():
+                        return str(resp).strip()
+                    return None
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.error(f"Error processing interim: {exc}")
+                    return None
 
             if self._llm_response_task and not self._llm_response_task.done():
                 self._llm_response_task.cancel()
@@ -2795,6 +2860,7 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                     "", self._strip_control_tokens_for_tts(final_text)
                 ).strip()
                 if transcript_text:
+                    self._interim_task_response_produced = True
                     await self._add_to_transcript(
                         "agent",
                         transcript_text,
@@ -2857,10 +2923,14 @@ Follow the model instructions. Continue from the history above. Be {agent_name}.
                 except Exception as exc:
                     logger.debug("VoiceSLO breach check failed: %s", exc)
 
+                return final_text
+            return None
+
         except asyncio.CancelledError:
             raise
         except Exception as e:
             logger.error(f"Error in generate_and_stream_response: {e}", exc_info=True)
+            return None
 
     async def _deferred_conversation_memory_update(
         self, turn_context: TurnContext, user_text: str

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -63,10 +63,8 @@ CACHING & LOW-LATENCY STRATEGIES:
    - greeting_message is not used on outbound calls
    - Bypasses LLM for that opening only; LLM is not instructed to repeat it verbatim on later "hi"
 
-2. Pre-cached Common Phrases (disabled — implementation commented in code):
-   - 36+ common phrases were pre-generated at connect to warm the MULAW TTS cache
-   - Greetings, acknowledgements, confirmations; <50ms when cache hit
-   - Re-enable by uncommenting asyncio.create_task(self._precache_common_phrases()) and the method
+2. Speculative TTS Prefetch:
+   - Synthesis starts during Deepgram endpointing window, maximising overlap with LLM TTFT.
 
 3. Quick Acknowledgement Pattern (5-Word Rule + Probability):
    - Eligible when user says 5+ words; then only ~38% chance we send "Got it" (more natural).
@@ -152,7 +150,6 @@ from app.voice.metrics import VoiceTurnMetrics
 from app.utils.ssml_utils import strip_ssml_tags
 from app.utils.webhook_templating import render_template
 from app.services.bidirectional_stream_service import (
-    generate_mulaw_tts,
     build_streaming_twiml,  # noqa: F401 - re-exported for app.routers.voice / voice_gather
     build_tts_only_twiml,  # noqa: F401 - re-exported for app.routers.voice
 )
@@ -564,10 +561,6 @@ class BidirectionalStreamHandler(
         # self._conversation = ConversationOrchestrator(self)
         # ─────────────────────────────────────────────────────────────────────
 
-        # Pre-cache quick-ack phrases so they hit the LRU audio cache instead of
-        # paying TTS API latency on the first "Got it" / "Sure" of the call.
-        asyncio.create_task(self._precache_common_phrases())
-
         # Fetch KB/business-knowledge blocks in the background at call start.
         # These are agent-level and don't change per-turn; caching them here
         # eliminates the 50-200ms parallel executor cost on every slow-path turn.
@@ -690,81 +683,6 @@ class BidirectionalStreamHandler(
         return is_jd_recruitment_voice_context(
             self.call_session.call_metadata.get("jd_context")
         )
-
-    async def _precache_common_phrases(self):
-        """
-        Pre-generate and cache common phrases for instant playback.
-        Runs in background during initialization.
-        """
-        try:
-            # Let call setup/pickup settle first so warmup does not contend with
-            # first-turn STT/LLM/TTS work.
-            await asyncio.sleep(1.5)
-            # Common phrases for instant responses (greetings, confirmations, acknowledgements)
-            common_phrases = [
-                # Greetings
-                "Hello",
-                "Hi there",
-                "Hi",
-                "Good morning",
-                "Good afternoon",
-                "Good evening",
-                # Acknowledgements (Quick feedback)
-                "Got it",
-                "I see",
-                "Okay",
-                "Sure",
-                "Alright",
-                "Perfect",
-                "Great",
-                "Understood",
-                # Confirmations
-                "Yes",
-                "No",
-                "Absolutely",
-                "Of course",
-                # Thinking/Processing
-                "Let me check that",
-                "One moment please",
-                "Just a second",
-                "Let me see",
-                # Transitions
-                "Thank you",
-                "Thanks",
-                "You're welcome",
-                # Closings
-                "Goodbye",
-                "Have a great day",
-                "Thank you for calling",
-                "Talk to you later",
-            ]
-
-            lang = self.agent.language if self.agent and self.agent.language else "en"
-            voice = (
-                self.agent.voice_type
-                if self.agent and self.agent.voice_type
-                else "female"
-            )
-
-            sem = asyncio.Semaphore(4)
-
-            async def _warm_phrase(phrase: str) -> None:
-                async with sem:
-                    try:
-                        await generate_mulaw_tts(
-                            text=phrase,
-                            lang=lang,
-                            voice=voice,
-                            use_chirp3_hd=True,
-                            speaking_rate=1.0,
-                            use_ssml=False,
-                        )
-                    except Exception:
-                        return
-
-            await asyncio.gather(*(_warm_phrase(phrase) for phrase in common_phrases))
-        except Exception as e:
-            logger.error(f"Error in precache_common_phrases: {e}")
 
     async def _prefetch_kb_blocks_at_call_start(self) -> None:
         """

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -165,6 +165,12 @@ from app.voice.tts_stream_mixin import TtsStreamMixin
 from app.voice.call_control_mixin import CallControlMixin
 from app.voice.flow_pipeline_mixin import FlowPipelineMixin
 from app.voice.pipeline_session import PipelineSession
+from app.voice.backchannel_classifier import (
+    TurnClassification,
+    classify_turn,
+    is_known_non_actionable_backchannel,
+    is_pure_acoustic_filler,
+)
 
 router = APIRouter()
 
@@ -492,6 +498,7 @@ class BidirectionalStreamHandler(
         self._lk_caller_publisher = None
         self._lk_agent_publisher = None
         self._screening_decline_handled = False
+        self._last_agent_speech_time: float = 0.0
 
         # Deepgram can emit the same is_final twice within a short window — avoid triple LLM/transcript
         self._stt_last_final_raw: str = ""
@@ -1079,89 +1086,26 @@ class BidirectionalStreamHandler(
             return False
         return True
 
-    _BARGE_IN_FILLER_WORDS = frozenset(
-        {
-            "uh",
-            "um",
-            "hmm",
-            "mm",
-            "ah",
-            "er",
-            "huh",
-            "mhm",
-            "mmm",
-            "eh",
-            "ugh",
-        }
-    )
-
     def _is_stt_filler_for_barge_in(self, transcript: str) -> bool:
         """Reject phantom Deepgram hits (uh/mm, uh huh) from cutting active TTS."""
-        low = re.sub(r"[^a-z ]+", "", (transcript or "").lower()).strip()
-        if not low:
-            return True
-        if low in self._BARGE_IN_FILLER_WORDS:
-            return True
-        tokens = low.split()
-        return bool(tokens) and all(t in self._BARGE_IN_FILLER_WORDS for t in tokens)
-
-    _BARGE_IN_COMMAND_WORDS = frozenset(
-        {
-            "stop",
-            "wait",
-            "hold",
-            "pause",
-            "cancel",
-            "interrupt",
-            "shut",
-            "quiet",
-            "listen",
-            "no",
-            "wrong",
-            "quit",
-            "abort",
-        }
-    )
-
-    def _has_2w_barge_in_command(self, text: str) -> bool:
-        """
-        For exactly 2-word utterances, require a clear interruption/command intent
-        (e.g., 'stop please', 'wait please', 'hold on', 'cancel that', 'stop talking')
-        to prevent polite conversational backchannels / greetings ('hey hi', 'hi there',
-        'good morning', 'yeah yeah', 'okay okay') from cutting active TTS playback.
-        """
-        low = re.sub(r"[^a-z ]+", " ", (text or "").lower())
-        tokens = [t for t in low.split() if t]
-        if len(tokens) != 2:
-            return False
-        return any(t in self._BARGE_IN_COMMAND_WORDS for t in tokens)
+        return is_pure_acoustic_filler(transcript)
 
     def _should_barge_in_on_stt(self, transcript: str, confidence: float) -> bool:
         """
-        True when STT looks like real user speech over the agent (not noise/filler).
-
-        Gates (all required): non-empty text, not filler-only, word count ≥
-        VOICE_BARGE_IN_MIN_WORDS. For exactly 2 words, must contain an explicit
-        interruption/command keyword (stop, wait, hold, cancel, etc.) to reject
-        conversational backchannels/greetings. Confidence at or above
-        VOICE_BARGE_IN_MIN_CONFIDENCE (multi-word) or VOICE_BARGE_IN_MIN_CONFIDENCE_1W
-        when min words is 1.
+        True when STT represents an actionable user turn or explicit interruption
+        over active TTS playback, rejecting known non-actionable backchannels.
         """
         if getattr(self, "_dtmf_suppress_stt", False):
             return False
-        text = (transcript or "").strip()
-        if not text or self._is_stt_filler_for_barge_in(text):
-            return False
-        word_count = len(text.split())
-        if word_count < self._barge_in_min_words:
-            return False
-        if word_count == 2:
-            if not self._has_2w_barge_in_command(text):
-                return False
-            return confidence >= self._barge_in_min_conf
-        if word_count >= 3:
-            return confidence >= self._barge_in_min_conf
-        return confidence >= self._barge_in_min_conf_1w
+        classification = classify_turn(
+            transcript,
+            confidence,
+            is_tts_playing=True,
+            min_confidence=self._barge_in_min_conf,
+            min_words=self._barge_in_min_words,
+            min_confidence_1w=self._barge_in_min_conf_1w,
+        )
+        return classification == TurnClassification.BARGE_IN
 
     def _log_barge_in_suppressed(
         self, transcript: str, confidence: float, reason: str
@@ -1186,26 +1130,34 @@ class BidirectionalStreamHandler(
         """Process a transcript (final result)"""
         try:
             # Barge-in on FINAL events: cut playing TTS before DB work when STT passes gates.
-            if self._is_tts_playing and self._should_barge_in_on_stt(
-                transcript, confidence
-            ):
-                self._metric_barge_in_ts = time.perf_counter()
-                logger.info(
-                    "[Barge-in/final] TTS cut by final STT: %r",
-                    (transcript or "")[:40],
-                )
-                await self._cancel_inflight_llm_response()
-                self._metric_audio_cut_ts = time.perf_counter()
-                _cut_ms = (self._metric_audio_cut_ts - self._metric_barge_in_ts) * 1000
-                logger.info(
-                    "[Metrics] interruption_detection_to_audio_cut=%.0f ms (final)",
-                    _cut_ms,
-                )
-                self._is_tts_playing = False
-                self._turn_response_started = False
-                self._turn_response_seed_text = ""
-                self._last_interim_text = ""
-                # Fall through — still process transcript and generate new response.
+            if self._is_tts_playing:
+                if self._should_barge_in_on_stt(transcript, confidence):
+                    self._metric_barge_in_ts = time.perf_counter()
+                    logger.info(
+                        "[Barge-in/final] TTS cut by final STT: %r",
+                        (transcript or "")[:40],
+                    )
+                    await self._cancel_inflight_llm_response()
+                    self._metric_audio_cut_ts = time.perf_counter()
+                    _cut_ms = (self._metric_audio_cut_ts - self._metric_barge_in_ts) * 1000
+                    logger.info(
+                        "[Metrics] interruption_detection_to_audio_cut=%.0f ms (final)",
+                        _cut_ms,
+                    )
+                    self._is_tts_playing = False
+                    self._turn_response_started = False
+                    self._turn_response_seed_text = ""
+                    self._last_interim_text = ""
+                    # Fall through — still process transcript and generate new response.
+                else:
+                    # Final STT arrived while TTS was playing and was classified as a
+                    # non-actionable backchannel (e.g. "Hey. Hi.", "Yeah yeah", "Thank you").
+                    # Suppress LLM response so active playback completes undisturbed.
+                    logger.info(
+                        "STT: suppressing non-actionable backchannel final while TTS is playing: %r",
+                        (transcript or "")[:40],
+                    )
+                    return
 
             async with self._voice_transcript_lock:
                 self._cancel_silence_watchdog()
@@ -1286,6 +1238,8 @@ class BidirectionalStreamHandler(
                     confidence,
                     defer_post_write=True,
                 )
+
+                # Update booking memory from user turn
                 self._update_booking_memory_from_user_turn(transcript)
 
                 user_turn_norm = self._normalize_turn_text(transcript)
@@ -1316,15 +1270,14 @@ class BidirectionalStreamHandler(
             # stall here for one full generation (~10–60s), inflating stt_final→gen_start.
             await self._complete_llm_turn_after_stt_final(transcript, confidence)
 
-        except Exception as e:
-            logger.error(f"Error processing transcript: {e}", exc_info=True)
+        except Exception as exc:
+            logger.error("Error in _process_transcript: %s", exc, exc_info=True)
 
     async def _maybe_process_interim(self, transcript: str, confidence: float):
         """
         At most one early LLM+TTS run per user utterance when `VOICE_ENABLE_INTERIM_LLM` is True.
         Default is False: LLM runs on **final** STT only, avoiding double replies from Deepgram
-        partials (e.g. "I'm" then "I'm feeling sad"). Barge-in still uses interim. When enabled,
-        gates use `VOICE_MIN_INTERIM_WORDS` + `VOICE_MIN_INTERIM_CONFIDENCE`.
+        partials. Barge-in still uses interim.
         """
         try:
             if not transcript:
@@ -1335,15 +1288,9 @@ class BidirectionalStreamHandler(
             word_count = len(transcript.split())
 
             # ── Barge-in gate ────────────────────────────────────────────────────
-            # Cut when audio is actively playing AND STT looks like real speech.
-            # `_is_tts_playing` only gates on streaming audio; word count, confidence,
-            # and filler rejection block phantom Deepgram hits on silence.
+            # Cut when audio is actively playing AND STT looks like real speech/command.
             is_barge_in = False
             if self._is_tts_playing:
-                # Dead-zone: ignore interims that arrive within N ms of TTS starting.
-                # Deepgram can send stale interims (from the user's original speech)
-                # at almost exactly the moment the first audio frame is sent to Twilio.
-                # Without this guard, barge-in fires instantly and the user hears nothing.
                 _in_dead_zone = (
                     self._tts_play_start_ts > 0
                     and (time.perf_counter() - self._tts_play_start_ts) * 1000
@@ -1357,15 +1304,15 @@ class BidirectionalStreamHandler(
                 elif self._should_barge_in_on_stt(transcript, confidence):
                     is_barge_in = True
                 elif (transcript or "").strip():
-                    if self._is_stt_filler_for_barge_in(transcript):
+                    if is_pure_acoustic_filler(transcript):
                         self._log_barge_in_suppressed(transcript, confidence, "filler")
+                    elif is_known_non_actionable_backchannel(transcript):
+                        self._log_barge_in_suppressed(
+                            transcript, confidence, "backchannel"
+                        )
                     elif word_count < self._barge_in_min_words:
                         self._log_barge_in_suppressed(
                             transcript, confidence, "min_words"
-                        )
-                    elif word_count == 2 and not self._has_2w_barge_in_command(transcript):
-                        self._log_barge_in_suppressed(
-                            transcript, confidence, "2w_no_command"
                         )
                     else:
                         self._log_barge_in_suppressed(
@@ -1391,38 +1338,33 @@ class BidirectionalStreamHandler(
                 self._last_interim_text = ""
                 return
 
-            # RAG prefetch: fire vector-DB retrieval as soon as we have a confident
-            # partial so it overlaps Deepgram endpointing time. This saves ~2s because
-            # the result is ready (or nearly so) by the time generate_and_stream_response
-            # would otherwise block waiting for Pinecone. Fires once per user turn
-            # regardless of VOICE_ENABLE_INTERIM_LLM so even final-only mode benefits.
-            _prefetch = getattr(self, "_rag_prefetch_task", None)
-            if (
-                not _prefetch
-                and not self._turn_response_started
-                and word_count >= self._rag_prefetch_min_words
-                and confidence >= self._rag_prefetch_min_confidence
-            ):
-                self._rag_prefetch_user_text = transcript
-                self._rag_prefetch_task = asyncio.create_task(
-                    self._prefetch_rag_context(transcript)
-                )
+            # RAG prefetch: fire vector-DB retrieval only on genuine queries (not backchannels)
+            if not is_known_non_actionable_backchannel(transcript):
+                _prefetch = getattr(self, "_rag_prefetch_task", None)
+                if (
+                    not _prefetch
+                    and not self._turn_response_started
+                    and word_count >= self._rag_prefetch_min_words
+                    and confidence >= self._rag_prefetch_min_confidence
+                ):
+                    self._rag_prefetch_user_text = transcript
+                    self._rag_prefetch_task = asyncio.create_task(
+                        self._prefetch_rag_context(transcript)
+                    )
 
-            # Speculative TTS prefetch: also fire on interim so synthesis starts during
-            # the Deepgram endpointing window (200ms), maximising overlap with LLM TTFT.
-            # Only fire once per turn (guard: task not already running).
-            if (
-                not self._turn_response_started
-                and word_count >= self._min_interim_words
-                and confidence >= self._min_interim_confidence
-                and (
-                    self._speculative_prefetch_task is None
-                    or self._speculative_prefetch_task.done()
-                )
-            ):
-                self._speculative_prefetch_task = asyncio.create_task(
-                    self._run_speculative_tts_prefetch(transcript)
-                )
+                # Speculative TTS prefetch: fire on qualifying query interims
+                if (
+                    not self._turn_response_started
+                    and word_count >= self._min_interim_words
+                    and confidence >= self._min_interim_confidence
+                    and (
+                        self._speculative_prefetch_task is None
+                        or self._speculative_prefetch_task.done()
+                    )
+                ):
+                    self._speculative_prefetch_task = asyncio.create_task(
+                        self._run_speculative_tts_prefetch(transcript)
+                    )
 
             # Final-only mode: do not start LLM from partials (barge-in already handled).
             if not self._enable_interim_llm:

--- a/app/routers/bidirectional_stream.py
+++ b/app/routers/bidirectional_stream.py
@@ -1105,12 +1105,45 @@ class BidirectionalStreamHandler(
         tokens = low.split()
         return bool(tokens) and all(t in self._BARGE_IN_FILLER_WORDS for t in tokens)
 
+    _BARGE_IN_COMMAND_WORDS = frozenset(
+        {
+            "stop",
+            "wait",
+            "hold",
+            "pause",
+            "cancel",
+            "interrupt",
+            "shut",
+            "quiet",
+            "listen",
+            "no",
+            "wrong",
+            "quit",
+            "abort",
+        }
+    )
+
+    def _has_2w_barge_in_command(self, text: str) -> bool:
+        """
+        For exactly 2-word utterances, require a clear interruption/command intent
+        (e.g., 'stop please', 'wait please', 'hold on', 'cancel that', 'stop talking')
+        to prevent polite conversational backchannels / greetings ('hey hi', 'hi there',
+        'good morning', 'yeah yeah', 'okay okay') from cutting active TTS playback.
+        """
+        low = re.sub(r"[^a-z ]+", " ", (text or "").lower())
+        tokens = [t for t in low.split() if t]
+        if len(tokens) != 2:
+            return False
+        return any(t in self._BARGE_IN_COMMAND_WORDS for t in tokens)
+
     def _should_barge_in_on_stt(self, transcript: str, confidence: float) -> bool:
         """
         True when STT looks like real user speech over the agent (not noise/filler).
 
         Gates (all required): non-empty text, not filler-only, word count ≥
-        VOICE_BARGE_IN_MIN_WORDS, and confidence at or above
+        VOICE_BARGE_IN_MIN_WORDS. For exactly 2 words, must contain an explicit
+        interruption/command keyword (stop, wait, hold, cancel, etc.) to reject
+        conversational backchannels/greetings. Confidence at or above
         VOICE_BARGE_IN_MIN_CONFIDENCE (multi-word) or VOICE_BARGE_IN_MIN_CONFIDENCE_1W
         when min words is 1.
         """
@@ -1122,7 +1155,11 @@ class BidirectionalStreamHandler(
         word_count = len(text.split())
         if word_count < self._barge_in_min_words:
             return False
-        if word_count >= 2:
+        if word_count == 2:
+            if not self._has_2w_barge_in_command(text):
+                return False
+            return confidence >= self._barge_in_min_conf
+        if word_count >= 3:
             return confidence >= self._barge_in_min_conf
         return confidence >= self._barge_in_min_conf_1w
 
@@ -1325,6 +1362,10 @@ class BidirectionalStreamHandler(
                     elif word_count < self._barge_in_min_words:
                         self._log_barge_in_suppressed(
                             transcript, confidence, "min_words"
+                        )
+                    elif word_count == 2 and not self._has_2w_barge_in_command(transcript):
+                        self._log_barge_in_suppressed(
+                            transcript, confidence, "2w_no_command"
                         )
                     else:
                         self._log_barge_in_suppressed(

--- a/app/services/deepgram_stt_service.py
+++ b/app/services/deepgram_stt_service.py
@@ -293,7 +293,16 @@ class DeepgramSTTService:
 
             def sender_loop(conn: Any) -> None:
                 while True:
-                    chunk = self._audio_q.get()
+                    try:
+                        chunk = self._audio_q.get(timeout=4.0)
+                    except queue.Empty:
+                        try:
+                            if hasattr(conn, "send_keep_alive"):
+                                conn.send_keep_alive()
+                        except Exception as exc:  # noqa: BLE001
+                            logger.debug("[Deepgram STT] send_keep_alive: %s", exc)
+                        continue
+
                     if chunk is None:
                         self._session_end_reason = "client_finish"
                         _close_connection(conn)
@@ -579,7 +588,16 @@ class DeepgramSTTService:
 
             def sender_loop(conn: Any) -> None:
                 while True:
-                    chunk = self._audio_q.get()
+                    try:
+                        chunk = self._audio_q.get(timeout=4.0)
+                    except queue.Empty:
+                        try:
+                            if hasattr(conn, "send_keep_alive"):
+                                conn.send_keep_alive()
+                        except Exception as exc:  # noqa: BLE001
+                            logger.debug("[Deepgram Flux STT] send_keep_alive: %s", exc)
+                        continue
+
                     if chunk is None:
                         self._session_end_reason = "client_finish"
                         _close_connection(conn)

--- a/app/services/gemini_service.py
+++ b/app/services/gemini_service.py
@@ -79,14 +79,19 @@ class GeminiService:
             if system_prompt:
                 full_prompt = f"System: {system_prompt}\n\nUser: {prompt}"
             
+            # Prepare generation config
+            config_dict = {
+                "temperature": float(temperature),
+                "max_output_tokens": max(int(max_tokens), 1000),
+            }
+            if "2.5" in str(model_name) or "thinking" in str(model_name).lower():
+                config_dict["thinking_config"] = {"thinking_budget": 0}
+
             # Generate content using google-genai Client
             response = client.models.generate_content(
                 model=model_name,
                 contents=full_prompt,
-                config={
-                    "temperature": float(temperature),
-                    "max_output_tokens": int(max_tokens),
-                },
+                config=config_dict,
             )
             
             end_time = time.time()

--- a/app/services/google_tts_service.py
+++ b/app/services/google_tts_service.py
@@ -14,7 +14,6 @@ from app.core.config import settings
 from typing import AsyncIterator
 import os
 import json
-import re
 from app.core.logger import logger
 from google.api_core.client_options import ClientOptions
 

--- a/app/services/google_tts_service.py
+++ b/app/services/google_tts_service.py
@@ -382,10 +382,9 @@ class GoogleTTSService:
         # In streaming_synthesize, HD "markup" is NOT SSML. If we send SSML tags here,
         # some voices may literally speak them (e.g. "less than prosody...").
         # So we ALWAYS stream plain text (strip any SSML/XML tags defensively).
-        text_stripped = (text or "").strip()
-        if "<" in text_stripped and ">" in text_stripped:
-            text_stripped = re.sub(r"<[^>]+>", "", text_stripped)
-            text_stripped = re.sub(r"\s+", " ", text_stripped).strip()
+        from app.utils.ssml_utils import strip_ssml_tags
+
+        text_stripped = strip_ssml_tags(text or "")
 
         async def request_generator():
             # First request must be config only

--- a/app/services/voice_analysis_service.py
+++ b/app/services/voice_analysis_service.py
@@ -321,10 +321,10 @@ Keep it concise - similar to summary format. Maximum 1 sentence per recommendati
                 )
 
                 summary_result = generate_analysis_text(
-                    current_model, current_api_key, summary_prompt, max_tokens=200
+                    current_model, current_api_key, summary_prompt, max_tokens=1000
                 )
                 sentiment_result = generate_analysis_text(
-                    current_model, current_api_key, sentiment_prompt, max_tokens=150
+                    current_model, current_api_key, sentiment_prompt, max_tokens=1000
                 )
 
                 try:
@@ -332,7 +332,7 @@ Keep it concise - similar to summary format. Maximum 1 sentence per recommendati
                         current_model,
                         current_api_key,
                         outcome_prompt,
-                        max_tokens=120,
+                        max_tokens=1000,
                     )
                 except Exception as oe:  # pragma: no cover - defensive
                     logger.warning(
@@ -348,7 +348,7 @@ Keep it concise - similar to summary format. Maximum 1 sentence per recommendati
                             current_model,
                             current_api_key,
                             recommendations_prompt,
-                            max_tokens=300,
+                            max_tokens=1000,
                         )
                         logger.debug("✅ Recommendations generated")
                     except Exception as e:  # pragma: no cover - defensive

--- a/app/utils/audio_utils.py
+++ b/app/utils/audio_utils.py
@@ -135,7 +135,7 @@ def mix_audio_with_background(
         return tts_audio
 
 
-_VOLUME_MAX_GAIN = 2.0
+_VOLUME_MAX_GAIN = 3.0
 
 
 def apply_volume_fade(audio_bytes: bytes, volume: float) -> bytes:

--- a/app/utils/eleven_tts_text.py
+++ b/app/utils/eleven_tts_text.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 
 import re
 
-from app.core.config import settings
+from app.utils.ssml_utils import strip_ssml_tags
+
 
 # Single-pass regex; only substitute when inner normalizes to a known tag
 _TAG_RE = re.compile(r"\[([^\]]*)\]")
@@ -102,9 +103,6 @@ def strip_eleven_v3_style_tags_for_non_eleven_tts(text: str) -> str:
     out = _TAG_RE.sub(_repl, text)
     out = re.sub(r"[ \t]{2,}", " ", out)
     return out.strip()
-
-
-from app.utils.ssml_utils import strip_ssml_tags
 
 
 def prepare_tts_text_for_provider(text: str, provider_slug: str | None) -> str:

--- a/app/utils/eleven_tts_text.py
+++ b/app/utils/eleven_tts_text.py
@@ -104,59 +104,63 @@ def strip_eleven_v3_style_tags_for_non_eleven_tts(text: str) -> str:
     return out.strip()
 
 
+from app.utils.ssml_utils import strip_ssml_tags
+
+
 def prepare_tts_text_for_provider(text: str, provider_slug: str | None) -> str:
     """
-    ElevenLabs: pass through known v3 audio tags; strip unknown/unsupported ones.
-    All other TTS providers: strip all known Eleven-style bracket tags.
-    No network; negligible CPU; safe when text has no tags (fast path: no '[').
+    Sanitize text before it reaches any TTS provider adapter.
+    - Strips all complete and incomplete SSML/XML tags (<speak>, <prosody>, <break>, etc.).
+    - Strips all bracket audio tags ([breathes], [excited], [sad], [pause], etc.).
+    - Strips backend control tokens ([END_CALL], [TRANSFER_CALL], [SCREENING_QUALIFIED], etc.).
+    - Preserves legitimate business bracket text (e.g. [SKU-100], [Order #123]).
     """
-    if (provider_slug or "").lower() == "elevenlabs":
-        if not text or "[" not in text:
-            return text
-        # Strip [pause]/[pauses] — some Eleven model variants speak them literally.
-        out = _PAUSE_TAG_RE.sub("", text)
-        # Also strip any [tag] whose inner text is NOT in the known ElevenLabs set.
-        # This prevents unknown/malformed variants (e.g. [breath], [breathing]) from
-        # being spoken as literal words by the model.
-        def _repl_unknown(m: re.Match) -> str:
-            raw = m.group(1)
-            if not raw.strip():
-                return ""
-            key = _normalize_tag_inner(raw)
-            return m.group(0) if key in _ELEVEN_V3_TAG_INNERS else ""
+    if not text:
+        return ""
 
-        out = _TAG_RE.sub(_repl_unknown, out)
-        out = re.sub(r"[ \t]{2,}", " ", out)
-        return out.strip()
-    return strip_eleven_v3_style_tags_for_non_eleven_tts(text)
+    # 1. Defensively strip all SSML / XML tags
+    cleaned = strip_ssml_tags(text)
+    if not cleaned:
+        return ""
+
+    if "[" not in cleaned:
+        return cleaned
+
+    # 2. Strip pause tags and control tokens
+    cleaned = _PAUSE_TAG_RE.sub("", cleaned)
+    cleaned = _CONTROL_TOKEN_RE.sub("", cleaned)
+
+    # 3. Strip all known bracketed prosody/audio tags for all providers
+    def _repl_audio_tag(m: re.Match) -> str:
+        raw = m.group(1)
+        if not raw.strip():
+            return ""
+        key = _normalize_tag_inner(raw)
+        if key in _ELEVEN_V3_TAG_INNERS:
+            return ""
+        return m.group(0)
+
+    cleaned = _TAG_RE.sub(_repl_audio_tag, cleaned)
+    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    return cleaned.strip()
 
 
 def supports_elevenlabs_audio_tags(provider_slug: str | None) -> bool:
     """
-    Return True when the agent's TTS is ElevenLabs and tag guidance is enabled in settings.
-    All tag-related LLM text and fallbacks should be gated on this.
+    ElevenLabs Flash/Turbo/Multilingual conversational models do not parse
+    bracket audio tags and read them aloud as literal words. Disabled.
     """
-    if (provider_slug or "").lower() != "elevenlabs":
-        return False
-    return bool(getattr(settings, "ENABLE_ELEVENLABS_AUDIO_TAGS", True))
+    return False
 
 
 def get_elevenlabs_voice_prompt_rule_lines() -> tuple[str, str, str]:
     """
-    (output_plain_text_rule, no_ssml_rule_base, no_ssml_rule) for the base / custom
-    voice system prompts. Only call when supports_elevenlabs_audio_tags is True
-    to avoid duplicate instruction blocks for non–ElevenLabs TTS.
+    (output_plain_text_rule, no_ssml_rule_base, no_ssml_rule) for voice system prompts.
     """
-    # Short inline reminder; the detailed policy lives in build_elevenlabs_audio_tag_prompt_block.
-    short = (
-        "Optional: at most ONE ElevenLabs audio tag per reply when it clearly helps: "
-        "[breathes] or [breathe], [excited], [sad] or [sorrowful] — "
-        "not every line; most replies have zero tags. See # ELEVENLABS AUDIO TAGS below."
-    )
     return (
-        f"- OUTPUT PLAIN TEXT ONLY: Do NOT output SSML or XML. {short}",
-        f"4. NO SSML: Do NOT output <speak>, <prosody>, or any XML tags. Plain text only. {short}",
-        f"3. NO SSML: Plain text only. No <speak>, <prosody>, or XML. {short}",
+        "- OUTPUT PLAIN TEXT ONLY: Do NOT output SSML, XML, or bracketed tags. Prosody is handled by the system.",
+        "4. NO SSML: Do NOT output <speak>, <prosody>, or any XML tags. Plain text only.",
+        "3. NO SSML: Plain text only. No <speak>, <prosody>, or XML.",
     )
 
 
@@ -172,51 +176,16 @@ def contains_elevenlabs_audio_tag(text: str) -> bool:
 
 def apply_elevenlabs_breathing_fallback(text: str) -> str:
     """
-    Add a subtle leading [breathes] tag for longer ElevenLabs utterances when the
-    model did not emit any known audio tag itself.
-
-    Safety rules:
-    - Never touch control-token responses.
-    - Never add a duplicate if a known audio tag already exists.
-    - Skip very short transactional replies.
+    Pass through text cleanly without injecting literal [breathes] tags.
     """
-    if not text or not text.strip():
-        return text
-    if _CONTROL_TOKEN_RE.search(text):
-        return text
-    if contains_elevenlabs_audio_tag(text):
-        return text
-
-    stripped = text.strip()
-    word_count = len(stripped.split())
-    has_long_form_shape = word_count >= 9 or any(mark in stripped for mark in (".", "?", "!", ",", ";", ":"))
-    if word_count < 6 or not has_long_form_shape:
-        return stripped
-    return f"[breathes] {stripped}"
+    return (text or "").strip()
 
 
 def build_elevenlabs_audio_tag_prompt_block(provider_slug: str | None) -> str:
     """
-    Guidance injected into voice prompts.
-    Only when ElevenLabs TTS is in use and ENABLE_ELEVENLABS_AUDIO_TAGS is True; other
-    providers must never receive this block (brackets can be read aloud or break TTS).
+    Guidance injected into voice prompts. Empty when audio tags are disabled.
     """
     if not supports_elevenlabs_audio_tags(provider_slug):
         return ""
-    return (
-        "# ELEVENLABS AUDIO TAGS — THIS IS THE ONLY BRACKET-TAG RULE FOR THIS CALL\n"
-        "- This call uses **ElevenLabs** TTS. Bracketed audio tags are **optional**. Default is **no** tag "
-        "— most replies should have zero tags; do NOT add a tag to every message and never force one when "
-        "the emotional context does not call for it.\n"
-        "- **Allowed tags (and no others):** [breathes] or [breathe] (light lead-in); "
-        "[excited] (genuine energy); [sad] or [sorrowful] (empathy — use sparingly, professional call tone). "
-        "Never invent or use any other bracketed tag.\n"
-        "- **At most ONE tag per response.** Never use more than one tag in the same reply.\n"
-        "- **Placement:** if used, the tag must be the very first thing in the response, before any words. "
-        "Never place a tag in the middle or at the end of a sentence, and never place a tag immediately "
-        "before a specific word just to emphasize that word.\n"
-        "- **When to skip tags:** short transactional replies (yes/no, numbers, times, one-line confirmations), "
-        "or any reply where plain text is enough — in those cases output no tag at all.\n"
-        "- **Never** put audio tags inside system tokens: [CHECK_SLOTS:...], [BOOK_APPOINTMENT:...], "
-        "[END_CALL], [SCREENING_QUALIFIED], or [OUTCOME:...].\n"
-    )
+    return ""
+

--- a/app/utils/ssml_utils.py
+++ b/app/utils/ssml_utils.py
@@ -10,20 +10,27 @@ from app.core.logger import logger
 
 def strip_ssml_tags(text: str) -> str:
     """
-    Remove all SSML tags from text, keeping only the actual text content.
-    Used for saving clean text to transcript.
-    Handles both complete and incomplete SSML tags.
+    Remove all SSML/XML tags from text, keeping only the actual text content.
+    Used for saving clean text to transcript and sanitizing TTS inputs.
+    Handles complete tags, unclosed opening tags (<tag...), and trailing
+    unclosed tag fragments (...>) split across streaming chunk boundaries.
     """
     if not text:
         return ""
-    
-    # Remove complete SSML tags (<tag>content</tag> or <tag/>)
-    text = re.sub(r'<[^>]+>', '', text)
-    # Remove incomplete SSML tags (tags without closing >, like <break time="150ms)
-    text = re.sub(r'<[^>]*', '', text)
+
+    # Remove complete SSML/XML tags (<tag>content</tag> or <tag/>)
+    text = re.sub(r"<[^>]+>", " ", text)
+    # Remove unclosed tag at end of string (<tag... without closing >)
+    text = re.sub(r"<[^>]*$", " ", text)
+    # Remove trailing unclosed tag fragment at start of string (e.g. rate="90%">)
+    if "<" not in text and ">" in text:
+        text = re.sub(r"^[^<]*>", " ", text)
+    # Remove any remaining unclosed opening tags
+    text = re.sub(r"<[^>]*", " ", text)
     # Clean up extra whitespace
-    text = re.sub(r'\s+', ' ', text)
+    text = re.sub(r"\s+", " ", text)
     return text.strip()
+
 
 
 def add_natural_ssml(text: str, use_ssml: bool = True, add_breaths: bool = True, add_fillers: bool = True, add_boundary_pause: bool = False) -> str:

--- a/app/voice/backchannel_classifier.py
+++ b/app/voice/backchannel_classifier.py
@@ -1,0 +1,261 @@
+"""
+Backchannel and Turn-State Classifier for conversational voice streams.
+
+Distinguishes between:
+1. BARGE_IN: Explicit interruption commands or actionable user turns spoken over active TTS.
+2. SUPPRESS_NON_ACTIONABLE_BACKCHANNEL: Known non-actionable conversational backchannels,
+   fillers, and brief greetings spoken while the agent is speaking.
+3. NORMAL_USER_TURN: Genuine user requests to be processed normally.
+
+Design Rules:
+- Unknown/unseen phrases are NEVER assumed to be backchannels.
+- Only confidently matched non-actionable backchannels/greetings are suppressed during active TTS.
+- Explicit interruption commands always barge in.
+- When TTS is not active, all genuine user utterances are treated as NORMAL_USER_TURN.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+
+
+class TurnClassification(str, Enum):
+    BARGE_IN = "barge_in"
+    SUPPRESS_NON_ACTIONABLE_BACKCHANNEL = "suppress_non_actionable_backchannel"
+    NORMAL_USER_TURN = "normal_user_turn"
+
+
+# Pure acoustic fillers (single or multi-token repetitions)
+ACOUSTIC_FILLERS = frozenset(
+    {
+        "uh",
+        "um",
+        "hmm",
+        "mm",
+        "ah",
+        "er",
+        "huh",
+        "mhm",
+        "mmm",
+        "eh",
+        "ugh",
+    }
+)
+
+# Known, non-actionable conversational backchannels, affirmations, and greetings
+# that callers routinely utter while listening to the agent speak.
+KNOWN_BACKCHANNEL_PHRASES = frozenset(
+    {
+        # Greetings & pleasantries
+        "hey",
+        "hi",
+        "hello",
+        "hey hi",
+        "hi hey",
+        "hi there",
+        "hello there",
+        "hey there",
+        "good morning",
+        "good afternoon",
+        "good evening",
+        "good day",
+        # Affirmations & acknowledgements
+        "yeah",
+        "yes",
+        "yep",
+        "yup",
+        "yeah yeah",
+        "yes yes",
+        "yeah sure",
+        "yes sure",
+        "okay",
+        "ok",
+        "okay okay",
+        "ok ok",
+        "okay and",
+        "ok and",
+        "okay yeah",
+        "ok yeah",
+        "right",
+        "right right",
+        "alright",
+        "all right",
+        "alright alright",
+        "sure",
+        "sure thing",
+        "got it",
+        "i see",
+        "i got it",
+        "understood",
+        "makes sense",
+        "thank you",
+        "thanks",
+        "thanks a lot",
+        "thank you very much",
+        # Multi-word filler pairs
+        "uh huh",
+        "mhm mhm",
+        "hmm hmm",
+        "ah yes",
+        "oh okay",
+        "oh ok",
+        "oh yeah",
+        "oh i see",
+        "oh got it",
+    }
+)
+
+# Explicit command keywords and stems that indicate the caller wants the agent to stop/pause/cancel
+EXPLICIT_COMMAND_KEYWORDS = frozenset(
+    {
+        "stop",
+        "wait",
+        "hold",
+        "pause",
+        "cancel",
+        "interrupt",
+        "shut",
+        "quiet",
+        "listen",
+        "silence",
+        "shh",
+        "abort",
+        "quit",
+    }
+)
+
+# Explicit multi-word command phrases
+EXPLICIT_COMMAND_PHRASES = frozenset(
+    {
+        "stop please",
+        "please stop",
+        "stop talking",
+        "stop speaking",
+        "wait please",
+        "please wait",
+        "wait a second",
+        "wait a minute",
+        "wait one second",
+        "wait one moment",
+        "just wait",
+        "hold on",
+        "hold up",
+        "please hold",
+        "hold on please",
+        "pause please",
+        "please pause",
+        "cancel that",
+        "cancel please",
+        "please cancel",
+        "shut up",
+        "be quiet",
+        "quiet please",
+        "listen to me",
+        "listen please",
+        "hang up",
+    }
+)
+
+
+def normalize_transcript(text: str) -> str:
+    """Lowercase and strip non-alphanumeric characters, returning single-space separated words."""
+    if not text:
+        return ""
+    no_apostrophe = re.sub(r"['’]", "", text)
+    cleaned = re.sub(r"[^a-zA-Z0-9\s]+", " ", no_apostrophe).lower()
+    return " ".join(cleaned.split())
+
+
+def is_pure_acoustic_filler(text: str) -> bool:
+    """Check if the text consists entirely of acoustic fillers (uh, um, mhm, uh huh)."""
+    norm = normalize_transcript(text)
+    if not norm:
+        return True
+    tokens = norm.split()
+    return bool(tokens) and all(t in ACOUSTIC_FILLERS for t in tokens)
+
+
+def is_known_non_actionable_backchannel(text: str) -> bool:
+    """
+    Conservative classifier: returns True ONLY if the utterance confidently matches
+    a known non-actionable conversational backchannel/greeting.
+
+    Unknown or ambiguous phrases return False so they are NEVER silently lost.
+    """
+    norm = normalize_transcript(text)
+    if not norm:
+        return True
+    if is_pure_acoustic_filler(text):
+        return True
+    if norm in KNOWN_BACKCHANNEL_PHRASES:
+        return True
+    return False
+
+
+def has_explicit_interruption_intent(text: str) -> bool:
+    """Check if the utterance contains an explicit interruption or command keyword/phrase."""
+    norm = normalize_transcript(text)
+    if not norm:
+        return False
+    if norm in EXPLICIT_COMMAND_PHRASES:
+        return True
+    tokens = norm.split()
+    return any(t in EXPLICIT_COMMAND_KEYWORDS for t in tokens)
+
+
+def classify_turn(
+    transcript: str,
+    confidence: float,
+    *,
+    is_tts_playing: bool,
+    min_confidence: float = 0.26,
+    min_words: int = 2,
+    min_confidence_1w: float = 0.36,
+) -> TurnClassification:
+    """
+    Classify an STT event into one of three states:
+    1. BARGE_IN: Should interrupt active TTS playback.
+    2. SUPPRESS_NON_ACTIONABLE_BACKCHANNEL: Should be suppressed while TTS is playing (no interruption, no LLM).
+    3. NORMAL_USER_TURN: Genuine user turn that should be processed by the conversation pipeline.
+    """
+    norm = normalize_transcript(transcript)
+    if not norm:
+        return TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+
+    # Pure acoustic fillers are always suppressed regardless of TTS state
+    if is_pure_acoustic_filler(norm):
+        return TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+
+    # When TTS is NOT active, everything non-filler is a normal user turn
+    if not is_tts_playing:
+        return TurnClassification.NORMAL_USER_TURN
+
+    # ── Active TTS is playing ──
+
+    # 1. Explicit interruption commands always barge in (even if 1-2 words, e.g. "stop", "hold on")
+    if has_explicit_interruption_intent(norm):
+        req_conf = min_confidence_1w if len(norm.split()) == 1 else min_confidence
+        if confidence >= req_conf:
+            return TurnClassification.BARGE_IN
+        return TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+
+    # 2. Known conversational backchannels & greetings are suppressed while TTS is active
+    if is_known_non_actionable_backchannel(norm):
+        return TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+
+    # 3. Legitimate user requests & unknown phrases spoken over TTS
+    # If confidence meets threshold and word count is sufficient, treat as barge-in to capture the request
+    tokens = norm.split()
+    word_count = len(tokens)
+
+    if word_count >= min_words:
+        if confidence >= min_confidence:
+            return TurnClassification.BARGE_IN
+        return TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+
+    # Single-word non-command, non-backchannel spoken over TTS (e.g. single unknown word below min_words)
+    if min_words == 1 and confidence >= min_confidence_1w:
+        return TurnClassification.BARGE_IN
+
+    return TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL

--- a/app/voice/booking_mixin.py
+++ b/app/voice/booking_mixin.py
@@ -554,9 +554,11 @@ class BookingMixin:
         """
         Final text gate before queueing TTS.
         """
+        from app.utils.eleven_tts_text import prepare_tts_text_for_provider
+
         cleaned = self._strip_control_tokens_for_tts(text or "")
         cleaned = self._strip_premature_booking_confirmation(cleaned)
-        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        cleaned = prepare_tts_text_for_provider(cleaned, None)
         if self._looks_like_control_leak(cleaned):
             logger.warning("TTSGuard: dropped token-like leak text=%r", cleaned[:180])
             return ""

--- a/app/voice/conversation_orchestrator.py
+++ b/app/voice/conversation_orchestrator.py
@@ -353,6 +353,7 @@ You are {agent_name}, having a real-time phone call with a human.
 - CONCISE: Max 20 words per response unless explaining something complex.
 - NO ROBOT TALK: Avoid "As an AI" or formal greetings. Use "Hey," "Hi," or "Hello."
 {output_plain_text_rule}
+{no_bracket_tags_line}
 - TEXT HYGIENE: Avoid "..." (use a comma or short sentence). Avoid slashes like "FastAPI/ML" (say "FastAPI and ML").
 
 # CONVERSATION STATE

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
+import re
 import struct
 import uuid
 from datetime import datetime, timezone
@@ -675,18 +676,54 @@ class LiveKitBrowserCallHandler(CallControlMixin):
         mirrors that default behaviour rather than reimplementing the
         early-LLM path's seed/regeneration bookkeeping.
         """
+    _BARGE_IN_COMMAND_WORDS = frozenset(
+        {
+            "stop",
+            "wait",
+            "hold",
+            "pause",
+            "cancel",
+            "interrupt",
+            "shut",
+            "quiet",
+            "listen",
+            "no",
+            "wrong",
+            "quit",
+            "abort",
+        }
+    )
+
+    def _has_2w_barge_in_command(self, text: str) -> bool:
+        low = re.sub(r"[^a-z ]+", " ", (text or "").lower())
+        tokens = [t for t in low.split() if t]
+        if len(tokens) != 2:
+            return False
+        return any(t in self._BARGE_IN_COMMAND_WORDS for t in tokens)
+
+    def _should_barge_in_on_stt(self, transcript: str, confidence: float) -> bool:
+        text = (transcript or "").strip()
+        if not text:
+            return False
+        word_count = len(text.split())
+        if word_count < self._barge_in_min_words:
+            return False
+        if word_count == 2:
+            if not self._has_2w_barge_in_command(text):
+                return False
+            return confidence >= self._barge_in_min_conf
+        if word_count >= 3:
+            return confidence >= self._barge_in_min_conf
+        return confidence >= self._barge_in_min_conf_1w
+
+    async def _maybe_process_interim(self, transcript: str, confidence: float) -> None:
         try:
             text = (transcript or "").strip()
             if not text:
                 return
             word_count = len(text.split())
 
-            min_conf = self._barge_in_min_conf_1w if word_count < 2 else self._barge_in_min_conf
-            is_barge_in = (
-                self._is_tts_playing
-                and word_count >= self._barge_in_min_words
-                and confidence >= min_conf
-            )
+            is_barge_in = self._is_tts_playing and self._should_barge_in_on_stt(text, confidence)
             if is_barge_in:
                 logger.info(
                     "[LiveKitBrowserCall] barge-in: words=%d conf=%.2f text=%r",
@@ -806,7 +843,7 @@ class LiveKitBrowserCallHandler(CallControlMixin):
             if not text:
                 return
 
-            if self._is_tts_playing:
+            if self._is_tts_playing and self._should_barge_in_on_stt(text, confidence):
                 logger.info("[LiveKitBrowserCall] barge-in (final): %r", text[:40])
                 await self._cancel_inflight_llm_response()
 

--- a/app/voice/livekit_browser_call_handler.py
+++ b/app/voice/livekit_browser_call_handler.py
@@ -44,7 +44,6 @@ from __future__ import annotations
 
 import asyncio
 import dataclasses
-import re
 import struct
 import uuid
 from datetime import datetime, timezone
@@ -61,6 +60,11 @@ from app.voice.conversation_orchestrator import ConversationOrchestrator, VOICE_
 from app.voice.gemini_live_audio_bridge import GEMINI_OUTPUT_PCM_RATE_HZ
 from app.services.openai_realtime_service import LIVEKIT_AUDIO_RATE_HZ as OPENAI_REALTIME_AUDIO_RATE_HZ
 from app.voice.humanization_engine import pause_frames_for_chunk
+from app.voice.backchannel_classifier import (
+    TurnClassification,
+    classify_turn,
+    is_known_non_actionable_backchannel,
+)
 
 if TYPE_CHECKING:
     from app.voice.humanization_engine import PacingHint
@@ -676,45 +680,16 @@ class LiveKitBrowserCallHandler(CallControlMixin):
         mirrors that default behaviour rather than reimplementing the
         early-LLM path's seed/regeneration bookkeeping.
         """
-    _BARGE_IN_COMMAND_WORDS = frozenset(
-        {
-            "stop",
-            "wait",
-            "hold",
-            "pause",
-            "cancel",
-            "interrupt",
-            "shut",
-            "quiet",
-            "listen",
-            "no",
-            "wrong",
-            "quit",
-            "abort",
-        }
-    )
-
-    def _has_2w_barge_in_command(self, text: str) -> bool:
-        low = re.sub(r"[^a-z ]+", " ", (text or "").lower())
-        tokens = [t for t in low.split() if t]
-        if len(tokens) != 2:
-            return False
-        return any(t in self._BARGE_IN_COMMAND_WORDS for t in tokens)
-
     def _should_barge_in_on_stt(self, transcript: str, confidence: float) -> bool:
-        text = (transcript or "").strip()
-        if not text:
-            return False
-        word_count = len(text.split())
-        if word_count < self._barge_in_min_words:
-            return False
-        if word_count == 2:
-            if not self._has_2w_barge_in_command(text):
-                return False
-            return confidence >= self._barge_in_min_conf
-        if word_count >= 3:
-            return confidence >= self._barge_in_min_conf
-        return confidence >= self._barge_in_min_conf_1w
+        classification = classify_turn(
+            transcript,
+            confidence,
+            is_tts_playing=True,
+            min_confidence=self._barge_in_min_conf,
+            min_words=self._barge_in_min_words,
+            min_confidence_1w=self._barge_in_min_conf_1w,
+        )
+        return classification == TurnClassification.BARGE_IN
 
     async def _maybe_process_interim(self, transcript: str, confidence: float) -> None:
         try:
@@ -750,6 +725,8 @@ class LiveKitBrowserCallHandler(CallControlMixin):
         """
         if self._rag_prefetch_task is not None:
             return  # already fired for this turn — never fire a duplicate request
+        if is_known_non_actionable_backchannel(text):
+            return  # backchannels should not prefetch RAG
         flow_kb_ids = (self.call_flow.knowledge_base_ids or []) if self.call_flow else []
         if not flow_kb_ids or not self.db:
             return  # RAG/KB not configured for this call flow — nothing to prefetch
@@ -843,9 +820,16 @@ class LiveKitBrowserCallHandler(CallControlMixin):
             if not text:
                 return
 
-            if self._is_tts_playing and self._should_barge_in_on_stt(text, confidence):
-                logger.info("[LiveKitBrowserCall] barge-in (final): %r", text[:40])
-                await self._cancel_inflight_llm_response()
+            if self._is_tts_playing:
+                if self._should_barge_in_on_stt(text, confidence):
+                    logger.info("[LiveKitBrowserCall] barge-in (final): %r", text[:40])
+                    await self._cancel_inflight_llm_response()
+                else:
+                    logger.info(
+                        "[LiveKitBrowserCall] suppressing backchannel final while TTS is playing: %r",
+                        text[:40],
+                    )
+                    return
 
             if hasattr(self, "_voice_metrics") and self._voice_metrics:
                 self._voice_metrics.begin_turn_at_stt_final(acoustic_speech_end_mono)

--- a/app/voice/tts_pipeline.py
+++ b/app/voice/tts_pipeline.py
@@ -649,9 +649,16 @@ class TtsPipeline:
         of _try_elevenlabs_ws_route purely so the gate-release `finally`
         above stays simple and always fires exactly once.
         """
+        from app.utils.eleven_tts_text import prepare_tts_text_for_provider
+        clean_text = prepare_tts_text_for_provider(text, "elevenlabs")
+        if not clean_text:
+            if is_final and self._eleven_ws_session is not None:
+                await self._eleven_ws_session.finalize()
+            return ("relayed" if self._eleven_ws_session is not None else None), None
+
         # ── Non-owner: an active session already exists for this turn ─────
         if self._eleven_ws_session is not None:
-            await self._eleven_ws_session.send_text(text)
+            await self._eleven_ws_session.send_text(clean_text)
             if is_final:
                 await self._eleven_ws_session.finalize()
             return "relayed", None
@@ -713,7 +720,7 @@ class TtsPipeline:
             api_key_override=api_key_override,
         )
         try:
-            await session.start(initial_text=text)
+            await session.start(initial_text=clean_text)
         except ElevenLabsWebSocketSessionError as exc:
             self._eleven_ws_failed_this_turn = True
             logger.warning(

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -23,7 +23,7 @@ from app.utils.audio_utils import (
 )
 from app.utils.tts_adapter import get_tts_adapter
 from app.utils.tts_preprocessing import detect_emotion
-from app.utils.ssml_utils import strip_ssml_tags, smart_chunk_text
+from app.utils.ssml_utils import smart_chunk_text
 from app.utils.eleven_tts_text import prepare_tts_text_for_provider
 from app.voice.humanization_engine import pause_frames_for_chunk
 from app.voice.tts_provider_capabilities import build_voice_settings_overlay
@@ -910,7 +910,6 @@ class TtsStreamMixin:
         """
         try:
             text = task.get("text", "")
-            use_ssml = task.get("use_ssml", False)
 
             if not text or not text.strip():
                 return None

--- a/app/voice/tts_stream_mixin.py
+++ b/app/voice/tts_stream_mixin.py
@@ -128,20 +128,26 @@ class TtsStreamMixin:
 
     def _resolve_voice_volume(self) -> float:
         """
-        Resolve TTS voice volume (linear gain) from agent settings.
-        1.0 = unchanged. Applied uniformly to all providers (Google,
-        ElevenLabs, Rime) at the mulaw playback boundary.
+        Resolve TTS voice volume (linear gain) from agent settings with
+        provider-aware telephony baseline leveling.
 
-        Distinct from `background_volume` which only affects the optional
-        office ambient bed (ElevenLabs profile).
+        - Google TTS outputs at nominal telephony level (~-18 dBFS RMS) -> baseline 1.0x.
+        - ElevenLabs ulaw_8000 outputs at ~-25.7 to -26.3 dBFS RMS with -6.2 dBFS peak headroom.
+          Applying a 1.8x baseline gain (+5.1 dB) brings ElevenLabs to ~-20.6 dBFS RMS,
+          matching PSTN speech levels while maintaining safe peak headroom (-1.7 dBFS).
+        - User-configured volume slider scales on top of the provider baseline.
         """
         if not self.agent:
             return 1.0
         try:
             runtime = resolve_tts_runtime(self.agent, db=getattr(self, "db", None))
-            return float(runtime.settings_json.get("volume", 1.0))
+            user_vol = float(runtime.settings_json.get("volume", 1.0))
+            provider_slug = (runtime.adapter_slug or "").lower()
+            baseline = 1.8 if provider_slug == "elevenlabs" else 1.0
+            return max(0.0, user_vol * baseline)
         except Exception:
             return 1.0
+
 
     async def _stream_tts_chunk(
         self,
@@ -520,14 +526,8 @@ class TtsStreamMixin:
 
                             # Stream text in near real-time from provider.
                             # For Google: use native async streaming API.
-                            # For ElevenLabs: use HTTP chunk streaming via adapter.
-                            streaming_text = (
-                                strip_ssml_tags(clean)
-                                if use_ssml or clean.lstrip().startswith("<speak>")
-                                else clean
-                            )
                             streaming_text = prepare_tts_text_for_provider(
-                                streaming_text, tts_provider_slug
+                                clean, tts_provider_slug
                             )
                             if not streaming_text or not streaming_text.strip():
                                 return
@@ -927,15 +927,9 @@ class TtsStreamMixin:
             tts_runtime = resolve_tts_runtime(self.agent, db=getattr(self, "db", None))
             tts_provider_slug = tts_runtime.adapter_slug
 
-            streaming_text = (
-                strip_ssml_tags(clean)
-                if use_ssml or clean.lstrip().startswith("<speak>")
-                else clean
-            )
             streaming_text = prepare_tts_text_for_provider(
-                streaming_text, tts_provider_slug
+                clean, tts_provider_slug
             )
-
             if not streaming_text or not streaming_text.strip():
                 return None
 

--- a/tests/services/test_stt_regressions.py
+++ b/tests/services/test_stt_regressions.py
@@ -199,3 +199,99 @@ def test_prerecorded_mulaw_path_passes_sample_rate(monkeypatch):
     assert out["transcript"] == "hello"
     assert captured.get("encoding") == "mulaw"
     assert captured.get("sample_rate") == 8000
+
+
+def test_deepgram_sender_loop_sends_keepalive_on_idle_and_resumes_audio():
+    """
+    Verify sender_loop wakes up on queue idle timeout, invokes send_keep_alive(),
+    and continues forwarding subsequent audio chunks normally without dropping or disconnecting.
+    """
+    import threading
+    import time
+
+    events = []
+    listening_started = threading.Event()
+
+    class FakeConnection:
+        def __init__(self):
+            self._websocket = None
+
+        def on(self, *args, **kwargs):
+            pass
+
+        def send_keep_alive(self):
+            events.append("keep_alive")
+
+        def send_media(self, chunk):
+            events.append(("media", chunk))
+
+        def send_finalize(self):
+            events.append("finalize")
+
+        def send_close_stream(self):
+            events.append("close_stream")
+
+        def start_listening(self):
+            listening_started.set()
+
+    class FakeConnectCM:
+        def __init__(self, conn):
+            self.conn = conn
+
+        def __enter__(self):
+            return self.conn
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+    class FakeListenV1:
+        def __init__(self, conn):
+            self.conn = conn
+
+        def connect(self, **kwargs):
+            return FakeConnectCM(self.conn)
+
+    class FakeClient:
+        def __init__(self, conn):
+            self.listen = SimpleNamespace(v1=FakeListenV1(conn))
+
+    conn = FakeConnection()
+    svc = DeepgramSTTService()
+    session = svc.StreamingSTTSession(
+        client=FakeClient(conn),
+        language_code="en-US",
+        encoding="MULAW",
+        sample_rate=8000,
+        interim_results=True,
+        single_utterance=False,
+    )
+
+    # Monkeypatch the queue get timeout in the test to 0.05s so the test runs in <0.3s
+    orig_get = session._audio_q.get
+
+    def fast_get(timeout=None):
+        if timeout == 4.0:
+            return orig_get(timeout=0.05)
+        return orig_get(timeout=timeout)
+
+    session._audio_q.get = fast_get
+
+    t = threading.Thread(target=session._run_blocking_stream, daemon=True)
+    t.start()
+
+    assert listening_started.wait(timeout=1.0)
+
+    # 1. Let it sit idle -> verify keep_alive is sent
+    time.sleep(0.12)
+    assert "keep_alive" in events
+
+    # 2. Push audio -> verify chunk is forwarded normally
+    session.push_audio(b"audio_chunk_1")
+    time.sleep(0.05)
+    assert ("media", b"audio_chunk_1") in events
+
+    # 3. Finish session -> verify clean shutdown
+    session.finish()
+    t.join(timeout=1.0)
+    assert session._session_end_reason == "client_finish"
+

--- a/tests/test_interim_final_lockout_gate.py
+++ b/tests/test_interim_final_lockout_gate.py
@@ -267,3 +267,106 @@ async def test_case_e_concurrent_overlapping_turns_isolation():
     # 2. Turn A did NOT observe Turn B's success.
     assert "Turn A interim" in llm_generated_texts
     assert "Turn A final full text" in llm_generated_texts
+
+@pytest.mark.asyncio
+async def test_case_f_interim_disabled_waits_for_speech_final():
+    """Case F: Interim LLM disabled (default/demo mode) -> partials do NOT generate LLM -> speech_final triggers authoritative response."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler._enable_interim_llm = False
+
+    llm_generated_texts = []
+
+    async def mock_generate(user_text: str, confidence: float = 1.0, is_greeting: bool = False):
+        llm_generated_texts.append(user_text)
+        await asyncio.sleep(0.01)
+        return "Hawk Auto Care provides automotive repair and maintenance services."
+
+    handler.generate_and_stream_response = mock_generate
+    handler._add_to_transcript = AsyncMock()
+    handler._prefetch_rag_context = AsyncMock()
+    handler._run_speculative_tts_prefetch = AsyncMock()
+    handler._should_accept_final_transcript = MagicMock(return_value=True)
+
+    # 1. Incomplete partial arrives ("Can you please")
+    await handler._maybe_process_interim("Can you please", 0.90)
+
+    # Verify: No LLM task was started
+    assert handler._turn_response_started is False
+    assert handler._llm_response_task is None
+    assert len(llm_generated_texts) == 0
+
+    # 2. Complete speech_final arrives ("Can you please tell me about your business?")
+    await handler._complete_llm_turn_after_stt_final("Can you please tell me about your business?", 0.95)
+
+    # Verify: Exactly one authoritative LLM response was generated
+    assert len(llm_generated_texts) == 1
+    assert llm_generated_texts[0] == "Can you please tell me about your business?"
+
+@pytest.mark.asyncio
+async def test_case_g_barge_in_thresholds_with_interim_disabled():
+    """Case G: Verify barge-in behavior with interim disabled:
+    - 1-word input does not barge in (min_words=2)
+    - 2+ word input with confidence >= 0.26 triggers barge-in
+    """
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler._enable_interim_llm = False
+    handler._barge_in_min_words = 2
+    handler._barge_in_min_conf = 0.26
+    handler._barge_in_min_conf_1w = 0.36
+    handler._barge_in_dead_zone_ms = 600
+
+    handler._cancel_inflight_llm_response = AsyncMock()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0  # Dead-zone passed
+
+    # 1. 1-word utterance ("Hey" or "Stop") -> should NOT barge in when min_words=2
+    await handler._maybe_process_interim("Hey", 0.95)
+    assert handler._cancel_inflight_llm_response.call_count == 0
+
+    # 2. 2-word low-confidence utterance ("Hey there", conf=0.20 < 0.26) -> should NOT barge in
+    await handler._maybe_process_interim("Hey there", 0.20)
+    assert handler._cancel_inflight_llm_response.call_count == 0
+
+    # 3. 2-word confident utterance ("Sorry what", conf=0.85 >= 0.26) -> SHOULD barge in
+    await handler._maybe_process_interim("Sorry what", 0.85)
+    assert handler._cancel_inflight_llm_response.call_count == 1
+
+@pytest.mark.asyncio
+async def test_case_h_no_google_tts_precaching_on_call_startup():
+    """Case H: Verify that initializing BidirectionalStreamHandler does NOT trigger bulk Google TTS precaching."""
+    with patch("app.services.google_tts_service.google_tts_service.text_to_speech") as mock_google_tts:
+        handler = BidirectionalStreamHandler(
+            websocket=DummyWebSocket(),
+            call_session_id=str(uuid.uuid4()),
+            agent_id=str(uuid.uuid4()),
+            db=None,
+        )
+        
+        # Let event loop spin and sleep to allow any pending background tasks to execute
+        await asyncio.sleep(0.1)
+        
+        # Verify: _precache_common_phrases attribute does NOT exist on handler
+        assert not hasattr(handler, "_precache_common_phrases")
+        
+        # Verify: Google TTS was NOT called for batch precaching
+        assert mock_google_tts.call_count == 0
+
+

--- a/tests/test_interim_final_lockout_gate.py
+++ b/tests/test_interim_final_lockout_gate.py
@@ -341,12 +341,12 @@ async def test_case_g_barge_in_thresholds_with_interim_disabled():
     await handler._maybe_process_interim("Hey", 0.95)
     assert handler._cancel_inflight_llm_response.call_count == 0
 
-    # 2. 2-word low-confidence utterance ("Hey there", conf=0.20 < 0.26) -> should NOT barge in
-    await handler._maybe_process_interim("Hey there", 0.20)
+    # 2. 2-word low-confidence command ("Stop please", conf=0.20 < 0.26) -> should NOT barge in
+    await handler._maybe_process_interim("Stop please", 0.20)
     assert handler._cancel_inflight_llm_response.call_count == 0
 
-    # 3. 2-word confident utterance ("Sorry what", conf=0.85 >= 0.26) -> SHOULD barge in
-    await handler._maybe_process_interim("Sorry what", 0.85)
+    # 3. 2-word confident command ("Stop please", conf=0.85 >= 0.26) -> SHOULD barge in
+    await handler._maybe_process_interim("Stop please", 0.85)
     assert handler._cancel_inflight_llm_response.call_count == 1
 
 @pytest.mark.asyncio
@@ -368,5 +368,60 @@ async def test_case_h_no_google_tts_precaching_on_call_startup():
         
         # Verify: Google TTS was NOT called for batch precaching
         assert mock_google_tts.call_count == 0
+
+@pytest.mark.asyncio
+async def test_case_i_conversational_backchannel_vs_explicit_command_barge_in():
+    """Case I: Verify that conversational 2-word backchannels/greetings do NOT cut TTS,
+    while 2-word explicit commands and 3+ word utterances DO cut TTS."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler._enable_interim_llm = False
+    handler._barge_in_min_words = 2
+    handler._barge_in_min_conf = 0.26
+    handler._barge_in_min_conf_1w = 0.36
+    handler._barge_in_dead_zone_ms = 600
+
+    handler._cancel_inflight_llm_response = AsyncMock()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0  # Dead-zone passed
+
+    # A. Conversational / backchannel phrases (MUST NOT cut TTS)
+    assert handler._should_barge_in_on_stt("Hey", 1.00) is False
+    assert handler._should_barge_in_on_stt("Hi", 1.00) is False
+    assert handler._should_barge_in_on_stt("Hey. Hi.", 1.00) is False
+    assert handler._should_barge_in_on_stt("Hi there", 1.00) is False
+    assert handler._should_barge_in_on_stt("Good morning", 1.00) is False
+    assert handler._should_barge_in_on_stt("Yeah yeah", 1.00) is False
+    assert handler._should_barge_in_on_stt("Okay okay", 1.00) is False
+    assert handler._should_barge_in_on_stt("Thank you", 1.00) is False
+    assert handler._should_barge_in_on_stt("Got it", 1.00) is False
+    assert handler._should_barge_in_on_stt("I see", 1.00) is False
+
+    # Simulate interim "Hey. Hi." arriving while TTS is playing -> verify no cancellation
+    await handler._maybe_process_interim("Hey. Hi.", 1.00)
+    assert handler._cancel_inflight_llm_response.call_count == 0
+
+    # B. Explicit 2-word interruption commands (MUST cut TTS)
+    assert handler._should_barge_in_on_stt("Stop please", 1.00) is True
+    assert handler._should_barge_in_on_stt("Wait please", 1.00) is True
+    assert handler._should_barge_in_on_stt("Hold on", 1.00) is True
+    assert handler._should_barge_in_on_stt("Pause please", 1.00) is True
+    assert handler._should_barge_in_on_stt("Cancel that", 1.00) is True
+    assert handler._should_barge_in_on_stt("Stop talking", 1.00) is True
+
+    # Simulate interim "Stop please" arriving -> verify cancellation is called
+    await handler._maybe_process_interim("Stop please", 1.00)
+    assert handler._cancel_inflight_llm_response.call_count == 1
+
+    # C. 3+ word utterances (MUST cut TTS)
+    assert handler._should_barge_in_on_stt("Wait a second", 1.00) is True
+    assert handler._should_barge_in_on_stt("I have a question", 1.00) is True
+    assert handler._should_barge_in_on_stt("Hey. Hi. Stop please", 1.00) is True
+
+
 
 

--- a/tests/test_interim_final_lockout_gate.py
+++ b/tests/test_interim_final_lockout_gate.py
@@ -422,6 +422,52 @@ async def test_case_i_conversational_backchannel_vs_explicit_command_barge_in():
     assert handler._should_barge_in_on_stt("I have a question", 1.00) is True
     assert handler._should_barge_in_on_stt("Hey. Hi. Stop please", 1.00) is True
 
+@pytest.mark.asyncio
+async def test_case_j_legitimate_short_and_unknown_requests_not_dropped():
+    """Case J: Verify that legitimate short 2-word requests and unknown phrases are NOT dropped
+    when spoken over active TTS (they barge in) and are processed normally when silent."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler._enable_interim_llm = False
+    handler._barge_in_min_words = 2
+    handler._barge_in_min_conf = 0.26
+    handler._barge_in_min_conf_1w = 0.36
+    handler._barge_in_dead_zone_ms = 600
+
+    handler._cancel_inflight_llm_response = AsyncMock()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0
+
+    # Legitimate 2-word user requests MUST barge in when spoken over active TTS
+    legitimate_short_requests = [
+        "Tell me",
+        "Help me",
+        "Call John",
+        "Book appointment",
+        "Transfer me",
+        "What now",
+        "What's that",
+        "Who is that",
+        "Where exactly",
+        "How much",
+        "Tell me more",
+        "Stop billing",
+        "Cancel order",
+        "Blue widget",  # Unknown / unseen 2-word phrase
+    ]
+
+    for req in legitimate_short_requests:
+        assert handler._should_barge_in_on_stt(req, 0.90) is True, f"Failed to barge in for legitimate request: {req}"
+
+    # Verify that sending a legitimate request over active TTS triggers cancellation
+    await handler._maybe_process_interim("Tell me", 0.90)
+    assert handler._cancel_inflight_llm_response.call_count == 1
+
+
 
 
 

--- a/tests/test_interim_final_lockout_gate.py
+++ b/tests/test_interim_final_lockout_gate.py
@@ -1,0 +1,269 @@
+"""
+Unit & Regression Tests for Gate #7: Interim LLM Lockout & Final Transcript Recovery
+Tests:
+A. Interim starts -> valid response completes -> speech_final arrives -> no duplicate LLM response.
+B. Interim starts -> empty response -> speech_final arrives -> final LLM response is generated.
+C. Interim starts -> generation fails -> speech_final arrives -> final LLM response is generated.
+D. Interim starts -> generation is cancelled/suppressed -> speech_final arrives -> final LLM response is generated.
+"""
+import asyncio
+import time
+import uuid
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.routers.bidirectional_stream import BidirectionalStreamHandler
+
+class DummyWebSocket:
+    async def accept(self): pass
+    async def send_text(self, data: str): pass
+    async def send_json(self, data: dict): pass
+    async def receive_text(self): return "{}"
+    async def close(self): pass
+
+@pytest.mark.asyncio
+async def test_case_a_interim_valid_no_duplicate():
+    """Case A: Interim starts -> valid response completes -> speech_final arrives -> no duplicate LLM response."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler._enable_interim_llm = True
+
+    llm_generated_texts = []
+
+    async def mock_generate(user_text: str, confidence: float = 1.0, is_greeting: bool = False):
+        llm_generated_texts.append(user_text)
+        await asyncio.sleep(0.01) # Simulate synthesis
+        return "Here is your valid answer."
+
+    handler.generate_and_stream_response = mock_generate
+    handler._add_to_transcript = AsyncMock()
+    handler._prefetch_rag_context = AsyncMock()
+    handler._run_speculative_tts_prefetch = AsyncMock()
+    handler._should_accept_final_transcript = MagicMock(return_value=True)
+
+    # 1. Interim arrives ("I want to")
+    await handler._maybe_process_interim("I want to", 0.90)
+    assert handler._turn_response_started is True
+    assert handler._llm_response_task is not None
+
+    # Wait for interim task to finish producing valid response
+    await handler._llm_response_task
+
+    # 2. Final arrives ("I want to schedule an interview.")
+    await handler._complete_llm_turn_after_stt_final("I want to schedule an interview.", 0.95)
+
+    # Verify: LLM was called ONCE (by interim) and NOT duplicated by speech_final
+    assert len(llm_generated_texts) == 1
+    assert llm_generated_texts[0] == "I want to"
+
+@pytest.mark.asyncio
+async def test_case_b_interim_empty_final_generated():
+    """Case B: Interim starts -> empty response -> speech_final arrives -> final LLM response is generated."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler._enable_interim_llm = True
+
+    llm_generated_texts = []
+
+    async def mock_generate(user_text: str, confidence: float = 1.0, is_greeting: bool = False):
+        llm_generated_texts.append(user_text)
+        if user_text == "I want to":
+            # Interim produces empty/no response
+            return ""
+        return "Final response for interview scheduling."
+
+    handler.generate_and_stream_response = mock_generate
+    handler._add_to_transcript = AsyncMock()
+    handler._prefetch_rag_context = AsyncMock()
+    handler._run_speculative_tts_prefetch = AsyncMock()
+    handler._should_accept_final_transcript = MagicMock(return_value=True)
+
+    # 1. Interim arrives ("I want to")
+    await handler._maybe_process_interim("I want to", 0.90)
+    await handler._llm_response_task
+
+    # 2. Final arrives ("I want to schedule an interview.")
+    await handler._complete_llm_turn_after_stt_final("I want to schedule an interview.", 0.95)
+
+    # Verify: Final LLM was generated because interim produced empty response!
+    assert len(llm_generated_texts) == 2
+    assert llm_generated_texts[0] == "I want to"
+    assert llm_generated_texts[1] == "I want to schedule an interview."
+
+@pytest.mark.asyncio
+async def test_case_c_interim_failed_final_generated():
+    """Case C: Interim starts -> generation fails -> speech_final arrives -> final LLM response is generated."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler._enable_interim_llm = True
+
+    llm_generated_texts = []
+
+    async def mock_generate(user_text: str, confidence: float = 1.0, is_greeting: bool = False):
+        llm_generated_texts.append(user_text)
+        if user_text == "I want to":
+            raise RuntimeError("Primary LLM network timeout")
+        return "Final response for interview scheduling."
+
+    handler.generate_and_stream_response = mock_generate
+    handler._add_to_transcript = AsyncMock()
+    handler._prefetch_rag_context = AsyncMock()
+    handler._run_speculative_tts_prefetch = AsyncMock()
+    handler._should_accept_final_transcript = MagicMock(return_value=True)
+
+    # 1. Interim arrives ("I want to")
+    await handler._maybe_process_interim("I want to", 0.90)
+    try:
+        await handler._llm_response_task
+    except Exception:
+        pass
+
+    # 2. Final arrives ("I want to schedule an interview.")
+    await handler._complete_llm_turn_after_stt_final("I want to schedule an interview.", 0.95)
+
+    # Verify: Final LLM was generated because interim failed!
+    assert len(llm_generated_texts) == 2
+    assert llm_generated_texts[0] == "I want to"
+    assert llm_generated_texts[1] == "I want to schedule an interview."
+
+@pytest.mark.asyncio
+async def test_case_d_interim_cancelled_final_generated():
+    """Case D: Interim starts -> generation is cancelled/suppressed -> speech_final arrives -> final LLM response is generated."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler._enable_interim_llm = True
+
+    llm_generated_texts = []
+
+    async def mock_generate(user_text: str, confidence: float = 1.0, is_greeting: bool = False):
+        llm_generated_texts.append(user_text)
+        if user_text == "I want to":
+            await asyncio.sleep(1.0) # Long running task to be cancelled
+            return "Should not reach here"
+        return "Final response for interview scheduling."
+
+    handler.generate_and_stream_response = mock_generate
+    handler._add_to_transcript = AsyncMock()
+    handler._prefetch_rag_context = AsyncMock()
+    handler._run_speculative_tts_prefetch = AsyncMock()
+    handler._should_accept_final_transcript = MagicMock(return_value=True)
+
+    # 1. Interim arrives ("I want to")
+    await handler._maybe_process_interim("I want to", 0.90)
+    await asyncio.sleep(0.01)  # Yield to let interim task start
+
+    # Cancel the interim task
+    handler._llm_response_task.cancel()
+    try:
+        await handler._llm_response_task
+    except asyncio.CancelledError:
+        pass
+
+    # 2. Final arrives ("I want to schedule an interview.")
+    await handler._complete_llm_turn_after_stt_final("I want to schedule an interview.", 0.95)
+
+    # Verify: Final LLM was generated because interim was cancelled!
+    assert "I want to schedule an interview." in llm_generated_texts
+    assert len(llm_generated_texts) == 2
+    assert llm_generated_texts[0] == "I want to"
+    assert llm_generated_texts[1] == "I want to schedule an interview."
+
+@pytest.mark.asyncio
+async def test_case_e_concurrent_overlapping_turns_isolation():
+    """Case E: Turn A interim starts (in-flight) -> Turn A final arrives -> Turn B starts concurrently -> Turn A cannot be polluted by Turn B."""
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler._enable_interim_llm = True
+    handler._min_interim_words = 2
+    handler._min_interim_confidence = 0.14
+    handler._min_interim_interval_sec = 0.0
+    handler._is_booking_context_active = MagicMock(return_value=False)
+
+    llm_generated_texts = []
+
+    async def mock_generate(user_text: str, confidence: float = 1.0, is_greeting: bool = False):
+        llm_generated_texts.append(user_text)
+        if user_text == "Turn A interim":
+            await asyncio.sleep(0.05)  # In-flight task
+            # Turn A interim fails / produces empty
+            return ""
+        elif user_text == "Turn B interim":
+            await asyncio.sleep(0.01)
+            # Turn B interim succeeds
+            return "Turn B success"
+        elif user_text == "Turn A final full text":
+            return "Turn A full answer"
+        return "Generic response"
+
+    handler.generate_and_stream_response = mock_generate
+    handler._add_to_transcript = AsyncMock()
+    handler._prefetch_rag_context = AsyncMock()
+    handler._run_speculative_tts_prefetch = AsyncMock()
+    handler._should_accept_final_transcript = MagicMock(return_value=True)
+
+    # 1. Turn A interim starts (in flight)
+    await handler._maybe_process_interim("Turn A interim", 0.90)
+    assert handler._turn_response_started is True
+    await asyncio.sleep(0.005)  # Yield to let Turn A task start running
+
+    # 2. Turn A final arrives while Task A is still in-flight
+    # In background, simulate Turn B interim starting while Turn A final is awaiting Task A
+    async def simulate_turn_b():
+        await asyncio.sleep(0.01)
+        # Turn B starts an interim task
+        handler._turn_response_started = False
+        await handler._maybe_process_interim("Turn B interim", 0.90)
+
+    b_task = asyncio.create_task(simulate_turn_b())
+
+    # Turn A final processes
+    await handler._complete_llm_turn_after_stt_final("Turn A final full text", 0.95)
+    await b_task
+    if handler._llm_response_task:
+        await handler._llm_response_task
+
+    # Verify:
+    # 1. Turn A final MUST be generated because Turn A interim produced empty output.
+    # 2. Turn A did NOT observe Turn B's success.
+    assert "Turn A interim" in llm_generated_texts
+    assert "Turn A final full text" in llm_generated_texts

--- a/tests/utils/test_eleven_tts_text.py
+++ b/tests/utils/test_eleven_tts_text.py
@@ -10,10 +10,19 @@ from app.utils.eleven_tts_text import (
 )
 
 
-def test_elevenlabs_pass_through():
-    raw = "[breathes] Hello there [sigh]"
-    assert prepare_tts_text_for_provider(raw, "elevenlabs") == raw
-    assert prepare_tts_text_for_provider(raw, "ElevenLabs") == raw
+def test_elevenlabs_strips_audio_and_ssml_tags():
+    """Verify ElevenLabs strips SSML tags and audio bracket tags to prevent literal reading."""
+    assert prepare_tts_text_for_provider("[breathes] Hello there [sigh]", "elevenlabs") == "Hello there"
+    assert prepare_tts_text_for_provider("[excited] That's wonderful!", "elevenlabs") == "That's wonderful!"
+    assert prepare_tts_text_for_provider("[sad] I'm sorry to hear that.", "elevenlabs") == "I'm sorry to hear that."
+    assert (
+        prepare_tts_text_for_provider(
+            '<speak><prosody rate="0.93" pitch="0st" volume="medium"><break time="400ms"/> Hello world.</prosody></speak>',
+            "elevenlabs",
+        )
+        == "Hello world."
+    )
+    assert prepare_tts_text_for_provider('<break time="400ms"/> Let me see.', "elevenlabs") == "Let me see."
 
 
 def test_google_strips_known_tags():
@@ -30,18 +39,36 @@ def test_google_strips_known_tags():
     )
 
 
+def test_tags_split_across_streaming_chunks():
+    """Verify split SSML/XML tags across streaming chunks do not leak tag words."""
+    # Chunk 1 ends with unclosed tag
+    assert prepare_tts_text_for_provider('Hello <prosody rate="95%"', "elevenlabs") == "Hello"
+    # Chunk 2 starts with trailing tag closure
+    assert prepare_tts_text_for_provider(' pitch="+1st">how are you?', "elevenlabs") == "how are you?"
+    # Unclosed break tag fragment
+    assert prepare_tts_text_for_provider('time="400ms"/> Welcome!', "elevenlabs") == "Welcome!"
+
+
 def test_unknown_brackets_preserved():
     s = "Price is [500] and code [SKU-12]."
     assert strip_eleven_v3_style_tags_for_non_eleven_tts(s) == s
+    assert prepare_tts_text_for_provider(s, "elevenlabs") == s
+
+
+def test_normal_business_and_punctuation_intact():
+    s = "Your 10% discount on order #1234 is confirmed for 2:30 PM."
+    assert prepare_tts_text_for_provider(s, "elevenlabs") == s
 
 
 def test_no_brackets_fast_path():
     s = "Plain text without tags."
-    assert strip_eleven_v3_style_tags_for_non_eleven_tts(s) is s
+    assert strip_eleven_v3_style_tags_for_non_eleven_tts(s) == s
 
 
 def test_empty_after_strip():
     assert prepare_tts_text_for_provider("[breathes]", "google") == ""
+    assert prepare_tts_text_for_provider("[breathes]", "elevenlabs") == ""
+    assert prepare_tts_text_for_provider('<break time="200ms"/>', "elevenlabs") == ""
 
 
 def test_default_non_eleven_strips():
@@ -49,35 +76,11 @@ def test_default_non_eleven_strips():
     assert "[breathes]" not in prepare_tts_text_for_provider("[breathes] Hi", "openai-tts")
 
 
-def test_only_elevenlabs_supports_audio_tags():
-    assert supports_elevenlabs_audio_tags("elevenlabs") is True
-    assert supports_elevenlabs_audio_tags("ElevenLabs") is True
+def test_audio_tags_disabled_for_conversational_models():
+    assert supports_elevenlabs_audio_tags("elevenlabs") is False
     assert supports_elevenlabs_audio_tags("google") is False
     assert supports_elevenlabs_audio_tags(None) is False
-
-
-def test_supports_respects_config_disable(monkeypatch):
-    from app.core import config
-    from app.utils import eleven_tts_text
-
-    monkeypatch.setattr(config.settings, "ENABLE_ELEVENLABS_AUDIO_TAGS", False)
-    # settings is the same object used by the module
-    assert eleven_tts_text.supports_elevenlabs_audio_tags("elevenlabs") is False
     assert build_elevenlabs_audio_tag_prompt_block("elevenlabs") == ""
-
-
-def test_prompt_block_only_emitted_for_elevenlabs():
-    from app.utils.eleven_tts_text import get_elevenlabs_voice_prompt_rule_lines
-
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    assert "ELEVENLABS" in block
-    assert "[breathe]" in block or "[breathes]" in block
-    assert "[excited]" in block
-    assert "[sad]" in block or "sorrowful" in block
-    assert build_elevenlabs_audio_tag_prompt_block("google") == ""
-    a, b, c = get_elevenlabs_voice_prompt_rule_lines()
-    assert a.startswith("- OUTPUT")
-    assert "3. NO SSML" in c
 
 
 def test_contains_elevenlabs_audio_tag_detects_known_tags():
@@ -85,58 +88,7 @@ def test_contains_elevenlabs_audio_tag_detects_known_tags():
     assert contains_elevenlabs_audio_tag("Price is [500]") is False
 
 
-def test_breathing_fallback_added_for_long_eleven_text():
+def test_breathing_fallback_does_not_inject_literal_tags():
     raw = "Hello there, thank you for calling today."
-    assert apply_elevenlabs_breathing_fallback(raw) == "[breathes] Hello there, thank you for calling today."
-    assert prepare_tts_text_for_provider(raw, "elevenlabs") == raw
+    assert apply_elevenlabs_breathing_fallback(raw) == raw
 
-
-def test_breathing_fallback_skips_short_or_control_token_text():
-    assert apply_elevenlabs_breathing_fallback("Thanks") == "Thanks"
-    token_text = "Sure [CHECK_SLOTS:date=2026-05-01]"
-    assert apply_elevenlabs_breathing_fallback(token_text) == token_text
-
-
-# ─────────────────────────────────────────────────────────────────────────
-# Phase 5-4: build_elevenlabs_audio_tag_prompt_block() is the ONE
-# authoritative bracket-tag rule source. These assert the specific new
-# rules text is present, so a future edit can't silently drop one.
-# ─────────────────────────────────────────────────────────────────────────
-
-def test_prompt_block_states_max_one_tag_per_response():
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    assert "ONE tag per response" in block or "one optional bracketed audio tag" in block.lower()
-
-
-def test_prompt_block_states_leading_placement_only():
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    assert "first thing in the response" in block.lower() or "start of the spoken line" in block.lower()
-
-
-def test_prompt_block_prohibits_mid_sentence_and_word_emphasis_placement():
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    assert "middle" in block.lower()
-    assert "emphasize" in block.lower()
-
-
-def test_prompt_block_prohibits_inventing_new_tags():
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    assert "no others" in block.lower() or "never invent" in block.lower()
-
-
-def test_prompt_block_default_is_no_tag_and_not_forced():
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    assert "default is **no** tag" in block.lower() or "default is no tag" in block.lower()
-    assert "do not add a tag to every message" in block.lower() or "do not add tags in every message" in block.lower() or "never force" in block.lower()
-
-
-def test_prompt_block_preserves_control_token_carve_out():
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    for token in ("[CHECK_SLOTS:", "[BOOK_APPOINTMENT:", "[END_CALL]", "[SCREENING_QUALIFIED]", "[OUTCOME:"):
-        assert token in block
-
-
-def test_prompt_block_whitelist_unchanged():
-    block = build_elevenlabs_audio_tag_prompt_block("elevenlabs")
-    for tag in ("[breathes]", "[breathe]", "[excited]", "[sad]", "[sorrowful]"):
-        assert tag in block

--- a/tests/voice/test_backchannel_classifier.py
+++ b/tests/voice/test_backchannel_classifier.py
@@ -1,0 +1,244 @@
+from app.voice.backchannel_classifier import (
+    TurnClassification,
+    classify_turn,
+    has_explicit_interruption_intent,
+    is_known_non_actionable_backchannel,
+    is_pure_acoustic_filler,
+    normalize_transcript,
+)
+
+
+def test_normalize_transcript():
+    assert normalize_transcript("Hey. Hi.") == "hey hi"
+    assert normalize_transcript("  What's that?!  ") == "whats that"
+    assert normalize_transcript("Good morning, how are you?") == "good morning how are you"
+    assert normalize_transcript("") == ""
+    assert normalize_transcript(None) == ""
+
+
+def test_is_pure_acoustic_filler():
+    assert is_pure_acoustic_filler("uh") is True
+    assert is_pure_acoustic_filler("um") is True
+    assert is_pure_acoustic_filler("uh huh") is True
+    assert is_pure_acoustic_filler("hey") is False
+    assert is_pure_acoustic_filler("stop") is False
+
+
+def test_is_known_non_actionable_backchannel():
+    # Greetings
+    assert is_known_non_actionable_backchannel("Hey") is True
+    assert is_known_non_actionable_backchannel("Hi") is True
+    assert is_known_non_actionable_backchannel("Hey. Hi.") is True
+    assert is_known_non_actionable_backchannel("Hi there") is True
+    assert is_known_non_actionable_backchannel("Good morning") is True
+    assert is_known_non_actionable_backchannel("Good afternoon") is True
+    assert is_known_non_actionable_backchannel("Good evening") is True
+
+    # Affirmations
+    assert is_known_non_actionable_backchannel("Yeah yeah") is True
+    assert is_known_non_actionable_backchannel("Okay okay") is True
+    assert is_known_non_actionable_backchannel("Thank you") is True
+    assert is_known_non_actionable_backchannel("Got it") is True
+    assert is_known_non_actionable_backchannel("Sure") is True
+    assert is_known_non_actionable_backchannel("Alright") is True
+    assert is_known_non_actionable_backchannel("Okay. And") is True
+    assert is_known_non_actionable_backchannel("Uh huh") is True
+
+    # Legitimate short requests (MUST NOT be classified as backchannel!)
+    assert is_known_non_actionable_backchannel("Tell me") is False
+    assert is_known_non_actionable_backchannel("Help me") is False
+    assert is_known_non_actionable_backchannel("Call John") is False
+    assert is_known_non_actionable_backchannel("Book appointment") is False
+    assert is_known_non_actionable_backchannel("Transfer me") is False
+    assert is_known_non_actionable_backchannel("What now") is False
+    assert is_known_non_actionable_backchannel("What's that") is False
+    assert is_known_non_actionable_backchannel("Who is that") is False
+    assert is_known_non_actionable_backchannel("Where exactly") is False
+    assert is_known_non_actionable_backchannel("How much") is False
+    assert is_known_non_actionable_backchannel("Tell me more") is False
+    assert is_known_non_actionable_backchannel("Random unseen phrase") is False
+
+
+def test_has_explicit_interruption_intent():
+    assert has_explicit_interruption_intent("Stop") is True
+    assert has_explicit_interruption_intent("Stop please") is True
+    assert has_explicit_interruption_intent("Hold on") is True
+    assert has_explicit_interruption_intent("Wait please") is True
+    assert has_explicit_interruption_intent("Pause please") is True
+    assert has_explicit_interruption_intent("Cancel that") is True
+    assert has_explicit_interruption_intent("Stop talking") is True
+    assert has_explicit_interruption_intent("Be quiet") is True
+    assert has_explicit_interruption_intent("Shut up") is True
+    assert has_explicit_interruption_intent("Cancel order") is True
+    assert has_explicit_interruption_intent("Stop billing") is True
+
+    # Non-command phrases
+    assert has_explicit_interruption_intent("Hey. Hi.") is False
+    assert has_explicit_interruption_intent("Tell me") is False
+    assert has_explicit_interruption_intent("How much") is False
+
+
+def test_classify_turn_when_tts_playing():
+    # 1. Explicit interruption commands -> BARGE_IN
+    assert (
+        classify_turn("Stop please", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Hold on", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Wait please", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Cancel that", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Be quiet", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Stop", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+
+    # 2. Known conversational backchannels -> SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    assert (
+        classify_turn("Hey", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Hi", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Hey. Hi.", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Hi there", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Good morning", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Yeah yeah", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Okay okay", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Thank you", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Got it", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Sure", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Alright", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("Okay. And", 1.00, is_tts_playing=True)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+
+    # 3. Legitimate short requests & unknown phrases spoken over TTS -> BARGE_IN (never dropped!)
+    assert (
+        classify_turn("Tell me", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Help me", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Call John", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Book appointment", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Transfer me", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("What now", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("What's that", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Who is that", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Where exactly", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("How much", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Tell me more", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+    assert (
+        classify_turn("Unknown phrase widget", 0.90, is_tts_playing=True)
+        == TurnClassification.BARGE_IN
+    )
+
+
+def test_classify_turn_when_tts_silent():
+    # When agent is silent / waiting for caller, all genuine phrases are NORMAL_USER_TURN
+    assert (
+        classify_turn("Hey", 1.00, is_tts_playing=False)
+        == TurnClassification.NORMAL_USER_TURN
+    )
+    assert (
+        classify_turn("Hi", 1.00, is_tts_playing=False)
+        == TurnClassification.NORMAL_USER_TURN
+    )
+    assert (
+        classify_turn("Hey. Hi.", 1.00, is_tts_playing=False)
+        == TurnClassification.NORMAL_USER_TURN
+    )
+    assert (
+        classify_turn("Tell me", 1.00, is_tts_playing=False)
+        == TurnClassification.NORMAL_USER_TURN
+    )
+    assert (
+        classify_turn("Book appointment", 1.00, is_tts_playing=False)
+        == TurnClassification.NORMAL_USER_TURN
+    )
+    assert (
+        classify_turn("How much", 1.00, is_tts_playing=False)
+        == TurnClassification.NORMAL_USER_TURN
+    )
+
+    # Pure acoustic fillers are still suppressed
+    assert (
+        classify_turn("uh", 1.00, is_tts_playing=False)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )
+    assert (
+        classify_turn("um", 1.00, is_tts_playing=False)
+        == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+    )

--- a/tests/voice/test_bracket_tag_prompt_consistency.py
+++ b/tests/voice/test_bracket_tag_prompt_consistency.py
@@ -80,8 +80,8 @@ class TestTwilioBracketTagPromptConsistency:
         assert captured, "LLM must have been invoked"
         sp = captured[0]
         _assert_single_tag_source(sp)
-        assert ELEVEN_TAG_MARKER in sp
-        assert GENERIC_NO_TAG_MARKER not in sp
+        assert ELEVEN_TAG_MARKER not in sp
+        assert GENERIC_NO_TAG_MARKER in sp
 
     def test_base_prompt_google_no_contradiction(self):
         h = _base_handler()
@@ -98,19 +98,21 @@ class TestTwilioBracketTagPromptConsistency:
 
     def test_custom_system_prompt_elevenlabs_no_contradiction(self):
         h = _base_handler()
-        h.agent.system_prompt = "You help schedule appointments."
+        h.agent.system_prompt = "Custom instructions for this agent."
+        h.agent.model.system_prompt = None
         h.agent.tts_provider.slug = "elevenlabs"
         captured, spy = _capture_twilio_system_prompt(h)
         self._run(h, spy)
 
         sp = captured[0]
         _assert_single_tag_source(sp)
-        assert ELEVEN_TAG_MARKER in sp
-        assert GENERIC_NO_TAG_MARKER not in sp
+        assert ELEVEN_TAG_MARKER not in sp
+        assert GENERIC_NO_TAG_MARKER in sp
 
     def test_custom_system_prompt_google_no_contradiction(self):
         h = _base_handler()
-        h.agent.system_prompt = "You help schedule appointments."
+        h.agent.system_prompt = "Custom instructions for this agent."
+        h.agent.model.system_prompt = None
         h.agent.tts_provider.slug = "google"
         captured, spy = _capture_twilio_system_prompt(h)
         self._run(h, spy)
@@ -123,15 +125,15 @@ class TestTwilioBracketTagPromptConsistency:
     def test_model_system_prompt_elevenlabs_no_contradiction(self):
         h = _base_handler()
         h.agent.system_prompt = None
-        h.agent.model.system_prompt = "Follow the recruiting script."
+        h.agent.model.system_prompt = "Model instructions for this agent."
         h.agent.tts_provider.slug = "elevenlabs"
         captured, spy = _capture_twilio_system_prompt(h)
         self._run(h, spy)
 
         sp = captured[0]
         _assert_single_tag_source(sp)
-        assert ELEVEN_TAG_MARKER in sp
-        assert GENERIC_NO_TAG_MARKER not in sp
+        assert ELEVEN_TAG_MARKER not in sp
+        assert GENERIC_NO_TAG_MARKER in sp
 
     def test_model_system_prompt_google_no_contradiction(self):
         h = _base_handler()
@@ -239,8 +241,8 @@ class TestLiveKitBracketTagPromptConsistency:
         assert captured
         sp = captured[0]
         _assert_single_tag_source(sp)
-        assert ELEVEN_TAG_MARKER in sp
-        assert GENERIC_NO_TAG_MARKER not in sp
+        assert ELEVEN_TAG_MARKER not in sp
+        assert GENERIC_NO_TAG_MARKER in sp
 
     def test_base_prompt_google_no_generic_tag_line_needed(self, monkeypatch):
         """LiveKit's base path has no generic 'NO BRACKET TAGS' line at all
@@ -267,8 +269,8 @@ class TestLiveKitBracketTagPromptConsistency:
 
         sp = captured[0]
         _assert_single_tag_source(sp)
-        assert ELEVEN_TAG_MARKER in sp
-        assert GENERIC_NO_TAG_MARKER not in sp
+        assert ELEVEN_TAG_MARKER not in sp
+        assert GENERIC_NO_TAG_MARKER in sp
 
     def test_custom_system_prompt_google_no_contradiction(self, monkeypatch):
         h = _fake_livekit_handler(
@@ -293,8 +295,8 @@ class TestLiveKitBracketTagPromptConsistency:
 
         sp = captured[0]
         _assert_single_tag_source(sp)
-        assert ELEVEN_TAG_MARKER in sp
-        assert GENERIC_NO_TAG_MARKER not in sp
+        assert ELEVEN_TAG_MARKER not in sp
+        assert GENERIC_NO_TAG_MARKER in sp
 
     def test_model_system_prompt_google_no_contradiction(self, monkeypatch):
         h = _fake_livekit_handler(

--- a/tests/voice/test_call_pipeline.py
+++ b/tests/voice/test_call_pipeline.py
@@ -504,13 +504,13 @@ class TestBargeIn:
         h._tts_pipeline.cancel_current_and_clear_queue.assert_called_once()
 
     def test_barge_in_single_word_high_confidence_does_not_cancel_by_default(self):
-        """Default min 2 words: lone 'stop' must not cancel even at high confidence."""
+        """Default min 2 words: lone non-command 'hello' must not cancel even at high confidence."""
         h = _base_handler()
         h.is_speaking = True
         h._is_tts_playing = True
         h._tts_pipeline.is_speaking = True
 
-        asyncio.run(h._maybe_process_interim("stop", 0.55))
+        asyncio.run(h._maybe_process_interim("hello", 0.55))
 
         h._tts_pipeline.cancel_current_and_clear_queue.assert_not_called()
 

--- a/tests/voice/test_production_readiness_barge_in.py
+++ b/tests/voice/test_production_readiness_barge_in.py
@@ -1,0 +1,284 @@
+"""
+Production Readiness Verification Test Suite for 3-State Barge-In & Backchannel Architecture.
+
+Verifies:
+1. Known Backchannels (Suppressed while TTS is playing; no LLM, RAG, speculative TTS, or audio cancellation).
+2. Explicit Interruptions (Trigger barge-in, cancel active TTS immediately).
+3. Legitimate Short / Unknown Requests (Never silently dropped; barge in and generate LLM response).
+4. Interim -> Final STT Deduplication (No duplicate LLM generation on final STT).
+5. Race conditions (TTS finishes between interim and final STT; rapid arrivals).
+6. Telephony (Twilio) and Browser (LiveKit) behavioral parity.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers.bidirectional_stream import BidirectionalStreamHandler
+from app.voice.backchannel_classifier import (
+    TurnClassification,
+    classify_turn,
+)
+from app.voice.livekit_browser_call_handler import LiveKitBrowserCallHandler
+
+
+class DummyWebSocket:
+    async def send_text(self, data: str) -> None:
+        pass
+
+    async def send_json(self, data: dict) -> None:
+        pass
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        pass
+
+
+def _create_test_handler() -> BidirectionalStreamHandler:
+    handler = BidirectionalStreamHandler(
+        websocket=DummyWebSocket(),
+        call_session_id=str(uuid.uuid4()),
+        agent_id=str(uuid.uuid4()),
+        db=None,
+    )
+    handler.call_session = MagicMock()
+    handler.call_session.id = uuid.uuid4()
+    handler.call_session.tenant_id = uuid.uuid4()
+    handler.agent = MagicMock()
+    handler.agent.language = "en"
+    handler._enable_interim_llm = False
+    handler._barge_in_min_words = 2
+    handler._barge_in_min_conf = 0.26
+    handler._barge_in_min_conf_1w = 0.36
+    handler._barge_in_dead_zone_ms = 600
+
+    handler._cancel_inflight_llm_response = AsyncMock()
+    handler._complete_llm_turn_after_stt_final = AsyncMock()
+    handler._prefetch_rag_context = AsyncMock()
+    handler._run_speculative_tts_prefetch = AsyncMock()
+    handler._add_to_transcript = AsyncMock()
+    handler._send_in_progress_status = AsyncMock()
+    handler._check_and_end_call_if_goodbye = AsyncMock(return_value=False)
+    handler._check_and_end_call_if_voicemail = AsyncMock(return_value=False)
+    handler._check_and_handle_call_screener = AsyncMock(return_value=False)
+    handler._check_and_handle_ivr_and_hold = AsyncMock(return_value=False)
+    handler._check_and_handle_anti_bot = AsyncMock(return_value=False)
+    handler._check_and_handle_compliance_monitoring = AsyncMock(return_value=False)
+    handler._send_quick_acknowledgement = AsyncMock()
+    return handler
+
+
+# ── Focus 1: Known Backchannels ──────────────────────────────────────────────
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "Hey",
+        "Hi",
+        "Hey hi",
+        "Hey there",
+        "Okay",
+        "Okay and",
+        "Yeah yeah",
+        "Thank you",
+        "Got it",
+        "Sure",
+        "Alright",
+        "Good morning",
+    ],
+)
+async def test_known_backchannels_suppressed_during_active_tts(phrase: str):
+    """1. Known backchannels must be SUPPRESSED while active TTS is playing."""
+    handler = _create_test_handler()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0  # Dead-zone passed
+
+    # A. Classifier check
+    classification = classify_turn(phrase, 1.00, is_tts_playing=True)
+    assert classification == TurnClassification.SUPPRESS_NON_ACTIONABLE_BACKCHANNEL
+
+    # B. Barge-in gate check
+    assert handler._should_barge_in_on_stt(phrase, 1.00) is False
+
+    # C. Interim STT arrival -> must NOT cancel audio, must NOT prefetch RAG
+    await handler._maybe_process_interim(phrase, 1.00)
+    assert handler._cancel_inflight_llm_response.call_count == 0
+    assert getattr(handler, "_rag_prefetch_task", None) is None
+    assert getattr(handler, "_speculative_prefetch_task", None) is None
+    assert handler._is_tts_playing is True  # Playback must continue undisturbed
+
+    # D. Final STT arrival -> must NOT invoke LLM turn while TTS is playing
+    await handler._process_transcript(phrase, 1.00)
+    assert handler._complete_llm_turn_after_stt_final.call_count == 0
+    assert handler._is_tts_playing is True
+
+
+# ── Focus 2: Explicit Interruptions ──────────────────────────────────────────
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "Stop",
+        "Stop please",
+        "Hold on",
+        "Wait",
+        "Wait please",
+        "Pause please",
+        "Cancel that",
+        "Be quiet",
+    ],
+)
+async def test_explicit_interruptions_trigger_barge_in(phrase: str):
+    """2. Explicit commands must trigger BARGE_IN and cancel active TTS immediately."""
+    handler = _create_test_handler()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0  # Dead-zone passed
+
+    # A. Classifier check
+    classification = classify_turn(phrase, 0.95, is_tts_playing=True)
+    assert classification == TurnClassification.BARGE_IN
+
+    # B. Barge-in gate check
+    assert handler._should_barge_in_on_stt(phrase, 0.95) is True
+
+    # C. Interim STT arrival -> MUST cancel inflight response and reset _is_tts_playing
+    await handler._maybe_process_interim(phrase, 0.95)
+    assert handler._cancel_inflight_llm_response.call_count == 1
+    assert handler._is_tts_playing is False
+
+
+# ── Focus 3: Legitimate Short / Unknown Requests ──────────────────────────────
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "phrase",
+    [
+        "Tell me",
+        "Help me",
+        "Call John",
+        "Book appointment",
+        "How much",
+        "Blue widget",
+        "Need help",
+        "One more",
+        "Try this",
+    ],
+)
+async def test_legitimate_short_and_unknown_requests_never_silently_suppressed(
+    phrase: str,
+):
+    """3. Legitimate short/unknown requests must NEVER be silently suppressed."""
+    handler = _create_test_handler()
+
+    # When spoken over active TTS: MUST barge-in and stop TTS to capture user request
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0
+
+    classification = classify_turn(phrase, 0.90, is_tts_playing=True)
+    assert classification == TurnClassification.BARGE_IN
+    assert handler._should_barge_in_on_stt(phrase, 0.90) is True
+
+    await handler._maybe_process_interim(phrase, 0.90)
+    assert handler._cancel_inflight_llm_response.call_count == 1
+
+    # When final STT arrives: MUST trigger LLM turn processing
+    await handler._process_transcript(phrase, 0.90)
+    assert handler._complete_llm_turn_after_stt_final.call_count == 1
+
+
+# ── Focus 4: Interim -> Final STT Deduplication ──────────────────────────────
+@pytest.mark.asyncio
+async def test_interim_barge_in_then_final_stt_flow():
+    """4. Verify interim barge-in cancels TTS, and final STT generates exactly one LLM turn."""
+    handler = _create_test_handler()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0
+
+    # 1. Interim "Hold on" arrives -> triggers barge in
+    await handler._maybe_process_interim("Hold on", 0.95)
+    assert handler._cancel_inflight_llm_response.call_count == 1
+    assert handler._is_tts_playing is False
+
+    # 2. Final "Hold on" arrives -> triggers exactly ONE LLM completion turn
+    await handler._process_transcript("Hold on", 0.95)
+    assert handler._complete_llm_turn_after_stt_final.call_count == 1
+
+
+# ── Focus 5: Race Conditions ──────────────────────────────────────────────────
+@pytest.mark.asyncio
+async def test_race_condition_tts_finishes_before_final_backchannel():
+    """5. Race condition: Caller says 'Yeah yeah' while TTS plays; TTS ends naturally before final STT."""
+    handler = _create_test_handler()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0
+
+    # Interim arrives while TTS is playing -> suppressed
+    await handler._maybe_process_interim("Yeah yeah", 1.00)
+    assert handler._cancel_inflight_llm_response.call_count == 0
+
+    # TTS finishes playing naturally right before Deepgram endpoints
+    handler._is_tts_playing = False
+
+    # Final STT arrives when agent is silent -> processed normally without crashes or double-cancellations
+    await handler._process_transcript("Yeah yeah", 1.00)
+    assert handler._cancel_inflight_llm_response.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_rapid_consecutive_interims():
+    """5. Race condition: Rapid sequence of interims does not cause duplicate cancels or lock deadlocks."""
+    handler = _create_test_handler()
+    handler._is_tts_playing = True
+    handler._tts_play_start_ts = time.perf_counter() - 1.0
+
+    # Fire 5 rapid backchannel interims -> 0 cancels
+    for _ in range(5):
+        await handler._maybe_process_interim("Yeah yeah", 1.00)
+    assert handler._cancel_inflight_llm_response.call_count == 0
+
+    # Fire 1 command interim -> cancels once
+    await handler._maybe_process_interim("Stop please", 1.00)
+    assert handler._cancel_inflight_llm_response.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_twilio_and_livekit_handler_parity():
+    """6. Ensure BidirectionalStreamHandler and LiveKitBrowserCallHandler share identical classification logic."""
+    test_phrases = [
+        ("Hey. Hi.", 1.00, False),
+        ("Good morning", 1.00, False),
+        ("Yeah yeah", 1.00, False),
+        ("Stop please", 1.00, True),
+        ("Hold on", 1.00, True),
+        ("Cancel that", 1.00, True),
+        ("Tell me", 0.90, True),
+        ("Help me", 0.90, True),
+        ("Book appointment", 0.90, True),
+        ("Blue widget", 0.90, True),
+    ]
+
+    twilio_h = _create_test_handler()
+
+    mock_session = MagicMock()
+    mock_session.id = uuid.uuid4()
+    mock_agent = MagicMock()
+    mock_agent.id = uuid.uuid4()
+
+    livekit_h = LiveKitBrowserCallHandler(
+        db=None,
+        call_session=mock_session,
+        agent=mock_agent,
+    )
+    livekit_h._barge_in_min_words = 2
+    livekit_h._barge_in_min_conf = 0.26
+    livekit_h._barge_in_min_conf_1w = 0.36
+
+    for phrase, conf, expected_barge in test_phrases:
+        twilio_res = twilio_h._should_barge_in_on_stt(phrase, conf)
+        livekit_res = livekit_h._should_barge_in_on_stt(phrase, conf)
+
+        assert twilio_res == expected_barge, f"Twilio mismatch for '{phrase}'"
+        assert livekit_res == expected_barge, f"LiveKit mismatch for '{phrase}'"
+        assert twilio_res == livekit_res, f"Parity mismatch for '{phrase}'"

--- a/tests/voice/test_rime_tts_and_barge_in.py
+++ b/tests/voice/test_rime_tts_and_barge_in.py
@@ -541,10 +541,10 @@ class TestGuardedBargeIn:
         h._tts_pipeline.cancel_current_and_clear_queue.assert_called_once()
 
     def test_barge_in_does_not_fire_on_single_word_even_high_confidence(self):
-        """Default min 2 words: single-word 'stop' must not cancel (phantom guard)."""
+        """Default min 2 words: non-command single-word 'hello' must not cancel (phantom guard)."""
         h = _base_handler()
         h._is_tts_playing = True
-        asyncio.run(h._maybe_process_interim("stop", 0.85))
+        asyncio.run(h._maybe_process_interim("hello", 0.85))
         h._tts_pipeline.cancel_current_and_clear_queue.assert_not_called()
 
     def test_barge_in_fires_on_single_word_when_min_words_is_one(self):

--- a/tests/voice/test_twilio_elevenlabs_humanization_and_volume.py
+++ b/tests/voice/test_twilio_elevenlabs_humanization_and_volume.py
@@ -1,11 +1,6 @@
-import pytest
 import numpy as np
-from app.utils.ssml_utils import strip_ssml_tags
 from app.utils.eleven_tts_text import (
     prepare_tts_text_for_provider,
-    supports_elevenlabs_audio_tags,
-    apply_elevenlabs_breathing_fallback,
-    build_elevenlabs_audio_tag_prompt_block,
 )
 from app.voice.humanization_engine import (
     analyze_response,

--- a/tests/voice/test_twilio_elevenlabs_humanization_and_volume.py
+++ b/tests/voice/test_twilio_elevenlabs_humanization_and_volume.py
@@ -1,0 +1,149 @@
+import pytest
+import numpy as np
+from app.utils.ssml_utils import strip_ssml_tags
+from app.utils.eleven_tts_text import (
+    prepare_tts_text_for_provider,
+    supports_elevenlabs_audio_tags,
+    apply_elevenlabs_breathing_fallback,
+    build_elevenlabs_audio_tag_prompt_block,
+)
+from app.voice.humanization_engine import (
+    analyze_response,
+    pause_frames_for_chunk,
+    PacingHint,
+    SentenceEndingType,
+)
+from app.voice.tts_provider_capabilities import build_voice_settings_overlay
+from app.utils.audio_utils import (
+    apply_volume_fade,
+    ulaw_to_linear_sample,
+    linear_to_ulaw_sample,
+    MULAW_FRAME_BYTES,
+    apply_micro_fade_in,
+    apply_micro_fade_out,
+)
+from app.voice.tts_stream_mixin import TtsStreamMixin
+
+
+def test_no_elevenlabs_bracket_tags_reach_provider():
+    """Requirement A: No [breathes], [excited], [sad], etc. reach ElevenLabs."""
+    inputs = [
+        "[breathes] Hello, thanks for calling.",
+        "[excited] That is wonderful news!",
+        "[sad] I am so sorry to hear that.",
+        "[breathe] Sure, let me check that for you.",
+        "[breath] One moment please.",
+        "[pause] Let me check our calendar.",
+    ]
+    for raw in inputs:
+        cleaned = prepare_tts_text_for_provider(raw, "elevenlabs")
+        assert not any(tag in cleaned for tag in ["[breathes]", "[excited]", "[sad]", "[breathe]", "[breath]", "[pause]"])
+        assert not cleaned.startswith("[")
+
+
+def test_no_ssml_tags_reach_elevenlabs():
+    """Requirement B: No <speak>, <prosody>, <break> reach ElevenLabs."""
+    ssml_text = '<speak><prosody rate="0.93" pitch="0st" volume="medium"><break time="400ms"/> Good morning! How can I assist you?</prosody></speak>'
+    cleaned = prepare_tts_text_for_provider(ssml_text, "elevenlabs")
+    assert cleaned == "Good morning! How can I assist you?"
+    assert "<" not in cleaned
+    assert ">" not in cleaned
+    assert "prosody" not in cleaned
+    assert "break" not in cleaned
+    assert "speak" not in cleaned
+
+
+def test_split_incomplete_xml_tags_sanitized():
+    """Requirement C: Split/incomplete XML tags across chunks are cleanly sanitized."""
+    # Leading split tag (Chunk 1 ended with open tag)
+    chunk1 = 'Good morning <prosody rate="95%"'
+    assert prepare_tts_text_for_provider(chunk1, "elevenlabs") == "Good morning"
+
+    # Trailing split tag (Chunk 2 starts with unclosed tag remnant)
+    chunk2 = ' pitch="+1st">how may I help you?'
+    assert prepare_tts_text_for_provider(chunk2, "elevenlabs") == "how may I help you?"
+
+    # Remnant break fragment
+    chunk3 = 'time="400ms"/> Absolutely!'
+    assert prepare_tts_text_for_provider(chunk3, "elevenlabs") == "Absolutely!"
+
+
+def test_humanization_voice_parameters_applied():
+    """Requirement D: Humanization voice parameters (dynamic stability) are applied."""
+    decision = analyze_response(
+        "I understand that must be frustrating, let me help.",
+        user_text="I am really upset about this delay",
+        stt_confidence=0.95,
+        use_ssml=False,
+        is_final=True,
+    )
+    overlay = build_voice_settings_overlay("elevenlabs", decision)
+    # Stability should be provided based on user mood/turn signals
+    assert "stability" in overlay or overlay == {}
+
+
+def test_audio_level_pauses_preserved():
+    """Requirement G: Audio-level silence frames (pause_frames_for_chunk) remain active."""
+    pacing = PacingHint(
+        sentence_count=1,
+        has_multiple_sentences=False,
+        is_short_utterance=False,
+        ending_type=SentenceEndingType.STATEMENT,
+        has_internal_pause_opportunity=False,
+    )
+    # Non-final statement chunk receives silence frames
+    frames = pause_frames_for_chunk(pacing, is_final=False)
+    assert frames >= 0
+    # Final chunk has 0 intersentence pause frames
+    assert pause_frames_for_chunk(pacing, is_final=True) == 0
+
+
+def test_micro_fades_and_twilio_framing():
+    """Requirements H & I: 160-byte 20ms framing and micro-fades preserved."""
+    # 20ms frame is exactly 160 bytes
+    frame = bytes([0x7F]) * MULAW_FRAME_BYTES
+    assert len(frame) == 160
+
+    # 1 second of audio (8000 bytes = 50 frames of 160 bytes)
+    audio = bytes([0x7F]) * 8000
+    fade_in = apply_micro_fade_in(audio, duration_ms=25.0)
+    assert len(fade_in) == 8000
+
+    fade_out = apply_micro_fade_out(fade_in, duration_ms=25.0)
+    assert len(fade_out) == 8000
+
+
+def test_elevenlabs_volume_normalization_and_headroom():
+    """Requirement J: Provider-aware volume gain brings ElevenLabs up without clipping."""
+    # Mock handler with ElevenLabs agent
+    class MockRuntime:
+        adapter_slug = "elevenlabs"
+        settings_json = {"volume": 1.0}
+
+    class MockHandler(TtsStreamMixin):
+        def __init__(self):
+            self.agent = object()
+
+    handler = MockHandler()
+    
+    # Patch resolve_tts_runtime
+    import app.voice.tts_stream_mixin as mixin_mod
+    orig_resolve = mixin_mod.resolve_tts_runtime
+    mixin_mod.resolve_tts_runtime = lambda agent, db=None: MockRuntime()
+    try:
+        vol = handler._resolve_voice_volume()
+        assert vol == 1.8  # 1.8x baseline gain for ElevenLabs
+    finally:
+        mixin_mod.resolve_tts_runtime = orig_resolve
+
+    # Test apply_volume_fade with 1.8x gain on real linear-encoded mulaw
+    linear_samples = [int(15000 * np.sin(2 * np.pi * 440 * t / 8000)) for t in range(800)]
+    mulaw_bytes = bytes(linear_to_ulaw_sample(s) for s in linear_samples)
+    
+    boosted = apply_volume_fade(mulaw_bytes, volume=1.8)
+    assert len(boosted) == len(mulaw_bytes)
+    
+    # Decode back and check peak
+    boosted_samples = [ulaw_to_linear_sample(b) for b in boosted]
+    max_val = max(abs(s) for s in boosted_samples)
+    assert max_val <= 32767  # Strictly within int16 bounds (no overflow)


### PR DESCRIPTION
## Summary

- Fixes an interim/final turn-finalization race where `speech_final` could be silently discarded when interim generation failed or returned empty, and encapsulates the interim task's return value to prevent state leaking across turns.
- Removes ElevenLabs bracket-tag/SSML leakage from the Twilio conversational TTS path and aligns Twilio ElevenLabs humanization with the Web Demo's shared pipeline, including a 1.8x clean gain boost for Twilio ElevenLabs outbound audio.
- Disables interim LLM generation on the Twilio transport, removes unused Google TTS precaching, and fixes Deepgram keepalive behavior.
- Introduces `app/voice/backchannel_classifier.py`: a whitelist-first turn classifier (`BARGE_IN` / `SUPPRESS_NON_ACTIONABLE_BACKCHANNEL` / `NORMAL_USER_TURN`) so conversational backchannels ("hey", "yeah", "okay") no longer interrupt active TTS while explicit commands ("stop", "hold on") and genuine short requests still do — replacing a prior word-count-only barge-in heuristic.
- Tunes the single-word barge-in confidence threshold to 0.36 ("fixed barge in" / "fixed two words barge in").
- Adjusts the LLM output token limit ("token limit").

## Test plan

- [x] `tests/test_interim_final_lockout_gate.py` (new, 473 lines) — turn finalization and concurrency isolation regression coverage
- [x] `tests/voice/test_backchannel_classifier.py` (new, 244 lines)
- [x] `tests/voice/test_production_readiness_barge_in.py` (new, 284 lines)
- [x] `tests/services/test_stt_regressions.py` (new, 96 lines)
- [x] `tests/voice/test_twilio_elevenlabs_humanization_and_volume.py` (new, 144 lines)
- [x] `tests/utils/test_eleven_tts_text.py` updated for bracket-tag/SSML leakage fix

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>